### PR TITLE
Maintain focus in viewer sidebars

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -42,6 +42,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   TabController? _leftPaneTabController;
   int _currentLeftPaneTabIndex = 0;
   final FocusNode _searchFieldFocusNode = FocusNode();
+  final FocusNode _navigationFieldFocusNode = FocusNode();
 
   void _ensureSearchTabIsActive() {
     widget.tab.showLeftPane.value = true;
@@ -122,6 +123,8 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     );
     if (_currentLeftPaneTabIndex == 1) {
       _searchFieldFocusNode.requestFocus();
+    } else {
+      _navigationFieldFocusNode.requestFocus();
     }
     _leftPaneTabController!.addListener(() {
       if (_currentLeftPaneTabIndex != _leftPaneTabController!.index) {
@@ -130,6 +133,17 @@ class _PdfBookScreenState extends State<PdfBookScreen>
         });
         if (_leftPaneTabController!.index == 1) {
           _searchFieldFocusNode.requestFocus();
+        } else if (_leftPaneTabController!.index == 0) {
+          _navigationFieldFocusNode.requestFocus();
+        }
+      }
+    });
+    widget.tab.showLeftPane.addListener(() {
+      if (widget.tab.showLeftPane.value) {
+        if (_leftPaneTabController!.index == 1) {
+          _searchFieldFocusNode.requestFocus();
+        } else if (_leftPaneTabController!.index == 0) {
+          _navigationFieldFocusNode.requestFocus();
         }
       }
     });
@@ -154,6 +168,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     widget.tab.pdfViewerController.removeListener(_onPdfViewerControllerUpdate);
     _leftPaneTabController?.dispose();
     _searchFieldFocusNode.dispose();
+    _navigationFieldFocusNode.dispose();
 
     super.dispose();
   }
@@ -462,6 +477,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                         builder: (context, outline, child) => OutlineView(
                           outline: outline,
                           controller: widget.tab.pdfViewerController,
+                          focusNode: _navigationFieldFocusNode,
                         ),
                       ),
                       ValueListenableBuilder(

--- a/lib/pdf_book/pdf_outlines_screen.dart
+++ b/lib/pdf_book/pdf_outlines_screen.dart
@@ -6,10 +6,12 @@ class OutlineView extends StatefulWidget {
     super.key,
     required this.outline,
     required this.controller,
+    required this.focusNode,
   });
 
   final List<PdfOutlineNode>? outline;
   final PdfViewerController controller;
+  final FocusNode focusNode;
 
   @override
   State<OutlineView> createState() => _OutlineViewState();
@@ -57,7 +59,12 @@ class _OutlineViewState extends State<OutlineView> {
       children: [
         TextField(
           controller: searchController,
+          focusNode: widget.focusNode,
+          autofocus: true,
           onChanged: (value) => setState(() {}),
+          onSubmitted: (_) {
+            widget.focusNode.requestFocus();
+          },
           decoration: InputDecoration(
             hintText: 'חיפוש סימניה...',
             suffixIcon: Row(

--- a/lib/pdf_book/pdf_search_screen.dart
+++ b/lib/pdf_book/pdf_search_screen.dart
@@ -169,6 +169,9 @@ class _PdfBookSearchViewState extends State<PdfBookSearchView> {
                     focusNode: widget.focusNode,
                     controller: widget.searchController,
                     textAlign: TextAlign.right,
+                    onSubmitted: (_) {
+                      widget.focusNode.requestFocus();
+                    },
                     decoration: InputDecoration(
                       suffixIcon: IconButton(
                         onPressed: widget.searchController.text.isNotEmpty

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -44,6 +44,7 @@ class TextBookViewerBloc extends StatefulWidget {
 class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     with TickerProviderStateMixin {
   final FocusNode textSearchFocusNode = FocusNode();
+  final FocusNode navigationSearchFocusNode = FocusNode();
   late TabController tabController;
 
   String? encodeQueryParameters(Map<String, String> params) {
@@ -57,6 +58,14 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
   void initState() {
     super.initState();
     tabController = TabController(length: 4, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    tabController.dispose();
+    textSearchFocusNode.dispose();
+    navigationSearchFocusNode.dispose();
+    super.dispose();
   }
 
   @override
@@ -676,6 +685,15 @@ $selectedText
   }
 
   Widget _buildTabBar(TextBookLoaded state) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (state.showLeftPane && !Platform.isAndroid) {
+        if (tabController.index == 1) {
+          textSearchFocusNode.requestFocus();
+        } else if (tabController.index == 0) {
+          navigationSearchFocusNode.requestFocus();
+        }
+      }
+    });
     return AnimatedSize(
       duration: const Duration(milliseconds: 300),
       child: SizedBox(
@@ -698,6 +716,8 @@ $selectedText
                       onTap: (value) {
                         if (value == 1 && !Platform.isAndroid) {
                           textSearchFocusNode.requestFocus();
+                        } else if (value == 0 && !Platform.isAndroid) {
+                          navigationSearchFocusNode.requestFocus();
                         }
                       },
                     ),
@@ -755,6 +775,7 @@ $selectedText
   Widget _buildTocViewer(BuildContext context, TextBookLoaded state) {
     return TocViewer(
       scrollController: state.scrollController,
+      focusNode: navigationSearchFocusNode,
       closeLeftPaneCallback: () =>
           context.read<TextBookBloc>().add(const ToggleLeftPane(false)),
     );

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -74,6 +74,9 @@ class TextBookSearchViewState extends State<TextBookSearchView>
           context.read<TextBookBloc>().add(UpdateSearchText(e));
           _searchTextUpdated();
         },
+        onSubmitted: (_) {
+          widget.focusNode.requestFocus();
+        },
         textAlign: TextAlign.right,
         textDirection: TextDirection.rtl,
         controller: searchTextController,

--- a/lib/text_book/view/toc_navigator_screen.dart
+++ b/lib/text_book/view/toc_navigator_screen.dart
@@ -11,10 +11,12 @@ class TocViewer extends StatefulWidget {
     super.key,
     required this.scrollController,
     required this.closeLeftPaneCallback,
+    required this.focusNode,
   });
 
   final void Function() closeLeftPaneCallback;
   final ItemScrollController scrollController;
+  final FocusNode focusNode;
 
   @override
   State<TocViewer> createState() => _TocViewerState();
@@ -159,7 +161,11 @@ class _TocViewerState extends State<TocViewer>
               TextField(
                 controller: searchController,
                 onChanged: (value) => setState(() {}),
+                focusNode: widget.focusNode,
                 autofocus: true,
+                onSubmitted: (_) {
+                  widget.focusNode.requestFocus();
+                },
                 decoration: InputDecoration(
                   hintText: 'איתור כותרת...',
                   suffixIcon: Row(


### PR DESCRIPTION
## Summary
- keep focus on search fields after submitting in both PDF and text viewers
- auto-focus navigation sidebar inputs for PDFs and texts
- manage new focus nodes within screens

## Testing
- `npm --version` *(fails: None)*

------
https://chatgpt.com/codex/tasks/task_e_68595b56199483339e8500796a4a8639