### PR TITLE
Add default sidebar open setting

### DIFF
--- a/lib/bookmarks/bookmark_screen.dart
+++ b/lib/bookmarks/bookmark_screen.dart
@@ -10,6 +10,7 @@ import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 class BookmarkView extends StatelessWidget {
   const BookmarkView({Key? key}) : super(key: key);
@@ -17,9 +18,19 @@ class BookmarkView extends StatelessWidget {
   void _openBook(
       BuildContext context, Book book, int index, List<String>? commentators) {
     final tab = book is PdfBook
-        ? PdfBookTab(book: book, pageNumber: index)
+        ? PdfBookTab(
+            book: book,
+            pageNumber: index,
+            openLeftPane:
+                Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+          )
         : TextBookTab(
-            book: book as TextBook, index: index, commentators: commentators);
+            book: book as TextBook,
+            index: index,
+            commentators: commentators,
+            openLeftPane:
+                Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+          );
 
     context.read<TabsBloc>().add(AddTab(tab));
     context.read<NavigationBloc>().add(const NavigateToScreen(Screen.reading));

--- a/lib/daf_yomi/daf_yomi_helper.dart
+++ b/lib/daf_yomi/daf_yomi_helper.dart
@@ -10,6 +10,7 @@ import 'package:otzaria/models/books.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:pdfrx/pdfrx.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 void openDafYomiBook(BuildContext context, String tractate, String daf) async {
   final libraryBlocState = BlocProvider.of<LibraryBloc>(context).state;
@@ -19,7 +20,12 @@ void openDafYomiBook(BuildContext context, String tractate, String daf) async {
     if (book is TextBook) {
       final tocEntry = await _findDafInToc(book, 'דף ${daf.trim()}');
       index = tocEntry?.index ?? 0;
-      final tab = TextBookTab(book: book, index: index, openLeftPane: true);
+      final tab = TextBookTab(
+        book: book,
+        index: index,
+        openLeftPane:
+            Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+      );
       BlocProvider.of<TabsBloc>(context).add(AddTab(tab));
     } else if (book is PdfBook) {
       final outline = await getDafYomiOutline(book, 'דף ${daf.trim()}');
@@ -27,6 +33,8 @@ void openDafYomiBook(BuildContext context, String tractate, String daf) async {
       final tab = PdfBookTab(
         book: book,
         pageNumber: index,
+        openLeftPane:
+            Settings.getValue<bool>('key-default-sidebar-open') ?? false,
       );
       BlocProvider.of<TabsBloc>(context).add(AddTab(tab));
     }
@@ -87,6 +95,8 @@ openPdfBookFromRef(String bookname, String ref, BuildContext context) async {
       final tab = PdfBookTab(
         book: book,
         pageNumber: outline.dest?.pageNumber ?? 0,
+        openLeftPane:
+            Settings.getValue<bool>('key-default-sidebar-open') ?? false,
       );
       BlocProvider.of<TabsBloc>(context).add(AddTab(tab));
     } else {
@@ -113,8 +123,12 @@ openTextBookFromRef(String bookname, String ref, BuildContext context) async {
   if (book != null) {
     final tocEntry = await _findDafInToc(book, ref);
     if (tocEntry != null) {
-      final tab =
-          TextBookTab(book: book, index: tocEntry.index, openLeftPane: true);
+      final tab = TextBookTab(
+        book: book,
+        index: tocEntry.index,
+        openLeftPane:
+            Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+      );
       BlocProvider.of<TabsBloc>(context).add(AddTab(tab));
     } else {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/find_ref/find_ref_screen.dart
+++ b/lib/find_ref/find_ref_screen.dart
@@ -14,6 +14,7 @@ import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 class FindRefScreen extends StatefulWidget {
   const FindRefScreen({super.key});
@@ -133,13 +134,19 @@ class _FindRefScreenState extends State<FindRefScreen> {
                                         title: state.refs[index].title,
                                         path: state.refs[index].filePath),
                                     pageNumber:
-                                        state.refs[index].segment.toInt())));
+                                        state.refs[index].segment.toInt(),
+                                    openLeftPane: Settings.getValue<bool>(
+                                            'key-default-sidebar-open') ??
+                                        false)));
                               } else {
                                 tabsBloc.add(AddTab(TextBookTab(
                                     book: TextBook(
                                       title: state.refs[index].title,
                                     ),
-                                    index: state.refs[index].segment.toInt())));
+                                    index: state.refs[index].segment.toInt(),
+                                    openLeftPane: Settings.getValue<bool>(
+                                            'key-default-sidebar-open') ??
+                                        false)));
                               }
                               navigationBloc
                                   .add(const NavigateToScreen(Screen.reading));

