### PR TITLE
Improve text TOC highlighting

### DIFF
--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -162,15 +162,16 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     if (state is TextBookLoaded) {
       final currentState = state as TextBookLoaded;
       String? newTitle;
+      int? index;
 
       if (event.visibleIndecies.isNotEmpty) {
-        newTitle = await refFromIndex(event.visibleIndecies.first,
-            Future.value(currentState.tableOfContents));
+        final first = event.visibleIndecies.first;
+        newTitle = await refFromIndex(
+            first, Future.value(currentState.tableOfContents));
+        index = closestTocEntryIndex(currentState.tableOfContents, first);
+      } else {
+        index = currentState.selectedIndex;
       }
-
-      int? index = event.visibleIndecies.isNotEmpty
-          ? event.visibleIndecies.first
-          : currentState.selectedIndex;
 
       emit(currentState.copyWith(
           visibleIndices: event.visibleIndecies,

--- a/lib/utils/ref_helper.dart
+++ b/lib/utils/ref_helper.dart
@@ -126,3 +126,23 @@ Future<String> refFromPageNumber(
   texts = texts.map((e) => e.trim()).toList();
   return texts.join(', ');
 }
+
+/// Returns the index of the last [TocEntry] whose [index] is less than or equal
+/// to [targetIndex]. If no such entry exists, returns `null`.
+int? closestTocEntryIndex(List<TocEntry> entries, int targetIndex) {
+  TocEntry? closest;
+
+  void search(List<TocEntry> toc) {
+    for (final entry in toc) {
+      if (entry.index <= targetIndex) {
+        if (closest == null || entry.index > closest!.index) {
+          closest = entry;
+        }
+        search(entry.children);
+      }
+    }
+  }
+
+  search(entries);
+  return closest?.index;
+}


### PR DESCRIPTION
## Summary
- keep bookmark indicator synced while scrolling text
- expose `closestTocEntryIndex` helper

## Testing
- `dart format lib/utils/ref_helper.dart lib/text_book/bloc/text_book_bloc.dart` *(fails: `dart: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859d8981f788333881601bdf3289632