### PR TITLE
Add dynamic tooltip shortcuts

### DIFF
--- a/lib/navigation/main_window_screen.dart
+++ b/lib/navigation/main_window_screen.dart
@@ -9,6 +9,7 @@ import 'package:otzaria/navigation/bloc/navigation_event.dart';
 import 'package:otzaria/navigation/bloc/navigation_state.dart';
 import 'package:otzaria/navigation/favoriets_screen.dart';
 import 'package:otzaria/settings/settings_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
@@ -80,28 +81,45 @@ class MainWindowScreenState extends State<MainWindowScreen>
   }
 
   List<NavigationDestination> _buildNavigationDestinations() {
-    return const [
+    String formatShortcut(String shortcut) => shortcut.toUpperCase();
+
+    final libraryShortcut =
+        Settings.getValue<String>('key-shortcut-open-library-browser') ??
+            'ctrl+l';
+    final findShortcut =
+        Settings.getValue<String>('key-shortcut-open-find-ref') ?? 'ctrl+o';
+    final browseShortcut =
+        Settings.getValue<String>('key-shortcut-open-reading-screen') ??
+            'ctrl+r';
+    final searchShortcut =
+        Settings.getValue<String>('key-shortcut-open-new-search') ?? 'ctrl+q';
+
+    return [
       NavigationDestination(
-        icon: Icon(Icons.library_books),
+        icon: const Icon(Icons.library_books),
         label: 'ספרייה',
+        tooltip: formatShortcut(libraryShortcut),
       ),
       NavigationDestination(
-        icon: Icon(Icons.auto_stories_rounded),
+        icon: const Icon(Icons.auto_stories_rounded),
         label: 'איתור',
+        tooltip: formatShortcut(findShortcut),
       ),
       NavigationDestination(
-        icon: Icon(Icons.menu_book),
+        icon: const Icon(Icons.menu_book),
         label: 'עיון',
+        tooltip: formatShortcut(browseShortcut),
       ),
       NavigationDestination(
-        icon: Icon(Icons.search),
+        icon: const Icon(Icons.search),
         label: 'חיפוש',
+        tooltip: formatShortcut(searchShortcut),
       ),
-      NavigationDestination(
+      const NavigationDestination(
         icon: Icon(Icons.star),
         label: 'מועדפים',
       ),
-      NavigationDestination(
+      const NavigationDestination(
         icon: Icon(Icons.settings),
         label: 'הגדרות',
       ),
@@ -177,7 +195,10 @@ class MainWindowScreenState extends State<MainWindowScreen>
                                     for (var destination
                                         in _buildNavigationDestinations())
                                       NavigationRailDestination(
-                                        icon: destination.icon,
+                                        icon: Tooltip(
+                                          message: destination.tooltip ?? '',
+                                          child: destination.icon,
+                                        ),
                                         label: Text(destination.label),
                                         padding: destination.label == 'הגדרות'
                                             ? EdgeInsets.only(

--- a/lib/navigation/main_window_screen.dart
+++ b/lib/navigation/main_window_screen.dart
@@ -96,24 +96,40 @@ class MainWindowScreenState extends State<MainWindowScreen>
 
     return [
       NavigationDestination(
-        icon: const Icon(Icons.library_books),
+        tooltip: '',
+        icon: Tooltip(
+          preferBelow: false,
+          message: formatShortcut(libraryShortcut),
+          child: const Icon(Icons.library_books),
+        ),
         label: 'ספרייה',
-        tooltip: formatShortcut(libraryShortcut),
       ),
       NavigationDestination(
-        icon: const Icon(Icons.auto_stories_rounded),
+        tooltip: '',
+        icon: Tooltip(
+          preferBelow: false,
+          message: formatShortcut(findShortcut),
+          child: const Icon(Icons.auto_stories_rounded),
+        ),
         label: 'איתור',
-        tooltip: formatShortcut(findShortcut),
       ),
       NavigationDestination(
-        icon: const Icon(Icons.menu_book),
+        tooltip: '',
+        icon: Tooltip(
+          preferBelow: false,
+          message: formatShortcut(browseShortcut),
+          child: const Icon(Icons.menu_book),
+        ),
         label: 'עיון',
-        tooltip: formatShortcut(browseShortcut),
       ),
       NavigationDestination(
-        icon: const Icon(Icons.search),
+        tooltip: '',
+        icon: Tooltip(
+          preferBelow: false,
+          message: formatShortcut(searchShortcut),
+          child: const Icon(Icons.search),
+        ),
         label: 'חיפוש',
-        tooltip: formatShortcut(searchShortcut),
       ),
       const NavigationDestination(
         icon: Icon(Icons.star),
@@ -196,6 +212,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
                                         in _buildNavigationDestinations())
                                       NavigationRailDestination(
                                         icon: Tooltip(
+                                          preferBelow: false,
                                           message: destination.tooltip ?? '',
                                           child: destination.icon,
                                         ),

--- a/lib/tabs/reading_screen.dart
+++ b/lib/tabs/reading_screen.dart
@@ -24,6 +24,7 @@ import 'package:otzaria/text_book/view/text_book_screen.dart';
 import 'package:otzaria/daf_yomi/calendar.dart';
 import 'package:otzaria/utils/text_manipulation.dart';
 import 'package:otzaria/workspaces/view/workspace_switcher_dialog.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 class ReadingScreen extends StatefulWidget {
   const ReadingScreen({Key? key}) : super(key: key);
@@ -245,6 +246,9 @@ class _ReadingScreenState extends State<ReadingScreen>
                   IconButton(
                     onPressed: () => closeTab(tab, context),
                     icon: const Icon(Icons.close, size: 10),
+                    tooltip: (Settings.getValue<String>('key-shortcut-close-tab') ??
+                            'ctrl+w')
+                        .toUpperCase(),
                   ),
                 ],
               ),

--- a/lib/tabs/reading_screen.dart
+++ b/lib/tabs/reading_screen.dart
@@ -243,12 +243,15 @@ class _ReadingScreenState extends State<ReadingScreen>
                     Tooltip(
                         message: tab.title,
                         child: Text(truncate(tab.title, 12))),
-                  IconButton(
-                    onPressed: () => closeTab(tab, context),
-                    icon: const Icon(Icons.close, size: 10),
-                    tooltip: (Settings.getValue<String>('key-shortcut-close-tab') ??
+                  Tooltip(
+                    preferBelow: false,
+                    message: (Settings.getValue<String>('key-shortcut-close-tab') ??
                             'ctrl+w')
                         .toUpperCase(),
+                    child: IconButton(
+                      onPressed: () => closeTab(tab, context),
+                      icon: const Icon(Icons.close, size: 10),
+                    ),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- show keybindings as tooltips on navigation buttons
- display shortcut hint on close tab button

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be194177c833382bf61ac473fc8b1