### PR TITLE
הוספת תפריט העתקת קישור ישיר לספרי טקסט ו-PDF

### DIFF
--- a/docs/deep_links.md
+++ b/docs/deep_links.md
@@ -37,6 +37,8 @@
 | `otzaria://open/book/<id>` | פותח ספר בעיון לפי מזהה מסד הנתונים |
 | `otzaria://open/book/<id>?index=<n>` | פותח את הספר בסעיף `n` (אינדקס לא שלילי). |
 | `otzaria://open/book/<id>?q=<text>` | פותח את הספר עם מחרוזת חיפוש להדגשה. ניתן לשלב עם `index`. |
+| `otzaria://open/pdf/<id>` | פותח ספר PDF לפי מזהה משותף עם ה-TextBook במסד הנתונים |
+| `otzaria://open/pdf/<id>?index=<n>` | פותח את ספר ה-PDF בעמוד `n` (מספר עמוד חיובי). |
 
 **דוגמאות:**
 
@@ -50,6 +52,8 @@ otzaria://open/book/1234?index=42
 otzaria://open/book/1234?q=%D7%91%D7%A8%D7%90%D7%A9%D7%99%D7%AA
 otzaria://open/book/1234?index=42&q=%D7%91%D7%A8%D7%90%D7%A9%D7%99%D7%AA
 otzaria://open/search?q=%D7%91%D7%A8%D7%90%D7%A9%D7%99%D7%AA
+otzaria://open/pdf/120
+otzaria://open/pdf/120?index=17
 ```
 
 **הערות על קידוד:** טקסט בעברית ב‑`q=` חייב להיות URL‑encoded (UTF‑8). ערך `index` שלילי או לא מספרי מתעלם — הספר ייפתח בתחילתו. `q=` ריק מתעלם.

--- a/lib/core/external_uri_router.dart
+++ b/lib/core/external_uri_router.dart
@@ -34,6 +34,15 @@ class OpenBookAction extends ExternalUriAction {
   });
 }
 
+/// פתיחת ספר PDF לפי מזהה משותף עם ה-TextBook ב-DB.
+///
+/// [page] — מספר עמוד התחלתי (אופציונלי).
+class OpenPdfBookAction extends ExternalUriAction {
+  final int bookId;
+  final int? page;
+  const OpenPdfBookAction(this.bookId, {this.page});
+}
+
 /// בקשת התקנה של תוסף ממאגר חיצוני.
 class InstallPluginAction extends ExternalUriAction {
   final PluginStoreInstallRequest request;
@@ -59,9 +68,11 @@ class RunSearchAction extends ExternalUriAction {
 /// * `otzaria://open/settings`              – הגדרות
 /// * `otzaria://open/tools`                 – מסך הכלים
 /// * `otzaria://open/tool/<tool-id>`        – לשונית כלי לפי מזהה מלא
-/// * `otzaria://open/book/<id>`             – פתיחת ספר בעיון לפי מזהה DB
+/// * `otzaria://open/book/<id>`             – פתיחת ספר טקסט בעיון לפי מזהה DB
 ///   - `?index=<n>` קפיצה לסעיף התחלתי (n >= 0)
 ///   - `?q=<text>`  מחרוזת חיפוש להדגשה
+/// * `otzaria://open/pdf/<id>`              – פתיחת ספר PDF לפי מזהה DB (משותף עם TextBook)
+///   - `?index=<n>` קפיצה לעמוד התחלתי (n >= 0)
 /// * `otzaria://plugin/install?url=<download>` – התקנת תוסף
 ///   - `&overwrite=true|false` דריסת תוסף קיים
 ///
@@ -155,6 +166,20 @@ class ExternalUriRouter {
         index: index,
         searchQuery: searchQuery,
       );
+    }
+
+    if (segments.length == 2 && firstLower == 'pdf') {
+      final bookId = int.tryParse(segments[1].trim());
+      if (bookId == null || bookId <= 0) {
+        return null;
+      }
+
+      final indexParam = uri.queryParameters['index']?.trim();
+      final parsedIndex =
+          indexParam == null || indexParam.isEmpty ? null : int.tryParse(indexParam);
+      final page = (parsedIndex != null && parsedIndex >= 0) ? parsedIndex : null;
+
+      return OpenPdfBookAction(bookId, page: page);
     }
 
     return null;

--- a/lib/core/external_uri_router.dart
+++ b/lib/core/external_uri_router.dart
@@ -175,7 +175,6 @@ class ExternalUriRouter {
       }
 
       final indexParam = uri.queryParameters['index']?.trim();
-      final parsedIndex =
       final parsedIndex = int.tryParse(indexParam ?? '');
       final page = (parsedIndex != null && parsedIndex >= 0) ? parsedIndex : null;
 

--- a/lib/core/external_uri_router.dart
+++ b/lib/core/external_uri_router.dart
@@ -176,7 +176,7 @@ class ExternalUriRouter {
 
       final indexParam = uri.queryParameters['index']?.trim();
       final parsedIndex = int.tryParse(indexParam ?? '');
-      final page = (parsedIndex != null && parsedIndex >= 0) ? parsedIndex : null;
+      final page = (parsedIndex != null && parsedIndex >= 1) ? parsedIndex : null;
 
       return OpenPdfBookAction(bookId, page: page);
     }

