### PR TITLE
Add Tanach nikud handling

### DIFF
--- a/lib/data/data_providers/file_system_data_provider.dart
+++ b/lib/data/data_providers/file_system_data_provider.dart
@@ -466,4 +466,23 @@ class FileSystemData {
     final titleToPath = await this.titleToPath;
     return titleToPath.keys.contains(title);
   }
+
+  /// Returns true if the book belongs to Tanach (Torah, Neviim or Ketuvim).
+  ///
+  /// The check is performed by examining the book path and verifying that it
+  /// resides under one of the Tanach directories.
+  Future<bool> isTanachBook(String title) async {
+    final path = await _getBookPath(title);
+    final normalized = path
+        .replaceAll('/', Platform.pathSeparator)
+        .replaceAll('\\', Platform.pathSeparator);
+    final tanachBase =
+        '${Platform.pathSeparator}אוצריא${Platform.pathSeparator}תנך${Platform.pathSeparator}';
+    final torah = tanachBase + 'תורה';
+    final neviim = tanachBase + 'נביאים';
+    final ktuvim = tanachBase + 'כתובים';
+    return normalized.contains(torah) ||
+        normalized.contains(neviim) ||
+        normalized.contains(ktuvim);
+  }
 }

--- a/lib/settings/settings_bloc.dart
+++ b/lib/settings/settings_bloc.dart
@@ -22,7 +22,8 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<UpdateUseFastSearch>(_onUpdateUseFastSearch);
     on<UpdateReplaceHolyNames>(_onUpdateReplaceHolyNames);
     on<UpdateAutoUpdateIndex>(_onUpdateAutoUpdateIndex);
-    on<UpdateDefaultRemoveNikud>(_onUpdateDefaultRemoveNikud);    
+    on<UpdateDefaultRemoveNikud>(_onUpdateDefaultRemoveNikud);
+    on<UpdateRemoveNikudFromTanach>(_onUpdateRemoveNikudFromTanach);
     on<UpdateDefaultSidebarOpen>(_onUpdateDefaultSidebarOpen);
   }
 
@@ -44,8 +45,9 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       useFastSearch: settings['useFastSearch'],
       replaceHolyNames: settings['replaceHolyNames'],
       autoUpdateIndex: settings['autoUpdateIndex'],
-      defaultRemoveNikud: settings['defaultRemoveNikud'], 
-      defaultSidebarOpen: settings['defaultSidebarOpen'],     
+      defaultRemoveNikud: settings['defaultRemoveNikud'],
+      removeNikudFromTanach: settings['removeNikudFromTanach'],
+      defaultSidebarOpen: settings['defaultSidebarOpen'],
     ));
   }
 
@@ -151,7 +153,15 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   ) async {
     await _repository.updateDefaultRemoveNikud(event.defaultRemoveNikud);
     emit(state.copyWith(defaultRemoveNikud: event.defaultRemoveNikud));
-  }  
+  }
+
+  Future<void> _onUpdateRemoveNikudFromTanach(
+    UpdateRemoveNikudFromTanach event,
+    Emitter<SettingsState> emit,
+  ) async {
+    await _repository.updateRemoveNikudFromTanach(event.removeNikudFromTanach);
+    emit(state.copyWith(removeNikudFromTanach: event.removeNikudFromTanach));
+  }
   Future<void> _onUpdateDefaultSidebarOpen(
     UpdateDefaultSidebarOpen event,
     Emitter<SettingsState> emit,

--- a/lib/settings/settings_event.dart
+++ b/lib/settings/settings_event.dart
@@ -127,6 +127,15 @@ class UpdateDefaultRemoveNikud extends SettingsEvent {
   List<Object?> get props => [defaultRemoveNikud];
 }
 
+class UpdateRemoveNikudFromTanach extends SettingsEvent {
+  final bool removeNikudFromTanach;
+
+  const UpdateRemoveNikudFromTanach(this.removeNikudFromTanach);
+
+  @override
+  List<Object?> get props => [removeNikudFromTanach];
+}
+
 class UpdateDefaultSidebarOpen extends SettingsEvent {
   final bool defaultSidebarOpen;
 

--- a/lib/settings/settings_repository.dart
+++ b/lib/settings/settings_repository.dart
@@ -16,7 +16,8 @@ class SettingsRepository {
   static const String keyReplaceHolyNames = 'key-replace-holy-names';
   static const String keyAutoUpdateIndex = 'key-auto-index-update';
   static const String keyDefaultNikud = 'key-default-nikud';
-  static const String keyDefaultSidebarOpen = 'key-default-sidebar-open';  
+  static const String keyRemoveNikudFromTanach = 'key-remove-nikud-tanach';
+  static const String keyDefaultSidebarOpen = 'key-default-sidebar-open';
 
   final SettingsWrapper _settings;
 
@@ -71,10 +72,14 @@ class SettingsRepository {
         keyDefaultNikud,
         defaultValue: false,
       ),
+      'removeNikudFromTanach': _settings.getValue<bool>(
+        keyRemoveNikudFromTanach,
+        defaultValue: false,
+      ),
       'defaultSidebarOpen': _settings.getValue<bool>(
         keyDefaultSidebarOpen,
         defaultValue: false,
-      ),      
+      ),
     };
   }
 
