### PR TITLE
שינויים בהתקנת full: החלפת VC++ Runtime והוספת WebView2

### DIFF
--- a/.github/workflows/build-and-announce.yml
+++ b/.github/workflows/build-and-announce.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       is_version: ${{ steps.check.outputs.is_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - name: Check if commit message is a version tag
         id: check
         run: |
@@ -41,7 +41,7 @@ jobs:
     #   CARGO_HOME:  ${{ github.workspace }}\.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -70,7 +70,7 @@ jobs:
       #   uses: dtolnay/rust-toolchain@stable
 
       # - name: Cache cargo registry and git
-      #   uses: actions/cache@v4
+      #   uses: actions/cache@v4.2.3
       #   with:
       #     path: |
       #       ${{ env.CARGO_HOME }}\registry
@@ -333,19 +333,19 @@ jobs:
           }
 
       - name: Upload Windows installer (regular)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-windows-installer
           path: installer/otzaria-*-windows.exe
 
       - name: Upload Windows installer (full)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-windows-installer-full
           path: installer/otzaria-*-windows-full.exe
 
       - name: Upload Windows ZIP
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-windows-zip
           path: otzaria-windows.zip
@@ -358,7 +358,7 @@ jobs:
       CARGO_HOME:  ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -412,7 +412,7 @@ jobs:
           rustup show
 
       - name: Cache cargo registry and git
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -569,20 +569,20 @@ jobs:
       
       - name: Upload Linux DEB package
         if: steps.find_packages.outputs.deb_file != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-linux-deb
           path: ${{ steps.find_packages.outputs.deb_file }}
           
       - name: Upload Linux RPM package
         if: steps.find_packages.outputs.rpm_file != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-linux-rpm
           path: ${{ steps.find_packages.outputs.rpm_file }}
        
       - name: Upload linux build (raw)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-linux-raw
           path: linux-build/*
@@ -620,7 +620,7 @@ jobs:
 
       - name: Upload Linux FULL bundle
         if: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-linux-full
           path: otzaria-linux-full.tar.gz
@@ -633,7 +633,7 @@ jobs:
       CARGO_HOME: ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -682,7 +682,7 @@ jobs:
           rustup show
 
       - name: Cache Rust
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -733,7 +733,7 @@ jobs:
           echo "All Android Rust targets installed successfully"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.gradle/caches
@@ -743,7 +743,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Pub
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.pub-cache
@@ -844,7 +844,7 @@ jobs:
           df -h
       
       - name: Upload apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-android.apk
           path: build/app/outputs/flutter-apk/app-release.apk
@@ -871,7 +871,7 @@ jobs:
 
       - name: Upload Android FULL bundle
         if: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-android-full
           path: otzaria-android-full.zip
@@ -893,7 +893,7 @@ jobs:
       CARGO_HOME:  ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -950,7 +950,7 @@ jobs:
 
       # (רשות אבל מומלץ) קאשינג לספריות cargo כדי לזרז בניות
       - name: Cache cargo registry and git
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1074,14 +1074,14 @@ jobs:
 
       - name: Upload macOS DMG
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-macos.dmg
           path: otzaria-macos.dmg
 
       - name: Upload macOS FULL bundle
         if: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: otzaria-macos-full
           path: otzaria-macos-full.zip
@@ -1093,10 +1093,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           path: artifacts
       
@@ -1409,7 +1409,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history + tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0   # חובה כדי לאפשר גישה לכל ההיסטוריה והתגים
           fetch-tags: true

--- a/.github/workflows/build-and-announce.yml
+++ b/.github/workflows/build-and-announce.yml
@@ -275,21 +275,19 @@ jobs:
             exit 1
           }
 
-      - name: Download Visual C++ Redistributable for full installer
+      - name: Download dependencies for full installer
         if: true
         shell: pwsh
         run: |
-          Write-Host "Downloading Visual C++ Redistributable for full installer..."
-          $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/abbodi1406/vcredist/releases/latest"
-          $asset = $latestRelease.assets | Where-Object { $_.name -eq "VisualCppRedist_AIO_x86_x64.exe" }
-          if (-not $asset) {
-            Write-Host "::error::Could not find VisualCppRedist_AIO_x86_x64.exe in latest release"
-            exit 1
-          }
-          Write-Host "Downloading from: $($asset.browser_download_url)"
-          Write-Host "Size: $([math]::Round($asset.size / 1MB, 2)) MB"
-          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile "installer\VisualCppRedist_AIO_x86_x64.exe"
-          Write-Host "Visual C++ Redistributable downloaded successfully"
+          Write-Host "Downloading Visual C++ Redistributable (official Microsoft)..."
+          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "installer\vc_redist.x64.exe"
+          $size = [math]::Round((Get-Item "installer\vc_redist.x64.exe").Length / 1MB, 2)
+          Write-Host "vc_redist.x64.exe downloaded successfully ($size MB)"
+
+          Write-Host "Downloading WebView2 Bootstrapper (Microsoft)..."
+          Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "installer\MicrosoftEdgeWebview2Setup.exe"
+          $size = [math]::Round((Get-Item "installer\MicrosoftEdgeWebview2Setup.exe").Length / 1MB, 2)
+          Write-Host "MicrosoftEdgeWebview2Setup.exe downloaded successfully ($size MB)"
 
       - name: Build Inno Setup installer
         shell: pwsh

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,5 +1,6 @@
 # Ignore Visual C++ Redistributable file (large file, should be downloaded separately)
-VisualCppRedist_AIO_x86_x64.exe
+VC_redist.x64.exe
+MicrosoftEdgeWebview2Setup.exe
 zstd.exe
 zstd-win64.zip
 7za.exe

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -153,16 +153,10 @@ function VCRedistNeedsInstall: Boolean;
 var
   Version: String;
 begin
-  // Check if Visual C++ 2015-2022 Redistributable is installed
-  // This checks for x64 version
-  Result := not RegQueryStringValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 
+  // בדיקת Visual C++ 2015-2022 Redistributable x64 (גרסה 14.x)
+  Result := not RegQueryStringValue(HKLM64,
+    'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
     'Version', Version);
-  if not Result then
-  begin
-    // Also check x86 version
-    Result := not RegQueryStringValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86', 
-      'Version', Version);
-  end;
 end;
 
 procedure ExtractBundledDatabase(const ArchiveName, DatabaseName: String);
@@ -301,7 +295,7 @@ begin
 end;
 
 [Run]
-Filename: "{tmp}\VisualCppRedist_AIO_x86_x64.exe"; Parameters: "/ai /gm2"; StatusMsg: "מתקין Visual C++ Redistributable..."; Flags: waituntilterminated; Check: VCRedistNeedsInstall
+Filename: "{tmp}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "מתקין Visual C++ Redistributable 2022..."; Flags: waituntilterminated; Check: VCRedistNeedsInstall
 Filename: "{app}\{#MyAppExeName}"; Description: "הפעל את {#MyAppName}"; Flags: nowait postinstall skipifsilent 
 
 [Icons]
@@ -327,7 +321,9 @@ Source: "library_db\talmud_bavli_latest.tar.zst"; DestDir: "{app}\_staging"; Fla
 Source: "zstd.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "7za.exe"; DestDir: "{app}"; Flags: ignoreversion
 
-Source: "VisualCppRedist_AIO_x86_x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
+; vc_redist.x64.exe — הגרסה הרשמית של Microsoft, כ-25MB במקום AIO (~50MB)
+; כוללת את 2015/2017/2019/2022 תחת אותו מספר גרסה (14.x)
+Source: "vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeedsInstall
 
 [INI]
 Filename: "{app}\system_install.marker"; Section: "Install"; Key: "Mode"; String: "Admin"; Check: IsAdminInstallMode

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -136,17 +136,7 @@ begin
     end;
   end;
   
-  // בדיקה אם התיקיות קיימות והצגת אזהרה
-  if DirExists(DataPath + '\books') then
-  begin
-    if MsgBox('שים לב: קיימים נתונים מספרייה ישנה בתיקייה ' + DataPath + '\books' + #13#10 +
-              'הקודמים יימחקו ויוחלפו בנתוני ההתקנה החדשה.' + #13#10#13#10 +
-              'האם להמשיך בהתקנה?',
-              mbConfirmation, MB_YESNO) = IDNO then
-    begin
-      Result := False;
-    end;
-  end;
+  // האזהרה על מחיקת ספרים קיימים מוצגת בדף בחירת תיקיית הספרים
 end;
 
 // ─── בדיקות רכיבי מערכת ───────────────────────────────────────────────────
@@ -192,13 +182,18 @@ begin
   Result := GetWebView2Version = '';
 end;
 
-// ─── משתנים גלובליים לבחירת רכיבים ────────────────────────────────────────
+// ─── משתנים גלובליים ────────────────────────────────────────────────────────
 
 var
   CompPage: TWizardPage;
   VCCheck, WV2Check: TCheckBox;
   VCLabel, WV2Label: TLabel;
   InstallVC, InstallWV2: Boolean;
+
+  BooksPage: TWizardPage;
+  BooksPathEdit: TEdit;
+  BooksPathBrowseBtn: TButton;
+  SelectedBooksPath: String;
 
 // ─── בניית עמוד בחירת רכיבים ───────────────────────────────────────────────
 
@@ -306,6 +301,177 @@ begin
   WV2Label.Height   := 30;
 end;
 
+// ─── דף בחירת תיקיית הספרים ─────────────────────────────────────────────────
+
+procedure BrowseBooksFolder(Sender: TObject);
+var
+  Dir: String;
+begin
+  Dir := BooksPathEdit.Text;
+  if BrowseForFolder('בחר תיקיית ספרים:', Dir, False) then
+    BooksPathEdit.Text := Dir;
+end;
+
+procedure CreateBooksPage;
+var
+  DefaultPath: String;
+  DescLabel, WarnLabel, PathLabel: TLabel;
+begin
+  BooksPage := CreateCustomPage(CompPage.ID,
+    'תיקיית הספרים',
+    'בחר היכן יישמרו ספרי הספרייה');
+
+  DefaultPath := GetDataDir('') + '\books';
+  SelectedBooksPath := DefaultPath;
+
+  DescLabel := TLabel.Create(BooksPage);
+  DescLabel.Parent   := BooksPage.Surface;
+  DescLabel.Left     := 0;
+  DescLabel.Top      := 0;
+  DescLabel.Width    := BooksPage.SurfaceWidth;
+  DescLabel.AutoSize := False;
+  DescLabel.WordWrap := True;
+  DescLabel.Caption  :=
+    'כאן יישמרו קבצי הספרים שמגיעים עם ההתקנה וכל ספר שתוסיף בעתיד.' + #13#10 +
+    'הנתיב שתבחר יוגדר אוטומטית בהגדרות התוכנה.';
+  DescLabel.Height := 35;
+
+  PathLabel := TLabel.Create(BooksPage);
+  PathLabel.Parent  := BooksPage.Surface;
+  PathLabel.Left    := 0;
+  PathLabel.Top     := 45;
+  PathLabel.Caption := 'נתיב תיקיית הספרים:';
+  PathLabel.AutoSize := True;
+
+  BooksPathEdit := TEdit.Create(BooksPage);
+  BooksPathEdit.Parent := BooksPage.Surface;
+  BooksPathEdit.Left   := 0;
+  BooksPathEdit.Top    := 63;
+  BooksPathEdit.Width  := BooksPage.SurfaceWidth - 90;
+  BooksPathEdit.Text   := DefaultPath;
+
+  BooksPathBrowseBtn := TButton.Create(BooksPage);
+  BooksPathBrowseBtn.Parent  := BooksPage.Surface;
+  BooksPathBrowseBtn.Left    := BooksPage.SurfaceWidth - 85;
+  BooksPathBrowseBtn.Top     := 61;
+  BooksPathBrowseBtn.Width   := 85;
+  BooksPathBrowseBtn.Caption := 'עיון...';
+  BooksPathBrowseBtn.OnClick := @BrowseBooksFolder;
+
+  // אזהרה על מחיקת נתונים קיימים — הועברה לכאן מ-InitializeSetup
+  WarnLabel := TLabel.Create(BooksPage);
+  WarnLabel.Parent     := BooksPage.Surface;
+  WarnLabel.Left       := 0;
+  WarnLabel.Top        := 100;
+  WarnLabel.Width      := BooksPage.SurfaceWidth;
+  WarnLabel.AutoSize   := False;
+  WarnLabel.WordWrap   := True;
+  WarnLabel.Height     := 45;
+  WarnLabel.Font.Color := clRed;
+
+  if DirExists(DefaultPath) then
+    WarnLabel.Caption :=
+      '⚠ שים לב: תיקיית ספרים קיימת כבר בנתיב זה.' + #13#10 +
+      'התקנה זו תמחק את תוכנה ותחליף בספרים החדשים שבחבילה.'
+  else
+    WarnLabel.Caption := '';
+end;
+
+// כתיבת נתיב הספרים ל-shared_preferences.json של האפליקציה
+procedure WriteLibraryPathToPrefs(const LibraryPath: String);
+var
+  PrefsDir, PrefsFile, JsonContent, JsonPath, NewLine: String;
+  Lines: TArrayOfString;
+  i, LastBrace: Integer;
+  Found, HasOtherKeys: Boolean;
+begin
+  PrefsDir  := ExpandConstant('{userappdata}\otzaria');
+  PrefsFile := PrefsDir + '\shared_preferences.json';
+
+  ForceDirectories(PrefsDir);
+
+  // החלפת \ ב-\\ ידנית — StringReplace ו-StringChange אינן אמינות ב-Inno Setup
+  JsonPath := '';
+  for i := 1 to Length(LibraryPath) do
+  begin
+    if LibraryPath[i] = '\' then
+      JsonPath := JsonPath + '\\'
+    else
+      JsonPath := JsonPath + LibraryPath[i];
+  end;
+  NewLine := '"key-library-path":"' + JsonPath + '"';
+
+  if FileExists(PrefsFile) then
+  begin
+    LoadStringsFromFile(PrefsFile, Lines);
+    Found := False;
+
+    // עדכון שורה קיימת — ללא פסיק (JSON לא יודע מה מגיע אחרי)
+    for i := 0 to GetArrayLength(Lines) - 1 do
+    begin
+      if Pos('"key-library-path"', Lines[i]) > 0 then
+      begin
+        Lines[i] := '  ' + NewLine;
+        Found := True;
+      end;
+    end;
+
+    if Found then
+    begin
+      // בנה JSON מחדש נקי — הסר פסיקים עודפים ואחד את המבנה
+      JsonContent := '';
+      for i := 0 to GetArrayLength(Lines) - 1 do
+        JsonContent := JsonContent + Lines[i] + #13#10;
+      SaveStringToFile(PrefsFile, JsonContent, False);
+      exit;
+    end;
+
+    // מפתח לא קיים — מוסיף. בדיקה אם הקובץ ריק ({})
+    HasOtherKeys := False;
+    for i := 0 to GetArrayLength(Lines) - 1 do
+    begin
+      if (Pos('"', Lines[i]) > 0) and (Pos('{', Lines[i]) = 0) and (Pos('}', Lines[i]) = 0) then
+      begin
+        HasOtherKeys := True;
+        break;
+      end;
+    end;
+
+    JsonContent := '';
+    for i := 0 to GetArrayLength(Lines) - 1 do
+      JsonContent := JsonContent + Lines[i] + #13#10;
+
+    // מחפש } אחרון
+    LastBrace := 0;
+    for i := Length(JsonContent) downto 1 do
+    begin
+      if JsonContent[i] = '}' then
+      begin
+        LastBrace := i;
+        break;
+      end;
+    end;
+
+    if LastBrace > 0 then
+    begin
+      if HasOtherKeys then
+        // יש מפתחות אחרים — מוסיף פסיק אחרי האחרון שלהם ואחר כך את השורה החדשה
+        JsonContent := Copy(JsonContent, 1, LastBrace - 1) +
+                       ',' + #13#10 + '  ' + NewLine + #13#10 + '}'
+      else
+        // קובץ ריק {} — מוסיף בלי פסיק
+        JsonContent := '{' + #13#10 + '  ' + NewLine + #13#10 + '}';
+      SaveStringToFile(PrefsFile, JsonContent, False);
+    end;
+  end
+  else
+  begin
+    // קובץ לא קיים — יוצר חדש תקין
+    JsonContent := '{' + #13#10 + '  ' + NewLine + #13#10 + '}';
+    SaveStringToFile(PrefsFile, JsonContent, False);
+  end;
+end;
+
 function ShouldInstallVC: Boolean;
 begin
   Result := InstallVC;
@@ -318,13 +484,13 @@ end;
 
 procedure InitializeWizard;
 begin
-  // אתחול ברירות מחדל: מתקין רק אם חסר
   InstallVC  := VCRedistNeedsInstall;
   InstallWV2 := WebView2NeedsInstall;
   CreateComponentsPage;
+  CreateBooksPage;
 end;
 
-// שמירת בחירות המשתמש בלחיצה על "הבא" מדף הרכיבים
+// שמירת בחירות בלחיצת "הבא"
 function NextButtonClick(CurPageID: Integer): Boolean;
 begin
   Result := True;
@@ -332,6 +498,15 @@ begin
   begin
     InstallVC  := VCCheck.Checked;
     InstallWV2 := WV2Check.Checked;
+  end;
+  if (BooksPage <> nil) and (CurPageID = BooksPage.ID) then
+  begin
+    SelectedBooksPath := BooksPathEdit.Text;
+    if SelectedBooksPath = '' then
+    begin
+      MsgBox('יש לבחור נתיב לתיקיית הספרים.', mbError, MB_OK);
+      Result := False;
+    end;
   end;
 end;
 
@@ -347,7 +522,7 @@ begin
     exit;
   end;
 
-  DatabasePath := ExpandConstant('{code:GetDataDir}\books\' + DatabaseName);
+  DatabasePath := SelectedBooksPath + '\' + DatabaseName;
   ZstdPath := ExpandConstant('{app}\zstd.exe');
 
   ForceDirectories(ExtractFileDir(DatabasePath));
@@ -376,9 +551,9 @@ begin
     exit;
   end;
 
-  ParentDir := ExpandConstant('{code:GetDataDir}\books');
+  ParentDir := SelectedBooksPath;
   TarPath := ParentDir + '\' + ChangeFileExt(ArchiveName, '');
-  TargetDir := ExpandConstant('{code:GetDataDir}\books\' + TargetDirName);
+  TargetDir := SelectedBooksPath + '\' + TargetDirName;
   ZstdPath := ExpandConstant('{app}\zstd.exe');
   SevenZipPath := ExpandConstant('{app}\7za.exe');
 
@@ -465,9 +640,16 @@ begin
   ExtractBundledTarArchive('talmud_bavli_latest.tar.zst', 'תלמוד בבלי');
   DeleteFile(ZstdPath);
   DeleteFile(SevenZipPath);
-  
+
   // Cleanup the temporary extraction directory
   DelTree(ExpandConstant('{app}\_staging'), True, True, True);
+
+  // יצירת תיקיית הספרים בנתיב שבחר המשתמש (אם שונה מברירת המחדל)
+  if SelectedBooksPath <> '' then
+  begin
+    ForceDirectories(SelectedBooksPath);
+    WriteLibraryPathToPrefs(SelectedBooksPath);
+  end;
 end;
 
 [Run]

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -149,6 +149,21 @@ begin
   end;
 end;
 
+function WebView2NeedsInstall: Boolean;
+var
+  Version: String;
+begin
+  // בדיקת WebView2 Runtime — נדרש על ידי flutter_inappwebview_windows
+  // ב-Windows 11 וב-Windows 10 עם Edge עדכני הוא כבר קיים
+  Result := not RegQueryStringValue(HKLM64,
+    'SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+    'pv', Version);
+  if Result then
+    Result := not RegQueryStringValue(HKCU,
+      'SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+      'pv', Version);
+end;
+
 function VCRedistNeedsInstall: Boolean;
 var
   Version: String;
@@ -296,7 +311,8 @@ end;
 
 [Run]
 Filename: "{tmp}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "מתקין Visual C++ Redistributable 2022..."; Flags: waituntilterminated; Check: VCRedistNeedsInstall
-Filename: "{app}\{#MyAppExeName}"; Description: "הפעל את {#MyAppName}"; Flags: nowait postinstall skipifsilent 
+Filename: "{tmp}\MicrosoftEdgeWebview2Setup.exe"; Parameters: "/silent /install"; StatusMsg: "מתקין Microsoft WebView2 Runtime..."; Flags: waituntilterminated; Check: WebView2NeedsInstall
+Filename: "{app}\{#MyAppExeName}"; Description: "הפעל את {#MyAppName}"; Flags: nowait postinstall skipifsilent
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
@@ -324,6 +340,9 @@ Source: "7za.exe"; DestDir: "{app}"; Flags: ignoreversion
 ; vc_redist.x64.exe — הגרסה הרשמית של Microsoft, כ-25MB במקום AIO (~50MB)
 ; כוללת את 2015/2017/2019/2022 תחת אותו מספר גרסה (14.x)
 Source: "vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeedsInstall
+; MicrosoftEdgeWebview2Setup.exe — bootstrapper קטן (~2MB) שמוריד ומתקין WebView2
+; נדרש על ידי flutter_inappwebview_windows; ב-Win10/11 עם Edge עדכני — כבר קיים
+Source: "MicrosoftEdgeWebview2Setup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: WebView2NeedsInstall
 
 [INI]
 Filename: "{app}\system_install.marker"; Section: "Install"; Key: "Mode"; String: "Admin"; Check: IsAdminInstallMode

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -137,6 +137,10 @@ begin
   end;
   
   // האזהרה על מחיקת ספרים קיימים מוצגת בדף בחירת תיקיית הספרים
+
+  // אתחול ברירות מחדל — גם להתקנה שקטה (/SILENT, /VERYSILENT)
+  InstallVC  := VCRedistNeedsInstall;
+  InstallWV2 := WebView2NeedsInstall;
 end;
 
 // ─── בדיקות רכיבי מערכת ───────────────────────────────────────────────────
@@ -685,7 +689,7 @@ Source: "7za.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeedsInstall
 ; MicrosoftEdgeWebview2Setup.exe — bootstrapper קטן (~2MB) שמוריד ומתקין WebView2
 ; נדרש על ידי flutter_inappwebview_windows; ב-Win10/11 עם Edge עדכני — כבר קיים
-Source: "MicrosoftEdgeWebview2Setup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: WebView2NeedsInstall
+Source: "MicrosoftEdgeWebview2Setup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: ShouldInstallWV2
 
 [INI]
 Filename: "{app}\system_install.marker"; Section: "Install"; Key: "Mode"; String: "Admin"; Check: IsAdminInstallMode

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -195,6 +195,7 @@ begin
   // אתחול ברירות מחדל — גם להתקנה שקטה (/SILENT, /VERYSILENT)
   InstallVC  := VCRedistNeedsInstall;
   InstallWV2 := WebView2NeedsInstall;
+  SelectedBooksPath := GetDataDir('') + '\books';
 end;
 
 // ─── בניית עמוד בחירת רכיבים ───────────────────────────────────────────────
@@ -416,9 +417,12 @@ begin
     // עדכון שורה קיימת — ללא פסיק (JSON לא יודע מה מגיע אחרי)
     for i := 0 to GetArrayLength(Lines) - 1 do
     begin
-      if Pos('"key-library-path"', Lines[i]) > 0 then
+      if Pos('"key-library-path":', Lines[i]) > 0 then
       begin
-        Lines[i] := '  ' + NewLine;
+        if (Lines[i] <> '') and (Lines[i][Length(Lines[i])] = ',') then
+          Lines[i] := '  ' + NewLine + ','
+        else
+          Lines[i] := '  ' + NewLine;
         Found := True;
       end;
     end;
@@ -689,7 +693,7 @@ Source: "7za.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 ; vc_redist.x64.exe — הגרסה הרשמית של Microsoft, כ-25MB במקום AIO (~50MB)
 ; כוללת את 2015/2017/2019/2022 תחת אותו מספר גרסה (14.x)
-Source: "vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeedsInstall
+Source: "vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: ShouldInstallVC
 ; MicrosoftEdgeWebview2Setup.exe — bootstrapper קטן (~2MB) שמוריד ומתקין WebView2
 ; נדרש על ידי flutter_inappwebview_windows; ב-Win10/11 עם Edge עדכני — כבר קיים
 Source: "MicrosoftEdgeWebview2Setup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: ShouldInstallWV2

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -224,18 +224,19 @@ begin
   HeaderLabel.WordWrap := True;
   HeaderLabel.Caption :=
     'להלן רכיבי המערכת הנדרשים לפעולת אוצריא.' + #13#10 +
-    'רכיבים המסומנים באדום חסרים ונדרשים להתקנה. ' +
-    'רכיבים ירוקים קיימים ואינם דורשים פעולה.';
-  HeaderLabel.Height := 40;
+    'רכיבים באדום חסרים — נדרשת התקנה.' + #13#10 +
+    'רכיבים ירוקים קיימים — אין צורך בפעולה.';
+  HeaderLabel.Height := ScaleY(60);  // 3 שורות קצרות, בלי עודף ריפוד
 
-  TopY := 55;
+  TopY := HeaderLabel.Height + ScaleY(6);
 
   // ─── Visual C++ Runtime ───────────────────────────────────────────────────
   VCCheck := TCheckBox.Create(CompPage);
   VCCheck.Parent  := CompPage.Surface;
   VCCheck.Left    := 0;
-  VCCheck.Top     := TopY;
+  VCCheck.Top     := TopY + ScaleY(2);
   VCCheck.Width   := CompPage.SurfaceWidth;
+  VCCheck.Height  := ScaleY(20);
   VCCheck.Caption := 'Visual C++ Redistributable 2022 (x64)';
 
   if VCVersion = '' then
@@ -255,16 +256,16 @@ begin
 
   VCLabel := TLabel.Create(CompPage);
   VCLabel.Parent   := CompPage.Surface;
-  VCLabel.Left     := 20;
-  VCLabel.Top      := TopY + 22;
-  VCLabel.Width    := CompPage.SurfaceWidth - 20;
+  VCLabel.Left     := ScaleX(20);
+  VCLabel.Top      := TopY + ScaleY(18);
+  VCLabel.Width    := CompPage.SurfaceWidth - ScaleX(20);
   VCLabel.AutoSize := False;
   VCLabel.WordWrap := True;
   VCLabel.Caption  := VCStatus;
   VCLabel.Font.Color := VCColor;
-  VCLabel.Height   := 30;
+  VCLabel.Height   := ScaleY(36);
 
-  TopY := TopY + 70;
+  TopY := TopY + ScaleY(58);
 
   // ─── WebView2 Runtime ─────────────────────────────────────────────────────
   WV2Check := TCheckBox.Create(CompPage);
@@ -272,6 +273,7 @@ begin
   WV2Check.Left    := 0;
   WV2Check.Top     := TopY;
   WV2Check.Width   := CompPage.SurfaceWidth;
+  WV2Check.Height  := ScaleY(20);
   WV2Check.Caption := 'Microsoft WebView2 Runtime';
 
   // WebView2 אינו חובה — משמש רק למערכת הפלאגינים (לא לקריאה/חיפוש/סימניות)
@@ -293,14 +295,14 @@ begin
 
   WV2Label := TLabel.Create(CompPage);
   WV2Label.Parent   := CompPage.Surface;
-  WV2Label.Left     := 20;
-  WV2Label.Top      := TopY + 22;
-  WV2Label.Width    := CompPage.SurfaceWidth - 20;
+  WV2Label.Left     := ScaleX(20);
+  WV2Label.Top      := TopY + ScaleY(18);
+  WV2Label.Width    := CompPage.SurfaceWidth - ScaleX(20);
   WV2Label.AutoSize := False;
   WV2Label.WordWrap := True;
   WV2Label.Caption  := WV2Status;
   WV2Label.Font.Color := WV2Color;
-  WV2Label.Height   := 30;
+  WV2Label.Height   := ScaleY(34);
 end;
 
 // ─── דף בחירת תיקיית הספרים ─────────────────────────────────────────────────
@@ -336,39 +338,42 @@ begin
   DescLabel.Caption  :=
     'כאן יישמרו קבצי הספרים שמגיעים עם ההתקנה וכל ספר שתוסיף בעתיד.' + #13#10 +
     'הנתיב שתבחר יוגדר אוטומטית בהגדרות התוכנה.';
-  DescLabel.Height := 35;
+  DescLabel.Height := ScaleY(42);  // 2 שורות צמודות יותר
 
   PathLabel := TLabel.Create(BooksPage);
-  PathLabel.Parent  := BooksPage.Surface;
-  PathLabel.Left    := 0;
-  PathLabel.Top     := 45;
-  PathLabel.Caption := 'נתיב תיקיית הספרים:';
-  PathLabel.AutoSize := True;
+  PathLabel.Parent   := BooksPage.Surface;
+  PathLabel.Left     := 0;
+  PathLabel.Top      := DescLabel.Height + ScaleY(2);
+  PathLabel.Width    := BooksPage.SurfaceWidth;
+  PathLabel.AutoSize := False;
+  PathLabel.Caption  := 'נתיב תיקיית הספרים:';
+  PathLabel.Height   := ScaleY(20);
 
   BooksPathEdit := TEdit.Create(BooksPage);
   BooksPathEdit.Parent := BooksPage.Surface;
   BooksPathEdit.Left   := 0;
-  BooksPathEdit.Top    := 63;
-  BooksPathEdit.Width  := BooksPage.SurfaceWidth - 90;
+  BooksPathEdit.Top    := PathLabel.Top + ScaleY(26);
+  BooksPathEdit.Width  := BooksPage.SurfaceWidth - ScaleX(84);
+  BooksPathEdit.Height := ScaleY(22);
   BooksPathEdit.Text   := DefaultPath;
 
   BooksPathBrowseBtn := TButton.Create(BooksPage);
   BooksPathBrowseBtn.Parent  := BooksPage.Surface;
-  BooksPathBrowseBtn.Left    := BooksPage.SurfaceWidth - 85;
-  BooksPathBrowseBtn.Top     := 61;
-  BooksPathBrowseBtn.Width   := 85;
+  BooksPathBrowseBtn.Left    := BooksPage.SurfaceWidth - ScaleX(78);
+  BooksPathBrowseBtn.Top     := BooksPathEdit.Top - ScaleY(1);
+  BooksPathBrowseBtn.Width   := ScaleX(78);
+  BooksPathBrowseBtn.Height  := ScaleY(23);
   BooksPathBrowseBtn.Caption := 'עיון...';
   BooksPathBrowseBtn.OnClick := @BrowseBooksFolder;
 
-  // אזהרה על מחיקת נתונים קיימים — הועברה לכאן מ-InitializeSetup
   WarnLabel := TLabel.Create(BooksPage);
   WarnLabel.Parent     := BooksPage.Surface;
   WarnLabel.Left       := 0;
-  WarnLabel.Top        := 100;
+  WarnLabel.Top        := BooksPathEdit.Top + BooksPathEdit.Height + ScaleY(8);
   WarnLabel.Width      := BooksPage.SurfaceWidth;
   WarnLabel.AutoSize   := False;
   WarnLabel.WordWrap   := True;
-  WarnLabel.Height     := 45;
+  WarnLabel.Height     := ScaleY(42);
   WarnLabel.Font.Color := clRed;
 
   if DirExists(DefaultPath) then

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -149,29 +149,190 @@ begin
   end;
 end;
 
-function WebView2NeedsInstall: Boolean;
+// ─── בדיקות רכיבי מערכת ───────────────────────────────────────────────────
+
+function GetVCVersion: String;
 var
   Version: String;
 begin
-  // בדיקת WebView2 Runtime — נדרש על ידי flutter_inappwebview_windows
-  // ב-Windows 11 וב-Windows 10 עם Edge עדכני הוא כבר קיים
-  Result := not RegQueryStringValue(HKLM64,
-    'SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
-    'pv', Version);
-  if Result then
-    Result := not RegQueryStringValue(HKCU,
+  if RegQueryStringValue(HKLM64,
+      'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
+      'Version', Version) then
+    Result := Version
+  else
+    Result := '';
+end;
+
+function GetWebView2Version: String;
+var
+  Version: String;
+begin
+  if RegQueryStringValue(HKLM64,
+      'SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+      'pv', Version) then
+  begin
+    Result := Version;
+    exit;
+  end;
+  if RegQueryStringValue(HKCU,
       'SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
-      'pv', Version);
+      'pv', Version) then
+    Result := Version
+  else
+    Result := '';
 end;
 
 function VCRedistNeedsInstall: Boolean;
-var
-  Version: String;
 begin
-  // בדיקת Visual C++ 2015-2022 Redistributable x64 (גרסה 14.x)
-  Result := not RegQueryStringValue(HKLM64,
-    'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
-    'Version', Version);
+  Result := GetVCVersion = '';
+end;
+
+function WebView2NeedsInstall: Boolean;
+begin
+  Result := GetWebView2Version = '';
+end;
+
+// ─── משתנים גלובליים לבחירת רכיבים ────────────────────────────────────────
+
+var
+  CompPage: TWizardPage;
+  VCCheck, WV2Check: TCheckBox;
+  VCLabel, WV2Label: TLabel;
+  InstallVC, InstallWV2: Boolean;
+
+// ─── בניית עמוד בחירת רכיבים ───────────────────────────────────────────────
+
+procedure CreateComponentsPage;
+var
+  VCVersion, WV2Version: String;
+  VCStatus, WV2Status: String;
+  VCColor, WV2Color: TColor;
+  TopY: Integer;
+  HeaderLabel: TLabel;
+begin
+  CompPage := CreateCustomPage(wpSelectDir,
+    'בחירת רכיבי מערכת להתקנה',
+    'בדיקת הרכיבים הנדרשים לאפליקציה');
+
+  VCVersion  := GetVCVersion;
+  WV2Version := GetWebView2Version;
+
+  // כותרת הסבר
+  HeaderLabel := TLabel.Create(CompPage);
+  HeaderLabel.Parent := CompPage.Surface;
+  HeaderLabel.Left   := 0;
+  HeaderLabel.Top    := 0;
+  HeaderLabel.Width  := CompPage.SurfaceWidth;
+  HeaderLabel.AutoSize := False;
+  HeaderLabel.WordWrap := True;
+  HeaderLabel.Caption :=
+    'להלן רכיבי המערכת הנדרשים לפעולת אוצריא.' + #13#10 +
+    'רכיבים המסומנים באדום חסרים ונדרשים להתקנה. ' +
+    'רכיבים ירוקים קיימים ואינם דורשים פעולה.';
+  HeaderLabel.Height := 40;
+
+  TopY := 55;
+
+  // ─── Visual C++ Runtime ───────────────────────────────────────────────────
+  VCCheck := TCheckBox.Create(CompPage);
+  VCCheck.Parent  := CompPage.Surface;
+  VCCheck.Left    := 0;
+  VCCheck.Top     := TopY;
+  VCCheck.Width   := CompPage.SurfaceWidth;
+  VCCheck.Caption := 'Visual C++ Redistributable 2022 (x64)';
+
+  if VCVersion = '' then
+  begin
+    VCStatus := '⚠ חסר — נדרשת התקנה! ללא רכיב זה האפליקציה לא תפעל.';
+    VCColor  := clRed;
+    VCCheck.Checked := True;
+    VCCheck.Enabled := False;  // חובה — לא ניתן לבטל
+  end
+  else
+  begin
+    VCStatus := '✓ קיים (גרסה: ' + VCVersion + ') — לא נדרשת פעולה.';
+    VCColor  := $006400;  // ירוק כהה
+    VCCheck.Checked := False;
+    VCCheck.Enabled := False;  // קיים — נעול כדי למנוע התקנה מיותרת
+  end;
+
+  VCLabel := TLabel.Create(CompPage);
+  VCLabel.Parent   := CompPage.Surface;
+  VCLabel.Left     := 20;
+  VCLabel.Top      := TopY + 22;
+  VCLabel.Width    := CompPage.SurfaceWidth - 20;
+  VCLabel.AutoSize := False;
+  VCLabel.WordWrap := True;
+  VCLabel.Caption  := VCStatus;
+  VCLabel.Font.Color := VCColor;
+  VCLabel.Height   := 30;
+
+  TopY := TopY + 70;
+
+  // ─── WebView2 Runtime ─────────────────────────────────────────────────────
+  WV2Check := TCheckBox.Create(CompPage);
+  WV2Check.Parent  := CompPage.Surface;
+  WV2Check.Left    := 0;
+  WV2Check.Top     := TopY;
+  WV2Check.Width   := CompPage.SurfaceWidth;
+  WV2Check.Caption := 'Microsoft WebView2 Runtime';
+
+  // WebView2 אינו חובה — משמש רק למערכת הפלאגינים (לא לקריאה/חיפוש/סימניות)
+  if WV2Version = '' then
+  begin
+    WV2Status := '⚠ חסר — מומלץ להתקין. ללא רכיב זה מערכת הפלאגינים לא תפעל,' +
+                 ' אך שאר האפליקציה תעבוד כרגיל.';
+    WV2Color  := $007FFF;  // כתום — אזהרה, לא שגיאה ($BBGGRR: B=00, G=7F, R=FF)
+    WV2Check.Checked := True;
+    WV2Check.Enabled := True;  // אופציונלי — ניתן לבטל
+  end
+  else
+  begin
+    WV2Status := '✓ קיים (גרסה: ' + WV2Version + ') — לא נדרשת פעולה.';
+    WV2Color  := $006400;
+    WV2Check.Checked := False;
+    WV2Check.Enabled := False;  // קיים — נעול כדי למנוע התקנה מיותרת
+  end;
+
+  WV2Label := TLabel.Create(CompPage);
+  WV2Label.Parent   := CompPage.Surface;
+  WV2Label.Left     := 20;
+  WV2Label.Top      := TopY + 22;
+  WV2Label.Width    := CompPage.SurfaceWidth - 20;
+  WV2Label.AutoSize := False;
+  WV2Label.WordWrap := True;
+  WV2Label.Caption  := WV2Status;
+  WV2Label.Font.Color := WV2Color;
+  WV2Label.Height   := 30;
+end;
+
+function ShouldInstallVC: Boolean;
+begin
+  Result := InstallVC;
+end;
+
+function ShouldInstallWV2: Boolean;
+begin
+  Result := InstallWV2;
+end;
+
+procedure InitializeWizard;
+begin
+  // אתחול ברירות מחדל: מתקין רק אם חסר
+  InstallVC  := VCRedistNeedsInstall;
+  InstallWV2 := WebView2NeedsInstall;
+  CreateComponentsPage;
+end;
+
+// שמירת בחירות המשתמש בלחיצה על "הבא" מדף הרכיבים
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if (CompPage <> nil) and (CurPageID = CompPage.ID) then
+  begin
+    InstallVC  := VCCheck.Checked;
+    InstallWV2 := WV2Check.Checked;
+  end;
 end;
 
 procedure ExtractBundledDatabase(const ArchiveName, DatabaseName: String);
@@ -310,8 +471,8 @@ begin
 end;
 
 [Run]
-Filename: "{tmp}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "מתקין Visual C++ Redistributable 2022..."; Flags: waituntilterminated; Check: VCRedistNeedsInstall
-Filename: "{tmp}\MicrosoftEdgeWebview2Setup.exe"; Parameters: "/silent /install"; StatusMsg: "מתקין Microsoft WebView2 Runtime..."; Flags: waituntilterminated; Check: WebView2NeedsInstall
+Filename: "{tmp}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "מתקין Visual C++ Redistributable 2022..."; Flags: waituntilterminated; Check: ShouldInstallVC
+Filename: "{tmp}\MicrosoftEdgeWebview2Setup.exe"; Parameters: "/silent /install"; StatusMsg: "מתקין Microsoft WebView2 Runtime..."; Flags: waituntilterminated; Check: ShouldInstallWV2
 Filename: "{app}\{#MyAppExeName}"; Description: "הפעל את {#MyAppName}"; Flags: nowait postinstall skipifsilent
 
 [Icons]

--- a/installer/otzaria_full.iss
+++ b/installer/otzaria_full.iss
@@ -48,6 +48,17 @@ Name: "hebrew"; MessagesFile: "compiler:Languages\Hebrew.isl"
 
 [Code]
 
+var
+  CompPage: TWizardPage;
+  VCCheck, WV2Check: TCheckBox;
+  VCLabel, WV2Label: TLabel;
+  InstallVC, InstallWV2: Boolean;
+
+  BooksPage: TWizardPage;
+  BooksPathEdit: TEdit;
+  BooksPathBrowseBtn: TButton;
+  SelectedBooksPath: String;
+
 function TryGetInstallDirFromRegistry(RootKey: Integer; const SubKey: String; var InstallDir: String): Boolean;
 begin
   Result := RegQueryStringValue(RootKey, SubKey, 'Inno Setup: App Path', InstallDir);
@@ -115,34 +126,6 @@ begin
     Result := ExpandConstant('{userappdata}\otzaria');
 end;
 
-function InitializeSetup(): Boolean;
-var
-  DataPath, OldPath: String;
-begin
-  Result := True;
-  DataPath := GetDataDir('');
-  OldPath := 'C:\אוצריא';
-  
-  // בדיקה אם יש התקנה ישנה בנתיב העברי
-  if DirExists(OldPath) then
-  begin
-    if MsgBox('נמצאה התקנה ישנה ב-' + OldPath + #13#10 +
-              'ספריית הספרים עוברת לנתיב חדש: ' + DataPath + #13#10#13#10 +
-              'האם להעביר את הנתונים למיקום החדש?',
-              mbConfirmation, MB_YESNO) = IDYES then
-    begin
-      // המשתמש יצטרך להעביר ידנית או שנוסיף קוד העברה
-      MsgBox('לאחר ההתקנה, תוכל להעביר את הנתונים מ-' + OldPath + ' ל-' + DataPath, mbInformation, MB_OK);
-    end;
-  end;
-  
-  // האזהרה על מחיקת ספרים קיימים מוצגת בדף בחירת תיקיית הספרים
-
-  // אתחול ברירות מחדל — גם להתקנה שקטה (/SILENT, /VERYSILENT)
-  InstallVC  := VCRedistNeedsInstall;
-  InstallWV2 := WebView2NeedsInstall;
-end;
-
 // ─── בדיקות רכיבי מערכת ───────────────────────────────────────────────────
 
 function GetVCVersion: String;
@@ -186,18 +169,33 @@ begin
   Result := GetWebView2Version = '';
 end;
 
-// ─── משתנים גלובליים ────────────────────────────────────────────────────────
-
+function InitializeSetup(): Boolean;
 var
-  CompPage: TWizardPage;
-  VCCheck, WV2Check: TCheckBox;
-  VCLabel, WV2Label: TLabel;
-  InstallVC, InstallWV2: Boolean;
+  DataPath, OldPath: String;
+begin
+  Result := True;
+  DataPath := GetDataDir('');
+  OldPath := 'C:\אוצריא';
 
-  BooksPage: TWizardPage;
-  BooksPathEdit: TEdit;
-  BooksPathBrowseBtn: TButton;
-  SelectedBooksPath: String;
+  // בדיקה אם יש התקנה ישנה בנתיב העברי
+  if DirExists(OldPath) then
+  begin
+    if MsgBox('נמצאה התקנה ישנה ב-' + OldPath + #13#10 +
+              'ספריית הספרים עוברת לנתיב חדש: ' + DataPath + #13#10#13#10 +
+              'האם להעביר את הנתונים למיקום החדש?',
+              mbConfirmation, MB_YESNO) = IDYES then
+    begin
+      // המשתמש יצטרך להעביר ידנית או שנוסיף קוד העברה
+      MsgBox('לאחר ההתקנה, תוכל להעביר את הנתונים מ-' + OldPath + ' ל-' + DataPath, mbInformation, MB_OK);
+    end;
+  end;
+
+  // האזהרה על מחיקת ספרים קיימים מוצגת בדף בחירת תיקיית הספרים
+
+  // אתחול ברירות מחדל — גם להתקנה שקטה (/SILENT, /VERYSILENT)
+  InstallVC  := VCRedistNeedsInstall;
+  InstallWV2 := WebView2NeedsInstall;
+end;
 
 // ─── בניית עמוד בחירת רכיבים ───────────────────────────────────────────────
 


### PR DESCRIPTION
מחקתי את הPR הקודם כיון שהוא היה קשור גם לשחרור חדש
וזה רק קובץ הfull

סיכום

החלפת VC++ Runtime: הוחלף VisualCppRedist_AIO_x86_x64.exe (כולל גרסאות ישנות ומיותרות) ב-vc_redist.x64.exe הרשמי של Microsoft (~25MB במקום ~50MB), עם /norestart למניעת הפעלה מחדש.

הוספת WebView2: הוסף MicrosoftEdgeWebview2Setup.exe לגרסת full — מותקן רק אם חסר במערכת, ומוגדר כאופציונלי (לא חובה). WebView2 נדרש רק למערכת הפלאגינים; קריאה, חיפוש וסימניות פועלים ללא תלות בו.

מסך בחירת רכיבים: לפני ההתקנה מוצג מסך המציג את מצב כל רכיב:

VC++ Runtime חסר: אדום + נעול + אזהרה שהאפליקציה לא תפעל
WebView2 חסר: כחול + ניתן לביטול + הסבר שרק הפלאגינים יושפעו
רכיב קיים: ירוק + כבוי עם גרסה מותקנת
מסך בחירת נתיב ספרים: לפני ההתקנה מוצג מסך לבחירת תיקיית הספרים; הנתיב נשמר אוטומטית בהגדרות התוכנה.

דרישות בנייה: הקבצים vc_redist.x64.exe ו-MicrosoftEdgeWebview2Setup.exe מורדים אוטומטית על ידי workflow הבנייה ב-GitHub Actions — אין צורך בהורדה ידנית.

תיקונים בעקבות סקירת קוד

WebView2 כאופציונלי: לאחר בדיקת הקוד נמצא שWebView2 משמש רק ב-lib/plugins/view/plugin_tab_page.dart — מערכת הפלאגינים בלבד. שודרג מחובה לאזהרה עם אפשרות ביטול.
תיקון כותרות חתוכות: שורות הכותרת במסך הרכיבים ובמסך הנתיב קוצרו והגבהים הותאמו כדי שכל הטקסט יוצג במלואו.
תוכנית בדיקה

 בניית otzaria_full.iss ווידוא שמסך הרכיבים מופיע לפני בחירת תיקייה
 בדיקה על מחשב ללא VC++ Runtime — מסומן אדום ונעול, מותקן אוטומטית
 בדיקה על מחשב עם VC++ Runtime — מסומן ירוק, לא מותקן מחדש
 בדיקה על מחשב ללא WebView2 — מסומן כחול, ניתן לביטול
 בדיקת מסך נתיב ספרים — הנתיב נשמר בהגדרות לאחר ההתקנה
 וידוא /norestart — אין הפעלה מחדש לאחר התקנת VC++

<img width="982" height="728" alt="image" src="https://github.com/user-attachments/assets/ee121e39-b489-4397-a568-c94670ec6132" />

<img width="988" height="716" alt="image" src="https://github.com/user-attachments/assets/0bce93b8-f41f-416b-86c5-ef6e54730e54" />
