### PR TITLE
Add persistent highlight for navigation items

### DIFF
--- a/lib/pdf_book/pdf_outlines_screen.dart
+++ b/lib/pdf_book/pdf_outlines_screen.dart
@@ -19,6 +19,32 @@ class _OutlineViewState extends State<OutlineView> {
   TextEditingController searchController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant OutlineView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerChanged);
+    searchController.dispose();
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
     final outline = widget.outline;
     if (outline == null || outline.isEmpty) {
@@ -117,13 +143,15 @@ class _OutlineViewState extends State<OutlineView> {
                 color: Colors.transparent,
                 child: ListTile(
                   title: Text(node.title),
-                  // === מה שהיה ב-InkWell עובר לפה ===
+                  selected: widget.controller.isReady &&
+                      node.dest?.pageNumber ==
+                          widget.controller.pageNumber,
+                  selectedColor: Theme.of(context).colorScheme.onSecondary,
+                  selectedTileColor:
+                      Theme.of(context).colorScheme.secondary.withOpacity(0.2),
                   onTap: navigateToEntry,
                   hoverColor: Theme.of(context).hoverColor,
                   mouseCursor: SystemMouseCursors.click,
-                  // אפשרויות נוספות אם צריך:
-                  // dense: true,
-                  // visualDensity: VisualDensity.compact,
                 ),
               )
             : Material(
@@ -134,6 +162,15 @@ class _OutlineViewState extends State<OutlineView> {
                   // גם לכותרת של הצומת המורחב נוסיף ListTile
                   title: ListTile(
                     title: Text(node.title),
+                    selected: widget.controller.isReady &&
+                        node.dest?.pageNumber ==
+                            widget.controller.pageNumber,
+                    selectedColor:
+                        Theme.of(context).colorScheme.onSecondary,
+                    selectedTileColor: Theme.of(context)
+                        .colorScheme
+                        .secondary
+                        .withOpacity(0.2),
                     onTap: navigateToEntry,
                     hoverColor: Theme.of(context).hoverColor,
                     mouseCursor: SystemMouseCursors.click,

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -168,10 +168,9 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
             Future.value(currentState.tableOfContents));
       }
 
-      int? index = currentState.selectedIndex;
-      if (!event.visibleIndecies.contains(index)) {
-        index = null;
-      }
+      int? index = event.visibleIndecies.isNotEmpty
+          ? event.visibleIndecies.first
+          : currentState.selectedIndex;
 
       emit(currentState.copyWith(
           visibleIndices: event.visibleIndecies,

--- a/lib/text_book/view/toc_navigator_screen.dart
+++ b/lib/text_book/view/toc_navigator_screen.dart
@@ -83,9 +83,19 @@ class _TocViewerState extends State<TocViewer>
     if (entry.children.isEmpty) {
       return Padding(
         padding: EdgeInsets.fromLTRB(0, 0, 10 * entry.level.toDouble(), 0),
-        child: ListTile(
-          title: Text(entry.text),
-          onTap: navigateToEntry,
+        child: BlocBuilder<TextBookBloc, TextBookState>(
+          builder: (context, state) {
+            final bool selected = state is TextBookLoaded &&
+                state.selectedIndex == entry.index;
+            return ListTile(
+              title: Text(entry.text),
+              selected: selected,
+              selectedColor: Theme.of(context).colorScheme.onSecondary,
+              selectedTileColor:
+                  Theme.of(context).colorScheme.secondary.withOpacity(0.2),
+              onTap: navigateToEntry,
+            );
+          },
         ),
       );
     } else {
@@ -97,9 +107,23 @@ class _TocViewerState extends State<TocViewer>
           ),
           child: ExpansionTile(
             initiallyExpanded: entry.level == 1,
-            title: GestureDetector(
-              onTap: navigateToEntry,
-              child: Text(showFullText ? entry.fullText : entry.text),
+            title: BlocBuilder<TextBookBloc, TextBookState>(
+              builder: (context, state) {
+                final bool selected = state is TextBookLoaded &&
+                    state.selectedIndex == entry.index;
+                return ListTile(
+                  title: Text(showFullText ? entry.fullText : entry.text),
+                  selected: selected,
+                  selectedColor:
+                      Theme.of(context).colorScheme.onSecondary,
+                  selectedTileColor: Theme.of(context)
+                      .colorScheme
+                      .secondary
+                      .withOpacity(0.2),
+                  onTap: navigateToEntry,
+                  contentPadding: EdgeInsets.zero,
+                );
+              },
             ),
             leading: const Icon(Icons.chevron_right_rounded),
             trailing: const SizedBox.shrink(),


### PR DESCRIPTION
## Summary
- keep `Navigation` outline in sync with page view
- highlight currently selected outline or TOC item
- update selected index when scrolling

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685554176bd883338140802653f75b16