### PR TITLE
Add contextual menus for text views

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -50,7 +50,11 @@ class _CombinedViewState extends State<CombinedView> {
       GlobalKey<SelectionAreaState>();
 
   ContextMenu _buildContextMenu(TextBookLoaded state) {
+    // 1. קבלת מידע על גודל המסך
+    final screenHeight = MediaQuery.of(context).size.height;
     return ContextMenu(
+      // 2. הגדרת הגובה המקסימלי ל-70% מגובה המסך
+      maxHeight: screenHeight * 0.9,
       entries: [
         MenuItem(label: 'חיפוש', onSelected: () => widget.openLeftPaneTab(1)),
         MenuItem.submenu(

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -138,8 +138,6 @@ class _CombinedViewState extends State<CombinedView> {
           curve: 10.0,
           accelerationFactor: 5,
           scrollController: state.scrollOffsetController,
-          child: ContextMenuRegion(
-            contextMenu: _buildContextMenu(state),
             child: SelectionArea(
               key: _selectionKey,
               contextMenuBuilder: (_, __) => const SizedBox.shrink(),
@@ -147,7 +145,6 @@ class _CombinedViewState extends State<CombinedView> {
                 contextMenu: _buildContextMenu(state),
                 child: buildOuterList(state),
               ),
-          ),
           ),
         );
       },

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -127,8 +127,12 @@ class _CombinedViewState extends State<CombinedView> {
             contextMenu: _buildContextMenu(state),
             child: SelectionArea(
               key: _selectionKey,
-              child: buildOuterList(state),
+              contextMenuBuilder: (_, __) => const SizedBox.shrink(),
+              child: ContextMenuRegion(
+                contextMenu: _buildContextMenu(state),
+                child: buildOuterList(state),
             ),
+          ),
           ),
         );
       },

--- a/lib/text_book/view/splited_view/simple_book_view.dart
+++ b/lib/text_book/view/splited_view/simple_book_view.dart
@@ -130,8 +130,6 @@ class _SimpleBookViewState extends State<SimpleBookView> {
           maxSpeed: 10000.0,
           curve: 10.0,
           accelerationFactor: 5,
-          child: ContextMenuRegion(
-            contextMenu: _buildContextMenu(state),
             child: SelectionArea(
               key: _selectionKey,
               contextMenuBuilder: (_, __) => const SizedBox.shrink(),
@@ -182,7 +180,6 @@ class _SimpleBookViewState extends State<SimpleBookView> {
               ),
             ),
             ),
-          ),
         );
       },
     );

--- a/lib/text_book/view/splited_view/simple_book_view.dart
+++ b/lib/text_book/view/splited_view/simple_book_view.dart
@@ -121,6 +121,9 @@ class _SimpleBookViewState extends State<SimpleBookView> {
             contextMenu: _buildContextMenu(state),
             child: SelectionArea(
               key: _selectionKey,
+              contextMenuBuilder: (_, __) => const SizedBox.shrink(),
+              child: ContextMenuRegion(
+                contextMenu: _buildContextMenu(state),              
               child: ScrollablePositionedList.builder(
                 key: PageStorageKey(widget.tab),
                 initialScrollIndex: state.visibleIndices.first,
@@ -164,6 +167,7 @@ class _SimpleBookViewState extends State<SimpleBookView> {
                   );
                 },
               ),
+            ),
             ),
           ),
         );

--- a/lib/text_book/view/splited_view/simple_book_view.dart
+++ b/lib/text_book/view/splited_view/simple_book_view.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:otzaria/settings/settings_bloc.dart';
 import 'package:otzaria/settings/settings_state.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
