### PR TITLE
Implement default remove nikud setting

### DIFF
--- a/lib/settings/settings_bloc.dart
+++ b/lib/settings/settings_bloc.dart
@@ -22,6 +22,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<UpdateUseFastSearch>(_onUpdateUseFastSearch);
     on<UpdateReplaceHolyNames>(_onUpdateReplaceHolyNames);
     on<UpdateAutoUpdateIndex>(_onUpdateAutoUpdateIndex);
+    on<UpdateDefaultRemoveNikud>(_onUpdateDefaultRemoveNikud);
   }
 
   Future<void> _onLoadSettings(
@@ -42,6 +43,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       useFastSearch: settings['useFastSearch'],
       replaceHolyNames: settings['replaceHolyNames'],
       autoUpdateIndex: settings['autoUpdateIndex'],
+      defaultRemoveNikud: settings['defaultRemoveNikud'],
     ));
   }
 
@@ -139,5 +141,13 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   ) async {
     await _repository.updateAutoUpdateIndex(event.autoUpdateIndex);
     emit(state.copyWith(autoUpdateIndex: event.autoUpdateIndex));
+  }
+
+  Future<void> _onUpdateDefaultRemoveNikud(
+    UpdateDefaultRemoveNikud event,
+    Emitter<SettingsState> emit,
+  ) async {
+    await _repository.updateDefaultRemoveNikud(event.defaultRemoveNikud);
+    emit(state.copyWith(defaultRemoveNikud: event.defaultRemoveNikud));
   }
 }

--- a/lib/settings/settings_event.dart
+++ b/lib/settings/settings_event.dart
@@ -117,3 +117,12 @@ class UpdateAutoUpdateIndex extends SettingsEvent {
   @override
   List<Object?> get props => [autoUpdateIndex];
 }
+
+class UpdateDefaultRemoveNikud extends SettingsEvent {
+  final bool defaultRemoveNikud;
+
+  const UpdateDefaultRemoveNikud(this.defaultRemoveNikud);
+
+  @override
+  List<Object?> get props => [defaultRemoveNikud];
+}

--- a/lib/settings/settings_repository.dart
+++ b/lib/settings/settings_repository.dart
@@ -15,6 +15,7 @@ class SettingsRepository {
   static const String keyUseFastSearch = 'key-use-fast-search';
   static const String keyReplaceHolyNames = 'key-replace-holy-names';
   static const String keyAutoUpdateIndex = 'key-auto-index-update';
+  static const String keyDefaultNikud = 'key-default-nikud';
 
   final SettingsWrapper _settings;
 
@@ -61,6 +62,10 @@ class SettingsRepository {
       'autoUpdateIndex': _settings.getValue<bool>(
         keyAutoUpdateIndex,
         defaultValue: true,
+      ),
+      'defaultRemoveNikud': _settings.getValue<bool>(
+        keyDefaultNikud,
+        defaultValue: false,
       ),
     };
   }
@@ -111,5 +116,9 @@ class SettingsRepository {
 
   Future<void> updateAutoUpdateIndex(bool value) async {
     await _settings.setValue(keyAutoUpdateIndex, value);
+  }
+
+  Future<void> updateDefaultRemoveNikud(bool value) async {
+    await _settings.setValue(keyDefaultNikud, value);
   }
 }

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -238,6 +238,19 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                               .add(UpdateShowTeamim(value));
                         },
                       ),
