### PR TITLE
Fix PDF search panel activation

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -44,6 +44,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   final FocusNode _searchFieldFocusNode = FocusNode();
 
   void _ensureSearchTabIsActive() {
+    widget.tab.showLeftPane.value = true;
     if (_leftPaneTabController != null && _leftPaneTabController!.index != 1) {
       _leftPaneTabController!.animateTo(1);
     }
@@ -167,7 +168,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyF):
               _ensureSearchTabIsActive,
         },
-        child: Scaffold(
+        child: Focus(
+          focusNode: FocusNode(),
+          autofocus: !Platform.isAndroid,
+          child: Scaffold(
           appBar: AppBar(
             title: ValueListenableBuilder(
                 valueListenable: widget.tab.currentTitle,
@@ -393,8 +397,9 @@ class _PdfBookScreenState extends State<PdfBookScreen>
             ],
           ),
         ),
-      );
-    });
+      ),
+    );
+  });
   }
 
   AnimatedSize _buildLeftPane() {


### PR DESCRIPTION
## Summary
- ensure the left pane opens when invoking PDF search
- add Focus widget so `Ctrl+F` shortcut is recognized

## Testing
- `flutter test --machine` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685742d23be48333bc477ee27ae63149