### PR TITLE
Fix search highlight crash on '[' input

### DIFF
--- a/lib/search/view/legacy_full_text_search_screen.dart
+++ b/lib/search/view/legacy_full_text_search_screen.dart
@@ -237,7 +237,7 @@ class TextFileSearchScreenState extends State<TextFileSearchScreen>
           ),
           subtitle: SearchHighlightText(
             result.snippet,
-            searchText: result.query,
+            searchRegExp: RegExp(RegExp.escape(result.query)),
             textAlign: TextAlign.justify,
           ),
           onTap: () {

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -150,8 +150,10 @@ class TextBookSearchViewState extends State<TextBookSearchView>
               } else {
                 final result = item.result!;
                 return ListTile(
-                    subtitle: SearchHighlightText(result.snippet,
-                        searchText: result.query),
+                    subtitle: SearchHighlightText(
+                        result.snippet,
+                        searchRegExp: RegExp(RegExp.escape(result.query)),
+                    ),
                     onTap: () {
                       widget.scrollControler.scrollTo(
                         index: result.index,


### PR DESCRIPTION
## Summary
- escape regex metacharacters before building `RegExp` for `SearchHighlightText`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860cc6d36848333b41a23ffb046360b