@@ -11,13 +12,17 @@ import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/widgets/progressive_scrolling.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:otzaria/tabs/models/tab.dart';
-import 'package:otzaria/utils/text_manipulation.dart';
+import 'package:otzaria/utils/text_manipulation.dart' as utils;
+import 'package:otzaria/text_book/view/links_screen.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/models/books.dart';
 
 class SimpleBookView extends StatefulWidget {
-  const SimpleBookView({
+  SimpleBookView({
     super.key,
     required this.data,
     required this.openBookCallback,
+    required this.openLeftPaneTab,
     required this.textSize,
     required this.showSplitedView,
     required this.tab,
@@ -25,6 +30,7 @@ class SimpleBookView extends StatefulWidget {
 
   final List<String> data;
   final Function(OpenedTab) openBookCallback;
+  final void Function(int) openLeftPaneTab;
   final bool showSplitedView;
   final double textSize;
   final TextBookTab tab;
@@ -34,55 +40,134 @@ class SimpleBookView extends StatefulWidget {
 }
 
 class _SimpleBookViewState extends State<SimpleBookView> {
+  final GlobalKey<SelectionAreaState> _selectionKey =
+      GlobalKey<SelectionAreaState>();
+
+  ContextMenu _buildContextMenu(TextBookLoaded state) {
+    return ContextMenu(
+      entries: [
+        MenuItem(label: 'חיפוש', onSelected: () => widget.openLeftPaneTab(1)),
+        MenuItem.submenu(
+          label: 'פרשנות',
+          items: [
+            MenuItem(
+              label: 'הצג את כל המפרשים',
+              onSelected: () => widget.openLeftPaneTab(2),
+            ),
+            const MenuDivider(),
+            ...state.availableCommentators.map(
+              (title) => MenuItem(
+                label: title,
+                onSelected: () {
+                  widget.openBookCallback(
+                    TextBookTab(
+                      book: TextBook(title: title),
+                      index: state.selectedIndex ?? state.visibleIndices.first,
+                      openLeftPane:
+                          Settings.getValue<bool>('key-default-sidebar-open') ??
+                              false,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+        MenuItem.submenu(
+          label: 'קישורים',
+          items: LinksViewer.getLinks(state)
+              .map(
+                (link) => MenuItem(
+                  label: link.heRef,
+                  onSelected: () {
+                    widget.openBookCallback(
+                      TextBookTab(
+                        book: TextBook(
+                          title: utils.getTitleFromPath(link.path2),
+                        ),
+                        index: link.index2 - 1,
+                        openLeftPane: Settings.getValue<bool>(
+                              'key-default-sidebar-open',
+                            ) ??
+                            false,
+                      ),
+                    );
+                  },
+                ),
+              )
+              .toList(),
+        ),
+        const MenuDivider(),
+        MenuItem(
+          label: 'בחר את כל הטקסט',
+          onSelected: () =>
+              _selectionKey.currentState?.selectableRegion.selectAll(),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<TextBookBloc, TextBookState>(builder: (context, state) {
-      if (state is! TextBookLoaded) return const Center();
-      return ProgressiveScroll(
+    return BlocBuilder<TextBookBloc, TextBookState>(
+      builder: (context, state) {
+        if (state is! TextBookLoaded) return const Center();
+        return ProgressiveScroll(
           scrollController: state.scrollOffsetController,
           maxSpeed: 10000.0,
           curve: 10.0,
           accelerationFactor: 5,
-          child: SelectionArea(
+          child: ContextMenuRegion(
+            contextMenu: _buildContextMenu(state),
+            child: SelectionArea(
+              key: _selectionKey,
               child: ScrollablePositionedList.builder(
-                  key: PageStorageKey(widget.tab),
-                  initialScrollIndex: state.visibleIndices.first,
-                  itemPositionsListener: state.positionsListener,
-                  itemScrollController: state.scrollController,
-                  scrollOffsetController: state.scrollOffsetController,
-                  itemCount: widget.data.length,
-                  itemBuilder: (context, index) {
-                    return BlocBuilder<SettingsBloc, SettingsState>(
-                        builder: (context, settingsState) {
+                key: PageStorageKey(widget.tab),
+                initialScrollIndex: state.visibleIndices.first,
+                itemPositionsListener: state.positionsListener,
+                itemScrollController: state.scrollController,
+                scrollOffsetController: state.scrollOffsetController,
+                itemCount: widget.data.length,
+                itemBuilder: (context, index) {
+                  return BlocBuilder<SettingsBloc, SettingsState>(
+                    builder: (context, settingsState) {
                       String data = widget.data[index];
                       if (!settingsState.showTeamim) {
-                        data = removeTeamim(data);
+                        data = utils.removeTeamim(data);
                       }
 
                       if (settingsState.replaceHolyNames) {
-                        data = replaceHolyNames(data);
+                        data = utils.replaceHolyNames(data);
                       }
                       return InkWell(
-                        onTap: () => context
-                            .read<TextBookBloc>()
-                            .add(UpdateSelectedIndex(index)),
+                        onTap: () => context.read<TextBookBloc>().add(
+                              UpdateSelectedIndex(index),
+                            ),
                         child: Html(
-                            // remove nikud if needed
-                            data: state.removeNikud
-                                ? highLight(
-                                    removeVolwels('$data\n'),
-                                    state.searchText)
-                                : highLight('$data\n',
-                                    state.searchText),
-                            style: {
-                              'body': Style(
-                                  fontSize: FontSize(widget.textSize),
-                                  fontFamily: settingsState.fontFamily,
-                                  textAlign: TextAlign.justify),
-                            }),
+                          // remove nikud if needed
+                          data: state.removeNikud
+                              ? utils.highLight(
+                                  utils.removeVolwels('$data\n'),
+                                  state.searchText,
+                                )
+                              : utils.highLight('$data\n', state.searchText),
+                          style: {
+                            'body': Style(
+                              fontSize: FontSize(widget.textSize),
+                              fontFamily: settingsState.fontFamily,
+                              textAlign: TextAlign.justify,
+                            ),
+                          },
+                        ),
                       );
-                    });
-                  })));
-    });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/text_book/view/splited_view/simple_book_view.dart
+++ b/lib/text_book/view/splited_view/simple_book_view.dart
@@ -44,7 +44,11 @@ class _SimpleBookViewState extends State<SimpleBookView> {
       GlobalKey<SelectionAreaState>();
 
   ContextMenu _buildContextMenu(TextBookLoaded state) {
+    // 1. קבלת מידע על גודל המסך
+    final screenHeight = MediaQuery.of(context).size.height;
     return ContextMenu(
+      // 2. הגדרת הגובה המקסימלי ל-70% מגובה המסך
+      maxHeight: screenHeight * 0.9,
       entries: [
         MenuItem(label: 'חיפוש', onSelected: () => widget.openLeftPaneTab(1)),
         MenuItem.submenu(

--- a/lib/text_book/view/splited_view/splited_view_screen.dart
+++ b/lib/text_book/view/splited_view/splited_view_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:multi_split_view/multi_split_view.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
@@ -9,17 +10,36 @@ import 'package:otzaria/text_book/view/splited_view/simple_book_view.dart';
 import 'package:otzaria/text_book/view/splited_view/commentary_list_for_splited_view.dart';
 
 class SplitedViewScreen extends StatelessWidget {
-  const SplitedViewScreen({
+  SplitedViewScreen({
     super.key,
     required this.content,
     required this.openBookCallback,
     required this.searchTextController,
+    required this.openLeftPaneTab,
     required this.tab,
   });
   final List<String> content;
   final void Function(OpenedTab) openBookCallback;
   final TextEditingValue searchTextController;
+  final void Function(int) openLeftPaneTab;
   final TextBookTab tab;
+
+  static final GlobalKey<SelectionAreaState> _selectionKey =
+      GlobalKey<SelectionAreaState>();
+
+  ContextMenu _buildContextMenu(TextBookLoaded state) {
+    return ContextMenu(
+      entries: [
+        MenuItem(label: 'חיפוש', onSelected: () => openLeftPaneTab(1)),
+        const MenuDivider(),
+        MenuItem(
+          label: 'בחר את כל הטקסט',
+          onSelected: () =>
+              _selectionKey.currentState?.selectableRegion.selectAll(),
+        ),
+      ],
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,23 +52,28 @@ class SplitedViewScreen extends StatelessWidget {
             (axis, index, resizable, dragging, highlighted, themeData) =>
                 const VerticalDivider(),
         children: [
-          SelectionArea(
-            child: CommentaryList(
-              index:
-                  0, // we don't need the index here, b/c we listen to the selected index in the commentary list
+          ContextMenuRegion(
+            contextMenu: _buildContextMenu(state as TextBookLoaded),
+            child: SelectionArea(
+              key: _selectionKey,
+              child: CommentaryList(
+                index:
+                    0, // we don't need the index here, b/c we listen to the selected index in the commentary list
 
-              fontSize: (state as TextBookLoaded).fontSize,
-              openBookCallback: openBookCallback,
-              showSplitView: state.showSplitView,
+                fontSize: (state as TextBookLoaded).fontSize,
+                openBookCallback: openBookCallback,
+                showSplitView: state.showSplitView,
+              ),
             ),
           ),
           SimpleBookView(
             data: content,
             textSize: state.fontSize,
             openBookCallback: openBookCallback,
+            openLeftPaneTab: openLeftPaneTab,
             showSplitedView: state.showSplitView,
             tab: tab,
-          )
+          ),
         ],
       ),
     );

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -49,8 +49,10 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
 
   String? encodeQueryParameters(Map<String, String> params) {
     return params.entries
-        .map((MapEntry<String, String> e) =>
-            '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}')
+        .map(
+          (MapEntry<String, String> e) =>
+              '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}',
+        )
         .join('&');
   }
 
@@ -66,6 +68,11 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     textSearchFocusNode.dispose();
     navigationSearchFocusNode.dispose();
     super.dispose();
+  }
+
+  void _openLeftPaneTab(int index) {
+    context.read<TextBookBloc>().add(const ToggleLeftPane(true));
+    tabController.index = index;
   }
 
   @override
@@ -85,13 +92,15 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
         }
 
         if (state is TextBookLoaded) {
-          return LayoutBuilder(builder: (context, constrains) {
-            final wideScreen = (MediaQuery.of(context).size.width >= 600);
-            return Scaffold(
-              appBar: _buildAppBar(context, state, wideScreen),
-              body: _buildBody(context, state, wideScreen),
-            );
-          });
+          return LayoutBuilder(
+            builder: (context, constrains) {
+              final wideScreen = (MediaQuery.of(context).size.width >= 600);
+              return Scaffold(
+                appBar: _buildAppBar(context, state, wideScreen),
+                body: _buildBody(context, state, wideScreen),
+              );
+            },
+          );
         }
 
         // Fallback
@@ -101,7 +110,10 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
   }
 
   PreferredSizeWidget _buildAppBar(
-      BuildContext context, TextBookLoaded state, bool wideScreen) {
+    BuildContext context,
+    TextBookLoaded state,
+    bool wideScreen,
+  ) {
     return AppBar(
       backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       shape: Border(
@@ -113,7 +125,6 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-
       title: _buildTitle(state),
       leading: _buildMenuButton(context, state),
       actions: _buildActions(context, state, wideScreen),
@@ -122,13 +133,13 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
 
   Widget _buildTitle(TextBookLoaded state) {
     return state.currentTitle != null
-      ? SelectionArea(
-              child: Text(
-                state.currentTitle!,
-                style: const TextStyle(fontSize: 17),
-                textAlign: TextAlign.end,
-              ),
-            )
+        ? SelectionArea(
+            child: Text(
+              state.currentTitle!,
+              style: const TextStyle(fontSize: 17),
+              textAlign: TextAlign.end,
+            ),
+          )
         : const SizedBox.shrink();
   }
 
@@ -136,14 +147,16 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     return IconButton(
       icon: const Icon(Icons.menu),
       tooltip: "ניווט וחיפוש",
-      onPressed: () => context.read<TextBookBloc>().add(
-            ToggleLeftPane(!state.showLeftPane),
-          ),
+      onPressed: () =>
+          context.read<TextBookBloc>().add(ToggleLeftPane(!state.showLeftPane)),
     );
   }
 
   List<Widget> _buildActions(
-      BuildContext context, TextBookLoaded state, bool wideScreen) {
+    BuildContext context,
+    TextBookLoaded state,
+    bool wideScreen,
+  ) {
     return [
       // PDF Button
       _buildPdfButton(context, state),
@@ -185,15 +198,18 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
   Widget _buildPdfButton(BuildContext context, TextBookLoaded state) {
     return FutureBuilder(
       future: DataRepository.instance.library.then(
-          (library) => library.findBookByTitle(state.book.title, PdfBook)),
+        (library) => library.findBookByTitle(state.book.title, PdfBook),
+      ),
       builder: (context, snapshot) => snapshot.hasData
           ? IconButton(
               icon: const Icon(Icons.picture_as_pdf),
               tooltip: 'פתח ספר במהדורה מודפסת ',
               onPressed: () async {
                 final library = DataRepository.instance.library;
-                final book = await library.then((library) =>
-                    library.findBookByTitle(state.book.title, PdfBook));
+                final book = await library.then(
+                  (library) =>
+                      library.findBookByTitle(state.book.title, PdfBook),
+                );
                 final index = await textToPdfPage(
                   state.book,
                   state.positionsListener.itemPositions.value.isNotEmpty
@@ -225,9 +241,8 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
 
   Widget _buildNikudButton(BuildContext context, TextBookLoaded state) {
     return IconButton(
-      onPressed: () => context.read<TextBookBloc>().add(
-            ToggleNikud(!state.removeNikud),
-          ),
+      onPressed: () =>
+          context.read<TextBookBloc>().add(ToggleNikud(!state.removeNikud)),
       icon: const Icon(Icons.format_overline),
       tooltip: 'הצג או הסתר ניקוד',
     );
@@ -240,15 +255,17 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
         final toc = state.book.tableOfContents;
         String ref = await refFromIndex(index, toc);
         bool bookmarkAdded = context.read<BookmarkBloc>().addBookmark(
-            ref: ref,
-            book: state.book,
-            index: index,
-            commentatorsToShow: state.activeCommentators);
+              ref: ref,
+              book: state.book,
+              index: index,
+              commentatorsToShow: state.activeCommentators,
+            );
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
-                  bookmarkAdded ? 'הסימניה נוספה בהצלחה' : 'הסימניה כבר קיימת'),
+                bookmarkAdded ? 'הסימניה נוספה בהצלחה' : 'הסימניה כבר קיימת',
+              ),
             ),
           );
         }
@@ -373,7 +390,9 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
   }
 
   Future<void> _showReportBugDialog(
-      BuildContext context, TextBookLoaded state) async {
+    BuildContext context,
+    TextBookLoaded state,
+  ) async {
     final currentRef = await refFromIndex(
       state.positionsListener.itemPositions.value.isNotEmpty
           ? state.positionsListener.itemPositions.value.first.index
@@ -401,10 +420,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     if (selectedText == null || selectedText.isEmpty) return;
     if (!mounted) return;
 
-    final shouldProceed = await _showConfirmationDialog(
-      context,
-      selectedText,
-    );
+    final shouldProceed = await _showConfirmationDialog(context, selectedText);
 
     if (shouldProceed != true) return;
 
@@ -431,25 +447,24 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       if (!await launchUrl(emailUri, mode: LaunchMode.externalApplication)) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('לא ניתן לפתוח את תוכנת הדואר'),
-            ),
+            const SnackBar(content: Text('לא ניתן לפתוח את תוכנת הדואר')),
           );
         }
       }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('לא ניתן לפתוח את תוכנת הדואר'),
-          ),
+          const SnackBar(content: Text('לא ניתן לפתוח את תוכנת הדואר')),
         );
       }
     }
   }
 
   Future<String?> _showTextSelectionDialog(
-      BuildContext context, String text, double fontSize) async {
+    BuildContext context,
+    String text,
+    double fontSize,
+  ) async {
     String? selectedContent;
     return showDialog<String>(
       context: context,
@@ -485,7 +500,9 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
                             onSelectionChanged: (selection, cause) {
                               if (selection.start != selection.end) {
                                 final newContent = text.substring(
-                                    selection.start, selection.end);
+                                  selection.start,
+                                  selection.end,
+                                );
                                 if (newContent.isNotEmpty) {
                                   setDialogState(() {
                                     selectedContent = newContent;
@@ -520,7 +537,9 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
   }
 
   Future<bool?> _showConfirmationDialog(
-      BuildContext context, String selectedText) {
+    BuildContext context,
+    String selectedText,
+  ) {
     return showDialog<bool>(
       context: context,
       builder: (BuildContext context) {
@@ -552,8 +571,12 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     );
   }
 
-  String _buildEmailBody(String bookTitle, String currentRef,
-      Map<String, String> bookDetails, String selectedText) {
+  String _buildEmailBody(
+    String bookTitle,
+    String currentRef,
+    Map<String, String> bookDetails,
+    String selectedText,
+  ) {
     return '''שם הספר: $bookTitle
 מיקום: $currentRef
 שם הקובץ: ${bookDetails['שם הקובץ']}
@@ -571,7 +594,8 @@ $selectedText
     try {
       final libraryPath = Settings.getValue('key-library-path');
       final file = File(
-          '$libraryPath${Platform.pathSeparator}אוצריא${Platform.pathSeparator}אודות התוכנה${Platform.pathSeparator}SourcesBooks.csv');
+        '$libraryPath${Platform.pathSeparator}אוצריא${Platform.pathSeparator}אודות התוכנה${Platform.pathSeparator}SourcesBooks.csv',
+      );
       if (await file.exists()) {
         final contents = await file.readAsString();
         final lines = contents.split('\n');
@@ -596,12 +620,15 @@ $selectedText
     return {
       'שם הקובץ': 'לא ניתן למצוא את הספר',
       'נתיב הקובץ': 'לא ניתן למצוא את הספר',
-      'תיקיית המקור': 'לא ניתן למצוא את הספר'
+      'תיקיית המקור': 'לא ניתן למצוא את הספר',
     };
   }
 
   Widget _buildBody(
-      BuildContext context, TextBookLoaded state, bool wideScreen) {
+    BuildContext context,
+    TextBookLoaded state,
+    bool wideScreen,
+  ) {
     return LayoutBuilder(
       builder: (context, constraints) => MediaQuery.of(context).size.width < 600
           ? Stack(
@@ -628,9 +655,7 @@ $selectedText
       child: GestureDetector(
         onScaleUpdate: (details) {
           context.read<TextBookBloc>().add(
-                UpdateFontSize(
-                  (state.fontSize * details.scale).clamp(15, 60),
-                ),
+                UpdateFontSize((state.fontSize * details.scale).clamp(15, 60)),
               );
         },
         child: NotificationListener<UserScrollNotification>(
@@ -645,7 +670,9 @@ $selectedText
           child: CallbackShortcuts(
             bindings: <ShortcutActivator, VoidCallback>{
               LogicalKeySet(
-                  LogicalKeyboardKey.control, LogicalKeyboardKey.keyF): () {
+                LogicalKeyboardKey.control,
+                LogicalKeyboardKey.keyF,
+              ): () {
                 context.read<TextBookBloc>().add(const ToggleLeftPane(true));
                 tabController.index = 1;
                 textSearchFocusNode.requestFocus();
@@ -668,6 +695,7 @@ $selectedText
         content: state.content,
         openBookCallback: widget.openBookCallback,
         searchTextController: TextEditingValue(text: state.searchText),
+        openLeftPaneTab: _openLeftPaneTab,
         tab: widget.tab,
       );
     }
@@ -689,6 +717,7 @@ $selectedText
       data: state.content,
       textSize: state.fontSize,
       openBookCallback: widget.openBookCallback,
+      openLeftPaneTab: _openLeftPaneTab,
       showSplitedView: ValueNotifier(state.showSplitView),
       tab: widget.tab,
     );
@@ -720,7 +749,7 @@ $selectedText
                         Tab(text: 'ניווט'),
                         Tab(text: 'חיפוש'),
                         Tab(text: 'פרשנות'),
-                        Tab(text: 'קישורים')
+                        Tab(text: 'קישורים'),
                       ],
                       controller: tabController,
                       onTap: (value) {
@@ -749,11 +778,13 @@ $selectedText
                     _buildTocViewer(context, state),
                     CallbackShortcuts(
                       bindings: <ShortcutActivator, VoidCallback>{
-                        LogicalKeySet(LogicalKeyboardKey.control,
-                            LogicalKeyboardKey.keyF): () {
-                          context
-                              .read<TextBookBloc>()
-                              .add(const ToggleLeftPane(true));
+                        LogicalKeySet(
+                          LogicalKeyboardKey.control,
+                          LogicalKeyboardKey.keyF,
+                        ): () {
+                          context.read<TextBookBloc>().add(
+                                const ToggleLeftPane(true),
+                              );
                           tabController.index = 1;
                           textSearchFocusNode.requestFocus();
                         },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -382,11 +382,12 @@ packages:
   flutter_context_menu:
     dependency: "direct main"
     description:
-      name: flutter_context_menu
-      sha256: "9f220a8fa0290c68e38000d6d62a0dc4555d490c15a5bd856a6e6d255d81b8dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3"
+      path: "."
+      ref: HEAD
+      resolved-ref: "4aacb40038062a058638b6d1456d0f31adaf6afe"
+      url: "https://github.com/Y-PLONI/flutter_context_menu"
+    source: git
+    version: "0.2.4"
   flutter_document_picker:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,10 @@ dependencies:
   expandable: ^5.0.1
   multi_split_view: ^2.4.0
   updat: ^1.3.2
-  flutter_context_menu: ^0.1.3
+  flutter_context_menu:
+    git:
+      url: https://github.com/Y-PLONI/flutter_context_menu
+
   printing:
   pdf: ^3.10.8
   kosher_dart: ^2.0.16


### PR DESCRIPTION
## Summary
- add custom context menus to CombinedView and SimpleBookView
- expose available links and commentators in context menus
- enable selecting all text via SelectionArea controller
- wire context menu actions to open sidebar tabs

## Testing
- `./flutter/bin/dart format lib/text_book/view/combined_view/combined_book_screen.dart lib/text_book/view/links_screen.dart lib/text_book/view/splited_view/simple_book_view.dart lib/text_book/view/splited_view/splited_view_screen.dart lib/text_book/view/text_book_screen.dart`
- `./flutter/bin/flutter test` *(fails: TestDeviceException)*

------
https://chatgpt.com/codex/tasks/task_e_686ab730700c83339327970dee9f0ffe