### PR TITLE
Add history shortcut on empty browse screen

### DIFF
--- a/lib/history/history_dialog.dart
+++ b/lib/history/history_dialog.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:otzaria/history/history_screen.dart';
+
+class HistoryDialog extends StatelessWidget {
+  const HistoryDialog({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.all(16),
+      child: Container(
+        width: MediaQuery.of(context).size.width * 0.8,
+        height: MediaQuery.of(context).size.height * 0.8,
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'היסטוריה',
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            const Expanded(child: HistoryView()),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/tabs/reading_screen.dart
+++ b/lib/tabs/reading_screen.dart
@@ -24,6 +24,7 @@ import 'package:otzaria/text_book/view/text_book_screen.dart';
 import 'package:otzaria/daf_yomi/calendar.dart';
 import 'package:otzaria/utils/text_manipulation.dart';
 import 'package:otzaria/workspaces/view/workspace_switcher_dialog.dart';
+import 'package:otzaria/history/history_dialog.dart';
 
 class ReadingScreen extends StatefulWidget {
   const ReadingScreen({Key? key}) : super(key: key);
@@ -77,6 +78,15 @@ class _ReadingScreenState extends State<ReadingScreen>
                           );
                     },
                     child: const Text('דפדף בספרייה'),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: TextButton(
+                    onPressed: () {
+                      _showHistoryDialog(context);
+                    },
+                    child: const Text('הצג היסטוריה'),
                   ),
                 ),
                 Padding(
@@ -325,5 +335,12 @@ class _ReadingScreenState extends State<ReadingScreen>
           .read<TabsBloc>()
           .add(CloseOtherTabs(state.tabs[state.currentTabIndex]));
     }
+  }
+
+  void _showHistoryDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => const HistoryDialog(),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add a HistoryDialog widget to display reading history
- show a **Show History** button in the empty reading screen

## Testing
- `dart format lib/history/history_dialog.dart lib/tabs/reading_screen.dart` *(fails: `dart: command not found`)*
- `flutter --version` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bdf7d19ec833387e576f4eab9a617