### PR TITLE
Fix keyboard focus handling

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -26,6 +26,7 @@ class CombinedView extends StatefulWidget {
     required this.textSize,
     required this.showSplitedView,
     required this.tab,
+    required this.focusNode,
   });
 
   final List<String> data;
@@ -33,6 +34,7 @@ class CombinedView extends StatefulWidget {
   final ValueNotifier<bool> showSplitedView;
   final double textSize;
   final TextBookTab tab;
+  final FocusNode focusNode;
 
   @override
   State<CombinedView> createState() => _CombinedViewState();
@@ -51,7 +53,10 @@ class _CombinedViewState extends State<CombinedView> {
               curve: 10.0,
               accelerationFactor: 5,
               scrollController: state.scrollOffsetController,
-              child: SelectionArea(child: buildOuterList(state)));
+              focusNode: widget.focusNode,
+              child: GestureDetector(
+                  onTap: () => widget.focusNode.requestFocus(),
+                  child: SelectionArea(child: buildOuterList(state))));
         });
   }
 
@@ -79,6 +84,7 @@ class _CombinedViewState extends State<CombinedView> {
         iconColor: Colors.transparent,
         tilePadding: const EdgeInsets.all(0.0),
         collapsedIconColor: Colors.transparent,
+        onExpansionChanged: (_) => widget.focusNode.requestFocus(),
         title: BlocBuilder<SettingsBloc, SettingsState>(
             builder: (context, settingsState) {
           String data = widget.data[index];
@@ -111,6 +117,7 @@ class _CombinedViewState extends State<CombinedView> {
                   fontSize: widget.textSize,
                   openBookCallback: widget.openBookCallback,
                   showSplitView: false,
+                  focusNode: widget.focusNode,
                 )
         ]);
   }

