### PR TITLE
Add show all buttons for commentator groups

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -45,28 +45,50 @@ class _CombinedViewState extends State<CombinedView> {
   final GlobalKey<SelectionAreaState> _selectionKey =
       GlobalKey<SelectionAreaState>();
 
-  /// helper קטן שמחזיר רשימת MenuEntry מקבוצה אחת
+  /// helper קטן שמחזיר רשימת MenuEntry מקבוצה אחת, כולל כפתור הצג/הסתר הכל
   List<ctx.MenuItem<void>> _buildGroup(
+    String groupName,
     List<String>? group,
     TextBookLoaded st,
   ) {
     if (group == null || group.isEmpty) return const [];
-    return group.map((title) {
-      // בודקים אם הפרשן הנוכחי פעיל
-      final bool isActive = st.activeCommentators.contains(title);
 
-      return ctx.MenuItem<void>(
-        label: title,
-        // הוספה: מוסיפים אייקון V אם הפרשן פעיל
-        icon: isActive ? Icons.check : null,
+    final bool groupActive =
+        group.every((title) => st.activeCommentators.contains(title));
+
+    return [
+      ctx.MenuItem<void>(
+        label: 'הצג את כל ${groupName}',
+        icon: groupActive ? Icons.check : null,
         onSelected: () {
           final current = List<String>.from(st.activeCommentators);
-          current.contains(title) ? current.remove(title) : current.add(title);
-          context.read<TextBookBloc>().add(UpdateCommentators(current));          
+          if (groupActive) {
+            current.removeWhere(group.contains);
+          } else {
+            for (final title in group) {
+              if (!current.contains(title)) current.add(title);
+            }
+          }
+          context.read<TextBookBloc>().add(UpdateCommentators(current));
         },
-      );
-    }).toList();
+      ),
+      ...group.map((title) {
+        final bool isActive = st.activeCommentators.contains(title);
+        return ctx.MenuItem<void>(
+          label: title,
+          icon: isActive ? Icons.check : null,
+          onSelected: () {
+            final current = List<String>.from(st.activeCommentators);
+            current.contains(title)
+                ? current.remove(title)
+                : current.add(title);
+            context.read<TextBookBloc>().add(UpdateCommentators(current));
+          },
+        );
+      }),
+    ];
   }
+
 
   ctx.ContextMenu _buildContextMenu(TextBookLoaded state) {
     // 1. קבלת מידע על גודל המסך
@@ -112,14 +134,14 @@ class _CombinedViewState extends State<CombinedView> {
             ),
             const ctx.MenuDivider(),
             // ראשונים
-            ..._buildGroup(state.rishonim, state),
+            ..._buildGroup('ראשונים', state.rishonim, state),
 
             // מוסיפים קו הפרדה רק אם יש גם ראשונים וגם אחרונים
             if (state.rishonim.isNotEmpty && state.acharonim.isNotEmpty)
               const ctx.MenuDivider(),
 
             // אחרונים
-            ..._buildGroup(state.acharonim, state),
+            ..._buildGroup('אחרונים', state.acharonim, state),
 
             // מוסיפים קו הפרדה רק אם יש גם אחרונים וגם בני זמננו
             if (state.acharonim.isNotEmpty &&
@@ -127,7 +149,7 @@ class _CombinedViewState extends State<CombinedView> {
               const ctx.MenuDivider(),
 
             // מחברי זמננו
-            ..._buildGroup(state.modernCommentators, state),
+            ..._buildGroup('מחברי זמננו', state.modernCommentators, state),
 
             // הוסף קו הפרדה רק אם יש קבוצות אחרות וגם פרשנים לא-משויכים
             if ((state.rishonim.isNotEmpty ||
@@ -137,7 +159,7 @@ class _CombinedViewState extends State<CombinedView> {
               const ctx.MenuDivider(),
 
             // הוסף את רשימת הפרשנים הלא משויכים
-            ..._buildGroup(ungrouped, state),
+            ..._buildGroup('שאר מפרשים', ungrouped, state),
           ],
         ),
         ctx.MenuItem.submenu(

--- a/lib/text_book/view/commentators_list_screen.dart
+++ b/lib/text_book/view/commentators_list_screen.dart
@@ -20,10 +20,18 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
   TextEditingController searchController = TextEditingController();
   List<String> selectedTopics = [];
   List<String> commentatorsList = [];
+  List<String> _rishonim = [];
+  List<String> _acharonim = [];
+  List<String> _modern = [];
+  List<String> _ungrouped = [];
   static const String _rishonimTitle = '__TITLE_RISHONIM__';
   static const String _acharonimTitle = '__TITLE_ACHARONim__';
   static const String _modernTitle = '__TITLE_MODERN__';
   static const String _ungroupedTitle = '__TITLE_UNGROUPED__';
+  static const String _rishonimButton = '__BUTTON_RISHONIM__';
+  static const String _acharonimButton = '__BUTTON_ACHARONIM__';
+  static const String _modernButton = '__BUTTON_MODERN__';
+  static const String _ungroupedButton = '__BUTTON_UNGROUPED__';
 
 
   Future<List<String>> filterGroup(List<String> group) async {
@@ -62,23 +70,32 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
         .where((c) => !alreadyListed.contains(c))
         .toList();
     final ungrouped = await filterGroup(ungroupedRaw);
+
+    _rishonim = rishonim;
+    _acharonim = acharonim;
+    _modern = modern;
+    _ungrouped = ungrouped;
   
     // בניית הרשימה עם כותרות לפני כל קבוצה קיימת
     final List<String> merged = [];
     
     if (rishonim.isNotEmpty) {
+      merged.add(_rishonimButton);
       merged.add(_rishonimTitle); // הוסף כותרת ראשונים
       merged.addAll(rishonim);
     }
     if (acharonim.isNotEmpty) {
+      merged.add(_acharonimButton);
       merged.add(_acharonimTitle); // הוסף כותרת אחרונים
       merged.addAll(acharonim);
     }
     if (modern.isNotEmpty) {
+      merged.add(_modernButton);
       merged.add(_modernTitle); // הוסף כותרת מחברי זמננו
       merged.addAll(modern);
     }
     if (ungrouped.isNotEmpty) {
+      merged.add(_ungroupedButton);
       merged.add(_ungroupedTitle); // הוסף כותרת לשאר
       merged.addAll(ungrouped);
     }
@@ -166,11 +183,11 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
                   CheckboxListTile(
                     title: const Text('הצג את כל הפרשנים'), // שמרתי את השינוי שלך
                     value: commentatorsList
-                        .where((e) => !e.startsWith('__TITLE_'))
+                        .where((e) => !e.startsWith('__TITLE_') && !e.startsWith('__BUTTON_'))
                         .every(state.activeCommentators.contains),
                     onChanged: (checked) {
                       final items = commentatorsList
-                          .where((e) => !e.startsWith('__TITLE_'))
+                          .where((e) => !e.startsWith('__TITLE_') && !e.startsWith('__BUTTON_'))
                           .toList();
                       if (checked ?? false) {
                         context.read<TextBookBloc>().add(UpdateCommentators(
@@ -191,6 +208,84 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
                     itemBuilder: (context, index) {
                       final item = commentatorsList[index];
           
+                      // בדוק אם הפריט הוא כפתור הצגת קבוצה
+                      if (item == _rishonimButton) {
+                        final allActive =
+                            _rishonim.every(state.activeCommentators.contains);
+                        return CheckboxListTile(
+                          title: const Text('הצג את כל הראשונים'),
+                          value: allActive,
+                          onChanged: (checked) {
+                            final current = List<String>.from(state.activeCommentators);
+                            if (checked ?? false) {
+                              for (final t in _rishonim) {
+                                if (!current.contains(t)) current.add(t);
+                              }
+                            } else {
+                              current.removeWhere(_rishonim.contains);
+                            }
+                            context.read<TextBookBloc>().add(UpdateCommentators(current));
+                          },
+                        );
+                      }
+                      if (item == _acharonimButton) {
+                        final allActive =
+                            _acharonim.every(state.activeCommentators.contains);
+                        return CheckboxListTile(
+                          title: const Text('הצג את כל האחרונים'),
+                          value: allActive,
+                          onChanged: (checked) {
+                            final current = List<String>.from(state.activeCommentators);
+                            if (checked ?? false) {
+                              for (final t in _acharonim) {
+                                if (!current.contains(t)) current.add(t);
+                              }
+                            } else {
+                              current.removeWhere(_acharonim.contains);
+                            }
+                            context.read<TextBookBloc>().add(UpdateCommentators(current));
+                          },
+                        );
+                      }
+                      if (item == _modernButton) {
+                        final allActive =
+                            _modern.every(state.activeCommentators.contains);
+                        return CheckboxListTile(
+                          title: const Text('הצג את כל מחברי זמננו'),
+                          value: allActive,
+                          onChanged: (checked) {
+                            final current = List<String>.from(state.activeCommentators);
+                            if (checked ?? false) {
+                              for (final t in _modern) {
+                                if (!current.contains(t)) current.add(t);
+                              }
+                            } else {
+                              current.removeWhere(_modern.contains);
+                            }
+                            context.read<TextBookBloc>().add(UpdateCommentators(current));
+                          },
+                        );
+                      }
+                      if (item == _ungroupedButton) {
+                        final allActive =
+                            _ungrouped.every(state.activeCommentators.contains);
+                        return CheckboxListTile(
+                          title: const Text('הצג את כל שאר המפרשים'),
+                          value: allActive,
+                          onChanged: (checked) {
+                            final current = List<String>.from(state.activeCommentators);
+                            if (checked ?? false) {
+                              for (final t in _ungrouped) {
+                                if (!current.contains(t)) current.add(t);
+                              }
+                            } else {
+                              current.removeWhere(_ungrouped.contains);
+                            }
+                            context.read<TextBookBloc>().add(UpdateCommentators(current));
+                          },
+                        );
+                      }
+
                       // בדוק אם הפריט הוא כותרת
                       if (item.startsWith('__TITLE_')) {
                         String titleText = '';

--- a/lib/text_book/view/commentators_list_screen.dart
+++ b/lib/text_book/view/commentators_list_screen.dart
@@ -80,23 +80,23 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
     final List<String> merged = [];
     
     if (rishonim.isNotEmpty) {
-      merged.add(_rishonimButton);
       merged.add(_rishonimTitle); // הוסף כותרת ראשונים
+      merged.add(_rishonimButton);
       merged.addAll(rishonim);
     }
     if (acharonim.isNotEmpty) {
-      merged.add(_acharonimButton);
       merged.add(_acharonimTitle); // הוסף כותרת אחרונים
+      merged.add(_acharonimButton);
       merged.addAll(acharonim);
     }
     if (modern.isNotEmpty) {
-      merged.add(_modernButton);
       merged.add(_modernTitle); // הוסף כותרת מחברי זמננו
+      merged.add(_modernButton);
       merged.addAll(modern);
     }
     if (ungrouped.isNotEmpty) {
-      merged.add(_ungroupedButton);
       merged.add(_ungroupedTitle); // הוסף כותרת לשאר
+      merged.add(_ungroupedButton);
       merged.addAll(ungrouped);
     }
       if (mounted) {


### PR DESCRIPTION
## Summary
- allow toggling all commentators of a group in the context menu
- allow toggling all commentators of a group in the sidebar list

## Testing
- `dart format lib/text_book/view/combined_view/combined_book_screen.dart lib/text_book/view/splited_view/simple_book_view.dart lib/text_book/view/commentators_list_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876aeadf0e4833386657efa25f639c1