### PR TITLE
Add bookmark titles to PDF search results

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -449,6 +449,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                           textSearcher: textSearcher,
                           searchController: widget.tab.searchController,
                           focusNode: _searchFieldFocusNode,
+                          outline: widget.tab.outline.value,
                           initialSearchText: widget.tab.searchText,
                           onSearchResultNavigated: _ensureSearchTabIsActive,
                         ),


### PR DESCRIPTION
## Summary
- accept an outline in `PdfBookSearchView`
- resolve search page numbers to bookmark titles via `refFromPageNumber`
- display bookmark titles for page headers when available
- pass document outline from `PdfBookScreen`

## Testing
- `dart format -o none --set-exit-if-changed lib/pdf_book/pdf_search_screen.dart lib/pdf_book/pdf_book_screen.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573b6d96708333874c8711c270b0b5