--- a/lib/history/history_screen.dart
+++ b/lib/history/history_screen.dart
@@ -11,15 +11,26 @@ import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 class HistoryView extends StatelessWidget {
   const HistoryView({Key? key}) : super(key: key);
   void _openBook(
       BuildContext context, Book book, int index, List<String>? commentators) {
     final tab = book is PdfBook
-        ? PdfBookTab(book: book, pageNumber: index)
+        ? PdfBookTab(
+            book: book,
+            pageNumber: index,
+            openLeftPane:
+                Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+          )
         : TextBookTab(
-            book: book as TextBook, index: index, commentators: commentators);
+            book: book as TextBook,
+            index: index,
+            commentators: commentators,
+            openLeftPane:
+                Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+          );
 
     context.read<TabsBloc>().add(AddTab(tab));
     context.read<NavigationBloc>().add(const NavigateToScreen(Screen.reading));

--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -16,6 +16,7 @@ import 'package:otzaria/models/books.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/daf_yomi/daf_yomi_helper.dart';
 import 'package:otzaria/file_sync/file_sync_bloc.dart';
 import 'package:otzaria/file_sync/file_sync_repository.dart';
@@ -406,19 +407,19 @@ class _LibraryBrowserState extends State<LibraryBrowser>
 
   void _openBook(Book book) {
     if (book is PdfBook) {
-      context
-          .read<TabsBloc>()
-          .add(AddTab(PdfBookTab(book: book, pageNumber: 1)));
+      context.read<TabsBloc>().add(AddTab(PdfBookTab(
+            book: book,
+            pageNumber: 1,
+            openLeftPane:
+                Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+          )));
     } else if (book is TextBook) {
-      context.read<TabsBloc>().add(
-            AddTab(
-              TextBookTab(
-                book: book,
-                index: 0,
-                openLeftPane: true,
-              ),
-            ),
-          );
+      context.read<TabsBloc>().add(AddTab(TextBookTab(
+            book: book,
+            index: 0,
+            openLeftPane:
+                Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+          )));
     }
     context.read<NavigationBloc>().add(const NavigateToScreen(Screen.reading));
   }

--- a/lib/search/view/legacy_full_text_search_screen.dart
+++ b/lib/search/view/legacy_full_text_search_screen.dart
@@ -243,9 +243,12 @@ class TextFileSearchScreenState extends State<TextFileSearchScreen>
           onTap: () {
             widget.openBookCallback(
               TextBookTab(
-                  book: TextBook(title: utils.getTitleFromPath(result.path)),
-                  index: result.index,
-                  searchText: result.query),
+                book: TextBook(title: utils.getTitleFromPath(result.path)),
+                index: result.index,
+                searchText: result.query,
+                openLeftPane:
+                    Settings.getValue<bool>('key-default-sidebar-open') ?? false,
+              ),
             );
           },
         );

--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/search/view/full_text_settings_widgets.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 class TantivySearchResults extends StatefulWidget {
   final SearchingTab tab;
@@ -81,6 +82,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                       path: result.filePath),
                                   pageNumber: result.segment.toInt() + 1,
                                   searchText: widget.tab.queryController.text,
+                                  openLeftPane: Settings.getValue<bool>(
+                                          'key-default-sidebar-open') ??
+                                      false,
                                 ),
                               ));
                         } else {
@@ -91,7 +95,10 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                     ),
                                     index: result.segment.toInt(),
                                     searchText:
-                                        widget.tab.queryController.text),
+                                        widget.tab.queryController.text,
+                                    openLeftPane: Settings.getValue<bool>(
+                                            'key-default-sidebar-open') ??
+                                        false),
                               ));
                         }
                       },

--- a/lib/settings/settings_bloc.dart
+++ b/lib/settings/settings_bloc.dart
@@ -23,6 +23,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<UpdateReplaceHolyNames>(_onUpdateReplaceHolyNames);
     on<UpdateAutoUpdateIndex>(_onUpdateAutoUpdateIndex);
     on<UpdateDefaultRemoveNikud>(_onUpdateDefaultRemoveNikud);
