### PR TITLE
Implement library watcher for automatic index updates

### DIFF
--- a/lib/data/data_providers/tantivy_data_provider.dart
+++ b/lib/data/data_providers/tantivy_data_provider.dart
@@ -142,4 +142,12 @@ class TantivyDataProvider {
     booksDone.clear();
     saveBooksDoneToDisk();
   }
+
+  /// Removes all indexed documents matching [filePath].
+  Future<void> deleteFileFromIndex(String filePath) async {
+    final index = await engine;
+    await index.deleteDocuments(field: 'filePath', value: filePath);
+    booksDone.removeWhere((e) => e.contains(filePath));
+    saveBooksDoneToDisk();
+  }
 }

--- a/lib/indexing/library_watcher.dart
+++ b/lib/indexing/library_watcher.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/utils/text_manipulation.dart';
+
+/// Watches the library directory for file changes and updates the search index.
+class LibraryWatcher {
+  final IndexingRepository _repository;
+  final TantivyDataProvider _dataProvider;
+  StreamSubscription<FileSystemEvent>? _subscription;
+
+  LibraryWatcher(this._repository, this._dataProvider);
+
+  /// Start watching the library directory recursively.
+  void start() {
+    final path = Settings.getValue<String>('key-library-path') ?? '.';
+    _subscription?.cancel();
+    _subscription = Directory(path).watch(recursive: true).listen(handleEvent);
+  }
+
+  /// Stop watching the directory.
+  void stop() {
+    _subscription?.cancel();
+    _subscription = null;
+  }
+
+  /// Handle a single file system [event].
+  @visibleForTesting
+  Future<void> handleEvent(FileSystemEvent event) async {
+    final filePath = event.path;
+
+    if (event is FileSystemModifyEvent || event is FileSystemCreateEvent) {
+      if (FileSystemEntity.isDirectorySync(filePath)) return;
+      final lower = filePath.toLowerCase();
+      if (!(lower.endsWith('.txt') ||
+          lower.endsWith('.docx') ||
+          lower.endsWith('.pdf'))) {
+        return;
+      }
+      await _dataProvider.deleteFileFromIndex(filePath);
+      final title = getTitleFromPath(filePath);
+      Book? book;
+      if (lower.endsWith('.pdf')) {
+        book = PdfBook(title: title, path: filePath, topics: '');
+      } else {
+        book = TextBook(title: title, topics: '');
+      }
+      await _repository.indexBook(book);
+    } else if (event is FileSystemDeleteEvent) {
+      await _dataProvider.deleteFileFromIndex(filePath);
+    }
+  }
+}

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -72,6 +72,24 @@ class IndexingRepository {
     _tantivyDataProvider.isIndexing.value = false;
   }
 
+  /// Index a single [book].
+  Future<void> indexBook(Book book) async {
+    _tantivyDataProvider.isIndexing.value = true;
+    try {
+      if (book is TextBook) {
+        await _indexTextBook(book);
+        _tantivyDataProvider.booksDone.add("${book.title}textBook");
+      } else if (book is PdfBook) {
+        await _indexPdfBook(book);
+        _tantivyDataProvider.booksDone.add("${book.title}pdfBook");
+      }
+      saveIndexedBooks();
+    } catch (e) {
+      debugPrint('Error adding ${book.title} to index: $e');
+    }
+    _tantivyDataProvider.isIndexing.value = false;
+  }
+
   /// Indexes a text-based book by processing its content and adding it to the search index and reference index.
   Future<void> _indexTextBook(TextBook book) async {
     final index = await _tantivyDataProvider.engine;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,8 +38,15 @@ import 'package:path_provider/path_provider.dart';
 import 'package:otzaria/app_bloc_observer.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/data/data_providers/hive_data_provider.dart';
+import 'package:otzaria/indexing/library_watcher.dart';
+import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
 
 import 'package:search_engine/search_engine.dart';
+
+final LibraryWatcher _libraryWatcher = LibraryWatcher(
+    IndexingRepository(TantivyDataProvider.instance),
+    TantivyDataProvider.instance);
 
 /// Application entry point that initializes necessary components and launches the app.
 ///
@@ -77,6 +84,7 @@ void main() async {
   Bloc.observer = AppBlocObserver();
 
   await initialize();
+  _libraryWatcher.start();
 
   final historyRepository = HistoryRepository();
 

--- a/test/unit/indexing/library_watcher_test.dart
+++ b/test/unit/indexing/library_watcher_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:otzaria/indexing/library_watcher.dart';
+import '../mocks/mock_indexing_dependencies.dart';
+
+void main() {
+  group('LibraryWatcher', () {
+    late MockIndexingRepository repository;
+    late MockTantivyDataProvider provider;
+    late LibraryWatcher watcher;
+
+    setUp(() {
+      repository = MockIndexingRepository();
+      provider = MockTantivyDataProvider();
+      watcher = LibraryWatcher(repository, provider);
+    });
+
+    test('handles create event', () async {
+      when(provider.deleteFileFromIndex(any)).thenAnswer((_) async {});
+      when(repository.indexBook(any)).thenAnswer((_) async {});
+      final event = FileSystemCreateEvent('book.txt', false);
+      await watcher.handleEvent(event);
+      verify(provider.deleteFileFromIndex('book.txt')).called(1);
+      verify(repository.indexBook(any)).called(1);
+    });
+
+    test('handles modify event', () async {
+      when(provider.deleteFileFromIndex(any)).thenAnswer((_) async {});
+      when(repository.indexBook(any)).thenAnswer((_) async {});
+      final event = FileSystemModifyEvent('book.txt', false, true);
+      await watcher.handleEvent(event);
+      verify(provider.deleteFileFromIndex('book.txt')).called(1);
+      verify(repository.indexBook(any)).called(1);
+    });
+
+    test('handles delete event', () async {
+      when(provider.deleteFileFromIndex(any)).thenAnswer((_) async {});
+      final event = FileSystemDeleteEvent('book.txt', false);
+      await watcher.handleEvent(event);
+      verify(provider.deleteFileFromIndex('book.txt')).called(1);
+      verifyNever(repository.indexBook(any));
+    });
+  });
+}

--- a/test/unit/mocks/mock_indexing_dependencies.dart
+++ b/test/unit/mocks/mock_indexing_dependencies.dart
@@ -1,0 +1,7 @@
+import 'package:mockito/mockito.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+
+class MockIndexingRepository extends Mock implements IndexingRepository {}
+
+class MockTantivyDataProvider extends Mock implements TantivyDataProvider {}


### PR DESCRIPTION
## Summary
- add a `LibraryWatcher` to monitor the library folder
- support removing indexed documents by file path
- expose `indexBook` method for indexing a single book
- start the watcher in `main.dart`
- provide unit tests for `LibraryWatcher`

## Testing
- `dart pub run test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867b2a31fb083338c20d9c4f7abc387