+                      SwitchSettingsTile(
+                        settingKey: 'key-default-nikud',
+                        title: 'הסרת ניקוד כברירת מחדל',
+                        enabledLabel: 'הניקוד יוסר כברירת מחדל',
+                        disabledLabel: 'הניקוד יוצג כברירת מחדל',
+                        leading: const Icon(Icons.text_fields),
+                        defaultValue: state.defaultRemoveNikud,
+                        onChange: (value) {
+                          context
+                              .read<SettingsBloc>()
+                              .add(UpdateDefaultRemoveNikud(value));
+                        },
+                      ),
                       const SwitchSettingsTile(
                         settingKey: 'key-splited-view',
                         title: 'ברירת המחדל להצגת המפרשים',

--- a/lib/settings/settings_state.dart
+++ b/lib/settings/settings_state.dart
@@ -14,6 +14,7 @@ class SettingsState extends Equatable {
   final bool useFastSearch;
   final bool replaceHolyNames;
   final bool autoUpdateIndex;
+  final bool defaultRemoveNikud;
 
   const SettingsState({
     required this.isDarkMode,
@@ -28,6 +29,7 @@ class SettingsState extends Equatable {
     required this.useFastSearch,
     required this.replaceHolyNames,
     required this.autoUpdateIndex,
+    required this.defaultRemoveNikud,
   });
 
   factory SettingsState.initial() {
@@ -44,6 +46,7 @@ class SettingsState extends Equatable {
       useFastSearch: true,
       replaceHolyNames: true,
       autoUpdateIndex: true,
+      defaultRemoveNikud: false,
     );
   }
 
@@ -60,6 +63,7 @@ class SettingsState extends Equatable {
     bool? useFastSearch,
     bool? replaceHolyNames,
     bool? autoUpdateIndex,
+    bool? defaultRemoveNikud,
   }) {
     return SettingsState(
       isDarkMode: isDarkMode ?? this.isDarkMode,
@@ -74,6 +78,7 @@ class SettingsState extends Equatable {
       useFastSearch: useFastSearch ?? this.useFastSearch,
       replaceHolyNames: replaceHolyNames ?? this.replaceHolyNames,
       autoUpdateIndex: autoUpdateIndex ?? this.autoUpdateIndex,
+      defaultRemoveNikud: defaultRemoveNikud ?? this.defaultRemoveNikud,
     );
   }
 
@@ -91,5 +96,6 @@ class SettingsState extends Equatable {
         useFastSearch,
         replaceHolyNames,
         autoUpdateIndex,
+        defaultRemoveNikud,
       ];
 }

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -75,7 +75,8 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
           showLeftPane: state.showLeftPane,
           showSplitView: Settings.getValue<bool>('key-splited-view') ?? false,
           activeCommentators: state.commentators,
-          removeNikud: false,
+          removeNikud:
+              Settings.getValue<bool>('key-default-nikud') ?? false,
           visibleIndices: [state.index],
           pinLeftPane: false,
           searchText: '',

--- a/test/unit/mocks/mock_settings_repository.mocks.dart
+++ b/test/unit/mocks/mock_settings_repository.mocks.dart
@@ -158,4 +158,14 @@ class MockSettingsRepository extends _i1.Mock
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> updateDefaultRemoveNikud(bool? value) => (super.noSuchMethod(
+        Invocation.method(
+          #updateDefaultRemoveNikud,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/test/unit/settings/settings_bloc_test.dart
+++ b/test/unit/settings/settings_bloc_test.dart
@@ -39,6 +39,7 @@ void main() {
         'useFastSearch': false,
         'replaceHolyNames': false,
         'autoUpdateIndex': false,
+        'defaultRemoveNikud': true,
       };
 
       blocTest<SettingsBloc, SettingsState>(
@@ -63,6 +64,7 @@ void main() {
             useFastSearch: mockSettings['useFastSearch'] as bool,
             replaceHolyNames: mockSettings['replaceHolyNames'] as bool,
             autoUpdateIndex: mockSettings['autoUpdateIndex'] as bool,
+            defaultRemoveNikud: mockSettings['defaultRemoveNikud'] as bool,
           ),
         ],
         verify: (_) {
@@ -129,6 +131,20 @@ void main() {
         ],
         verify: (_) {
           verify(mockRepository.updateFontFamily(newFontFamily)).called(1);
+        },
+      );
+    });
+
+    group('UpdateDefaultRemoveNikud', () {
+      blocTest<SettingsBloc, SettingsState>(
+        'emits updated state when UpdateDefaultRemoveNikud is added',
+        build: () => settingsBloc,
+        act: (bloc) => bloc.add(const UpdateDefaultRemoveNikud(true)),
+        expect: () => [
+          settingsBloc.state.copyWith(defaultRemoveNikud: true),
+        ],
+        verify: (_) {
+          verify(mockRepository.updateDefaultRemoveNikud(true)).called(1);
         },
       );
     });

--- a/test/unit/settings/settings_repository_test.dart
+++ b/test/unit/settings/settings_repository_test.dart
@@ -63,6 +63,10 @@ void main() {
               SettingsRepository.keyAutoUpdateIndex,
               defaultValue: true))
           .thenReturn(true);
+      when(mockSettingsWrapper.getValue<bool>(
+              SettingsRepository.keyDefaultNikud,
+              defaultValue: false))
+          .thenReturn(false);
 
       final settings = await repository.loadSettings();
 
@@ -79,6 +83,7 @@ void main() {
       expect(settings['useFastSearch'], true);
       expect(settings['replaceHolyNames'], true);
       expect(settings['autoUpdateIndex'], true);
+      expect(settings['defaultRemoveNikud'], false);
     });
 
     test('loadSettings returns custom values when settings are set', () async {
@@ -128,6 +133,10 @@ void main() {
               SettingsRepository.keyAutoUpdateIndex,
               defaultValue: true))
           .thenReturn(false);
+      when(mockSettingsWrapper.getValue<bool>(
+              SettingsRepository.keyDefaultNikud,
+              defaultValue: false))
+          .thenReturn(true);
 
       final settings = await repository.loadSettings();
 
@@ -144,6 +153,7 @@ void main() {
       expect(settings['useFastSearch'], false);
       expect(settings['replaceHolyNames'], false);
       expect(settings['autoUpdateIndex'], false);
+      expect(settings['defaultRemoveNikud'], true);
     });
 
     test('updateDarkMode calls setValue on settings wrapper', () async {
@@ -163,6 +173,14 @@ void main() {
     test('updateFontSize calls setValue on settings wrapper', () async {
       await repository.updateFontSize(20.0);
       verify(mockSettingsWrapper.setValue(SettingsRepository.keyFontSize, 20.0))
+          .called(1);
+    });
+
+    test('updateDefaultRemoveNikud calls setValue on settings wrapper',
+        () async {
+      await repository.updateDefaultRemoveNikud(true);
+      verify(mockSettingsWrapper.setValue(
+              SettingsRepository.keyDefaultNikud, true))
           .called(1);
     });
   });


### PR DESCRIPTION
## Summary
- add keyDefaultNikud in SettingsRepository with load/update methods
- extend SettingsState with defaultRemoveNikud
- create UpdateDefaultRemoveNikud event and handle it in SettingsBloc
- include switch for default nikud removal in Settings screen
- use default nikud removal when loading TextBook
- update tests and mocks for new setting

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c816102048333af885f0f4b9bb0a3