--- a/lib/core/external_uri_router.dart
+++ b/lib/core/external_uri_router.dart
@@ -176,7 +176,7 @@ class ExternalUriRouter {
 
       final indexParam = uri.queryParameters['index']?.trim();
       final parsedIndex =
-          indexParam == null || indexParam.isEmpty ? null : int.tryParse(indexParam);
+      final parsedIndex = int.tryParse(indexParam ?? '');
       final page = (parsedIndex != null && parsedIndex >= 0) ? parsedIndex : null;
 
       return OpenPdfBookAction(bookId, page: page);

--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -627,6 +627,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           .where((b) => b is TextBook && b.title == title)
           .firstOrNull;
       final pdfBook = PdfBook(
+        id: matchingTextBook?.id,
         title: title,
         category: targetCategory,
         path: entity.path,

--- a/lib/models/books.dart
+++ b/lib/models/books.dart
@@ -366,6 +366,7 @@ class PdfBook extends FileBook {
 
   factory PdfBook.fromJson(Map<String, dynamic> json) {
     return PdfBook(
+      id: json['id'] as int?,
       title: json['title'],
       path: json['path'],
       categoryPath: json['categoryPath'],
@@ -379,6 +380,7 @@ class PdfBook extends FileBook {
   @override
   Map<String, dynamic> toJson() {
     return {
+      'id': id,
       'title': title,
       'path': path,
       'type': 'PdfBook',

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -575,6 +575,8 @@ class MainWindowScreenState extends State<MainWindowScreen>
           index: index,
           searchQuery: searchQuery,
         ));
+      case OpenPdfBookAction(:final bookId, :final page):
+        unawaited(_openPdfBookByExternalId(bookId, page: page));
       case InstallPluginAction(:final request):
         context.read<NavigationBloc>().add(const NavigateToScreen(Screen.more));
         context.read<PluginSystemBloc>().add(
@@ -610,6 +612,19 @@ class MainWindowScreenState extends State<MainWindowScreen>
       return;
     }
     openBook(context, book, index ?? 0, searchQuery ?? '');
+  }
+
+  Future<void> _openPdfBookByExternalId(int bookId, {int? page}) async {
+    final library = await DataRepository.instance.library;
+    if (!mounted) return;
+    final book = library.getAllBooks().firstWhereOrNull(
+          (b) => b is PdfBook && b.id == bookId,
+        );
+    if (book == null) {
+      UiSnack.showError('ספר ה-PDF עם המזהה $bookId לא נמצא בספרייה');
+      return;
+    }
+    openBook(context, book, page ?? 1, '');
   }
 
   void _openToolWhenAvailable(String toolId, {int attemptsLeft = 6}) {

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -3664,7 +3664,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   String _buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
 
   String _buildSectionLink(int bookId, int index) =>
-      'otzaria://open/book/$bookId?index=${index.clamp(0, double.maxFinite.toInt())}';
+      'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
 
   Future<void> _copyLinkToClipboard(String url) async {
     await Clipboard.setData(ClipboardData(text: url));

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -3588,32 +3588,31 @@ class _PdfBookScreenState extends State<PdfBookScreen>
             ? 'העתק קישור ישיר'
             : 'העתק קישור ישיר (לא זמין לספר זה)',
         onPressed: null,
-        submenuItems: () {
-          final bookId = widget.tab.book.id;
-          return [
-            ActionButtonData(
-              widget: const SizedBox.shrink(),
-              icon: FluentIcons.link_24_regular,
-              tooltip: 'העתק קישור ישיר לספר זה',
-              onPressed: bookId != null
-                  ? () => copyLinkToClipboard(buildBookLink(bookId))
-                  : null,
-            ),
-            ActionButtonData(
-              widget: const SizedBox.shrink(),
-              icon: FluentIcons.link_multiple_24_regular,
-              tooltip: 'העתק קישור ישיר לעמוד זה',
-              onPressed: bookId != null
-                  ? () {
+        submenuItems: widget.tab.book.id != null
+            ? () {
+                final bookId = widget.tab.book.id!;
+                return [
+                  ActionButtonData(
+                    widget: const SizedBox.shrink(),
+                    icon: FluentIcons.link_24_regular,
+                    tooltip: 'העתק קישור ישיר לספר זה',
+                    onPressed: () =>
+                        copyLinkToClipboard(buildBookLink(bookId)),
+                  ),
+                  ActionButtonData(
+                    widget: const SizedBox.shrink(),
+                    icon: FluentIcons.link_multiple_24_regular,
+                    tooltip: 'העתק קישור ישיר לעמוד זה',
+                    onPressed: () {
                       final page =
                           widget.tab.pdfViewerController.pageNumber ??
                               widget.tab.pageNumber;
                       copyLinkToClipboard(buildSectionLink(bookId, page));
-                    }
-                  : null,
-            ),
-          ];
-        }(),
+                    },
+                  ),
+                ];
+              }()
+            : null,
       ),
       if (widget.isInCombinedView)
         ActionButtonData(

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -53,6 +53,7 @@ import 'package:otzaria/text_book/models/commentator_group.dart';
 import 'package:otzaria/printing/printing_helpers.dart';
 import 'package:otzaria/printing/view/printing_screen.dart';
 import 'package:otzaria/shortcuts/shortcut_helper.dart';
+import 'package:otzaria/utils/link_helpers.dart';
 
 final GlobalKey pdfBookNavigationTourTargetKey = GlobalKey(
   debugLabel: 'pdf_book_navigation_tour_target',
@@ -3587,31 +3588,32 @@ class _PdfBookScreenState extends State<PdfBookScreen>
             ? 'העתק קישור ישיר'
             : 'העתק קישור ישיר (לא זמין לספר זה)',
         onPressed: null,
-        submenuItems: [
-          ActionButtonData(
-            widget: const SizedBox.shrink(),
-            icon: FluentIcons.link_24_regular,
-            tooltip: 'העתק קישור ישיר לספר זה',
-            onPressed: widget.tab.book.id != null
-                ? () => _copyLinkToClipboard(
-                      _buildBookLink(widget.tab.book.id!),
-                    )
-                : null,
-          ),
-          ActionButtonData(
-            widget: const SizedBox.shrink(),
-            icon: FluentIcons.link_multiple_24_regular,
-            tooltip: 'העתק קישור ישיר לעמוד זה',
-            onPressed: widget.tab.book.id != null
-                ? () {
-                    final page = widget.tab.pdfViewerController.pageNumber ??
-                        widget.tab.pageNumber;
-                    _copyLinkToClipboard(
-                        _buildSectionLink(widget.tab.book.id!, page));
-                  }
-                : null,
-          ),
-        ],
+        submenuItems: () {
+          final bookId = widget.tab.book.id;
+          return [
+            ActionButtonData(
+              widget: const SizedBox.shrink(),
+              icon: FluentIcons.link_24_regular,
+              tooltip: 'העתק קישור ישיר לספר זה',
+              onPressed: bookId != null
+                  ? () => copyLinkToClipboard(buildBookLink(bookId))
+                  : null,
+            ),
+            ActionButtonData(
+              widget: const SizedBox.shrink(),
+              icon: FluentIcons.link_multiple_24_regular,
+              tooltip: 'העתק קישור ישיר לעמוד זה',
+              onPressed: bookId != null
+                  ? () {
+                      final page =
+                          widget.tab.pdfViewerController.pageNumber ??
+                              widget.tab.pageNumber;
+                      copyLinkToClipboard(buildSectionLink(bookId, page));
+                    }
+                  : null,
+            ),
+          ];
+        }(),
       ),
       if (widget.isInCombinedView)
         ActionButtonData(
@@ -3657,18 +3659,6 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     if (!context.mounted) return;
 
     openBook(context, textBook, index ?? 0, '', ignoreHistory: true);
-  }
-
-  // --- העתקת קישור ישיר ---
-
-  String _buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
-
-  String _buildSectionLink(int bookId, int index) =>
-      'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
-
-  Future<void> _copyLinkToClipboard(String url) async {
-    await Clipboard.setData(ClipboardData(text: url));
-    UiSnack.show('הקישור הועתק ללוח');
   }
 
   void _handleBookmarkPress(BuildContext context) {

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -3597,7 +3597,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                     icon: FluentIcons.link_24_regular,
                     tooltip: 'העתק קישור ישיר לספר זה',
                     onPressed: () =>
-                        copyLinkToClipboard(buildBookLink(bookId)),
+                        copyLinkToClipboard(buildPdfBookLink(bookId)),
                   ),
                   ActionButtonData(
                     widget: const SizedBox.shrink(),
@@ -3607,7 +3607,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                       final page =
                           widget.tab.pdfViewerController.pageNumber ??
                               widget.tab.pageNumber;
-                      copyLinkToClipboard(buildSectionLink(bookId, page));
+                      copyLinkToClipboard(buildPdfPageLink(bookId, page));
                     },
                   ),
                 ];

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -3579,6 +3579,40 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           tooltip: 'הדפס',
           onPressed: () => _handlePrintPress(context),
         ),
+      // העתק קישור ישיר
+      ActionButtonData(
+        widget: const SizedBox.shrink(),
+        icon: FluentIcons.link_24_regular,
+        tooltip: widget.tab.book.id != null
+            ? 'העתק קישור ישיר'
+            : 'העתק קישור ישיר (לא זמין לספר זה)',
+        onPressed: null,
+        submenuItems: [
+          ActionButtonData(
+            widget: const SizedBox.shrink(),
+            icon: FluentIcons.link_24_regular,
+            tooltip: 'העתק קישור ישיר לספר זה',
+            onPressed: widget.tab.book.id != null
+                ? () => _copyLinkToClipboard(
+                      _buildBookLink(widget.tab.book.id!),
+                    )
+                : null,
+          ),
+          ActionButtonData(
+            widget: const SizedBox.shrink(),
+            icon: FluentIcons.link_multiple_24_regular,
+            tooltip: 'העתק קישור ישיר לעמוד זה',
+            onPressed: widget.tab.book.id != null
+                ? () {
+                    final page = widget.tab.pdfViewerController.pageNumber ??
+                        widget.tab.pageNumber;
+                    _copyLinkToClipboard(
+                        _buildSectionLink(widget.tab.book.id!, page));
+                  }
+                : null,
+          ),
+        ],
+      ),
       if (widget.isInCombinedView)
         ActionButtonData(
           widget: const SizedBox.shrink(),
@@ -3623,6 +3657,18 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     if (!context.mounted) return;
 
     openBook(context, textBook, index ?? 0, '', ignoreHistory: true);
+  }
+
+  // --- העתקת קישור ישיר ---
+
+  String _buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
+
+  String _buildSectionLink(int bookId, int index) =>
+      'otzaria://open/book/$bookId?index=${index.clamp(0, double.maxFinite.toInt())}';
+
+  Future<void> _copyLinkToClipboard(String url) async {
+    await Clipboard.setData(ClipboardData(text: url));
+    UiSnack.show('הקישור הועתק ללוח');
   }
 
   void _handleBookmarkPress(BuildContext context) {

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -54,6 +54,7 @@ import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
 import 'package:otzaria/settings/services/nikud_display_service.dart';
 import 'package:otzaria/text_book/view/page_shape/page_shape_settings_dialog.dart';
 import 'package:otzaria/text_book/view/page_shape/utils/page_shape_settings_manager.dart';
+import 'package:otzaria/utils/link_helpers.dart';
 import 'package:otzaria/text_book/view/page_shape/utils/default_commentators.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
@@ -724,18 +725,6 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     _pageShapeSidebarTabNotifier.dispose();
     _settingsSub.cancel();
     super.dispose();
-  }
-
-  // --- העתקת קישור ישיר ---
-
-  String _buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
-
-  String _buildSectionLink(int bookId, int index) =>
-      'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
-
-  Future<void> _copyLinkToClipboard(String url) async {
-    await Clipboard.setData(ClipboardData(text: url));
-    UiSnack.show('הקישור הועתק ללוח');
   }
 
   void _openPersonalNotesForCurrentView(TextBookLoaded state) {
@@ -1651,36 +1640,36 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       ActionButtonData(
         widget: const SizedBox.shrink(),
         icon: FluentIcons.link_24_regular,
-        tooltip: state.book.id != null
-            ? 'העתק קישור ישיר'
-            : 'העתק קישור ישיר (לא זמין לספר זה)',
+        tooltip: 'העתק קישור ישיר',
         onPressed: null,
-        submenuItems: [
-          ActionButtonData(
-            widget: const SizedBox.shrink(),
-            icon: FluentIcons.link_24_regular,
-            tooltip: 'העתק קישור ישיר לספר זה',
-            onPressed: state.book.id != null
-                ? () => _copyLinkToClipboard(
-                      _buildBookLink(state.book.id!),
-                    )
-                : null,
-          ),
-          ActionButtonData(
-            widget: const SizedBox.shrink(),
-            icon: FluentIcons.link_multiple_24_regular,
-            tooltip: 'העתק קישור ישיר למקטע זה',
-            onPressed: state.book.id != null
-                ? () {
-                    final index =
-                        state.positionsListener.itemPositions.value.isNotEmpty
-                            ? state.positionsListener.itemPositions.value.first.index
-                            : 0;
-                    _copyLinkToClipboard(_buildSectionLink(state.book.id!, index));
-                  }
-                : null,
-          ),
-        ],
+        submenuItems: () {
+          final bookId = state.book.id;
+          return [
+            ActionButtonData(
+              widget: const SizedBox.shrink(),
+              icon: FluentIcons.link_24_regular,
+              tooltip: 'העתק קישור ישיר לספר זה',
+              onPressed: bookId != null
+                  ? () => copyLinkToClipboard(buildBookLink(bookId))
+                  : null,
+            ),
+            ActionButtonData(
+              widget: const SizedBox.shrink(),
+              icon: FluentIcons.link_multiple_24_regular,
+              tooltip: 'העתק קישור ישיר למקטע זה',
+              onPressed: bookId != null
+                  ? () {
+                      final index = state
+                              .positionsListener.itemPositions.value.isNotEmpty
+                          ? state.positionsListener.itemPositions.value.first
+                              .index
+                          : 0;
+                      copyLinkToClipboard(buildSectionLink(bookId, index));
+                    }
+                  : null,
+            ),
+          ];
+        }(),
       ),
 
       // תת-תפריט "פעולות נוספות" - רק בתצוגה משולבת

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -726,6 +726,18 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     super.dispose();
   }
 
+  // --- העתקת קישור ישיר ---
+
+  String _buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
+
+  String _buildSectionLink(int bookId, int index) =>
+      'otzaria://open/book/$bookId?index=${index.clamp(0, double.maxFinite.toInt())}';
+
+  Future<void> _copyLinkToClipboard(String url) async {
+    await Clipboard.setData(ClipboardData(text: url));
+    UiSnack.show('הקישור הועתק ללוח');
+  }
+
   void _openPersonalNotesForCurrentView(TextBookLoaded state) {
     if (state.showPageShapeView) {
       _pageShapeSidebarTabNotifier.value = 1;
@@ -1634,6 +1646,36 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
           tooltip: 'אודות הספר',
           onPressed: () => showBookSourceDialog(context, state),
         ),
+
+      // העתק קישור ישיר
+      ActionButtonData(
+        widget: const SizedBox.shrink(),
+        icon: FluentIcons.link_24_regular,
+        tooltip: 'העתק קישור ישיר',
+        onPressed: null,
+        submenuItems: [
+          ActionButtonData(
+            widget: const SizedBox.shrink(),
+            icon: FluentIcons.link_24_regular,
+            tooltip: 'העתק קישור ישיר לספר זה',
+            onPressed: () => _copyLinkToClipboard(
+              _buildBookLink(state.book.id ?? 0),
+            ),
+          ),
+          ActionButtonData(
+            widget: const SizedBox.shrink(),
+            icon: FluentIcons.link_multiple_24_regular,
+            tooltip: 'העתק קישור ישיר למקטע זה',
+            onPressed: () {
+              final index =
+                  state.positionsListener.itemPositions.value.isNotEmpty
+                      ? state.positionsListener.itemPositions.value.first.index
+                      : 0;
+              _copyLinkToClipboard(_buildSectionLink(state.book.id ?? 0, index));
+            },
+          ),
+        ],
+      ),
 
       // תת-תפריט "פעולות נוספות" - רק בתצוגה משולבת
       if (widget.isInCombinedView)

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -1651,7 +1651,9 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       ActionButtonData(
         widget: const SizedBox.shrink(),
         icon: FluentIcons.link_24_regular,
-        tooltip: 'העתק קישור ישיר',
+        tooltip: state.book.id != null
+            ? 'העתק קישור ישיר'
+            : 'העתק קישור ישיר (לא זמין לספר זה)',
         onPressed: null,
         submenuItems: [
           ActionButtonData(

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -731,7 +731,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
   String _buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
 
   String _buildSectionLink(int bookId, int index) =>
-      'otzaria://open/book/$bookId?index=${index.clamp(0, double.maxFinite.toInt())}';
+      'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
 
   Future<void> _copyLinkToClipboard(String url) async {
     await Clipboard.setData(ClipboardData(text: url));

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -1660,9 +1660,11 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
             widget: const SizedBox.shrink(),
             icon: FluentIcons.link_24_regular,
             tooltip: 'העתק קישור ישיר לספר זה',
-            onPressed: () => _copyLinkToClipboard(
-              _buildBookLink(state.book.id ?? 0),
-            ),
+            onPressed: state.book.id != null
+                ? () => _copyLinkToClipboard(
+                      _buildBookLink(state.book.id!),
+                    )
+                : null,
           ),
           ActionButtonData(
             widget: const SizedBox.shrink(),

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -1670,13 +1670,15 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
             widget: const SizedBox.shrink(),
             icon: FluentIcons.link_multiple_24_regular,
             tooltip: 'העתק קישור ישיר למקטע זה',
-            onPressed: () {
-              final index =
-                  state.positionsListener.itemPositions.value.isNotEmpty
-                      ? state.positionsListener.itemPositions.value.first.index
-                      : 0;
-              _copyLinkToClipboard(_buildSectionLink(state.book.id ?? 0, index));
-            },
+            onPressed: state.book.id != null
+                ? () {
+                    final index =
+                        state.positionsListener.itemPositions.value.isNotEmpty
+                            ? state.positionsListener.itemPositions.value.first.index
+                            : 0;
+                    _copyLinkToClipboard(_buildSectionLink(state.book.id!, index));
+                  }
+                : null,
           ),
         ],
       ),

--- a/lib/utils/book_link_builder.dart
+++ b/lib/utils/book_link_builder.dart
@@ -1,0 +1,10 @@
+/// לוגיקה טהורה לבניית קישורי deep link לספרים.
+/// קובץ זה אינו תלוי ב-Flutter ולכן ניתן לבדיקה עם dart test רגיל.
+
+/// בניית קישור ישיר לספר לפי מזהה
+String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
+
+/// בניית קישור ישיר למקטע/עמוד ספציפי בספר.
+/// ערכי index שליליים מוחלפים ב-0.
+String buildSectionLink(int bookId, int index) =>
+    'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';

--- a/lib/utils/book_link_builder.dart
+++ b/lib/utils/book_link_builder.dart
@@ -1,5 +1,5 @@
-/// לוגיקה טהורה לבניית קישורי deep link לספרים.
-/// קובץ זה אינו תלוי ב-Flutter ולכן ניתן לבדיקה עם dart test רגיל.
+// לוגיקה טהורה לבניית קישורי deep link לספרים.
+// קובץ זה אינו תלוי ב-Flutter ולכן ניתן לבדיקה עם dart test רגיל.
 
 /// בניית קישור ישיר לספר לפי מזהה
 String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';

--- a/lib/utils/book_link_builder.dart
+++ b/lib/utils/book_link_builder.dart
@@ -1,10 +1,18 @@
 // לוגיקה טהורה לבניית קישורי deep link לספרים.
 // קובץ זה אינו תלוי ב-Flutter ולכן ניתן לבדיקה עם dart test רגיל.
 
-/// בניית קישור ישיר לספר לפי מזהה
+/// בניית קישור ישיר לספר טקסט לפי מזהה
 String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
 
-/// בניית קישור ישיר למקטע/עמוד ספציפי בספר.
+/// בניית קישור ישיר לספר PDF לפי מזהה (משותף עם TextBook)
+String buildPdfBookLink(int bookId) => 'otzaria://open/pdf/$bookId';
+
+/// בניית קישור ישיר למקטע ספציפי בספר טקסט.
 /// ערכי index שליליים מוחלפים ב-0.
 String buildSectionLink(int bookId, int index) =>
     'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
+
+/// בניית קישור ישיר לעמוד ספציפי בספר PDF.
+/// ערכי page שליליים מוחלפים ב-1.
+String buildPdfPageLink(int bookId, int page) =>
+    'otzaria://open/pdf/$bookId?index=${page < 1 ? 1 : page}';

--- a/lib/utils/link_helpers.dart
+++ b/lib/utils/link_helpers.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/services.dart';
+import 'package:otzaria/core/ui_snack.dart';
+
+/// בניית קישור ישיר לספר לפי מזהה
+String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
+
+/// בניית קישור ישיר למקטע/עמוד ספציפי בספר
+/// ערכי index שליליים מוחלפים ב-0
+String buildSectionLink(int bookId, int index) =>
+    'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
+
+/// העתקת קישור ללוח והצגת הודעה
+Future<void> copyLinkToClipboard(String url) async {
+  await Clipboard.setData(ClipboardData(text: url));
+  UiSnack.show('הקישור הועתק ללוח');
+}

--- a/lib/utils/link_helpers.dart
+++ b/lib/utils/link_helpers.dart
@@ -1,13 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:otzaria/core/ui_snack.dart';
 
-/// בניית קישור ישיר לספר לפי מזהה
-String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
-
-/// בניית קישור ישיר למקטע/עמוד ספציפי בספר
-/// ערכי index שליליים מוחלפים ב-0
-String buildSectionLink(int bookId, int index) =>
-    'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
+export 'package:otzaria/utils/book_link_builder.dart';
 
 /// העתקת קישור ללוח והצגת הודעה
 Future<void> copyLinkToClipboard(String url) async {

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -836,9 +836,11 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
   required List<PopupMenuEntry<T>> menuChildren,
   ValueChanged<T>? onSelected,
 }) {
+  final isRtl = Directionality.of(context) == TextDirection.rtl;
   return buildAppCustomPopupMenuItem<T>(
     context: context,
     metrics: metrics,
+    enabled: true,
     child: Builder(
       builder: (innerContext) => InkWell(
         onTap: () async {
@@ -848,21 +850,19 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
           final overlay = Overlay.of(innerContext)
               .context
               .findRenderObject() as RenderBox;
+          final overlaySize = overlay.size;
           final itemRect = MatrixUtils.transformRect(
             renderBox.getTransformTo(overlay),
             Offset.zero & renderBox.size,
           );
-          // פתח תפריט חדש לצד ימין של הפריט, בלי לסגור את הראשי
+          // פתח תפריט לצד המתאים — ימין ב-LTR, שמאל ב-RTL
+          // אם אין מקום, Flutter יתאים אוטומטית
+          final double xPos = isRtl ? itemRect.left : itemRect.right;
           final selected = await showMenu<T>(
             context: innerContext,
             position: RelativeRect.fromRect(
-              Rect.fromLTWH(
-                itemRect.right,
-                itemRect.top,
-                0,
-                0,
-              ),
-              Offset.zero & overlay.size,
+              Rect.fromLTWH(xPos, itemRect.top, 0, 0),
+              Offset.zero & overlaySize,
             ),
             items: menuChildren,
           );
@@ -881,7 +881,9 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
           label: label,
           icon: icon,
           trailing: Icon(
-            FluentIcons.chevron_right_24_regular,
+            isRtl
+                ? FluentIcons.chevron_left_24_regular
+                : FluentIcons.chevron_right_24_regular,
             size: metrics.iconSize * 0.75,
           ),
         ),

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -833,20 +833,44 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
   required AppMenuMetrics metrics,
   required String label,
   IconData? icon,
-  required List<Widget> menuChildren,
+  required List<PopupMenuEntry<T>> menuChildren,
+  ValueChanged<T>? onSelected,
 }) {
   return buildAppCustomPopupMenuItem<T>(
     context: context,
     metrics: metrics,
-    child: Directionality(
-      textDirection: TextDirection.rtl,
-      child: SubmenuButton(
-        alignmentOffset: const Offset(0, -8),
-        menuStyle: const MenuStyle(
-          alignment: AlignmentDirectional.topEnd,
-        ),
-        menuChildren: menuChildren,
-        style: buildAppSubmenuItemStyle(context, metrics),
+    child: Builder(
+      builder: (innerContext) => InkWell(
+        onTap: () async {
+          final renderBox =
+              innerContext.findRenderObject() as RenderBox?;
+          if (renderBox == null) return;
+          final overlay = Overlay.of(innerContext)
+              .context
+              .findRenderObject() as RenderBox;
+          final itemRect = MatrixUtils.transformRect(
+            renderBox.getTransformTo(overlay),
+            Offset.zero & renderBox.size,
+          );
+          // פתח תפריט חדש לצד ימין של הפריט, בלי לסגור את הראשי
+          final selected = await showMenu<T>(
+            context: innerContext,
+            position: RelativeRect.fromRect(
+              Rect.fromLTWH(
+                itemRect.right,
+                itemRect.top,
+                0,
+                0,
+              ),
+              Offset.zero & overlay.size,
+            ),
+            items: menuChildren,
+          );
+          if (selected != null) {
+            onSelected?.call(selected);
+          }
+        },
+        borderRadius: BorderRadius.circular(metrics.itemBorderRadius),
         child: buildAppMenuRowContent(
           context,
           metrics,

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -868,6 +868,10 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
           );
           if (selected != null) {
             onSelected?.call(selected);
+            // סגור גם את התפריט הראשי
+            if (innerContext.mounted) {
+              Navigator.of(innerContext).pop();
+            }
           }
         },
         borderRadius: BorderRadius.circular(metrics.itemBorderRadius),

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -848,7 +848,9 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
                 final renderBox =
                     innerContext.findRenderObject() as RenderBox?;
                 if (renderBox == null) return;
-                final overlay = Overlay.of(innerContext)
+                final overlayState = Overlay.maybeOf(innerContext);
+                if (overlayState == null) return;
+                final overlay = overlayState.context.findRenderObject() as RenderBox;
                     .context
                     .findRenderObject() as RenderBox;
                 final overlaySize = overlay.size;

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -835,7 +835,6 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
   IconData? icon,
   required List<Widget> menuChildren,
 }) {
-  final colorScheme = Theme.of(context).colorScheme;
   return buildAppCustomPopupMenuItem<T>(
     context: context,
     metrics: metrics,
@@ -852,11 +851,7 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
           mainAxisSize: MainAxisSize.min,
           children: [
             if (icon != null) ...[
-              Icon(
-                icon,
-                size: metrics.iconSize,
-                color: colorScheme.onSurface,
-              ),
+              Icon(icon, size: metrics.iconSize),
               const SizedBox(width: 8),
             ],
             Text(
@@ -865,14 +860,12 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
               style: TextStyle(
                 fontSize: metrics.fontSize,
                 fontWeight: metrics.itemFontWeight,
-                color: colorScheme.onSurface,
               ),
             ),
             const SizedBox(width: 4),
             Icon(
               FluentIcons.chevron_right_24_regular,
               size: metrics.iconSize * 0.75,
-              color: colorScheme.onSurfaceVariant,
             ),
           ],
         ),

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -840,40 +840,39 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
   return buildAppCustomPopupMenuItem<T>(
     context: context,
     metrics: metrics,
-    enabled: true,
+    enabled: onSelected != null,
     child: Builder(
       builder: (innerContext) => InkWell(
-        onTap: () async {
-          final renderBox =
-              innerContext.findRenderObject() as RenderBox?;
-          if (renderBox == null) return;
-          final overlay = Overlay.of(innerContext)
-              .context
-              .findRenderObject() as RenderBox;
-          final overlaySize = overlay.size;
-          final itemRect = MatrixUtils.transformRect(
-            renderBox.getTransformTo(overlay),
-            Offset.zero & renderBox.size,
-          );
-          // פתח תפריט לצד המתאים — ימין ב-LTR, שמאל ב-RTL
-          // אם אין מקום, Flutter יתאים אוטומטית
-          final double xPos = isRtl ? itemRect.left : itemRect.right;
-          final selected = await showMenu<T>(
-            context: innerContext,
-            position: RelativeRect.fromRect(
-              Rect.fromLTWH(xPos, itemRect.top, 0, 0),
-              Offset.zero & overlaySize,
-            ),
-            items: menuChildren,
-          );
-          if (selected != null) {
-            onSelected?.call(selected);
-            // סגור גם את התפריט הראשי
-            if (innerContext.mounted) {
-              Navigator.of(innerContext).pop();
-            }
-          }
-        },
+        onTap: onSelected == null
+            ? null
+            : () async {
+                final renderBox =
+                    innerContext.findRenderObject() as RenderBox?;
+                if (renderBox == null) return;
+                final overlay = Overlay.of(innerContext)
+                    .context
+                    .findRenderObject() as RenderBox;
+                final overlaySize = overlay.size;
+                final itemRect = MatrixUtils.transformRect(
+                  renderBox.getTransformTo(overlay),
+                  Offset.zero & renderBox.size,
+                );
+                // תמיד פתח לצד ימין (itemRect.right) — התפריט הראשי תמיד בצד שמאל
+                final selected = await showMenu<T>(
+                  context: innerContext,
+                  position: RelativeRect.fromRect(
+                    Rect.fromLTWH(itemRect.right, itemRect.top, 0, 0),
+                    Offset.zero & overlaySize,
+                  ),
+                  items: menuChildren,
+                );
+                if (selected != null) {
+                  onSelected.call(selected);
+                  if (innerContext.mounted) {
+                    Navigator.of(innerContext).pop();
+                  }
+                }
+              },
         borderRadius: BorderRadius.circular(metrics.itemBorderRadius),
         child: buildAppMenuRowContent(
           context,
@@ -881,9 +880,10 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
           label: label,
           icon: icon,
           trailing: Icon(
+            // ב-RTL התפריט נפתח ימינה → חץ ימינה
             isRtl
-                ? FluentIcons.chevron_left_24_regular
-                : FluentIcons.chevron_right_24_regular,
+                ? FluentIcons.chevron_right_24_regular
+                : FluentIcons.chevron_left_24_regular,
             size: metrics.iconSize * 0.75,
           ),
         ),

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -835,17 +835,48 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
   IconData? icon,
   required List<Widget> menuChildren,
 }) {
+  final colorScheme = Theme.of(context).colorScheme;
   return buildAppCustomPopupMenuItem<T>(
     context: context,
     metrics: metrics,
-    child: SubmenuButton(
-      menuChildren: menuChildren,
-      style: buildAppSubmenuItemStyle(context, metrics),
-      child: buildAppMenuRowContent(
-        context,
-        metrics,
-        label: label,
-        icon: icon,
+    child: Directionality(
+      textDirection: TextDirection.rtl,
+      child: SubmenuButton(
+        alignmentOffset: const Offset(0, -8),
+        menuStyle: const MenuStyle(
+          alignment: AlignmentDirectional.topEnd,
+        ),
+        menuChildren: menuChildren,
+        style: buildAppSubmenuItemStyle(context, metrics),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(
+                icon,
+                size: metrics.iconSize,
+                color: colorScheme.onSurface,
+              ),
+              const SizedBox(width: 8),
+            ],
+            Text(
+              label,
+              textDirection: TextDirection.rtl,
+              style: TextStyle(
+                fontFamily: 'Roboto',
+                fontSize: metrics.fontSize,
+                fontWeight: metrics.itemFontWeight,
+                color: colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Icon(
+              FluentIcons.chevron_right_24_regular,
+              size: metrics.iconSize * 0.75,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
       ),
     ),
   );

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -863,7 +863,6 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
               label,
               textDirection: TextDirection.rtl,
               style: TextStyle(
-                fontFamily: 'Roboto',
                 fontSize: metrics.fontSize,
                 fontWeight: metrics.itemFontWeight,
                 color: colorScheme.onSurface,

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -847,27 +847,15 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
         ),
         menuChildren: menuChildren,
         style: buildAppSubmenuItemStyle(context, metrics),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (icon != null) ...[
-              Icon(icon, size: metrics.iconSize),
-              const SizedBox(width: 8),
-            ],
-            Text(
-              label,
-              textDirection: TextDirection.rtl,
-              style: TextStyle(
-                fontSize: metrics.fontSize,
-                fontWeight: metrics.itemFontWeight,
-              ),
-            ),
-            const SizedBox(width: 4),
-            Icon(
-              FluentIcons.chevron_right_24_regular,
-              size: metrics.iconSize * 0.75,
-            ),
-          ],
+        child: buildAppMenuRowContent(
+          context,
+          metrics,
+          label: label,
+          icon: icon,
+          trailing: Icon(
+            FluentIcons.chevron_right_24_regular,
+            size: metrics.iconSize * 0.75,
+          ),
         ),
       ),
     ),

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -836,7 +836,6 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
   required List<PopupMenuEntry<T>> menuChildren,
   ValueChanged<T>? onSelected,
 }) {
-  final isRtl = Directionality.of(context) == TextDirection.rtl;
   return buildAppCustomPopupMenuItem<T>(
     context: context,
     metrics: metrics,
@@ -857,11 +856,16 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
                   renderBox.getTransformTo(overlay),
                   Offset.zero & renderBox.size,
                 );
-                // תמיד פתח לצד ימין (itemRect.right) — התפריט הראשי תמיד בצד שמאל
+                // חשב את צד הפתיחה לפי מיקום הפריט במסך:
+                // אם הפריט בחצי הימני של המסך — פתח שמאלה, אחרת ימינה
+                final openToRight =
+                    itemRect.center.dx < overlaySize.width / 2;
+                final xPos =
+                    openToRight ? itemRect.right : itemRect.left;
                 final selected = await showMenu<T>(
                   context: innerContext,
                   position: RelativeRect.fromRect(
-                    Rect.fromLTWH(itemRect.right, itemRect.top, 0, 0),
+                    Rect.fromLTWH(xPos, itemRect.top, 0, 0),
                     Offset.zero & overlaySize,
                   ),
                   items: menuChildren,
@@ -880,10 +884,8 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
           label: label,
           icon: icon,
           trailing: Icon(
-            // ב-RTL התפריט נפתח ימינה → חץ ימינה
-            isRtl
-                ? FluentIcons.chevron_right_24_regular
-                : FluentIcons.chevron_left_24_regular,
+            // החץ מצביע לכיוון פתיחת התת-תפריט (ימינה)
+            FluentIcons.chevron_right_24_regular,
             size: metrics.iconSize * 0.75,
           ),
         ),

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -851,8 +851,6 @@ PopupMenuEntry<T> buildAppSubmenuPopupMenuItem<T>({
                 final overlayState = Overlay.maybeOf(innerContext);
                 if (overlayState == null) return;
                 final overlay = overlayState.context.findRenderObject() as RenderBox;
-                    .context
-                    .findRenderObject() as RenderBox;
                 final overlaySize = overlay.size;
                 final itemRect = MatrixUtils.transformRect(
                   renderBox.getTransformTo(overlay),

--- a/lib/widgets/navigation/responsive_action_bar.dart
+++ b/lib/widgets/navigation/responsive_action_bar.dart
@@ -229,31 +229,28 @@ class _ResponsiveActionBarState extends State<ResponsiveActionBar> {
               // אם יש submenuItems, נבנה תת-תפריט
               if (action.submenuItems != null &&
                   action.submenuItems!.isNotEmpty) {
+                final subEntries = action.submenuItems!
+                    .map((subAction) => buildAppPopupMenuItem<ActionButtonData>(
+                          context,
+                          AppMenuEntry<ActionButtonData>(
+                            value: subAction,
+                            label: subAction.tooltip ?? '',
+                            icon: subAction.icon,
+                            enabled: subAction.onPressed != null,
+                          ),
+                          menuMetrics,
+                          null,
+                          key: widget.menuItemKeysByTooltip?[
+                              subAction.tooltip ?? ''],
+                        ))
+                    .toList();
                 return buildAppSubmenuPopupMenuItem<ActionButtonData>(
                   context: context,
                   metrics: menuMetrics,
                   label: action.tooltip ?? '',
                   icon: action.icon,
-                  menuChildren: action.submenuItems!.map((subAction) {
-                    return MenuItemButton(
-                      leadingIcon: subAction.icon != null
-                          ? Icon(subAction.icon, size: menuMetrics.iconSize)
-                          : null,
-                      style: buildAppSubmenuItemStyle(context, menuMetrics),
-                      onPressed: () {
-                        Navigator.of(context).pop(); // סוגר את התפריט הראשי
-                        subAction.onPressed?.call();
-                      },
-                      child: KeyedSubtree(
-                        key: widget
-                            .menuItemKeysByTooltip?[subAction.tooltip ?? ''],
-                        child: Text(
-                          subAction.tooltip ?? '',
-                          textDirection: TextDirection.rtl,
-                        ),
-                      ),
-                    );
-                  }).toList(),
+                  menuChildren: subEntries,
+                  onSelected: (subAction) => subAction.onPressed?.call(),
                 );
               }
 

--- a/test/copy_direct_link_test.dart
+++ b/test/copy_direct_link_test.dart
@@ -1,0 +1,129 @@
+// בדיקות עבור פיצ'ר copy-direct-link
+// Feature: copy-direct-link, Property 1: book link format
+// Feature: copy-direct-link, Property 2: section link format
+
+import 'package:test/test.dart';
+
+// פונקציות עזר — העתק של הלוגיקה מ-text_book_screen.dart / pdf_book_screen.dart
+// (הפונקציות הן private methods, לכן בודקים את הלוגיקה ישירות כאן)
+
+String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
+
+String buildSectionLink(int bookId, int index) =>
+    'otzaria://open/book/$bookId?index=${index.clamp(0, double.maxFinite.toInt())}';
+
+void main() {
+  group('copy-direct-link — buildBookLink', () {
+    // בדיקות יחידה ספציפיות
+    test('מחזיר פורמט נכון עבור bookId=1', () {
+      expect(buildBookLink(1), equals('otzaria://open/book/1'));
+    });
+
+    test('מחזיר פורמט נכון עבור bookId=999', () {
+      expect(buildBookLink(999), equals('otzaria://open/book/999'));
+    });
+
+    test('מחזיר פורמט נכון עבור bookId גדול', () {
+      expect(buildBookLink(123456), equals('otzaria://open/book/123456'));
+    });
+
+    // Property 1: פורמט קישור ספר
+    // עבור כל bookId חיובי, הפלט הוא בדיוק 'otzaria://open/book/<bookId>'
+    test('Property 1: פורמט קישור ספר — 200 ערכים אקראיים', () {
+      // Validates: Requirements 1.5, 3.1
+      final random = List.generate(200, (i) => i + 1); // bookIds 1..200
+      for (final bookId in random) {
+        final link = buildBookLink(bookId);
+        expect(
+          link,
+          equals('otzaria://open/book/$bookId'),
+          reason: 'bookId=$bookId',
+        );
+        // ודא שאין פרמטרים נוספים
+        expect(link.contains('?'), isFalse, reason: 'bookId=$bookId');
+        // ודא שהסכמה נכונה
+        expect(link.startsWith('otzaria://open/book/'), isTrue,
+            reason: 'bookId=$bookId');
+      }
+    });
+
+    test('Property 1: ערכי bookId גדולים', () {
+      // Validates: Requirements 1.5, 3.1
+      for (final bookId in [1000, 9999, 100000, 999999]) {
+        final link = buildBookLink(bookId);
+        expect(link, equals('otzaria://open/book/$bookId'));
+      }
+    });
+  });
+
+  group('copy-direct-link — buildSectionLink', () {
+    // בדיקות יחידה ספציפיות
+    test('מחזיר פורמט נכון עבור bookId=1, index=0', () {
+      expect(
+          buildSectionLink(1, 0), equals('otzaria://open/book/1?index=0'));
+    });
+
+    test('מחזיר פורמט נכון עבור bookId=42, index=100', () {
+      expect(
+          buildSectionLink(42, 100), equals('otzaria://open/book/42?index=100'));
+    });
+
+    // edge case: index שלילי → ?index=0
+    test('edge case: index שלילי מוחלף ב-0', () {
+      expect(buildSectionLink(1, -1), equals('otzaria://open/book/1?index=0'));
+      expect(buildSectionLink(5, -100), equals('otzaria://open/book/5?index=0'));
+    });
+
+    test('edge case: index=0 נשמר כ-0', () {
+      expect(buildSectionLink(1, 0), equals('otzaria://open/book/1?index=0'));
+    });
+
+    // Property 2: פורמט קישור מקטע
+    // עבור כל bookId חיובי ו-index כלשהו, הפלט הוא
+    // 'otzaria://open/book/<bookId>?index=<max(0,index)>'
+    test('Property 2: פורמט קישור מקטע — ערכי index אי-שליליים', () {
+      // Validates: Requirements 1.6, 2.6, 3.2, 3.4
+      for (int bookId = 1; bookId <= 50; bookId++) {
+        for (int index = 0; index <= 100; index += 10) {
+          final link = buildSectionLink(bookId, index);
+          expect(
+            link,
+            equals('otzaria://open/book/$bookId?index=$index'),
+            reason: 'bookId=$bookId, index=$index',
+          );
+        }
+      }
+    });
+
+    test('Property 2: ערכי index שליליים מוחלפים ב-0', () {
+      // Validates: Requirements 3.4
+      for (int bookId = 1; bookId <= 20; bookId++) {
+        for (final negIndex in [-1, -5, -100, -9999]) {
+          final link = buildSectionLink(bookId, negIndex);
+          expect(
+            link,
+            equals('otzaria://open/book/$bookId?index=0'),
+            reason: 'bookId=$bookId, index=$negIndex',
+          );
+        }
+      }
+    });
+
+    test('Property 2: הקישור תמיד מכיל ?index=', () {
+      // Validates: Requirements 3.2
+      for (int bookId = 1; bookId <= 30; bookId++) {
+        for (int index = -5; index <= 50; index += 5) {
+          final link = buildSectionLink(bookId, index);
+          expect(link.contains('?index='), isTrue,
+              reason: 'bookId=$bookId, index=$index');
+          expect(link.startsWith('otzaria://open/book/'), isTrue,
+              reason: 'bookId=$bookId, index=$index');
+          // ודא שה-index בפועל הוא max(0, index)
+          final expectedIndex = index < 0 ? 0 : index;
+          expect(link.endsWith('?index=$expectedIndex'), isTrue,
+              reason: 'bookId=$bookId, index=$index');
+        }
+      }
+    });
+  });
+}

--- a/test/copy_direct_link_test.dart
+++ b/test/copy_direct_link_test.dart
@@ -2,12 +2,8 @@
 // Feature: copy-direct-link, Property 1: book link format
 // Feature: copy-direct-link, Property 2: section link format
 
+import 'package:otzaria/utils/book_link_builder.dart';
 import 'package:test/test.dart';
-
-// הלוגיקה הטהורה — מועתקת מ-link_helpers.dart לצורך בדיקה ללא תלות ב-Flutter
-String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
-String buildSectionLink(int bookId, int index) =>
-    'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
 
 void main() {
   group('copy-direct-link — buildBookLink', () {
@@ -78,10 +74,8 @@ void main() {
         for (int index = -5; index <= 50; index += 5) {
           final link = buildSectionLink(bookId, index);
           final expectedIndex = index < 0 ? 0 : index;
-          expect(
-              link,
-              equals(
-                  'otzaria://open/book/$bookId?index=$expectedIndex'),
+          expect(link,
+              equals('otzaria://open/book/$bookId?index=$expectedIndex'),
               reason: 'bookId=$bookId, index=$index');
         }
       }

--- a/test/copy_direct_link_test.dart
+++ b/test/copy_direct_link_test.dart
@@ -4,17 +4,13 @@
 
 import 'package:test/test.dart';
 
-// פונקציות עזר — העתק של הלוגיקה מ-text_book_screen.dart / pdf_book_screen.dart
-// (הפונקציות הן private methods, לכן בודקים את הלוגיקה ישירות כאן)
-
+// הלוגיקה הטהורה — מועתקת מ-link_helpers.dart לצורך בדיקה ללא תלות ב-Flutter
 String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
-
 String buildSectionLink(int bookId, int index) =>
     'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
 
 void main() {
   group('copy-direct-link — buildBookLink', () {
-    // בדיקות יחידה ספציפיות
     test('מחזיר פורמט נכון עבור bookId=1', () {
       expect(buildBookLink(1), equals('otzaria://open/book/1'));
     });
@@ -27,100 +23,65 @@ void main() {
       expect(buildBookLink(123456), equals('otzaria://open/book/123456'));
     });
 
-    // Property 1: פורמט קישור ספר
-    // עבור כל bookId חיובי, הפלט הוא בדיוק 'otzaria://open/book/<bookId>'
-    test('Property 1: פורמט קישור ספר — 200 ערכים אקראיים', () {
-      // Validates: Requirements 1.5, 3.1
-      final random = List.generate(200, (i) => i + 1); // bookIds 1..200
-      for (final bookId in random) {
+    // Property 1: פורמט קישור ספר — Validates: Requirements 1.5, 3.1
+    test('Property 1: פורמט קישור ספר — 200 ערכים', () {
+      for (int bookId = 1; bookId <= 200; bookId++) {
         final link = buildBookLink(bookId);
-        expect(
-          link,
-          equals('otzaria://open/book/$bookId'),
-          reason: 'bookId=$bookId',
-        );
-        // ודא שאין פרמטרים נוספים
+        expect(link, equals('otzaria://open/book/$bookId'),
+            reason: 'bookId=$bookId');
         expect(link.contains('?'), isFalse, reason: 'bookId=$bookId');
-        // ודא שהסכמה נכונה
         expect(link.startsWith('otzaria://open/book/'), isTrue,
             reason: 'bookId=$bookId');
-      }
-    });
-
-    test('Property 1: ערכי bookId גדולים', () {
-      // Validates: Requirements 1.5, 3.1
-      for (final bookId in [1000, 9999, 100000, 999999]) {
-        final link = buildBookLink(bookId);
-        expect(link, equals('otzaria://open/book/$bookId'));
       }
     });
   });
 
   group('copy-direct-link — buildSectionLink', () {
-    // בדיקות יחידה ספציפיות
     test('מחזיר פורמט נכון עבור bookId=1, index=0', () {
-      expect(
-          buildSectionLink(1, 0), equals('otzaria://open/book/1?index=0'));
-    });
-
-    test('מחזיר פורמט נכון עבור bookId=42, index=100', () {
-      expect(
-          buildSectionLink(42, 100), equals('otzaria://open/book/42?index=100'));
-    });
-
-    // edge case: index שלילי → ?index=0
-    test('edge case: index שלילי מוחלף ב-0', () {
-      expect(buildSectionLink(1, -1), equals('otzaria://open/book/1?index=0'));
-      expect(buildSectionLink(5, -100), equals('otzaria://open/book/5?index=0'));
-    });
-
-    test('edge case: index=0 נשמר כ-0', () {
       expect(buildSectionLink(1, 0), equals('otzaria://open/book/1?index=0'));
     });
 
-    // Property 2: פורמט קישור מקטע
-    // עבור כל bookId חיובי ו-index כלשהו, הפלט הוא
-    // 'otzaria://open/book/<bookId>?index=<max(0,index)>'
-    test('Property 2: פורמט קישור מקטע — ערכי index אי-שליליים', () {
-      // Validates: Requirements 1.6, 2.6, 3.2, 3.4
+    test('מחזיר פורמט נכון עבור bookId=42, index=100', () {
+      expect(buildSectionLink(42, 100),
+          equals('otzaria://open/book/42?index=100'));
+    });
+
+    test('edge case: index שלילי מוחלף ב-0', () {
+      expect(buildSectionLink(1, -1), equals('otzaria://open/book/1?index=0'));
+      expect(
+          buildSectionLink(5, -100), equals('otzaria://open/book/5?index=0'));
+    });
+
+    // Property 2: פורמט קישור מקטע — Validates: Requirements 1.6, 2.6, 3.2, 3.4
+    test('Property 2: ערכי index אי-שליליים', () {
       for (int bookId = 1; bookId <= 50; bookId++) {
         for (int index = 0; index <= 100; index += 10) {
           final link = buildSectionLink(bookId, index);
-          expect(
-            link,
-            equals('otzaria://open/book/$bookId?index=$index'),
-            reason: 'bookId=$bookId, index=$index',
-          );
+          expect(link, equals('otzaria://open/book/$bookId?index=$index'),
+              reason: 'bookId=$bookId, index=$index');
         }
       }
     });
 
     test('Property 2: ערכי index שליליים מוחלפים ב-0', () {
-      // Validates: Requirements 3.4
       for (int bookId = 1; bookId <= 20; bookId++) {
         for (final negIndex in [-1, -5, -100, -9999]) {
           final link = buildSectionLink(bookId, negIndex);
-          expect(
-            link,
-            equals('otzaria://open/book/$bookId?index=0'),
-            reason: 'bookId=$bookId, index=$negIndex',
-          );
+          expect(link, equals('otzaria://open/book/$bookId?index=0'),
+              reason: 'bookId=$bookId, index=$negIndex');
         }
       }
     });
 
-    test('Property 2: הקישור תמיד מכיל ?index=', () {
-      // Validates: Requirements 3.2
+    test('Property 2: הקישור תמיד מכיל ?index= עם max(0,index)', () {
       for (int bookId = 1; bookId <= 30; bookId++) {
         for (int index = -5; index <= 50; index += 5) {
           final link = buildSectionLink(bookId, index);
-          expect(link.contains('?index='), isTrue,
-              reason: 'bookId=$bookId, index=$index');
-          expect(link.startsWith('otzaria://open/book/'), isTrue,
-              reason: 'bookId=$bookId, index=$index');
-          // ודא שה-index בפועל הוא max(0, index)
           final expectedIndex = index < 0 ? 0 : index;
-          expect(link.endsWith('?index=$expectedIndex'), isTrue,
+          expect(
+              link,
+              equals(
+                  'otzaria://open/book/$bookId?index=$expectedIndex'),
               reason: 'bookId=$bookId, index=$index');
         }
       }

--- a/test/copy_direct_link_test.dart
+++ b/test/copy_direct_link_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 String buildBookLink(int bookId) => 'otzaria://open/book/$bookId';
 
 String buildSectionLink(int bookId, int index) =>
-    'otzaria://open/book/$bookId?index=${index.clamp(0, double.maxFinite.toInt())}';
+    'otzaria://open/book/$bookId?index=${index < 0 ? 0 : index}';
 
 void main() {
   group('copy-direct-link — buildBookLink', () {


### PR DESCRIPTION
- הוספת פריט תת-תפריט 'העתק קישור ישיר' בתפריט 3 הנקודות של ספרי טקסט וספרי PDF
- תת-תפריט כולל שתי אפשרויות: 'העתק קישור ישיר לספר זה' ו'העתק קישור ישיר למקטע/עמוד זה'
- הקישורים מבוססים על סכמת otzaria://open/book/<id> הקיימת
- לאחר ההעתקה מוצגת הודעת UiSnack 'הקישור הועתק ללוח'
- בספרי PDF ללא מזהה במסד הנתונים הכפתורים מושבתים
- תיקון PdfBook.fromJson/toJson לשמירת שדה id
- שיפור עיצוב תת-תפריט: חץ כיוון + פתיחה ימינה
- הוספת בדיקות property-based לפונקציות בניית הקישורים

<img width="303" height="337" alt="image" src="https://github.com/user-attachments/assets/590fe609-c7a9-4c89-bc2e-f9602de0a957" />

<img width="309" height="375" alt="image" src="https://github.com/user-attachments/assets/acb27699-26a3-4f7b-afd2-b502526d4331" />

הערות
שלב א בוצע בהצלחה הוספת הלחצן העתק קישור ישיר בתפריט 3 נקודות בספרי טקסט (בספרי PDF לא פעיל כרגע עד שיסדרו שיקבל את הID הנכון)
שלב ב של הוספת לחצן זה בתפריט מקש ימני מחכה לביצוע (אולי ע"י @palmoni5) של אופציה של העתקת קישור עם טקסט מודגש כמו שביקשתי [כאן](https://otzaria.org/forum/post/16214)

/gemini review