+    on<UpdateDefaultSidebarOpen>(_onUpdateDefaultSidebarOpen);
   }
 
   Future<void> _onLoadSettings(
@@ -44,6 +45,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       replaceHolyNames: settings['replaceHolyNames'],
       autoUpdateIndex: settings['autoUpdateIndex'],
       defaultRemoveNikud: settings['defaultRemoveNikud'],
+      defaultSidebarOpen: settings['defaultSidebarOpen'],
     ));
   }
 
@@ -149,5 +151,13 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   ) async {
     await _repository.updateDefaultRemoveNikud(event.defaultRemoveNikud);
     emit(state.copyWith(defaultRemoveNikud: event.defaultRemoveNikud));
+  }
+
+  Future<void> _onUpdateDefaultSidebarOpen(
+    UpdateDefaultSidebarOpen event,
+    Emitter<SettingsState> emit,
+  ) async {
+    await _repository.updateDefaultSidebarOpen(event.defaultSidebarOpen);
+    emit(state.copyWith(defaultSidebarOpen: event.defaultSidebarOpen));
   }
 }

--- a/lib/settings/settings_event.dart
+++ b/lib/settings/settings_event.dart
@@ -126,3 +126,12 @@ class UpdateDefaultRemoveNikud extends SettingsEvent {
   @override
   List<Object?> get props => [defaultRemoveNikud];
 }
+
+class UpdateDefaultSidebarOpen extends SettingsEvent {
+  final bool defaultSidebarOpen;
+
+  const UpdateDefaultSidebarOpen(this.defaultSidebarOpen);
+
+  @override
+  List<Object?> get props => [defaultSidebarOpen];
+}

--- a/lib/settings/settings_repository.dart
+++ b/lib/settings/settings_repository.dart
@@ -16,6 +16,7 @@ class SettingsRepository {
   static const String keyReplaceHolyNames = 'key-replace-holy-names';
   static const String keyAutoUpdateIndex = 'key-auto-index-update';
   static const String keyDefaultNikud = 'key-default-nikud';
+  static const String keyDefaultSidebarOpen = 'key-default-sidebar-open';
 
   final SettingsWrapper _settings;
 
@@ -65,6 +66,10 @@ class SettingsRepository {
       ),
       'defaultRemoveNikud': _settings.getValue<bool>(
         keyDefaultNikud,
+        defaultValue: false,
+      ),
+      'defaultSidebarOpen': _settings.getValue<bool>(
+        keyDefaultSidebarOpen,
         defaultValue: false,
       ),
     };
