### PR TITLE
Implement sidebar width management

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/utils/open_book.dart';
 import 'package:otzaria/utils/ref_helper.dart';
 import 'package:pdfrx/pdfrx.dart';
 import 'package:provider/provider.dart';
+import 'package:multi_split_view/multi_split_view.dart';
 import 'pdf_search_screen.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'pdf_outlines_screen.dart';
@@ -301,11 +302,24 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                   }),
             ],
           ),
-          body: Row(
-            children: [
-              _buildLeftPane(),
-              Expanded(
-                child: ColorFiltered(
+          body: LayoutBuilder(builder: (context, constraints) {
+            final controller = MultiSplitViewController(
+              areas: [
+                Area(size: widget.tab.showLeftPane.value ? widget.tab.leftPaneWidth.value : 0),
+                Area(weight: 1),
+              ],
+            );
+            return MultiSplitView(
+              controller: controller,
+              axis: Axis.horizontal,
+              resizable: true,
+              dividerBuilder: (axis, index, resizable, dragging, highlighted, themeData) => const VerticalDivider(),
+              onDividerDragEnd: (index) {
+                widget.tab.leftPaneWidth.value = controller.areas[0].size ?? widget.tab.leftPaneWidth.value;
+              },
+              children: [
+                _buildLeftPane(),
+                ColorFiltered(
                   colorFilter: ColorFilter.mode(
                       Colors.white,
                       Provider.of<SettingsBloc>(context, listen: true)
@@ -417,19 +431,11 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   });
   }
 
-  AnimatedSize _buildLeftPane() {
-    return AnimatedSize(
-      duration: const Duration(milliseconds: 300),
-      child: ValueListenableBuilder(
-        valueListenable: widget.tab.showLeftPane,
-        builder: (context, showLeftPane, child) => SizedBox(
-          width: showLeftPane ? 300 : 0,
-          child: child!,
-        ),
-        child: Container(
-          color: Theme.of(context).colorScheme.surface,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(1, 0, 4, 0),
+  Widget _buildLeftPane() {
+    return Container(
+      color: Theme.of(context).colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(1, 0, 4, 0),
             child: Column(
               children: [
                 Row(

--- a/lib/tabs/models/pdf_tab.dart
+++ b/lib/tabs/models/pdf_tab.dart
@@ -38,6 +38,9 @@ class PdfBookTab extends OpenedTab {
   ///a flag that tells if the left pane should be pinned on scrolling
   final pinLeftPane = ValueNotifier<bool>(false);
 
+  /// The width of the left pane.
+  late final ValueNotifier<double> leftPaneWidth;
+
   /// Creates a new instance of [PdfBookTab].
   ///
   /// The [book] parameter represents the PDF book, and the [pageNumber]
@@ -46,11 +49,13 @@ class PdfBookTab extends OpenedTab {
     required this.book,
     required this.pageNumber,
     bool openLeftPane = false,
+    double leftPaneWidth = 300,
     this.searchText = '',
     this.pdfSearchMatches,
     this.pdfSearchCurrentMatchIndex,
   }) : super(book.title) {
     showLeftPane = ValueNotifier<bool>(openLeftPane);
+    this.leftPaneWidth = ValueNotifier<double>(leftPaneWidth);
     searchController.text = searchText;
   }
 
@@ -61,7 +66,8 @@ class PdfBookTab extends OpenedTab {
     return PdfBookTab(
         book:
             PdfBook(title: getTitleFromPath(json['path']), path: json['path']),
-        pageNumber: json['pageNumber']);
+        pageNumber: json['pageNumber'],
+        leftPaneWidth: (json['leftPaneWidth'] ?? 300).toDouble());
   }
 
   /// Converts the [PdfBookTab] instance into a JSON map.
@@ -73,6 +79,7 @@ class PdfBookTab extends OpenedTab {
       'path': book.path,
       'pageNumber':
           (pdfViewerController.isReady ? pdfViewerController.pageNumber : 1),
+      'leftPaneWidth': leftPaneWidth.value,
       'type': 'PdfBookTab'
     };
   }

--- a/lib/tabs/models/tab.dart
+++ b/lib/tabs/models/tab.dart
@@ -19,11 +19,13 @@ abstract class OpenedTab {
         index: tab.index,
         book: tab.book,
         commentators: tab.commentators,
+        leftPaneWidth: tab.leftPaneWidth,
       );
     } else if (tab is PdfBookTab) {
       return PdfBookTab(
         book: tab.book,
         pageNumber: tab.pageNumber,
+        leftPaneWidth: tab.leftPaneWidth.value,
       );
     }
     return tab;

--- a/lib/tabs/models/text_tab.dart
+++ b/lib/tabs/models/text_tab.dart
@@ -21,6 +21,8 @@ class TextBookTab extends OpenedTab {
 
   List<String>? commentators;
 
+  double leftPaneWidth;
+
   /// Creates a new instance of [TextBookTab].
   ///
   /// The [index] parameter represents the initial index of the item in the scrollable list,
@@ -34,6 +36,7 @@ class TextBookTab extends OpenedTab {
     this.commentators,
     bool openLeftPane = false,
     bool splitedView = true,
+    this.leftPaneWidth = 400,
   }) : super(book.title) {
     // Initialize the bloc with initial state
     bloc = TextBookBloc(
@@ -61,6 +64,7 @@ class TextBookTab extends OpenedTab {
       ),
       commentators: List<String>.from(json['commentators']),
       splitedView: json['splitedView'],
+      leftPaneWidth: (json['leftPaneWidth'] ?? 400).toDouble(),
     );
   }
 
@@ -78,6 +82,7 @@ class TextBookTab extends OpenedTab {
       commentators = loadedState.activeCommentators;
       splitedView = loadedState.showSplitView;
       index = loadedState.visibleIndices.first;
+      leftPaneWidth = loadedState.leftPaneWidth;
     }
 
     return {
@@ -85,6 +90,7 @@ class TextBookTab extends OpenedTab {
       'initalIndex': index,
       'commentators': commentators,
       'splitedView': splitedView,
+      'leftPaneWidth': leftPaneWidth,
       'type': 'TextBookTab'
     };
   }

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -24,6 +24,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     on<UpdateSelectedIndex>(_onUpdateSelectedIndex);
     on<TogglePinLeftPane>(_onTogglePinLeftPane);
     on<UpdateSearchText>(_onUpdateSearchText);
+    on<UpdateLeftPaneWidth>(_onUpdateLeftPaneWidth);
   }
 
   Future<void> _onLoadContent(
@@ -211,6 +212,19 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       final currentState = state as TextBookLoaded;
       emit(currentState.copyWith(
         searchText: event.text,
+        selectedIndex: currentState.selectedIndex,
+      ));
+    }
+  }
+
+  void _onUpdateLeftPaneWidth(
+    UpdateLeftPaneWidth event,
+    Emitter<TextBookState> emit,
+  ) {
+    if (state is TextBookLoaded) {
+      final currentState = state as TextBookLoaded;
+      emit(currentState.copyWith(
+        leftPaneWidth: event.width,
         selectedIndex: currentState.selectedIndex,
       ));
     }

--- a/lib/text_book/bloc/text_book_event.dart
+++ b/lib/text_book/bloc/text_book_event.dart
@@ -84,6 +84,15 @@ class TogglePinLeftPane extends TextBookEvent {
   List<Object?> get props => [pin];
 }
 
+class UpdateLeftPaneWidth extends TextBookEvent {
+  final double width;
+
+  const UpdateLeftPaneWidth(this.width);
+
+  @override
+  List<Object?> get props => [width];
+}
+
 class UpdateSearchText extends TextBookEvent {
   final String text;
 

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -53,6 +53,7 @@ class TextBookLoaded extends TextBookState {
   final List<int> visibleIndices;
   final int? selectedIndex;
   final bool pinLeftPane;
+  final double leftPaneWidth;
   final String searchText;
   final String? currentTitle;
 
@@ -75,6 +76,7 @@ class TextBookLoaded extends TextBookState {
     required this.visibleIndices,
     this.selectedIndex,
     required this.pinLeftPane,
+    required this.leftPaneWidth,
     required this.searchText,
     required this.scrollController,
     required this.scrollOffsetController,
@@ -101,6 +103,7 @@ class TextBookLoaded extends TextBookState {
       tableOfContents: const [],
       removeNikud: false,
       pinLeftPane: false,
+      leftPaneWidth: 400,
       searchText: '',
       scrollController: ItemScrollController(),
       scrollOffsetController: ScrollOffsetController(),
@@ -123,6 +126,7 @@ class TextBookLoaded extends TextBookState {
     int? selectedIndex,
     List<int>? visibleIndices,
     bool? pinLeftPane,
+    double? leftPaneWidth,
     String? searchText,
     ItemScrollController? scrollController,
     ScrollOffsetController? scrollOffsetController,
@@ -144,6 +148,7 @@ class TextBookLoaded extends TextBookState {
       visibleIndices: visibleIndices ?? this.visibleIndices,
       selectedIndex: selectedIndex,
       pinLeftPane: pinLeftPane ?? this.pinLeftPane,
+      leftPaneWidth: leftPaneWidth ?? this.leftPaneWidth,
       searchText: searchText ?? this.searchText,
       scrollController: scrollController ?? this.scrollController,
       scrollOffsetController:
@@ -168,6 +173,7 @@ class TextBookLoaded extends TextBookState {
         visibleIndices,
         selectedIndex,
         pinLeftPane,
+        leftPaneWidth,
         searchText,
         currentTitle,
       ];

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -21,6 +21,7 @@ import 'package:otzaria/text_book/view/links_screen.dart';
 import 'package:otzaria/text_book/view/splited_view/splited_view_screen.dart';
 import 'package:otzaria/text_book/view/text_book_search_screen.dart';
 import 'package:otzaria/text_book/view/toc_navigator_screen.dart';
+import 'package:multi_split_view/multi_split_view.dart';
 import 'package:otzaria/utils/open_book.dart';
 import 'package:otzaria/utils/page_converter.dart';
 import 'package:otzaria/utils/ref_helper.dart';
@@ -613,12 +614,28 @@ $selectedText
                 ),
               ],
             )
-          : Row(
-              children: [
-                _buildTabBar(state),
-                Expanded(child: _buildHTMLViewer(state)),
-              ],
-            ),
+          : (() {
+              final controller = MultiSplitViewController(areas: [
+                Area(size: state.showLeftPane ? state.leftPaneWidth : 0),
+                Area(weight: 1),
+              ]);
+              return MultiSplitView(
+                controller: controller,
+                axis: Axis.horizontal,
+                resizable: true,
+                dividerBuilder:
+                    (axis, index, resizable, dragging, highlighted, themeData) =>
+                        const VerticalDivider(),
+                onDividerDragEnd: (index) {
+                  context.read<TextBookBloc>().add(
+                      UpdateLeftPaneWidth(controller.areas[0].size ?? state.leftPaneWidth));
+                },
+                children: [
+                  _buildTabBar(state),
+                  _buildHTMLViewer(state),
+                ],
+              );
+            })(),
     );
   }
 


### PR DESCRIPTION
## Summary
- add left pane width to `PdfBookTab` and persist in JSON
- track sidebar width in `TextBookLoaded` state
- allow updating left pane width via new bloc event
- use `MultiSplitView` for PDF and text views
- persist width when the divider moves

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3fb8f698833391642d24be34bfb2