@@ -125,10 +130,13 @@ class SettingsRepository {
   Future<void> updateAutoUpdateIndex(bool value) async {
     await _settings.setValue(keyAutoUpdateIndex, value);
   }
-  
+
   Future<void> updateDefaultRemoveNikud(bool value) async {
     await _settings.setValue(keyDefaultNikud, value);
-  }  
+  }
+  Future<void> updateRemoveNikudFromTanach(bool value) async {
+    await _settings.setValue(keyRemoveNikudFromTanach, value);
+  }
   Future<void> updateDefaultSidebarOpen(bool value) async {
     await _settings.setValue(keyDefaultSidebarOpen, value);
   }
@@ -161,6 +169,7 @@ class SettingsRepository {
     await _settings.setValue(keyReplaceHolyNames, true);
     await _settings.setValue(keyAutoUpdateIndex, true);
     await _settings.setValue(keyDefaultNikud, false);
+    await _settings.setValue(keyRemoveNikudFromTanach, false);
     await _settings.setValue(keyDefaultSidebarOpen, false);
     
     // Mark as initialized

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -310,6 +310,19 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                               .add(UpdateDefaultRemoveNikud(value));
                         },
                       ),
+                      SwitchSettingsTile(
+                        settingKey: 'key-remove-nikud-tanach',
+                        title: 'הסרת ניקוד מספרי התנ"ך',
+                        enabledLabel: 'גם ספרי התנ"ך יוצגו ללא ניקוד',
+                        disabledLabel: 'בספרי התנ"ך יוצג ניקוד',
+                        leading: const Icon(Icons.book),
+                        defaultValue: state.removeNikudFromTanach,
+                        onChange: (value) {
+                          context
+                              .read<SettingsBloc>()
+                              .add(UpdateRemoveNikudFromTanach(value));
+                        },
+                      ),
                       const SwitchSettingsTile(
                         settingKey: 'key-splited-view',
                         title: 'ברירת המחדל להצגת המפרשים',

--- a/lib/settings/settings_state.dart
+++ b/lib/settings/settings_state.dart
@@ -15,6 +15,7 @@ class SettingsState extends Equatable {
   final bool replaceHolyNames;
   final bool autoUpdateIndex;
   final bool defaultRemoveNikud;
+  final bool removeNikudFromTanach;
   final bool defaultSidebarOpen;
 
   const SettingsState({
@@ -31,7 +32,8 @@ class SettingsState extends Equatable {
     required this.replaceHolyNames,
     required this.autoUpdateIndex,
     required this.defaultRemoveNikud,
-    required this.defaultSidebarOpen, 
+    required this.removeNikudFromTanach,
+    required this.defaultSidebarOpen,
   });
 
   factory SettingsState.initial() {
@@ -49,7 +51,8 @@ class SettingsState extends Equatable {
       replaceHolyNames: true,
       autoUpdateIndex: true,
       defaultRemoveNikud: false,
-      defaultSidebarOpen: false,     
+      removeNikudFromTanach: false,
+      defaultSidebarOpen: false,
     );
   }
 
@@ -67,7 +70,8 @@ class SettingsState extends Equatable {
     bool? replaceHolyNames,
     bool? autoUpdateIndex,
     bool? defaultRemoveNikud,
-    bool? defaultSidebarOpen, 
+    bool? removeNikudFromTanach,
+    bool? defaultSidebarOpen,
   }) {
     return SettingsState(
       isDarkMode: isDarkMode ?? this.isDarkMode,
@@ -82,8 +86,10 @@ class SettingsState extends Equatable {
       useFastSearch: useFastSearch ?? this.useFastSearch,
       replaceHolyNames: replaceHolyNames ?? this.replaceHolyNames,
       autoUpdateIndex: autoUpdateIndex ?? this.autoUpdateIndex,
-      defaultRemoveNikud: defaultRemoveNikud ?? this.defaultRemoveNikud,  
-      defaultSidebarOpen: defaultSidebarOpen ?? this.defaultSidebarOpen,    
+      defaultRemoveNikud: defaultRemoveNikud ?? this.defaultRemoveNikud,
+      removeNikudFromTanach:
+          removeNikudFromTanach ?? this.removeNikudFromTanach,
+      defaultSidebarOpen: defaultSidebarOpen ?? this.defaultSidebarOpen,
     );
   }
 
@@ -102,6 +108,7 @@ class SettingsState extends Equatable {
         replaceHolyNames,
         autoUpdateIndex,
         defaultRemoveNikud,
-        defaultSidebarOpen,       
+        removeNikudFromTanach,
+        defaultSidebarOpen,
       ];
 }

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -6,6 +6,7 @@ import 'package:otzaria/utils/ref_helper.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:otzaria/utils/text_manipulation.dart' as utils;
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
 
 class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
   final TextBookRepository _repository;
@@ -51,6 +52,15 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         // ממיינים את רשימת המפרשים לקבוצות לפי תקופה
         final eras = await utils.splitByEra(availableCommentators);
 
+        final defaultRemoveNikud =
+            Settings.getValue<bool>('key-default-nikud') ?? false;
+        final removeNikudFromTanach =
+            Settings.getValue<bool>('key-remove-nikud-tanach') ?? false;
+        final isTanach =
+            await FileSystemData.instance.isTanachBook(book.title);
+        final removeNikud = defaultRemoveNikud &&
+            (removeNikudFromTanach || !isTanach);
+
         // Create controllers if this is the first load
         final ItemScrollController scrollController = ItemScrollController();
         final ScrollOffsetController scrollOffsetController =
@@ -81,8 +91,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
           rishonim: eras['ראשונים']!,
           acharonim: eras['אחרונים']!,
           modernCommentators: eras['מחברי זמננו']!,
-          removeNikud:
-              Settings.getValue<bool>('key-default-nikud') ?? false,
+          removeNikud: removeNikud,
           visibleIndices: [state.index],
           pinLeftPane: false,
           searchText: '',

--- a/test/unit/mocks/mock_settings_repository.mocks.dart
+++ b/test/unit/mocks/mock_settings_repository.mocks.dart
@@ -169,6 +169,16 @@ class MockSettingsRepository extends _i1.Mock
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> updateRemoveNikudFromTanach(bool? value) => (super.noSuchMethod(
+        Invocation.method(
+          #updateRemoveNikudFromTanach,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
   _i3.Future<void> updateDefaultSidebarOpen(bool? value) => (super.noSuchMethod(
         Invocation.method(
           #updateDefaultSidebarOpen,

--- a/test/unit/settings/settings_bloc_test.dart
+++ b/test/unit/settings/settings_bloc_test.dart
@@ -39,8 +39,9 @@ void main() {
         'useFastSearch': false,
         'replaceHolyNames': false,
         'autoUpdateIndex': false,
-        'defaultRemoveNikud': true,    
-        'defaultSidebarOpen': true,    
+        'defaultRemoveNikud': true,
+        'removeNikudFromTanach': true,
+        'defaultSidebarOpen': true,
       };
 
       blocTest<SettingsBloc, SettingsState>(
@@ -66,7 +67,9 @@ void main() {
             replaceHolyNames: mockSettings['replaceHolyNames'] as bool,
             autoUpdateIndex: mockSettings['autoUpdateIndex'] as bool,
             defaultRemoveNikud: mockSettings['defaultRemoveNikud'] as bool,
-            defaultSidebarOpen: mockSettings['defaultSidebarOpen'] as bool,         
+            removeNikudFromTanach:
+                mockSettings['removeNikudFromTanach'] as bool,
+            defaultSidebarOpen: mockSettings['defaultSidebarOpen'] as bool,
           ),
         ],
         verify: (_) {
@@ -147,6 +150,20 @@ void main() {
         ],
         verify: (_) {
           verify(mockRepository.updateDefaultRemoveNikud(true)).called(1);
+        },
+      );
+    });
+
+    group('UpdateRemoveNikudFromTanach', () {
+      blocTest<SettingsBloc, SettingsState>(
+        'emits updated state when UpdateRemoveNikudFromTanach is added',
+        build: () => settingsBloc,
+        act: (bloc) => bloc.add(const UpdateRemoveNikudFromTanach(true)),
+        expect: () => [
+          settingsBloc.state.copyWith(removeNikudFromTanach: true),
+        ],
+        verify: (_) {
+          verify(mockRepository.updateRemoveNikudFromTanach(true)).called(1);
         },
       );
     });

--- a/test/unit/settings/settings_repository_test.dart
+++ b/test/unit/settings/settings_repository_test.dart
@@ -68,6 +68,10 @@ void main() {
               defaultValue: false))
           .thenReturn(false);
       when(mockSettingsWrapper.getValue<bool>(
+              SettingsRepository.keyRemoveNikudFromTanach,
+              defaultValue: false))
+          .thenReturn(false);
+      when(mockSettingsWrapper.getValue<bool>(
               SettingsRepository.keyDefaultSidebarOpen,
               defaultValue: false))
           .thenReturn(false);
@@ -88,6 +92,7 @@ void main() {
       expect(settings['replaceHolyNames'], true);
       expect(settings['autoUpdateIndex'], true);
       expect(settings['defaultRemoveNikud'], false);
+      expect(settings['removeNikudFromTanach'], false);
       expect(settings['defaultSidebarOpen'], false);
     });
 
@@ -143,6 +148,10 @@ void main() {
               defaultValue: false))
           .thenReturn(true);
       when(mockSettingsWrapper.getValue<bool>(
+              SettingsRepository.keyRemoveNikudFromTanach,
+              defaultValue: false))
+          .thenReturn(true);
+      when(mockSettingsWrapper.getValue<bool>(
               SettingsRepository.keyDefaultSidebarOpen,
               defaultValue: false))
           .thenReturn(true);
@@ -163,6 +172,7 @@ void main() {
       expect(settings['replaceHolyNames'], false);
       expect(settings['autoUpdateIndex'], false);
       expect(settings['defaultRemoveNikud'], true);
+      expect(settings['removeNikudFromTanach'], true);
       expect(settings['defaultSidebarOpen'], true);
     });
 
@@ -191,6 +201,14 @@ void main() {
       await repository.updateDefaultRemoveNikud(true);
       verify(mockSettingsWrapper.setValue(
               SettingsRepository.keyDefaultNikud, true))
+          .called(1);
+    });
+
+    test('updateRemoveNikudFromTanach calls setValue on settings wrapper',
+        () async {
+      await repository.updateRemoveNikudFromTanach(true);
+      verify(mockSettingsWrapper.setValue(
+              SettingsRepository.keyRemoveNikudFromTanach, true))
           .called(1);
     });
 
@@ -280,6 +298,9 @@ when(mockSettingsWrapper.getValue<String?>(
       verify(mockSettingsWrapper.setValue(SettingsRepository.keyReplaceHolyNames, true)).called(1);
       verify(mockSettingsWrapper.setValue(SettingsRepository.keyAutoUpdateIndex, true)).called(1);
       verify(mockSettingsWrapper.setValue(SettingsRepository.keyDefaultNikud, false)).called(1);
+      verify(mockSettingsWrapper.setValue(
+              SettingsRepository.keyRemoveNikudFromTanach, false))
+          .called(1);
       verify(mockSettingsWrapper.setValue(SettingsRepository.keyDefaultSidebarOpen, false)).called(1);
     });
 


### PR DESCRIPTION
## Summary
- detect Tanach books via new `isTanachBook` helper
- add setting `removeNikudFromTanach`
- wire up setting through bloc, repository and screen
- compute default nikud removal using new rules
- update tests and mocks

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc0985eb48333ae55db4c5b3ac13a