--- a/lib/text_book/view/combined_view/commentary_list_for_combined_view.dart
+++ b/lib/text_book/view/combined_view/commentary_list_for_combined_view.dart
@@ -13,6 +13,7 @@ class CommentaryListForCombinedView extends StatefulWidget {
   final double fontSize;
   final int index;
   final bool showSplitView;
+  final FocusNode focusNode;
 
   const CommentaryListForCombinedView({
     super.key,
@@ -20,6 +21,7 @@ class CommentaryListForCombinedView extends StatefulWidget {
     required this.fontSize,
     required this.index,
     required this.showSplitView,
+    required this.focusNode,
   });
 
   @override
@@ -51,6 +53,7 @@ class _CommentaryListForCombinedViewState
                     maxSpeed: 10000.0,
                     curve: 10.0,
                     accelerationFactor: 5,
+                    focusNode: widget.focusNode,
                     child: ScrollablePositionedList.builder(
                       key: PageStorageKey(thisLinksSnapshot.data![0].heRef),
                       physics: const ClampingScrollPhysics(),
@@ -58,6 +61,7 @@ class _CommentaryListForCombinedViewState
                       shrinkWrap: true,
                       itemCount: thisLinksSnapshot.data!.length,
                       itemBuilder: (context, index1) => GestureDetector(
+                        onTap: () => widget.focusNode.requestFocus(),
                         child: ListTile(
                           focusNode: FocusNode(),
                           title: Text(thisLinksSnapshot.data![index1].heRef),

--- a/lib/text_book/view/splited_view/commentary_list_for_splited_view.dart
+++ b/lib/text_book/view/splited_view/commentary_list_for_splited_view.dart
@@ -13,6 +13,7 @@ class CommentaryList extends StatefulWidget {
   final double fontSize;
   final int index;
   final bool showSplitView;
+  final FocusNode focusNode;
 
   const CommentaryList({
     super.key,
@@ -20,6 +21,7 @@ class CommentaryList extends StatefulWidget {
     required this.fontSize,
     required this.index,
     required this.showSplitView,
+    required this.focusNode,
   });
 
   @override
@@ -52,6 +54,7 @@ class _CommentaryListState extends State<CommentaryList> {
                     maxSpeed: 10000.0,
                     curve: 10.0,
                     accelerationFactor: 5,
+                    focusNode: widget.focusNode,
                     child: ScrollablePositionedList.builder(
                       key: PageStorageKey(thisLinksSnapshot.data![0].heRef),
                       physics: const ClampingScrollPhysics(),
@@ -59,6 +62,7 @@ class _CommentaryListState extends State<CommentaryList> {
                       shrinkWrap: true,
                       itemCount: thisLinksSnapshot.data!.length,
                       itemBuilder: (context, index1) => GestureDetector(
+                        onTap: () => widget.focusNode.requestFocus(),
                         child: ListTile(
                           title: Text(thisLinksSnapshot.data![index1].heRef),
                           subtitle: CommentaryContent(

--- a/lib/text_book/view/splited_view/simple_book_view.dart
+++ b/lib/text_book/view/splited_view/simple_book_view.dart
@@ -21,6 +21,7 @@ class SimpleBookView extends StatefulWidget {
     required this.textSize,
     required this.showSplitedView,
     required this.tab,
+    required this.focusNode,
   });
 
   final List<String> data;
@@ -28,6 +29,7 @@ class SimpleBookView extends StatefulWidget {
   final bool showSplitedView;
   final double textSize;
   final TextBookTab tab;
+  final FocusNode focusNode;
 
   @override
   State<SimpleBookView> createState() => _SimpleBookViewState();
@@ -43,8 +45,11 @@ class _SimpleBookViewState extends State<SimpleBookView> {
           maxSpeed: 10000.0,
           curve: 10.0,
           accelerationFactor: 5,
-          child: SelectionArea(
-              child: ScrollablePositionedList.builder(
+          focusNode: widget.focusNode,
+          child: GestureDetector(
+              onTap: () => widget.focusNode.requestFocus(),
+              child: SelectionArea(
+                  child: ScrollablePositionedList.builder(
                   key: PageStorageKey(widget.tab),
                   initialScrollIndex: state.visibleIndices.first,
                   itemPositionsListener: state.positionsListener,
@@ -63,9 +68,12 @@ class _SimpleBookViewState extends State<SimpleBookView> {
                         data = replaceHolyNames(data);
                       }
                       return InkWell(
-                        onTap: () => context
-                            .read<TextBookBloc>()
-                            .add(UpdateSelectedIndex(index)),
+                        onTap: () {
+                          widget.focusNode.requestFocus();
+                          context
+                              .read<TextBookBloc>()
+                              .add(UpdateSelectedIndex(index));
+                        },
                         child: Html(
                             // remove nikud if needed
                             data: state.removeNikud

--- a/lib/text_book/view/splited_view/splited_view_screen.dart
+++ b/lib/text_book/view/splited_view/splited_view_screen.dart
@@ -15,11 +15,13 @@ class SplitedViewScreen extends StatelessWidget {
     required this.openBookCallback,
     required this.searchTextController,
     required this.tab,
+    required this.focusNode,
   });
   final List<String> content;
   final void Function(OpenedTab) openBookCallback;
   final TextEditingValue searchTextController;
   final TextBookTab tab;
+  final FocusNode focusNode;
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +42,7 @@ class SplitedViewScreen extends StatelessWidget {
               fontSize: (state as TextBookLoaded).fontSize,
               openBookCallback: openBookCallback,
               showSplitView: state.showSplitView,
+              focusNode: focusNode,
             ),
           ),
           SimpleBookView(
@@ -48,6 +51,7 @@ class SplitedViewScreen extends StatelessWidget {
             openBookCallback: openBookCallback,
             showSplitedView: state.showSplitView,
             tab: tab,
+            focusNode: focusNode,
           )
         ],
       ),

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -45,6 +45,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     with TickerProviderStateMixin {
   final FocusNode textSearchFocusNode = FocusNode();
   final FocusNode navigationSearchFocusNode = FocusNode();
+  final FocusNode viewerFocusNode = FocusNode();
   late TabController tabController;
 
   String? encodeQueryParameters(Map<String, String> params) {
@@ -65,6 +66,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     tabController.dispose();
     textSearchFocusNode.dispose();
     navigationSearchFocusNode.dispose();
+    viewerFocusNode.dispose();
     super.dispose();
   }
 
@@ -633,6 +635,7 @@ $selectedText
                 ),
               );
         },
+        onTap: () => viewerFocusNode.requestFocus(),
         child: NotificationListener<UserScrollNotification>(
           onNotification: (scrollNotification) {
             if (!state.pinLeftPane) {
@@ -652,8 +655,8 @@ $selectedText
               },
             },
             child: Focus(
-              focusNode: FocusNode(),
-              autofocus: !Platform.isAndroid,
+              focusNode: viewerFocusNode,
+              autofocus: false,
               child: _buildSplitedOrCombinedView(state),
             ),
           ),
@@ -669,6 +672,7 @@ $selectedText
         openBookCallback: widget.openBookCallback,
         searchTextController: TextEditingValue(text: state.searchText),
         tab: widget.tab,
+        focusNode: viewerFocusNode,
       );
     }
 
@@ -691,6 +695,7 @@ $selectedText
       openBookCallback: widget.openBookCallback,
       showSplitedView: ValueNotifier(state.showSplitView),
       tab: widget.tab,
+      focusNode: viewerFocusNode,
     );
   }
 

--- a/lib/widgets/progressive_scrolling.dart
+++ b/lib/widgets/progressive_scrolling.dart
@@ -10,6 +10,8 @@ class ProgressiveScroll extends StatefulWidget {
   final double maxSpeed;
   final double accelerationFactor;
   final double curve;
+  final FocusNode? focusNode;
+  final bool autofocus;
 
   const ProgressiveScroll({
     Key? key,
@@ -18,6 +20,8 @@ class ProgressiveScroll extends StatefulWidget {
     this.maxSpeed = 5000.0,
     this.accelerationFactor = 0.1,
     this.curve = 2.0,
+    this.focusNode,
+    this.autofocus = false,
   }) : super(key: key);
 
   @override
@@ -88,9 +92,9 @@ class _ProgressiveScrollState extends State<ProgressiveScroll> {
   @override
   Widget build(BuildContext context) {
     return KeyboardListener(
-      focusNode: FocusNode(),
+      focusNode: widget.focusNode ?? FocusNode(),
       onKeyEvent: _handleKeyEvent,
-      autofocus: true,
+      autofocus: widget.autofocus,
       child: widget.child,
     );
   }


### PR DESCRIPTION
## Summary
- require focus for PDF navigation keyboard shortcuts
- allow ProgressiveScroll to use external FocusNode
- focus main viewer when interacting with it
- prevent text viewer scroll when sidebar is focused

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686588854da88333a4db04ca9abac6f9