### PR TITLE
תיקון לוו גרירה במצב פאנל צף על תוכן

### DIFF
--- a/lib/widgets/layout/adaptive_side_pane.dart
+++ b/lib/widgets/layout/adaptive_side_pane.dart
@@ -67,7 +67,6 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
   static const double _kWideInnerSideGap = 12;
   static const double _kNarrowTopGap = 14;
   static const double _kNarrowBottomGap = 10;
-  static const double _kNarrowHandleInset = 4;
   static const double _kHandleHitSize = 36;
 
   Color _effectivePaneColor(BuildContext context) {
@@ -114,7 +113,6 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
     BuildContext context,
     Widget child, {
     required bool paneOnRight,
-    required bool isWide,
   }) {
     final paneColor = _effectivePaneColor(context);
     const shellRadius = BorderRadius.all(Radius.circular(18));
@@ -143,15 +141,7 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
       return shell;
     }
 
-    // במסך רחב, ה-handle צריך להיות בקצה החיצוני (בין שני החלונות)
-    // במסך צר, ה-handle צריך להיות בתוך החלונית
-    final handleAtOuterWindowEdge = isWide;
-    
-    // כשה-handle בקצה החיצוני, נזיז אותו החוצה כדי שיהיה בין החלונות
-    // כשה-handle בתוך החלונית, נזיז אותו פנימה מעט
-    final handleOffset = handleAtOuterWindowEdge 
-        ? -(_kHandleHitSize / 2) 
-        : _kNarrowHandleInset;
+    const handleOffset = -(_kHandleHitSize / 2);
 
     return Stack(
       clipBehavior: Clip.none,
@@ -160,14 +150,8 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
         Positioned(
           top: 0,
           bottom: 0,
-          // כשהחלונית בצד ימין והhandle בקצה החיצוני, נמקם אותו משמאל לחלונית
-          // כשהחלונית בצד שמאל והhandle בקצה החיצוני, נמקם אותו מימין לחלונית
-          left: handleAtOuterWindowEdge
-              ? (paneOnRight ? handleOffset : null)
-              : (paneOnRight ? null : handleOffset),
-          right: handleAtOuterWindowEdge
-              ? (paneOnRight ? null : handleOffset)
-              : (paneOnRight ? handleOffset : null),
+          left: paneOnRight ? handleOffset : null,
+          right: paneOnRight ? null : handleOffset,
           child: ResizableDragHandle(
             isVertical: true,
             hitSize: _kHandleHitSize,
@@ -197,7 +181,6 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
               child: child,
             ),
       paneOnRight: _isPaneOnRight(context),
-      isWide: false,
     );
   }
 
@@ -227,7 +210,6 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
               context,
               widePaneContent,
               paneOnRight: paneOnRight,
-              isWide: true,
             ),
           );
 
@@ -288,7 +270,6 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
                 context,
                 narrowPaneContent,
                 paneOnRight: paneOnRight,
-                isWide: false,
               )
             : narrowPaneContent;
 


### PR DESCRIPTION
בחלונית צד הוו גרירה היה מוגדר בכיוון התוכן ותוקן בימים האחרונים שיהיה בגבול הפאנל
כשאין תוכן והחלונית צפה על התוכן היה באג (עוד מהתחלה) שהוו היה בצד של מסגרת החלון ולא בצד התוכן
קומיט זה מתקן שתמיד הוו יהיה בצד התוכן ולא בצד מסגרת החלון