### PR TITLE
Fix: Preserve Line Breaks When Copying Text

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -20,7 +20,7 @@ import 'pdf_thumbnails_screen.dart';
 import 'package:printing/printing.dart';
 import 'package:otzaria/utils/page_converter.dart';
 import 'package:flutter/gestures.dart';
-
+//test
 class PdfBookScreen extends StatefulWidget {
   final PdfBookTab tab;
 

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -185,7 +185,18 @@ List<ctx.MenuItem<void>> _buildGroup(
       itemCount: widget.data.length,
       itemBuilder: (context, index) {
         ExpansibleController controller = ExpansibleController();
-        return buildExpansiomTile(controller, index, state);
+        // WORKAROUND: Add an invisible newline character to preserve line breaks
+        // when copying text from the SelectionArea. This addresses a known
+        // issue in Flutter where newlines are stripped when copying from
+        // multiple widgets.
+        // See: https://github.com/flutter/flutter/issues/104548#issuecomment-2051481671
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            buildExpansiomTile(controller, index, state),
+            const Text('\n', style: TextStyle(fontSize: 0, height: 0)),
+          ],
+        );
       },
     );
   }

--- a/lib/text_book/view/splited_view/simple_book_view.dart
+++ b/lib/text_book/view/splited_view/simple_book_view.dart
@@ -169,43 +169,55 @@ class _SimpleBookViewState extends State<SimpleBookView> {
                   scrollOffsetController: state.scrollOffsetController,
                   itemCount: widget.data.length,
                   itemBuilder: (context, index) {
-                  return BlocBuilder<SettingsBloc, SettingsState>(
-                    builder: (context, settingsState) {
-                      String data = widget.data[index];
-                      if (!settingsState.showTeamim) {
-                        data = utils.removeTeamim(data);
-                      }
+                    // WORKAROUND: Add an invisible newline character to preserve line breaks
+                    // when copying text from the SelectionArea. This addresses a known
+                    // issue in Flutter where newlines are stripped when copying from
+                    // multiple widgets.
+                    // See: https://github.com/flutter/flutter/issues/104548#issuecomment-2051481671
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        BlocBuilder<SettingsBloc, SettingsState>(
+                          builder: (context, settingsState) {
+                            String data = widget.data[index];
+                            if (!settingsState.showTeamim) {
+                              data = utils.removeTeamim(data);
+                            }
 
-                      if (settingsState.replaceHolyNames) {
-                        data = utils.replaceHolyNames(data);
-                      }
-                      return InkWell(
-                        onTap: () => context.read<TextBookBloc>().add(
-                              UpdateSelectedIndex(index),
-                            ),
-                        child: Html(
-                          // remove nikud if needed
-                          data: state.removeNikud
-                              ? utils.highLight(
-                                  utils.removeVolwels('$data\n'),
-                                  state.searchText,
-                                )
-                              : utils.highLight('$data\n', state.searchText),
-                          style: {
-                            'body': Style(
-                              fontSize: FontSize(widget.textSize),
-                              fontFamily: settingsState.fontFamily,
-                              textAlign: TextAlign.justify,
-                            ),
+                            if (settingsState.replaceHolyNames) {
+                              data = utils.replaceHolyNames(data);
+                            }
+                            return InkWell(
+                              onTap: () => context.read<TextBookBloc>().add(
+                                    UpdateSelectedIndex(index),
+                                  ),
+                              child: Html(
+                                // remove nikud if needed
+                                data: state.removeNikud
+                                    ? utils.highLight(
+                                        utils.removeVolwels('$data\n'),
+                                        state.searchText,
+                                      )
+                                    : utils.highLight('$data\n', state.searchText),
+                                style: {
+                                  'body': Style(
+                                    fontSize: FontSize(widget.textSize),
+                                    fontFamily: settingsState.fontFamily,
+                                    textAlign: TextAlign.justify,
+                                  ),
+                                },
+                              ),
+                            );
                           },
                         ),
-                      );
-                    },
-                  );
-                },
+                        const Text('\n', style: TextStyle(fontSize: 0, height: 0)),
+                      ],
+                    );
+                  },
+                ),
               ),
             ),
-            ),
+            
         );
       },
     );

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - pdfrx (0.0.3):
+  - pdfrx (0.0.6):
     - Flutter
     - FlutterMacOS
   - printing (1.0.0):
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   isar_flutter_libs: 43385c99864c168fadba7c9adeddc5d38838ca6a
   package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  pdfrx: 07fc287c47ea8d027c4ed56457f8a1aa74d73594
+  pdfrx: 7d42fd227c1ea6a48d7e687cfe27d503238c7f97
   printing: 1dd6a1fce2209ec240698e2439a4adbb9b427637
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   search_engine: 9c03e685433b964792a1c30891140147ad75835b

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
This pull request addresses an issue where copying text spanning multiple paragraphs from the book view would result in the loss of line breaks. This made the pasted text appear as a single, unformatted block.
The root cause is a known issue in Flutter's SelectionArea widget, which does not automatically insert newline characters when selecting text across separate child widgets.

This was fixed by implementing a workaround suggested in: https://github.com/flutter/flutter/issues/104548#issuecomment-2051481671