@@ -120,5 +125,9 @@ class SettingsRepository {
 
   Future<void> updateDefaultRemoveNikud(bool value) async {
     await _settings.setValue(keyDefaultNikud, value);
+  }
+
+  Future<void> updateDefaultSidebarOpen(bool value) async {
+    await _settings.setValue(keyDefaultSidebarOpen, value);
   }
 }

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -260,6 +260,19 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                         defaultValue: false,
                       ),
                       SwitchSettingsTile(
+                        settingKey: 'key-default-sidebar-open',
+                        title: 'פתיחת סרגל צד כברירת מחדל',
+                        enabledLabel: 'סרגל הצד יפתח אוטומטית',
+                        disabledLabel: 'סרגל הצד ישאר סגור',
+                        leading: const Icon(Icons.menu_open),
+                        defaultValue: state.defaultSidebarOpen,
+                        onChange: (value) {
+                          context
+                              .read<SettingsBloc>()
+                              .add(UpdateDefaultSidebarOpen(value));
+                        },
+                      ),
+                      SwitchSettingsTile(
                         settingKey: 'key-use-fast-search',
                         title: 'חיפוש מהיר באמצעות אינדקס',
                         enabledLabel:

--- a/lib/settings/settings_state.dart
+++ b/lib/settings/settings_state.dart
@@ -15,6 +15,7 @@ class SettingsState extends Equatable {
   final bool replaceHolyNames;
   final bool autoUpdateIndex;
   final bool defaultRemoveNikud;
+  final bool defaultSidebarOpen;
 
   const SettingsState({
     required this.isDarkMode,
@@ -30,6 +31,7 @@ class SettingsState extends Equatable {
     required this.replaceHolyNames,
     required this.autoUpdateIndex,
     required this.defaultRemoveNikud,
+    required this.defaultSidebarOpen,
   });
 
   factory SettingsState.initial() {
@@ -47,6 +49,7 @@ class SettingsState extends Equatable {
       replaceHolyNames: true,
       autoUpdateIndex: true,
       defaultRemoveNikud: false,
+      defaultSidebarOpen: false,
     );
   }
 
@@ -64,6 +67,7 @@ class SettingsState extends Equatable {
     bool? replaceHolyNames,
     bool? autoUpdateIndex,
     bool? defaultRemoveNikud,
+    bool? defaultSidebarOpen,
   }) {
     return SettingsState(
       isDarkMode: isDarkMode ?? this.isDarkMode,
@@ -79,6 +83,7 @@ class SettingsState extends Equatable {
       replaceHolyNames: replaceHolyNames ?? this.replaceHolyNames,
       autoUpdateIndex: autoUpdateIndex ?? this.autoUpdateIndex,
       defaultRemoveNikud: defaultRemoveNikud ?? this.defaultRemoveNikud,
+      defaultSidebarOpen: defaultSidebarOpen ?? this.defaultSidebarOpen,
     );
   }
 
@@ -97,5 +102,6 @@ class SettingsState extends Equatable {
         replaceHolyNames,
         autoUpdateIndex,
         defaultRemoveNikud,
+        defaultSidebarOpen,
       ];
 }

--- a/lib/text_book/view/combined_view/commentary_content.dart
+++ b/lib/text_book/view/combined_view/commentary_content.dart
@@ -39,6 +39,8 @@ class _CommentaryContentState extends State<CommentaryContent> {
         widget.openBookCallback(TextBookTab(
           book: TextBook(title: utils.getTitleFromPath(widget.link.path2)),
           index: widget.link.index2 - 1,
+          openLeftPane:
+              Settings.getValue<bool>('key-default-sidebar-open') ?? false,
         ));
       },
       child: FutureBuilder(

--- a/lib/text_book/view/links_screen.dart
+++ b/lib/text_book/view/links_screen.dart
@@ -8,6 +8,7 @@ import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/utils/text_manipulation.dart' as utils;
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'dart:io';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/models/links.dart';
@@ -70,11 +71,15 @@ class _LinksViewerState extends State<LinksViewer>
                   onTap: () {
                     widget.openTabcallback(
                       TextBookTab(
-                          book: TextBook(
-                            title: utils
-                                .getTitleFromPath(snapshot.data![index].path2),
-                          ),
-                          index: snapshot.data![index].index2 - 1),
+                        book: TextBook(
+                          title: utils
+                              .getTitleFromPath(snapshot.data![index].path2),
+                        ),
+                        index: snapshot.data![index].index2 - 1,
+                        openLeftPane:
+                            Settings.getValue<bool>('key-default-sidebar-open') ??
+                                false,
+                      ),
                     );
                     if (MediaQuery.of(context).size.width < 600) {
                       widget.closeLeftPanelCallback();

--- a/lib/utils/open_book.dart
+++ b/lib/utils/open_book.dart
@@ -8,15 +8,22 @@ import 'package:otzaria/models/books.dart';
 import "package:flutter_bloc/flutter_bloc.dart";
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 
 void openBook(BuildContext context, Book book, int index, String searchQuery) {
   if (book is TextBook) {
-    context.read<TabsBloc>().add(
-        AddTab(TextBookTab(book: book, index: index, searchText: searchQuery)));
+    context.read<TabsBloc>().add(AddTab(TextBookTab(
+        book: book,
+        index: index,
+        searchText: searchQuery,
+        openLeftPane:
+            Settings.getValue<bool>('key-default-sidebar-open') ?? false)));
   } else if (book is PdfBook) {
     context.read<TabsBloc>().add(AddTab(PdfBookTab(
           book: book,
           pageNumber: index,
+          openLeftPane:
+              Settings.getValue<bool>('key-default-sidebar-open') ?? false,
         )));
   }
   context.read<NavigationBloc>().add(const NavigateToScreen(Screen.reading));

--- a/test/unit/mocks/mock_settings_repository.mocks.dart
+++ b/test/unit/mocks/mock_settings_repository.mocks.dart
@@ -168,4 +168,14 @@ class MockSettingsRepository extends _i1.Mock
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> updateDefaultSidebarOpen(bool? value) => (super.noSuchMethod(
+        Invocation.method(
+          #updateDefaultSidebarOpen,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/test/unit/settings/settings_bloc_test.dart
+++ b/test/unit/settings/settings_bloc_test.dart
@@ -40,6 +40,7 @@ void main() {
         'replaceHolyNames': false,
         'autoUpdateIndex': false,
         'defaultRemoveNikud': true,
+        'defaultSidebarOpen': true,
       };
 
       blocTest<SettingsBloc, SettingsState>(
@@ -65,6 +66,7 @@ void main() {
             replaceHolyNames: mockSettings['replaceHolyNames'] as bool,
             autoUpdateIndex: mockSettings['autoUpdateIndex'] as bool,
             defaultRemoveNikud: mockSettings['defaultRemoveNikud'] as bool,
+            defaultSidebarOpen: mockSettings['defaultSidebarOpen'] as bool,
           ),
         ],
         verify: (_) {
@@ -145,6 +147,20 @@ void main() {
         ],
         verify: (_) {
           verify(mockRepository.updateDefaultRemoveNikud(true)).called(1);
+        },
+      );
+    });
+
+    group('UpdateDefaultSidebarOpen', () {
+      blocTest<SettingsBloc, SettingsState>(
+        'emits updated state when UpdateDefaultSidebarOpen is added',
+        build: () => settingsBloc,
+        act: (bloc) => bloc.add(const UpdateDefaultSidebarOpen(true)),
+        expect: () => [
+          settingsBloc.state.copyWith(defaultSidebarOpen: true),
+        ],
+        verify: (_) {
+          verify(mockRepository.updateDefaultSidebarOpen(true)).called(1);
         },
       );
     });

--- a/test/unit/settings/settings_repository_test.dart
+++ b/test/unit/settings/settings_repository_test.dart
@@ -67,6 +67,10 @@ void main() {
               SettingsRepository.keyDefaultNikud,
               defaultValue: false))
           .thenReturn(false);
+      when(mockSettingsWrapper.getValue<bool>(
+              SettingsRepository.keyDefaultSidebarOpen,
+              defaultValue: false))
+          .thenReturn(false);
 
       final settings = await repository.loadSettings();
 
@@ -84,6 +88,7 @@ void main() {
       expect(settings['replaceHolyNames'], true);
       expect(settings['autoUpdateIndex'], true);
       expect(settings['defaultRemoveNikud'], false);
+      expect(settings['defaultSidebarOpen'], false);
     });
 
     test('loadSettings returns custom values when settings are set', () async {
@@ -137,6 +142,10 @@ void main() {
               SettingsRepository.keyDefaultNikud,
               defaultValue: false))
           .thenReturn(true);
+      when(mockSettingsWrapper.getValue<bool>(
+              SettingsRepository.keyDefaultSidebarOpen,
+              defaultValue: false))
+          .thenReturn(true);
 
       final settings = await repository.loadSettings();
 
@@ -154,6 +163,7 @@ void main() {
       expect(settings['replaceHolyNames'], false);
       expect(settings['autoUpdateIndex'], false);
       expect(settings['defaultRemoveNikud'], true);
+      expect(settings['defaultSidebarOpen'], true);
     });
 
     test('updateDarkMode calls setValue on settings wrapper', () async {
@@ -181,6 +191,14 @@ void main() {
       await repository.updateDefaultRemoveNikud(true);
       verify(mockSettingsWrapper.setValue(
               SettingsRepository.keyDefaultNikud, true))
+          .called(1);
+    });
+
+    test('updateDefaultSidebarOpen calls setValue on settings wrapper',
+        () async {
+      await repository.updateDefaultSidebarOpen(true);
+      verify(mockSettingsWrapper.setValue(
+              SettingsRepository.keyDefaultSidebarOpen, true))
           .called(1);
     });
   });


### PR DESCRIPTION
## Summary
- let users control whether new books open with sidebar visible
- wire new state & event into the settings bloc and repository
- update settings screen UI with a switch
- honor the setting when opening `TextBookTab` or `PdfBookTab`
- update unit tests for the new setting

## Testing
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c883798308333891faca03f27e7fd