### PR TITLE
ריפקטור גלילה בצורת הדף: איחוד לוגיקה והעברת ניהול ל-BLoC

### DIFF
--- a/lib/migration/dao/repository/seforim_repository.dart
+++ b/lib/migration/dao/repository/seforim_repository.dart
@@ -1831,6 +1831,14 @@ class SeforimRepository {
   /// @param sql The SQL query to execute
   Future<void> executeRawQuery(String sql) async {
     final db = await _database.database;
+    final normalizedSql = sql.trim().toUpperCase();
+    final isPragma = normalizedSql.startsWith('PRAGMA ');
+
+    if (isPragma && (Platform.isAndroid || Platform.isIOS)) {
+      await db.rawQuery(sql);
+      return;
+    }
+
     await db.execute(sql);
   }
 
@@ -2344,9 +2352,9 @@ class SeforimRepository {
   Future<void> _executeRawQuery(String sql) async {
     final db = await _database.database;
     final normalizedSql = sql.trim().toUpperCase();
-    final isJournalModePragma = normalizedSql.startsWith('PRAGMA JOURNAL_MODE');
+    final isPragma = normalizedSql.startsWith('PRAGMA ');
 
-    if (isJournalModePragma && (Platform.isAndroid || Platform.isIOS)) {
+    if (isPragma && (Platform.isAndroid || Platform.isIOS)) {
       await db.rawQuery(sql);
       return;
     }

--- a/lib/navigation/custom_title_bar.dart
+++ b/lib/navigation/custom_title_bar.dart
@@ -43,7 +43,6 @@ class CustomTitleBar extends StatefulWidget {
 
 const double _kAppBarControlsWidth = 125.0;
 const double _kAppBarControlsWidthRightAligned = 125.0;
-const int _kActionButtonsCount = 1; // settings בלבד
 const double _kActionButtonWidth = 56.0;
 const double _kWindowCaptionButtonsWidth = 138.0;
 const double _kWindowCaptionButtonWidth = 46.0;
@@ -218,7 +217,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
           ? _kAppBarControlsWidthRightAligned
           : _kAppBarControlsWidth,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: [
           IconButton(
             icon: const Icon(FluentIcons.history_24_regular, size: 18),
@@ -226,12 +225,14 @@ class _CustomTitleBarState extends State<CustomTitleBar>
             onPressed: () => _showHistoryDialog(context),
             style: _kIconButtonStyle,
           ),
+          const SizedBox(width: 4),
           IconButton(
             icon: const Icon(FluentIcons.bookmark_24_regular, size: 18),
             tooltip: 'הצג סימניות (${bookmarksShortcut.toUpperCase()})',
             onPressed: () => _showBookmarksDialog(context),
             style: _kIconButtonStyle,
           ),
+          const SizedBox(width: 4),
           IconButton(
             icon: const Icon(FluentIcons.add_square_24_regular, size: 18),
             tooltip: 'החלף שולחן עבודה (${workspaceShortcut.toUpperCase()})',
@@ -249,13 +250,13 @@ class _CustomTitleBarState extends State<CustomTitleBar>
         navState.currentScreen == Screen.search) {
       return _buildReadingTabs(context, settingsState);
     } else if (navState.currentScreen == Screen.library) {
-      return _buildLibraryTitle(context);
+      return _buildLibraryTitle(context, settingsState);
     } else {
-      return _buildStandardTitle(context, navState);
+      return _buildStandardTitle(context, navState, settingsState);
     }
   }
 
-  Widget _buildLibraryTitle(BuildContext context) {
+  Widget _buildLibraryTitle(BuildContext context, SettingsState settingsState) {
     return BlocBuilder<LibraryBloc, LibraryState>(
       buildWhen: (previous, current) =>
           previous.currentCategory != current.currentCategory,
@@ -279,14 +280,22 @@ class _CustomTitleBarState extends State<CustomTitleBar>
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 4.0),
-              child: IconButton(
-                icon: const Icon(FluentIcons.settings_24_regular, size: 18),
-                tooltip: 'הגדרות ספרייה',
-                onPressed: () => showLibrarySettingsDialog(context),
-                style: _kIconButtonStyle.copyWith(
-                  foregroundColor: WidgetStatePropertyAll(
-                      Theme.of(context).colorScheme.onSurfaceVariant),
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                textDirection: TextDirection.ltr,
+                children: [
+                  if (!kIsWeb && Platform.isAndroid)
+                    _buildAndroidFullscreenButton(context, settingsState),
+                  IconButton(
+                    icon: const Icon(FluentIcons.settings_24_regular, size: 18),
+                    tooltip: 'הגדרות ספרייה',
+                    onPressed: () => showLibrarySettingsDialog(context),
+                    style: _kIconButtonStyle.copyWith(
+                      foregroundColor: WidgetStatePropertyAll(
+                          Theme.of(context).colorScheme.onSurfaceVariant),
+                    ),
+                  ),
+                ],
               ),
             ),
           ],
@@ -295,7 +304,8 @@ class _CustomTitleBarState extends State<CustomTitleBar>
     );
   }
 
-  Widget _buildStandardTitle(BuildContext context, NavigationState navState) {
+  Widget _buildStandardTitle(BuildContext context, NavigationState navState,
+      SettingsState settingsState) {
     String title = 'אוצריא';
     switch (navState.currentScreen) {
       case Screen.find:
@@ -311,17 +321,54 @@ class _CustomTitleBarState extends State<CustomTitleBar>
         break;
     }
 
-    return DragToMoveArea(
-      child: Center(
-        child: Text(
-          title,
-          style: Theme.of(context).textTheme.titleMedium,
+    return Row(
+      children: [
+        Expanded(
+          child: DragToMoveArea(
+            child: Center(
+              child: Text(
+                title,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+          ),
+        ),
+        if (!kIsWeb && Platform.isAndroid)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4.0),
+            child: _buildAndroidFullscreenButton(context, settingsState),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildAndroidFullscreenButton(
+      BuildContext context, SettingsState settingsState) {
+    return IconButton(
+      icon: Icon(
+        settingsState.isFullscreen
+            ? FluentIcons.full_screen_minimize_24_regular
+            : FluentIcons.full_screen_maximize_24_regular,
+        size: 18,
+      ),
+      tooltip: settingsState.isFullscreen ? 'צא ממסך מלא' : 'מסך מלא',
+      onPressed: () async {
+        final newFullscreenState = !settingsState.isFullscreen;
+        await FullscreenHelper.toggleFullscreen(
+          context,
+          newFullscreenState,
+        );
+      },
+      style: _kIconButtonStyle.copyWith(
+        foregroundColor: WidgetStatePropertyAll(
+          Theme.of(context).colorScheme.onSurfaceVariant,
         ),
       ),
     );
   }
 
   Widget _buildReadingTabs(BuildContext context, SettingsState settingsState) {
+    final showAndroidFullscreenButton = !kIsWeb && Platform.isAndroid;
     return BlocBuilder<TabsBloc, TabsState>(
       builder: (context, state) {
         if (!state.hasOpenTabs) {
@@ -342,13 +389,20 @@ class _CustomTitleBarState extends State<CustomTitleBar>
         double rightSpacerWidth = 0;
 
         if (!settingsState.alignTabsToRight) {
+          final showAndroidFullscreenButton = !kIsWeb && Platform.isAndroid;
           bool showWindowControls = !kIsWeb &&
               (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
+          final int readingActionButtonsCount =
+              1 + (showAndroidFullscreenButton ? 1 : 0);
           double windowControlsWidth = showWindowControls
               ? _kWindowCaptionButtonsWidth + _kWindowCaptionButtonWidth
               : 0.0;
-          double actionButtonsWidth = _kAppBarControlsWidth;
-          double extraButtonsWidth = _kActionButtonsCount * _kActionButtonWidth;
+          double actionButtonsWidth = (settingsState.alignTabsToRight
+                  ? _kAppBarControlsWidthRightAligned
+                  : _kAppBarControlsWidth) +
+              (showAndroidFullscreenButton ? _kActionButtonWidth : 0);
+          double extraButtonsWidth =
+              readingActionButtonsCount * _kActionButtonWidth;
 
           double totalLeft = actionButtonsWidth;
           double totalRight = extraButtonsWidth + windowControlsWidth;
@@ -357,6 +411,12 @@ class _CustomTitleBarState extends State<CustomTitleBar>
             leftSpacerWidth = totalRight - totalLeft;
           } else {
             rightSpacerWidth = totalLeft - totalRight;
+          }
+
+          // באנדרואיד אנחנו רוצים את כפתורי ההגדרות/מסך מלא צמודים לשמאל
+          // בלי spacer נוסף בצד שמאל.
+          if (showAndroidFullscreenButton) {
+            rightSpacerWidth = 0;
           }
         }
 
@@ -418,17 +478,48 @@ class _CustomTitleBarState extends State<CustomTitleBar>
               ),
             ),
 
-            // כפתורים נוספים (הגדרות)
+            // כפתורים נוספים (הגדרות/מסך מלא באנדרואיד)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 4.0),
-              child: IconButton(
-                icon: const Icon(FluentIcons.settings_24_regular, size: 18),
-                tooltip: 'הגדרות תצוגת הספרים',
-                onPressed: () => showReadingSettingsDialog(context),
-                style: _kIconButtonStyle.copyWith(
-                  foregroundColor: WidgetStatePropertyAll(
-                      Theme.of(context).colorScheme.onSurfaceVariant),
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                textDirection: TextDirection.ltr,
+                children: [
+                  if (showAndroidFullscreenButton)
+                    IconButton(
+                      icon: Icon(
+                        settingsState.isFullscreen
+                            ? FluentIcons.full_screen_minimize_24_regular
+                            : FluentIcons.full_screen_maximize_24_regular,
+                        size: 18,
+                      ),
+                      tooltip: settingsState.isFullscreen
+                          ? 'צא ממסך מלא'
+                          : 'מסך מלא',
+                      onPressed: () async {
+                        final newFullscreenState = !settingsState.isFullscreen;
+                        await FullscreenHelper.toggleFullscreen(
+                          context,
+                          newFullscreenState,
+                        );
+                      },
+                      style: _kIconButtonStyle.copyWith(
+                        foregroundColor: WidgetStatePropertyAll(
+                          Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  IconButton(
+                    icon: const Icon(FluentIcons.settings_24_regular, size: 18),
+                    tooltip: 'הגדרות תצוגת הספרים',
+                    onPressed: () => showReadingSettingsDialog(context),
+                    style: _kIconButtonStyle.copyWith(
+                      foregroundColor: WidgetStatePropertyAll(
+                        Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
             if (rightSpacerWidth > 0) SizedBox(width: rightSpacerWidth),

--- a/lib/navigation/custom_title_bar.dart
+++ b/lib/navigation/custom_title_bar.dart
@@ -42,7 +42,7 @@ class CustomTitleBar extends StatefulWidget {
 }
 
 const double _kAppBarControlsWidth = 125.0;
-const double _kAppBarControlsWidthRightAligned = 105.0;
+const double _kAppBarControlsWidthRightAligned = 125.0;
 const int _kActionButtonsCount = 1; // settings בלבד
 const double _kActionButtonWidth = 56.0;
 const double _kWindowCaptionButtonsWidth = 138.0;
@@ -50,8 +50,9 @@ const double _kWindowCaptionButtonWidth = 46.0;
 
 /// סגנון משותף לכפתורי האייקון בשורת הכותרת
 final ButtonStyle _kIconButtonStyle = IconButton.styleFrom(
-  minimumSize: const Size(32, 32),
+  minimumSize: const Size(28, 28),
   padding: EdgeInsets.zero,
+  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
   shape: RoundedRectangleBorder(
     borderRadius: BorderRadius.circular(8),
   ),
@@ -217,7 +218,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
           ? _kAppBarControlsWidthRightAligned
           : _kAppBarControlsWidth,
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           IconButton(
             icon: const Icon(FluentIcons.history_24_regular, size: 18),

--- a/lib/settings/engine/settings_repository.dart
+++ b/lib/settings/engine/settings_repository.dart
@@ -209,7 +209,7 @@ class SettingsRepository {
       ),
       'libraryShowPreview': _settings.getValue<bool>(
         keyLibraryShowPreview,
-        defaultValue: true,
+        defaultValue: false,
       ),
       'shortcuts': await getShortcuts(),
       'enablePerBookSettings': _settings.getValue<bool>(
@@ -652,7 +652,7 @@ class SettingsRepository {
     await _settings.setValue(keyCopyHeaderFormat, 'same_line_after_brackets');
     await _settings.setValue(keyIsFullscreen, false);
     await _settings.setValue(keyLibraryViewMode, 'grid');
-    await _settings.setValue(keyLibraryShowPreview, true);
+    await _settings.setValue(keyLibraryShowPreview, false);
     await _settings.setValue(keyEnablePerBookSettings, true);
     await _settings.setValue(keyAlignTabsToRight, false);
     await _settings.setValue(keyPersonalNotesCollapsedByDefault, true);

--- a/lib/settings/engine/settings_state.dart
+++ b/lib/settings/engine/settings_state.dart
@@ -110,7 +110,7 @@ class SettingsState extends Equatable {
       copyHeaderFormat: 'same_line_after_brackets',
       isFullscreen: false,
       libraryViewMode: 'grid',
-      libraryShowPreview: true,
+      libraryShowPreview: false,
       shortcuts: {},
       enablePerBookSettings: true,
       isOfflineMode: false,

--- a/lib/settings/tabs/system_settings_tab.dart
+++ b/lib/settings/tabs/system_settings_tab.dart
@@ -846,15 +846,12 @@ class _MemorialCardsGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       final spacing = 12.0;
-      final crossAxisCount = constraints.maxWidth < 560 ? 2 : 3;
-      final itemWidth =
-          (constraints.maxWidth - spacing * (crossAxisCount - 1)) /
-              crossAxisCount;
-      final itemHeight = crossAxisCount == 2 ? 158.0 : 150.0;
+      final itemWidth = (constraints.maxWidth - spacing * 2) / 3;
+      const itemHeight = 150.0;
       final aspectRatio = itemWidth / itemHeight;
 
       return GridView.count(
-        crossAxisCount: crossAxisCount,
+        crossAxisCount: 3,
         crossAxisSpacing: spacing,
         mainAxisSpacing: spacing,
         childAspectRatio: aspectRatio,

--- a/lib/settings/tabs/system_settings_tab.dart
+++ b/lib/settings/tabs/system_settings_tab.dart
@@ -846,12 +846,15 @@ class _MemorialCardsGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       final spacing = 12.0;
-      final itemWidth = (constraints.maxWidth - spacing * 2) / 3;
-      const itemHeight = 150.0;
+      final crossAxisCount = constraints.maxWidth < 560 ? 2 : 3;
+      final itemWidth =
+          (constraints.maxWidth - spacing * (crossAxisCount - 1)) /
+              crossAxisCount;
+      final itemHeight = crossAxisCount == 2 ? 158.0 : 150.0;
       final aspectRatio = itemWidth / itemHeight;
 
       return GridView.count(
-        crossAxisCount: 3,
+        crossAxisCount: crossAxisCount,
         crossAxisSpacing: spacing,
         mainAxisSpacing: spacing,
         childAspectRatio: aspectRatio,

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -49,6 +49,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     on<ToggleNikud>(_onToggleNikud);
     on<UpdateVisibleIndecies>(_onUpdateVisibleIndecies);
     on<UpdateSelectedIndex>(_onUpdateSelectedIndex);
+    on<SelectAndScrollToIndex>(_onSelectAndScrollToIndex);
     on<HighlightLine>(_onHighlightLine);
     on<ClearHighlightedLine>(_onClearHighlightedLine);
     on<TogglePinLeftPane>(_onTogglePinLeftPane);
@@ -249,6 +250,9 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         selectedTextEnd: state is TextBookLoaded
             ? (state as TextBookLoaded).selectedTextEnd
             : null,
+        pageShapeAnchorIndex:
+            visibleIndices.isNotEmpty ? visibleIndices.first : null,
+        pageShapePreferSelectedNextSync: false,
       ));
 
       // ── שלב 5: טעינות ברקע - לא חוסמות את ה-UI ──
@@ -447,11 +451,21 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         selectedIndex: index,
       );
 
+      final shouldUseSelected =
+          currentState.pageShapePreferSelectedNextSync && index != null;
+      final pageShapeAnchorIndex = shouldUseSelected
+          ? index
+          : (event.visibleIndecies.isNotEmpty
+              ? event.visibleIndecies.first
+              : index);
+
       emit(currentState.copyWith(
         visibleIndices: event.visibleIndecies,
         currentTitle: newTitle,
         selectedIndex: index,
         visibleLinks: visibleLinks,
+        pageShapeAnchorIndex: pageShapeAnchorIndex,
+        pageShapePreferSelectedNextSync: false,
       ));
     }
   }
@@ -469,18 +483,60 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     UpdateSelectedIndex event,
     Emitter<TextBookState> emit,
   ) {
-    if (state is TextBookLoaded) {
-      final currentState = state as TextBookLoaded;
-      final visibleLinks = _getVisibleLinks(
-        links: currentState.links,
-        visibleIndices: currentState.visibleIndices,
-        selectedIndex: event.index,
+    if (state is! TextBookLoaded) return;
+    final currentState = state as TextBookLoaded;
+    _emitSelectedIndex(
+      currentState,
+      emit,
+      event.index,
+      preferForPageShape: true,
+    );
+  }
+
+  void _onSelectAndScrollToIndex(
+    SelectAndScrollToIndex event,
+    Emitter<TextBookState> emit,
+  ) {
+    if (state is! TextBookLoaded) return;
+    final currentState = state as TextBookLoaded;
+    if (currentState.content.isEmpty) return;
+
+    final boundedIndex = event.index.clamp(0, currentState.content.length - 1);
+
+    _emitSelectedIndex(
+      currentState,
+      emit,
+      boundedIndex,
+      preferForPageShape: true,
+    );
+
+    if (scrollController.isAttached) {
+      scrollController.scrollTo(
+        index: boundedIndex,
+        duration: Duration(milliseconds: event.durationMs),
+        alignment: event.alignment,
       );
-      emit(currentState.copyWith(
-        selectedIndex: event.index,
-        visibleLinks: visibleLinks,
-      ));
     }
+  }
+
+  void _emitSelectedIndex(
+    TextBookLoaded currentState,
+    Emitter<TextBookState> emit,
+    int? index, {
+    required bool preferForPageShape,
+  }) {
+    final visibleLinks = _getVisibleLinks(
+      links: currentState.links,
+      visibleIndices: currentState.visibleIndices,
+      selectedIndex: index,
+    );
+
+    emit(currentState.copyWith(
+      selectedIndex: index,
+      visibleLinks: visibleLinks,
+      pageShapeAnchorIndex: index ?? currentState.pageShapeAnchorIndex,
+      pageShapePreferSelectedNextSync: preferForPageShape && index != null,
+    ));
   }
 
   void _onHighlightLine(

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -514,7 +514,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       scrollController.scrollTo(
         index: boundedIndex,
         duration: Duration(milliseconds: event.durationMs),
-        alignment: event.alignment,
+        alignment: event.alignment ?? 0.0,
       );
     }
   }

--- a/lib/text_book/bloc/text_book_event.dart
+++ b/lib/text_book/bloc/text_book_event.dart
@@ -117,6 +117,21 @@ class UpdateSelectedIndex extends TextBookEvent {
   List<Object?> get props => [index];
 }
 
+class SelectAndScrollToIndex extends TextBookEvent {
+  final int index;
+  final int durationMs;
+  final double? alignment;
+
+  const SelectAndScrollToIndex(
+    this.index, {
+    this.durationMs = 300,
+    this.alignment,
+  });
+
+  @override
+  List<Object?> get props => [index, durationMs, alignment];
+}
+
 class HighlightLine extends TextBookEvent {
   final int lineIndex;
 

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -101,6 +101,8 @@ class TextBookLoaded extends TextBookState {
   final int? selectedTextStart;
   final int? selectedTextEnd;
   final int? highlightedLine;
+  final int? pageShapeAnchorIndex;
+  final bool pageShapePreferSelectedNextSync;
 
   // Editor state
   final bool isEditorOpen;
@@ -144,6 +146,8 @@ class TextBookLoaded extends TextBookState {
     this.selectedTextStart,
     this.selectedTextEnd,
     this.highlightedLine,
+    this.pageShapeAnchorIndex,
+    this.pageShapePreferSelectedNextSync = false,
     this.isEditorOpen = false,
     this.editorIndex,
     this.editorSectionId,
@@ -183,6 +187,8 @@ class TextBookLoaded extends TextBookState {
       selectedTextStart: null,
       selectedTextEnd: null,
       highlightedLine: null,
+      pageShapeAnchorIndex: index,
+      pageShapePreferSelectedNextSync: false,
       isEditorOpen: false,
       editorIndex: null,
       editorSectionId: null,
@@ -222,6 +228,8 @@ class TextBookLoaded extends TextBookState {
     int? selectedTextStart,
     int? selectedTextEnd,
     int? highlightedLine,
+    int? pageShapeAnchorIndex,
+    bool? pageShapePreferSelectedNextSync,
     bool clearHighlight = false,
     bool? isEditorOpen,
     int? editorIndex,
@@ -262,6 +270,9 @@ class TextBookLoaded extends TextBookState {
       selectedTextEnd: selectedTextEnd ?? this.selectedTextEnd,
       highlightedLine:
           clearHighlight ? null : (highlightedLine ?? this.highlightedLine),
+      pageShapeAnchorIndex: pageShapeAnchorIndex ?? this.pageShapeAnchorIndex,
+      pageShapePreferSelectedNextSync: pageShapePreferSelectedNextSync ??
+          this.pageShapePreferSelectedNextSync,
       isEditorOpen: isEditorOpen ?? this.isEditorOpen,
       editorIndex: editorIndex ?? this.editorIndex,
       editorSectionId: editorSectionId ?? this.editorSectionId,
@@ -296,6 +307,8 @@ class TextBookLoaded extends TextBookState {
         selectedTextStart,
         selectedTextEnd,
         highlightedLine,
+        pageShapeAnchorIndex,
+        pageShapePreferSelectedNextSync,
         isEditorOpen,
         editorIndex,
         editorSectionId,

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -589,8 +589,6 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       ItemPositionsListener.create();
   List<Link> _relevantLinks = [];
   int? _lastSyncedIndex; // האינדקס האחרון שסונכרן
-  int? _lastObservedSelectedIndex; // הבחירה האחרונה שנצפתה
-  bool _preferSelectedIndexNextSync = false; // סנכרון חד-פעמי אחרי בחירה ידנית
   StreamSubscription<TextBookState>? _blocSubscription;
   Set<int> _highlightedIndices = {}; // אינדקסים להדגשה
   bool _highlightEnabled = false;
@@ -654,7 +652,6 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
     // סנכרון ראשוני עם ה-state הנוכחי
     final currentState = context.read<TextBookBloc>().state;
     if (currentState is TextBookLoaded && mounted) {
-      _lastObservedSelectedIndex = currentState.selectedIndex;
       // נדחה מעט כדי לוודא שה-ScrollController מוכן
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
@@ -667,10 +664,6 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       if (state is TextBookLoaded && mounted) {
         // עדכון קישורים רלוונטיים כשנטענים קישורים חדשים ב-Bloc
         _refreshRelevantLinks(state);
-        if (state.selectedIndex != _lastObservedSelectedIndex) {
-          _preferSelectedIndexNextSync = state.selectedIndex != null;
-          _lastObservedSelectedIndex = state.selectedIndex;
-        }
         _syncWithMainText(state);
         _updateHighlights(state);
       }
@@ -857,7 +850,6 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
         _content = lines;
         _isLoading = false;
         _lastSyncedIndex = null; // איפוס לסנכרון ראשוני
-        _preferSelectedIndexNextSync = false;
       });
 
       // סנכרון ראשוני - נדחה מעט כדי לוודא שה-ScrollController מוכן
@@ -908,22 +900,12 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       return;
     }
 
-    // קביעת האינדקס הנוכחי בטקסט הראשי:
-    // בחירה ידנית חדשה (selectedIndex) מקבלת קדימות חד-פעמית,
-    // וביתר הזמן נצמדים ל-visibleIndices כדי לשמור על גלילה חלקה.
-    final useSelectedIndex =
-        _preferSelectedIndexNextSync && state.selectedIndex != null;
+    final currentMainIndex = state.pageShapeAnchorIndex ??
+        (state.visibleIndices.isNotEmpty
+            ? state.visibleIndices.first
+            : state.selectedIndex);
 
-    int currentMainIndex;
-    if (useSelectedIndex) {
-      currentMainIndex = state.selectedIndex!;
-      _preferSelectedIndexNextSync = false;
-    } else if (state.visibleIndices.isNotEmpty) {
-      currentMainIndex = state.visibleIndices.first;
-    } else if (state.selectedIndex != null) {
-      // fallback למקרה שאין visibleIndices
-      currentMainIndex = state.selectedIndex!;
-    } else {
+    if (currentMainIndex == null) {
       return; // אין מידע על מיקום נוכחי
     }
 

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -589,6 +589,8 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       ItemPositionsListener.create();
   List<Link> _relevantLinks = [];
   int? _lastSyncedIndex; // האינדקס האחרון שסונכרן
+  int? _lastObservedSelectedIndex; // הבחירה האחרונה שנצפתה
+  bool _preferSelectedIndexNextSync = false; // סנכרון חד-פעמי אחרי בחירה ידנית
   StreamSubscription<TextBookState>? _blocSubscription;
   Set<int> _highlightedIndices = {}; // אינדקסים להדגשה
   bool _highlightEnabled = false;
@@ -652,6 +654,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
     // סנכרון ראשוני עם ה-state הנוכחי
     final currentState = context.read<TextBookBloc>().state;
     if (currentState is TextBookLoaded && mounted) {
+      _lastObservedSelectedIndex = currentState.selectedIndex;
       // נדחה מעט כדי לוודא שה-ScrollController מוכן
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
@@ -662,10 +665,29 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
 
     _blocSubscription = context.read<TextBookBloc>().stream.listen((state) {
       if (state is TextBookLoaded && mounted) {
+        // עדכון קישורים רלוונטיים כשנטענים קישורים חדשים ב-Bloc
+        _refreshRelevantLinks(state);
+        if (state.selectedIndex != _lastObservedSelectedIndex) {
+          _preferSelectedIndexNextSync = state.selectedIndex != null;
+          _lastObservedSelectedIndex = state.selectedIndex;
+        }
         _syncWithMainText(state);
         _updateHighlights(state);
       }
     });
+  }
+
+  /// עדכון קישורים רלוונטיים מה-state (נקרא בכל שינוי state)
+  void _refreshRelevantLinks(TextBookLoaded state) {
+    if (state.links.length == _relevantLinks.length &&
+        _relevantLinks.isNotEmpty) {
+      return; // הקישורים לא השתנו
+    }
+    _relevantLinks = state.links.where((link) {
+      final linkTitle = utils.getTitleFromPath(link.path2);
+      return linkTitle == widget.commentatorName &&
+          LinkTypes.isCommentaryOrTargum(link.connectionType);
+    }).toList();
   }
 
   void _updateHighlights(TextBookLoaded state) {
@@ -724,12 +746,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       if (!mounted) return;
 
       if (state is TextBookLoaded) {
-        // סינון קישורים לפי שם המפרש ולפי סוג הקישור (COMMENTARY/TARGUM)
-        _relevantLinks = state.links.where((link) {
-          final linkTitle = utils.getTitleFromPath(link.path2);
-          return linkTitle == widget.commentatorName &&
-              LinkTypes.isCommentaryOrTargum(link.connectionType);
-        }).toList();
+        _refreshRelevantLinks(state);
       }
 
       // מציאת הספר המלא של המפרש עם categoryId
@@ -840,6 +857,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
         _content = lines;
         _isLoading = false;
         _lastSyncedIndex = null; // איפוס לסנכרון ראשוני
+        _preferSelectedIndexNextSync = false;
       });
 
       // סנכרון ראשוני - נדחה מעט כדי לוודא שה-ScrollController מוכן
@@ -890,12 +908,20 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       return;
     }
 
-    // קביעת האינדקס הנוכחי בטקסט הראשי
-    // נעדיף את visibleIndices כי זה המיקום האמיתי בגלילה
+    // קביעת האינדקס הנוכחי בטקסט הראשי:
+    // בחירה ידנית חדשה (selectedIndex) מקבלת קדימות חד-פעמית,
+    // וביתר הזמן נצמדים ל-visibleIndices כדי לשמור על גלילה חלקה.
+    final useSelectedIndex =
+        _preferSelectedIndexNextSync && state.selectedIndex != null;
+
     int currentMainIndex;
-    if (state.visibleIndices.isNotEmpty) {
+    if (useSelectedIndex) {
+      currentMainIndex = state.selectedIndex!;
+      _preferSelectedIndexNextSync = false;
+    } else if (state.visibleIndices.isNotEmpty) {
       currentMainIndex = state.visibleIndices.first;
     } else if (state.selectedIndex != null) {
+      // fallback למקרה שאין visibleIndices
       currentMainIndex = state.selectedIndex!;
     } else {
       return; // אין מידע על מיקום נוכחי
@@ -963,15 +989,6 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
     return TextBookStateBuilder(
       loadingWidget: const SizedBox(),
       builder: (context, state) {
-        // ניסיון סנכרון נוסף כשה-widget נבנה (במקרה שהסנכרון הראשוני נכשל)
-        if (_lastSyncedIndex == null && _scrollController.isAttached) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted) {
-              _syncWithMainText(state);
-            }
-          });
-        }
-
         return BlocBuilder<SettingsBloc, SettingsState>(
           builder: (context, settingsState) {
             // מפרשים תחתונים משתמשים בגופן מההגדרות, עליונים בגופן הרגיל

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -107,14 +107,26 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
   void _scrollToCurrentPosition() {
     final bloc = context.read<TextBookBloc>();
     final state = bloc.state;
-    if (state is TextBookLoaded && _scrollController.isAttached) {
-      final targetIndex = state.selectedIndex ??
-          (state.visibleIndices.isNotEmpty ? state.visibleIndices.first : null);
+    if (state is! TextBookLoaded) return;
 
-      if (targetIndex != null && targetIndex < widget.content.length) {
-        _scrollController.jumpTo(index: targetIndex);
-      }
-    }
+    final targetIndex = state.selectedIndex ??
+        (state.visibleIndices.isNotEmpty ? state.visibleIndices.first : null);
+    if (targetIndex == null || targetIndex >= widget.content.length) return;
+
+    bloc.add(SelectAndScrollToIndex(
+      targetIndex,
+      durationMs: 1,
+    ));
+  }
+
+  void _selectAndScrollTo(int index, {int durationMs = 300, double? alignment}) {
+    context.read<TextBookBloc>().add(
+          SelectAndScrollToIndex(
+            index,
+            durationMs: durationMs,
+            alignment: alignment,
+          ),
+        );
   }
 
   /// טיפול באירועי מקלדת - חיצים לניווט
@@ -130,14 +142,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       final currentIndex = state.selectedIndex ?? 0;
       final nextIndex = (currentIndex + 1).clamp(0, widget.content.length - 1);
       if (nextIndex != currentIndex) {
-        context.read<TextBookBloc>().add(UpdateSelectedIndex(nextIndex));
-        if (_scrollController.isAttached) {
-          _scrollController.scrollTo(
-            index: nextIndex,
-            duration: const Duration(milliseconds: 200),
-            alignment: 0.5,
-          );
-        }
+        _selectAndScrollTo(nextIndex, durationMs: 200, alignment: 0.5);
       }
       return true;
     }
@@ -146,14 +151,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       final currentIndex = state.selectedIndex ?? 0;
       final prevIndex = (currentIndex - 1).clamp(0, widget.content.length - 1);
       if (prevIndex != currentIndex) {
-        context.read<TextBookBloc>().add(UpdateSelectedIndex(prevIndex));
-        if (_scrollController.isAttached) {
-          _scrollController.scrollTo(
-            index: prevIndex,
-            duration: const Duration(milliseconds: 200),
-            alignment: 0.5,
-          );
-        }
+        _selectAndScrollTo(prevIndex, durationMs: 200, alignment: 0.5);
       }
       return true;
     }
@@ -162,14 +160,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     if (event.logicalKey == LogicalKeyboardKey.pageDown) {
       final currentIndex = state.selectedIndex ?? 0;
       final nextIndex = (currentIndex + 10).clamp(0, widget.content.length - 1);
-      context.read<TextBookBloc>().add(UpdateSelectedIndex(nextIndex));
-      if (_scrollController.isAttached) {
-        _scrollController.scrollTo(
-          index: nextIndex,
-          duration: const Duration(milliseconds: 300),
-          alignment: 0.5,
-        );
-      }
+      _selectAndScrollTo(nextIndex, alignment: 0.5);
       return true;
     }
 
@@ -177,27 +168,14 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     if (event.logicalKey == LogicalKeyboardKey.pageUp) {
       final currentIndex = state.selectedIndex ?? 0;
       final prevIndex = (currentIndex - 10).clamp(0, widget.content.length - 1);
-      context.read<TextBookBloc>().add(UpdateSelectedIndex(prevIndex));
-      if (_scrollController.isAttached) {
-        _scrollController.scrollTo(
-          index: prevIndex,
-          duration: const Duration(milliseconds: 300),
-          alignment: 0.5,
-        );
-      }
+      _selectAndScrollTo(prevIndex, alignment: 0.5);
       return true;
     }
 
     // Home - תחילת הספר
     if (event.logicalKey == LogicalKeyboardKey.home &&
         HardwareKeyboard.instance.isControlPressed) {
-      context.read<TextBookBloc>().add(const UpdateSelectedIndex(0));
-      if (_scrollController.isAttached) {
-        _scrollController.scrollTo(
-          index: 0,
-          duration: const Duration(milliseconds: 300),
-        );
-      }
+      _selectAndScrollTo(0);
       return true;
     }
 
@@ -205,13 +183,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     if (event.logicalKey == LogicalKeyboardKey.end &&
         HardwareKeyboard.instance.isControlPressed) {
       final lastIndex = widget.content.length - 1;
-      context.read<TextBookBloc>().add(UpdateSelectedIndex(lastIndex));
-      if (_scrollController.isAttached) {
-        _scrollController.scrollTo(
-          index: lastIndex,
-          duration: const Duration(milliseconds: 300),
-        );
-      }
+      _selectAndScrollTo(lastIndex);
       return true;
     }
 

--- a/lib/utils/fullscreen_helper.dart
+++ b/lib/utils/fullscreen_helper.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
@@ -11,21 +14,31 @@ class FullscreenHelper {
     BuildContext context,
     bool isFullscreen,
   ) async {
-    // עדכון ה-state ב-Bloc
     final settingsBloc = context.read<SettingsBloc>();
     if (settingsBloc.state.isFullscreen != isFullscreen) {
       settingsBloc.add(UpdateIsFullscreen(isFullscreen));
     }
 
-    // פעולות על מנהל החלונות
-    // חשוב: להסתיר את ה-title bar לפני המעבר למסך מלא כדי למנוע הבהוב
-    if (isFullscreen) {
-      await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
-      await windowManager.setFullScreen(true);
-    } else {
-      await windowManager.setFullScreen(false);
-      // אנחנו משתמשים ב-CustomTitleBar ולכן תמיד רוצים להסתיר את הכותרת המקורית
-      await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
+    if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+      if (isFullscreen) {
+        await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+      } else {
+        await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      }
+      return;
+    }
+
+    if (!kIsWeb &&
+        (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+      // חשוב: להסתיר את ה-title bar לפני המעבר למסך מלא כדי למנוע הבהוב
+      if (isFullscreen) {
+        await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
+        await windowManager.setFullScreen(true);
+      } else {
+        await windowManager.setFullScreen(false);
+        // אנחנו משתמשים ב-CustomTitleBar ולכן תמיד רוצים להסתיר את הכותרת המקורית
+        await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
+      }
     }
   }
 }

--- a/test/unit/settings/settings_bloc_test.dart
+++ b/test/unit/settings/settings_bloc_test.dart
@@ -57,7 +57,7 @@ void main() {
         'copyHeaderFormat': 'same_line_after_brackets',
         'isFullscreen': false,
         'libraryViewMode': 'grid',
-        'libraryShowPreview': true,
+        'libraryShowPreview': false,
         'enablePerBookSettings': true,
         'shortcuts': <String, String>{},
         'isOfflineMode': false,


### PR DESCRIPTION
## מה בוצע
- בוצע ריפקטור לפונקציות הגלילה בצורת הדף כדי לצמצם כפילויות ולרכז את ניהול הגלילה ב-`TextBookBloc`.
- נוספו לשכבת ה-BLoC אירוע וזרימה אחידה לגלילה ובחירת שורה בטקסט הראשי.
- סנכרון המפרשים נשען כעת על אינדקס עוגן שמנוהל ב-state של ה-BLoC, במקום ניהול מקומי בכל pane.

## שינויים עיקריים
1. **BLoC**
   - נוסף event חדש: `SelectAndScrollToIndex` (`lib/text_book/bloc/text_book_event.dart`).
   - נוספה לוגיקת טיפול אחידה בגלילה לבחירה:
     - `_onSelectAndScrollToIndex`
     - `_emitSelectedIndex`
   - עדכון `UpdateVisibleIndecies` כך שיחשב ויעדכן `pageShapeAnchorIndex` באופן עקבי.

2. **State**
   - נוספו לשכבת `TextBookLoaded` שדות ייעודיים לסנכרון גלילת page_shape:
     - `pageShapeAnchorIndex`
     - `pageShapePreferSelectedNextSync`

3. **Page Shape UI**
   - ב-`page_shape_screen.dart` הוסר ניהול מקומי כפול של העדפת `selectedIndex` לסנכרון.
   - `_syncWithMainText` משתמש ב-`state.pageShapeAnchorIndex` שמגיע מה-BLoC.

4. **SimpleTextViewer**
   - ריכוז קריאות גלילה דרך helper יחיד (`_selectAndScrollTo`) במקום כפילויות של `scrollTo` בכל מקש.
   - אירועי מקלדת (חיצים/PageUp/PageDown/Home/End) שולחים כעת `SelectAndScrollToIndex` ל-BLoC.

## למה זה פותר את הבעיה
- מקור האי-עקביות בגלילה היה פיצול לוגיקה בין ה-UI לבין state מקומי בחלוניות המפרשים.
- כעת מקור האמת לאינדקס הסנכרון הוא ה-BLoC, ולכן גלילת הספר הראשי והמפרשים נשארת עקבית.

## בדיקות
- לא ניתן להריץ `flutter analyze` בסביבה זו כי `flutter` לא מותקן (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a2b0da28833381b785a8f197333d)