### PR TITLE
Improve search interface consistency

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -40,11 +40,13 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     ..addListener(_onTextSearcherUpdated);
   TabController? _leftPaneTabController;
   int _currentLeftPaneTabIndex = 0;
+  final FocusNode _searchFieldFocusNode = FocusNode();
 
   void _ensureSearchTabIsActive() {
     if (_leftPaneTabController != null && _leftPaneTabController!.index != 1) {
       _leftPaneTabController!.animateTo(1);
     }
+    _searchFieldFocusNode.requestFocus();
   }
 
   late TabController _tabController;
@@ -114,11 +116,17 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       vsync: this,
       initialIndex: _currentLeftPaneTabIndex,
     );
+    if (_currentLeftPaneTabIndex == 1) {
+      _searchFieldFocusNode.requestFocus();
+    }
     _leftPaneTabController!.addListener(() {
       if (_currentLeftPaneTabIndex != _leftPaneTabController!.index) {
         setState(() {
           _currentLeftPaneTabIndex = _leftPaneTabController!.index;
         });
+        if (_leftPaneTabController!.index == 1) {
+          _searchFieldFocusNode.requestFocus();
+        }
       }
     });
   }
@@ -142,6 +150,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     widget.tab.pdfViewerController
         .removeListener(_onPdfViewerControllerUpdate);
     _leftPaneTabController?.dispose();
+    _searchFieldFocusNode.dispose();
 
     super.dispose();
   }
@@ -438,6 +447,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                         child: PdfBookSearchView(
                           textSearcher: textSearcher,
                           searchController: widget.tab.searchController,
+                          focusNode: _searchFieldFocusNode,
                           initialSearchText: widget.tab.searchText,
                           onSearchResultNavigated: _ensureSearchTabIsActive,
                         ),

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -9,6 +9,14 @@ import 'package:search_highlight_text/search_highlight_text.dart';
 import 'package:otzaria/text_book/models/search_results.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+class _GroupedResultItem {
+  final String? header;
+  final TextSearchResult? result;
+  const _GroupedResultItem.header(this.header) : result = null;
+  const _GroupedResultItem.result(this.result) : header = null;
+  bool get isHeader => header != null;
+}
+
 class TextBookSearchView extends StatefulWidget {
   final String data;
   final ItemScrollController scrollControler;
@@ -42,9 +50,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     searchTextController.text =
         (context.read<TextBookBloc>().state as TextBookLoaded).searchText;
     scrollControler = widget.scrollControler;
-    if (!Platform.isAndroid) {
-      widget.focusNode.requestFocus();
-    }
+    widget.focusNode.requestFocus();
   }
 
   void _searchTextUpdated() {
@@ -68,6 +74,8 @@ class TextBookSearchViewState extends State<TextBookSearchView>
           context.read<TextBookBloc>().add(UpdateSearchText(e));
           _searchTextUpdated();
         },
+        textAlign: TextAlign.right,
+        textDirection: TextDirection.rtl,
         controller: searchTextController,
         decoration: InputDecoration(
           hintText: 'חפש כאן..',
@@ -102,30 +110,53 @@ class TextBookSearchViewState extends State<TextBookSearchView>
         ),
       // END --- Added Code for Result Count
       Expanded(
-        child: ListView.builder(
+        child: Builder(builder: (context) {
+          final List<_GroupedResultItem> items = [];
+          String? lastAddress;
+          for (final r in searchResults) {
+            if (lastAddress != r.address) {
+              items.add(_GroupedResultItem.header(r.address));
+              lastAddress = r.address;
+            }
+            items.add(_GroupedResultItem.result(r));
+          }
+
+          return ListView.builder(
             shrinkWrap: true,
-            itemCount: searchResults.length,
+            itemCount: items.length,
             itemBuilder: (context, index) {
-              // Original itemBuilder content:
-              final result = searchResults[index]; // Safe if itemCount > 0
-              return ListTile(
-                  title: Text(
-                    result.address,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
+              final item = items[index];
+              if (item.isHeader) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                  child: Text(
+                    item.header!,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                    ),
+                    textDirection: TextDirection.rtl,
                   ),
-                  subtitle: SearchHighlightText(result.snippet,
-                      searchText: result.query),
-                  onTap: () {
-                    widget.scrollControler.scrollTo(
-                      index: result.index,
-                      duration: const Duration(milliseconds: 250),
-                      curve: Curves.ease,
-                    );
-                    if (Platform.isAndroid) {
-                      widget.closeLeftPaneCallback();
-                    }
-                  });
-            }),
+                );
+              } else {
+                final result = item.result!;
+                return ListTile(
+                    subtitle: SearchHighlightText(result.snippet,
+                        searchText: result.query),
+                    onTap: () {
+                      widget.scrollControler.scrollTo(
+                        index: result.index,
+                        duration: const Duration(milliseconds: 250),
+                        curve: Curves.ease,
+                      );
+                      if (Platform.isAndroid) {
+                        widget.closeLeftPaneCallback();
+                      }
+                    });
+              }
+            },
+          );
+        }),
       )
     ]);
   }


### PR DESCRIPTION
## Summary
- normalize PDF search layout: text alignment and result count placement
- remove PDF search navigation arrows
- autofocus search field when switching to PDF search tab
- always focus text search field on open and align to RTL
- group text search results by section header

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558850e9248333a42a6448f3c5f9d5