### PR TITLE
שיפור: שורת טאבים ברוחב שווה לחיסכון במקום וסדר במצב טאבים מוצמדים לימין בלבד

### DIFF
--- a/lib/core/focus_repository.dart
+++ b/lib/core/focus_repository.dart
@@ -218,12 +218,12 @@ class FocusRepository {
 
   /// שחזור עם debounce — עבור resize רציף.
   ///
-  /// מבטל את הטיימר הקודם בכל קריאה וממתין 3000ms ללא resize נוסף.
+  /// מבטל את הטיימר הקודם בכל קריאה וממתין 150ms ללא resize נוסף.
   /// גם כאן [_effectiveRestorer] מחושב **בזמן ריצת הטיימר**, לא בזמן הקריאה.
   void scheduleRestoreDebounced() {
     _resizeDebounceTimer?.cancel();
     if (_effectiveRestorer == null) return;
-    _resizeDebounceTimer = Timer(const Duration(seconds: 3), () {
+    _resizeDebounceTimer = Timer(const Duration(milliseconds: 150), () {
       final r = _effectiveRestorer;
       if (r != null && r.canRestore()) r.restore();
     });

--- a/lib/core/focus_repository.dart
+++ b/lib/core/focus_repository.dart
@@ -218,12 +218,12 @@ class FocusRepository {
 
   /// שחזור עם debounce — עבור resize רציף.
   ///
-  /// מבטל את הטיימר הקודם בכל קריאה וממתין 150ms ללא resize נוסף.
+  /// מבטל את הטיימר הקודם בכל קריאה וממתין 3000ms ללא resize נוסף.
   /// גם כאן [_effectiveRestorer] מחושב **בזמן ריצת הטיימר**, לא בזמן הקריאה.
   void scheduleRestoreDebounced() {
     _resizeDebounceTimer?.cancel();
     if (_effectiveRestorer == null) return;
-    _resizeDebounceTimer = Timer(const Duration(milliseconds: 150), () {
+    _resizeDebounceTimer = Timer(const Duration(seconds: 3), () {
       final r = _effectiveRestorer;
       if (r != null && r.canRestore()) r.restore();
     });

--- a/lib/library/view/book_preview_panel.dart
+++ b/lib/library/view/book_preview_panel.dart
@@ -389,6 +389,7 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
           controller: _pdfController!,
           params: PdfViewerParams(
             backgroundColor: Theme.of(context).colorScheme.surface,
+            // ignore: deprecated_member_use
             maxScale: 10,
             horizontalCacheExtent: 0,
             verticalCacheExtent: 1,

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -24,7 +24,6 @@ import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/bookmarks/view/bookmark_screen.dart';
 import 'package:otzaria/workspaces/view/workspace_switcher_dialog.dart';
 import 'package:otzaria/utils/ui/fullscreen_helper.dart';
-import 'package:otzaria/utils/text/text_manipulation.dart';
 import 'package:otzaria/history/bloc/history_bloc.dart';
 import 'package:otzaria/history/bloc/history_event.dart';
 import 'package:otzaria/library/bloc/library_bloc.dart';
@@ -660,10 +659,6 @@ class _CustomTitleBarState extends State<CustomTitleBar>
     // מזהים את כיוון השפה כדי לדעת מאיזה צד לפתוח את הרווח
     final isRtl = Directionality.of(context) == TextDirection.rtl;
 
-    bool isTabActive(int tabIndex) {
-      return tabIndex == state.currentTabIndex;
-    }
-
     // State לניהול hover על הטאב
     bool isTabHovered = false;
 
@@ -713,6 +708,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                                   tab.title,
                                   overflow: TextOverflow.clip,
                                   maxLines: 1,
+                                  softWrap: false,
                                 ),
                               ),
                             ],
@@ -729,6 +725,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                               title,
                               overflow: TextOverflow.clip,
                               maxLines: 1,
+                              softWrap: false,
                             ),
                           ),
                         ),
@@ -756,6 +753,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                                       tab.title,
                                       overflow: TextOverflow.clip,
                                       maxLines: 1,
+                                      softWrap: false,
                                     ),
                                   ),
                                 ],
@@ -779,6 +777,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                                 tab.title,
                                 overflow: TextOverflow.clip,
                                 maxLines: 1,
+                                softWrap: false,
                               ),
                             );
                           },

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -54,6 +55,10 @@ const double _kActionButtonWidth = 56.0;
 const double _kWindowCaptionButtonsWidth = 138.0;
 const double _kWindowCaptionButtonWidth = 46.0;
 
+// קבועים לחישוב רוחב טאבים בסגנון Chrome
+const double _kMaxTabWidth = 200.0;
+const double _kMinTabWidth = 56.0;
+
 /// סגנון משותף לכפתורי האייקון בשורת הכותרת
 final ButtonStyle _kIconButtonStyle = IconButton.styleFrom(
   minimumSize: const Size(32, 32),
@@ -69,10 +74,59 @@ class _CustomTitleBarState extends State<CustomTitleBar>
   bool _tabsOverflow = false;
   TabController? _tabController;
 
+  // ניהול רוחב טאבים בסגנון Chrome
+  int _displayedTabCount = 0;
+  List<OpenedTab>? _previousTabs;
+  Timer? _tabCloseDebounce;
+
   @override
   void dispose() {
+    _tabCloseDebounce?.cancel();
     _tabController?.dispose();
     super.dispose();
+  }
+
+  /// מעדכן את _displayedTabCount לפי הלוגיקה:
+  /// - פתיחת טאב: מיידי
+  /// - סגירת הטאב האחרון ברשימה: מיידי
+  /// - סגירת טאב אחר: עיכוב 2 שניות
+  void _updateTabsDisplay(TabsState state) {
+    final newTabs = state.tabs;
+    final newCount = newTabs.length;
+    final prevTabs = _previousTabs;
+    _previousTabs = List.unmodifiable(newTabs);
+
+    if (prevTabs == null) return; // אתחול ראשוני מטופל בבנאי
+
+    final prevCount = prevTabs.length;
+    if (newCount == prevCount) return;
+
+    if (newCount > prevCount) {
+      // נפתח טאב חדש — מיידי
+      _tabCloseDebounce?.cancel();
+      setState(() => _displayedTabCount = newCount);
+      return;
+    }
+
+    // נסגר טאב — בדוק אם היה הטאב האחרון
+    final bool lastTabRemoved = prevTabs.isNotEmpty &&
+        newCount == prevCount - 1 &&
+        (newCount == 0 || !newTabs.contains(prevTabs.last));
+
+    if (lastTabRemoved) {
+      // הטאב האחרון נסגר — מיידי (כפתור ה-X נשאר באותו מקום)
+      _tabCloseDebounce?.cancel();
+      setState(() => _displayedTabCount = newCount);
+    } else {
+      // טאב פנימי נסגר — עיכוב 2 שניות למניעת קפיצות
+      _tabCloseDebounce?.cancel();
+      _tabCloseDebounce = Timer(const Duration(seconds: 2), () {
+        if (mounted) {
+          setState(
+              () => _displayedTabCount = context.read<TabsBloc>().state.tabs.length);
+        }
+      });
+    }
   }
 
   void _handleReadingTabControllerChange() {
@@ -350,8 +404,15 @@ class _CustomTitleBarState extends State<CustomTitleBar>
   }
 
   Widget _buildReadingTabs(BuildContext context, SettingsState settingsState) {
-    return BlocBuilder<TabsBloc, TabsState>(
+    return BlocConsumer<TabsBloc, TabsState>(
+      listener: (context, state) => _updateTabsDisplay(state),
       builder: (context, state) {
+        // אתחול ראשוני של המספר המוצג
+        if (_previousTabs == null) {
+          _displayedTabCount = state.tabs.length;
+          _previousTabs = List.unmodifiable(state.tabs);
+        }
+
         if (!state.hasOpenTabs) {
           return DragToMoveArea(
             child: Center(
@@ -396,57 +457,72 @@ class _CustomTitleBarState extends State<CustomTitleBar>
               ),
             // אזור הטאבים המעודכן
             Expanded(
-              child: DragTarget<OpenedTab>(
-                onWillAcceptWithDetails: (details) => state.tabs.length > 1,
-                onAcceptWithDetails: (details) {
-                  // מקבלים את רוחב המסך הכולל ואת מיקום העכבר בעת העזיבה
-                  final RenderBox renderBox =
-                      context.findRenderObject() as RenderBox;
-                  final localOffset = renderBox.globalToLocal(details.offset);
-                  final isLeftHalf =
-                      localOffset.dx < (renderBox.size.width / 2);
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  // חישוב רוחב טאב בסגנון Chrome
+                  final int displayCount = _displayedTabCount.clamp(1, 9999);
+                  double tabWidth =
+                      constraints.maxWidth / displayCount;
+                  tabWidth = tabWidth.clamp(_kMinTabWidth, _kMaxTabWidth);
 
-                  // בודקים אם כיוון האפליקציה הוא מימין לשמאל (RTL) - אוצריא בעברית
-                  final isRtl = Directionality.of(context) == TextDirection.rtl;
+                  return DragTarget<OpenedTab>(
+                    onWillAcceptWithDetails: (details) => state.tabs.length > 1,
+                    onAcceptWithDetails: (details) {
+                      // מקבלים את רוחב המסך הכולל ואת מיקום העכבר בעת העזיבה
+                      final RenderBox renderBox =
+                          context.findRenderObject() as RenderBox;
+                      final localOffset =
+                          renderBox.globalToLocal(details.offset);
+                      final isLeftHalf =
+                          localOffset.dx < (renderBox.size.width / 2);
 
-                  // חישוב האינדקס החדש
-                  int newIndex;
-                  if (isRtl) {
-                    newIndex = isLeftHalf ? state.tabs.length - 1 : 0;
-                  } else {
-                    newIndex = isLeftHalf ? 0 : state.tabs.length - 1;
-                  }
+                      // בודקים אם כיוון האפליקציה הוא מימין לשמאל (RTL)
+                      final isRtl =
+                          Directionality.of(context) == TextDirection.rtl;
 
-                  final draggedTab = details.data;
-                  final currentIndex = state.tabs.indexOf(draggedTab);
+                      // חישוב האינדקס החדש
+                      int newIndex;
+                      if (isRtl) {
+                        newIndex = isLeftHalf ? state.tabs.length - 1 : 0;
+                      } else {
+                        newIndex = isLeftHalf ? 0 : state.tabs.length - 1;
+                      }
 
-                  // מבצעים את ההעברה רק אם הטאב באמת שינה מיקום
-                  if (currentIndex != -1 && currentIndex != newIndex) {
-                    context.read<TabsBloc>().add(MoveTab(draggedTab, newIndex));
-                  }
-                },
-                builder: (context, candidateData, rejectedData) {
-                  return DragToMoveArea(
-                    child: KeyedSubtree(
-                      key: tourReadingTabsTargetKey,
-                      child: ScrollableTabBarWithArrows(
-                        controller: _tabController!,
-                        tabAlignment: settingsState.alignTabsToRight
-                            ? TabAlignment.start
-                            : TabAlignment.center,
-                        hideArrowsWhenNotScrollable:
-                            settingsState.alignTabsToRight,
-                        onOverflowChanged: (overflow) {
-                          if (mounted && _tabsOverflow != overflow) {
-                            setState(() => _tabsOverflow = overflow);
-                          }
-                        },
-                        tabs: state.tabs
-                            .map((tab) =>
-                                _buildTab(context, tab, state, settingsState))
-                            .toList(),
-                      ),
-                    ),
+                      final draggedTab = details.data;
+                      final currentIndex = state.tabs.indexOf(draggedTab);
+
+                      // מבצעים את ההעברה רק אם הטאב באמת שינה מיקום
+                      if (currentIndex != -1 && currentIndex != newIndex) {
+                        context
+                            .read<TabsBloc>()
+                            .add(MoveTab(draggedTab, newIndex));
+                      }
+                    },
+                    builder: (context, candidateData, rejectedData) {
+                      return DragToMoveArea(
+                        child: KeyedSubtree(
+                          key: tourReadingTabsTargetKey,
+                          child: ScrollableTabBarWithArrows(
+                            controller: _tabController!,
+                            tabAlignment: settingsState.alignTabsToRight
+                                ? TabAlignment.start
+                                : TabAlignment.center,
+                            hideArrowsWhenNotScrollable:
+                                settingsState.alignTabsToRight,
+                            onOverflowChanged: (overflow) {
+                              if (mounted && _tabsOverflow != overflow) {
+                                setState(() => _tabsOverflow = overflow);
+                              }
+                            },
+                            tabWidth: tabWidth,
+                            tabs: state.tabs
+                                .map((tab) => _buildTab(
+                                    context, tab, state, settingsState))
+                                .toList(),
+                          ),
+                        ),
+                      );
+                    },
                   );
                 },
               ),

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -57,7 +57,8 @@ const double _kWindowCaptionButtonWidth = 46.0;
 
 // קבועים לחישוב רוחב טאבים בסגנון Chrome
 const double _kMaxTabWidth = 200.0;
-const double _kMinTabWidth = 56.0;
+// מינימום: padding (12) + tab padding (16) + pin icon (15) + X (25) + 2 אותיות עברית (20)
+const double _kMinTabWidth = 88.0;
 
 /// סגנון משותף לכפתורי האייקון בשורת הכותרת
 final ButtonStyle _kIconButtonStyle = IconButton.styleFrom(
@@ -657,136 +658,137 @@ class _CustomTitleBarState extends State<CustomTitleBar>
 
     // פונקציה פנימית לבניית המראה של הטאב כדי למנוע כפילות קוד באנימציות
     Widget buildTabAppearance(StateSetter? setState) {
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if ((index == 0 && !isTabActive(0)) ||
-              (index > 0 && !isTabActive(index) && !isTabActive(index - 1)))
-            Container(
-              width: 1,
-              height: 24,
-              margin: const EdgeInsets.only(top: 6, bottom: 6),
-              color: Colors.grey.shade400,
-            ),
-          Container(
-            constraints: const BoxConstraints(maxHeight: 32),
-            padding: EdgeInsets.only(
-                left: 6,
-                right: (index == 0 && settingsState.alignTabsToRight) ? 0 : 6,
-                top: 0,
-                bottom: 0),
-            child: CustomPaint(
-              painter: isSelected
-                  ? _TabBackgroundPainter(
-                      Theme.of(context).colorScheme.surfaceContainer)
-                  : null,
-              child: Tab(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: DefaultTextStyle(
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.onSurface,
-                      fontWeight:
-                          isSelected ? FontWeight.w600 : FontWeight.normal,
-                      fontSize: 14,
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        _buildPinIconInline(context, tab, isTabHovered),
-                        if (tab is CombinedTab)
-                          Tooltip(
-                            message: tab.title,
-                            child: Row(
-                              children: [
-                                const Padding(
-                                  padding: EdgeInsets.all(8.0),
-                                  child: Icon(
-                                      FluentIcons.panel_left_text_24_regular,
-                                      size: 16),
+      return Container(
+        constraints: const BoxConstraints(maxHeight: 32),
+        padding: EdgeInsets.only(
+            left: 6,
+            right: (index == 0 && settingsState.alignTabsToRight) ? 0 : 6,
+            top: 0,
+            bottom: 0),
+        child: CustomPaint(
+          painter: isSelected
+              ? _TabBackgroundPainter(
+                  Theme.of(context).colorScheme.surfaceContainer)
+              : null,
+          child: Tab(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: DefaultTextStyle(
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurface,
+                  fontWeight:
+                      isSelected ? FontWeight.w600 : FontWeight.normal,
+                  fontSize: 14,
+                ),
+                child: Row(
+                  children: [
+                    _buildPinIconInline(context, tab, isTabHovered),
+                    if (tab is CombinedTab)
+                      Expanded(
+                        child: Tooltip(
+                          message: tab.title,
+                          child: Row(
+                            children: [
+                              const Icon(
+                                  FluentIcons.panel_left_text_24_regular,
+                                  size: 16),
+                              const SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  tab.title,
+                                  overflow: TextOverflow.ellipsis,
+                                  maxLines: 1,
                                 ),
-                                Text(truncate(tab.title, 20)),
-                              ],
-                            ),
-                          )
-                        else if (tab is SearchingTab)
-                          ValueListenableBuilder<String>(
-                            valueListenable: tab.titleNotifier,
-                            builder: (context, title, child) => Tooltip(
-                              message: title,
-                              child: Text(
-                                truncate(title, 25),
                               ),
-                            ),
-                          )
-                        else if (tab is PdfBookTab)
-                          ValueListenableBuilder<String>(
-                            valueListenable: tab.currentTitle,
-                            builder: (context, currentTitleValue, child) {
-                              final tooltipMessage =
-                                  currentTitleValue.isNotEmpty
-                                      ? '${tab.title}, $currentTitleValue'
-                                      : tab.title;
-                              return Tooltip(
-                                message: tooltipMessage,
-                                child: Row(
-                                  children: [
-                                    const Padding(
-                                      padding: EdgeInsets.all(8.0),
-                                      child: Icon(
-                                          FluentIcons.document_pdf_24_regular,
-                                          size: 16),
-                                    ),
-                                    Text(truncate(tab.title, 12)),
-                                  ],
-                                ),
-                              );
-                            },
-                          )
-                        else
-                          ValueListenableBuilder<String>(
-                            valueListenable: (tab as TextBookTab).currentTitle,
-                            builder: (context, currentTitleValue, child) {
-                              final tooltipMessage =
-                                  currentTitleValue.isNotEmpty
-                                      ? '${tab.title}, $currentTitleValue'
-                                      : tab.title;
-                              return Tooltip(
-                                message: tooltipMessage,
-                                child: Text(truncate(tab.title, 12)),
-                              );
-                            },
-                          ),
-                        Tooltip(
-                          preferBelow: false,
-                          message: closeTabShortcut.toUpperCase(),
-                          child: IconButton(
-                            constraints: const BoxConstraints(
-                              minWidth: 25,
-                              minHeight: 25,
-                              maxWidth: 25,
-                              maxHeight: 25,
-                            ),
-                            onPressed: () => closeTab(tab, context),
-                            icon: const Icon(FluentIcons.dismiss_24_regular,
-                                size: 10),
+                            ],
                           ),
                         ),
-                      ],
+                      )
+                    else if (tab is SearchingTab)
+                      Expanded(
+                        child: ValueListenableBuilder<String>(
+                          valueListenable: tab.titleNotifier,
+                          builder: (context, title, child) => Tooltip(
+                            message: title,
+                            child: Text(
+                              title,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                            ),
+                          ),
+                        ),
+                      )
+                    else if (tab is PdfBookTab)
+                      Expanded(
+                        child: ValueListenableBuilder<String>(
+                          valueListenable: tab.currentTitle,
+                          builder: (context, currentTitleValue, child) {
+                            final tooltipMessage =
+                                currentTitleValue.isNotEmpty
+                                    ? '${tab.title}, $currentTitleValue'
+                                    : tab.title;
+                            return Tooltip(
+                              message: tooltipMessage,
+                              child: Row(
+                                children: [
+                                  const Icon(
+                                      FluentIcons.document_pdf_24_regular,
+                                      size: 16),
+                                  const SizedBox(width: 4),
+                                  Expanded(
+                                    child: Text(
+                                      tab.title,
+                                      overflow: TextOverflow.ellipsis,
+                                      maxLines: 1,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
+                      )
+                    else
+                      Expanded(
+                        child: ValueListenableBuilder<String>(
+                          valueListenable: (tab as TextBookTab).currentTitle,
+                          builder: (context, currentTitleValue, child) {
+                            final tooltipMessage =
+                                currentTitleValue.isNotEmpty
+                                    ? '${tab.title}, $currentTitleValue'
+                                    : tab.title;
+                            return Tooltip(
+                              message: tooltipMessage,
+                              child: Text(
+                                tab.title,
+                                overflow: TextOverflow.ellipsis,
+                                maxLines: 1,
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    Tooltip(
+                      preferBelow: false,
+                      message: closeTabShortcut.toUpperCase(),
+                      child: IconButton(
+                        constraints: const BoxConstraints(
+                          minWidth: 25,
+                          minHeight: 25,
+                          maxWidth: 25,
+                          maxHeight: 25,
+                        ),
+                        onPressed: () => closeTab(tab, context),
+                        icon: const Icon(FluentIcons.dismiss_24_regular,
+                            size: 10),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
               ),
             ),
           ),
-          if (index == state.tabs.length - 1 && !isTabActive(index))
-            Container(
-              width: 1,
-              height: 24,
-              margin: const EdgeInsets.only(top: 6, bottom: 6),
-              color: Colors.grey.shade400,
-            ),
-        ],
+        ),
       );
     }
 

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' show max;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -57,8 +58,8 @@ const double _kWindowCaptionButtonWidth = 46.0;
 
 // קבועים לחישוב רוחב טאבים בסגנון Chrome
 const double _kMaxTabWidth = 200.0;
-// מינימום: padding (12) + tab padding (16) + pin icon (15) + X (25) + 2 אותיות עברית (20)
-const double _kMinTabWidth = 88.0;
+// מינימום: padding (4) + tab padding (8) + pin icon (15) + X (25) + 2 אותיות עברית (20)
+const double _kMinTabWidth = 72.0;
 
 /// סגנון משותף לכפתורי האייקון בשורת הכותרת
 final ButtonStyle _kIconButtonStyle = IconButton.styleFrom(
@@ -461,7 +462,10 @@ class _CustomTitleBarState extends State<CustomTitleBar>
               child: LayoutBuilder(
                 builder: (context, constraints) {
                   // חישוב רוחב טאב בסגנון Chrome
-                  final int displayCount = _displayedTabCount.clamp(1, 9999);
+                  // שימוש ב-max כדי שבפתיחת טאב חדש (לפני שה-setState מתעדכן)
+                  // לא יהיו יותר טאבים ממה שמחושב — ימנע overflow וחיצי גלילה מיותרים
+                  final int displayCount =
+                      max(_displayedTabCount, state.tabs.length).clamp(1, 9999);
                   double tabWidth =
                       constraints.maxWidth / displayCount;
                   tabWidth = tabWidth.clamp(_kMinTabWidth, _kMaxTabWidth);
@@ -528,6 +532,10 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                 },
               ),
             ),
+
+            // רווח קבוע בין הכרטסיה האחרונה לבין סמל ההגדרות (~חצי טאב)
+            // רלוונטי רק במצב צמוד-לימין; במצב ממורכז אין צורך ברווח זה
+            if (settingsState.alignTabsToRight) const SizedBox(width: 36),
 
             // כפתורים נוספים (הגדרות)
             DragToMoveArea(
@@ -603,24 +611,27 @@ class _CustomTitleBarState extends State<CustomTitleBar>
   /// בונה אייקון הצמדה inline עם hover state מהטאב
   Widget _buildPinIconInline(
       BuildContext context, OpenedTab tab, bool isHovered) {
-    return GestureDetector(
-      onTap: () => context.read<TabsBloc>().add(TogglePinTab(tab)),
-      child: Padding(
-        padding: const EdgeInsets.only(right: 1.0),
-        child: Tooltip(
-          message: tab.isPinned ? 'בטל הצמדה' : 'הצמד כרטיסיה',
-          child: AnimatedOpacity(
-            duration: const Duration(milliseconds: 150),
-            opacity: (tab.isPinned || isHovered) ? 1.0 : 0.0,
-            child: Icon(
-              tab.isPinned
-                  ? FluentIcons.pin_24_filled
-                  : FluentIcons.pin_24_regular,
-              size: 14,
-            ),
-          ),
-        ),
-      ),
+    final show = tab.isPinned || isHovered;
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 150),
+      curve: Curves.easeInOut,
+      child: show
+          ? GestureDetector(
+              onTap: () => context.read<TabsBloc>().add(TogglePinTab(tab)),
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(start: 1.0, end: 4.0),
+                child: Tooltip(
+                  message: tab.isPinned ? 'בטל הצמדה' : 'הצמד כרטיסיה',
+                  child: Icon(
+                    tab.isPinned
+                        ? FluentIcons.pin_24_filled
+                        : FluentIcons.pin_24_regular,
+                    size: 14,
+                  ),
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
     );
   }
 
@@ -661,8 +672,8 @@ class _CustomTitleBarState extends State<CustomTitleBar>
       return Container(
         constraints: const BoxConstraints(maxHeight: 32),
         padding: EdgeInsets.only(
-            left: 6,
-            right: (index == 0 && settingsState.alignTabsToRight) ? 0 : 6,
+            left: 2,
+            right: (index == 0 && settingsState.alignTabsToRight) ? 0 : 2,
             top: 0,
             bottom: 0),
         child: CustomPaint(
@@ -672,7 +683,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
               : null,
           child: Tab(
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              padding: const EdgeInsets.symmetric(horizontal: 4.0),
               child: DefaultTextStyle(
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSurface,
@@ -680,23 +691,27 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                       isSelected ? FontWeight.w600 : FontWeight.normal,
                   fontSize: 14,
                 ),
-                child: Row(
-                  children: [
-                    _buildPinIconInline(context, tab, isTabHovered),
+                  child: Transform.translate(
+                    offset: const Offset(0, -2),
+                    child: Row(
+                      children: [
+                        if (isSelected) const SizedBox(width: 4),
+                        _buildPinIconInline(context, tab, isTabHovered),
                     if (tab is CombinedTab)
                       Expanded(
                         child: Tooltip(
                           message: tab.title,
                           child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
                               const Icon(
                                   FluentIcons.panel_left_text_24_regular,
-                                  size: 16),
-                              const SizedBox(width: 4),
+                                  size: 14),
+                              const SizedBox(width: 2),
                               Expanded(
                                 child: Text(
                                   tab.title,
-                                  overflow: TextOverflow.ellipsis,
+                                  overflow: TextOverflow.clip,
                                   maxLines: 1,
                                 ),
                               ),
@@ -712,7 +727,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                             message: title,
                             child: Text(
                               title,
-                              overflow: TextOverflow.ellipsis,
+                              overflow: TextOverflow.clip,
                               maxLines: 1,
                             ),
                           ),
@@ -730,15 +745,16 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                             return Tooltip(
                               message: tooltipMessage,
                               child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.center,
                                 children: [
                                   const Icon(
                                       FluentIcons.document_pdf_24_regular,
-                                      size: 16),
-                                  const SizedBox(width: 4),
+                                      size: 14),
+                                  const SizedBox(width: 2),
                                   Expanded(
                                     child: Text(
                                       tab.title,
-                                      overflow: TextOverflow.ellipsis,
+                                      overflow: TextOverflow.clip,
                                       maxLines: 1,
                                     ),
                                   ),
@@ -761,7 +777,7 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                               message: tooltipMessage,
                               child: Text(
                                 tab.title,
-                                overflow: TextOverflow.ellipsis,
+                                overflow: TextOverflow.clip,
                                 maxLines: 1,
                               ),
                             );
@@ -783,8 +799,15 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                             size: 10),
                       ),
                     ),
-                  ],
-                ),
+                    if (!isSelected && index != state.currentTabIndex - 1)
+                      Container(
+                        width: 1,
+                        height: 16,
+                        color: Theme.of(context).colorScheme.outlineVariant,
+                      ),
+                      ],
+                    ),
+                  ),
               ),
             ),
           ),

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -33,6 +33,7 @@ import 'package:otzaria/workspaces/bloc/workspace_event.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/tour/tour_target_keys.dart';
+import 'package:otzaria/utils/text/text_manipulation.dart' show truncate;
 
 class CustomTitleBar extends StatefulWidget {
   final VoidCallback? onReadingSettingsPressed;
@@ -460,14 +461,15 @@ class _CustomTitleBarState extends State<CustomTitleBar>
             Expanded(
               child: LayoutBuilder(
                 builder: (context, constraints) {
-                  // חישוב רוחב טאב בסגנון Chrome
-                  // שימוש ב-max כדי שבפתיחת טאב חדש (לפני שה-setState מתעדכן)
-                  // לא יהיו יותר טאבים ממה שמחושב — ימנע overflow וחיצי גלילה מיותרים
-                  final int displayCount =
-                      max(_displayedTabCount, state.tabs.length).clamp(1, 9999);
-                  double tabWidth =
-                      constraints.maxWidth / displayCount;
-                  tabWidth = tabWidth.clamp(_kMinTabWidth, _kMaxTabWidth);
+                  // חישוב רוחב טאב שווה — רק במצב צמוד-לימין
+                  // במצב ממורכז: tabWidth=null → כל טאב ברוחב הטבעי שלו (כמקור)
+                  double? tabWidth;
+                  if (settingsState.alignTabsToRight) {
+                    final int displayCount =
+                        max(_displayedTabCount, state.tabs.length).clamp(1, 9999);
+                    tabWidth = (constraints.maxWidth / displayCount)
+                        .clamp(_kMinTabWidth, _kMaxTabWidth);
+                  }
 
                   return DragTarget<OpenedTab>(
                     onWillAcceptWithDetails: (details) => state.tabs.length > 1,
@@ -659,11 +661,145 @@ class _CustomTitleBarState extends State<CustomTitleBar>
     // מזהים את כיוון השפה כדי לדעת מאיזה צד לפתוח את הרווח
     final isRtl = Directionality.of(context) == TextDirection.rtl;
 
+    bool isTabActive(int tabIndex) => tabIndex == state.currentTabIndex;
+
     // State לניהול hover על הטאב
     bool isTabHovered = false;
 
+    // מצב ממורכז: מחזיר את המבנה המקורי ללא שינוי
+    Widget buildTabAppearanceCentered(StateSetter? setState) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if ((index == 0 && !isTabActive(0)) ||
+              (index > 0 && !isTabActive(index) && !isTabActive(index - 1)))
+            Container(
+              width: 1,
+              height: 24,
+              margin: const EdgeInsets.only(top: 6, bottom: 6),
+              color: Colors.grey.shade400,
+            ),
+          Container(
+            constraints: const BoxConstraints(maxHeight: 32),
+            padding: const EdgeInsets.only(left: 6, right: 6, top: 0, bottom: 0),
+            child: CustomPaint(
+              painter: isSelected
+                  ? _TabBackgroundPainter(
+                      Theme.of(context).colorScheme.surfaceContainer)
+                  : null,
+              child: Tab(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: DefaultTextStyle(
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurface,
+                      fontWeight:
+                          isSelected ? FontWeight.w600 : FontWeight.normal,
+                      fontSize: 14,
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _buildPinIconInline(context, tab, isTabHovered),
+                        if (tab is CombinedTab)
+                          Tooltip(
+                            message: tab.title,
+                            child: Row(
+                              children: [
+                                const Padding(
+                                  padding: EdgeInsets.all(8.0),
+                                  child: Icon(
+                                      FluentIcons.panel_left_text_24_regular,
+                                      size: 16),
+                                ),
+                                Text(truncate(tab.title, 20)),
+                              ],
+                            ),
+                          )
+                        else if (tab is SearchingTab)
+                          ValueListenableBuilder<String>(
+                            valueListenable: tab.titleNotifier,
+                            builder: (context, title, child) => Tooltip(
+                              message: title,
+                              child: Text(truncate(title, 25)),
+                            ),
+                          )
+                        else if (tab is PdfBookTab)
+                          ValueListenableBuilder<String>(
+                            valueListenable: tab.currentTitle,
+                            builder: (context, currentTitleValue, child) {
+                              final tooltipMessage =
+                                  currentTitleValue.isNotEmpty
+                                      ? '\${tab.title}, \$currentTitleValue'
+                                      : tab.title;
+                              return Tooltip(
+                                message: tooltipMessage,
+                                child: Row(
+                                  children: [
+                                    const Padding(
+                                      padding: EdgeInsets.all(8.0),
+                                      child: Icon(
+                                          FluentIcons.document_pdf_24_regular,
+                                          size: 16),
+                                    ),
+                                    Text(truncate(tab.title, 12)),
+                                  ],
+                                ),
+                              );
+                            },
+                          )
+                        else
+                          ValueListenableBuilder<String>(
+                            valueListenable: (tab as TextBookTab).currentTitle,
+                            builder: (context, currentTitleValue, child) {
+                              final tooltipMessage =
+                                  currentTitleValue.isNotEmpty
+                                      ? '\${tab.title}, \$currentTitleValue'
+                                      : tab.title;
+                              return Tooltip(
+                                message: tooltipMessage,
+                                child: Text(truncate(tab.title, 12)),
+                              );
+                            },
+                          ),
+                        Tooltip(
+                          preferBelow: false,
+                          message: closeTabShortcut.toUpperCase(),
+                          child: IconButton(
+                            constraints: const BoxConstraints(
+                              minWidth: 25,
+                              minHeight: 25,
+                              maxWidth: 25,
+                              maxHeight: 25,
+                            ),
+                            onPressed: () => closeTab(tab, context),
+                            icon: const Icon(FluentIcons.dismiss_24_regular,
+                                size: 10),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (index == state.tabs.length - 1 && !isTabActive(index))
+            Container(
+              width: 1,
+              height: 24,
+              margin: const EdgeInsets.only(top: 6, bottom: 6),
+              color: Colors.grey.shade400,
+            ),
+        ],
+      );
+    }
+
     // פונקציה פנימית לבניית המראה של הטאב כדי למנוע כפילות קוד באנימציות
     Widget buildTabAppearance(StateSetter? setState) {
+      if (!settingsState.alignTabsToRight) {
+        return buildTabAppearanceCentered(setState);
+      }
       return Container(
         constraints: const BoxConstraints(maxHeight: 32),
         padding: EdgeInsetsDirectional.only(
@@ -704,11 +840,16 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                                   size: 14),
                               const SizedBox(width: 2),
                               Expanded(
-                                child: Text(
-                                  tab.title,
-                                  overflow: TextOverflow.clip,
-                                  maxLines: 1,
-                                  softWrap: false,
+                                child: ClipRect(
+                                  child: OverflowBox(
+                                    alignment: Alignment.centerRight,
+                                    maxWidth: double.infinity,
+                                    child: Text(
+                                      tab.title,
+                                      maxLines: 1,
+                                      softWrap: false,
+                                    ),
+                                  ),
                                 ),
                               ),
                             ],
@@ -721,11 +862,16 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                           valueListenable: tab.titleNotifier,
                           builder: (context, title, child) => Tooltip(
                             message: title,
-                            child: Text(
-                              title,
-                              overflow: TextOverflow.clip,
-                              maxLines: 1,
-                              softWrap: false,
+                            child: ClipRect(
+                              child: OverflowBox(
+                                alignment: Alignment.centerRight,
+                                maxWidth: double.infinity,
+                                child: Text(
+                                  title,
+                                  maxLines: 1,
+                                  softWrap: false,
+                                ),
+                              ),
                             ),
                           ),
                         ),
@@ -749,11 +895,16 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                                       size: 14),
                                   const SizedBox(width: 2),
                                   Expanded(
-                                    child: Text(
-                                      tab.title,
-                                      overflow: TextOverflow.clip,
-                                      maxLines: 1,
-                                      softWrap: false,
+                                    child: ClipRect(
+                                      child: OverflowBox(
+                                        alignment: Alignment.centerRight,
+                                        maxWidth: double.infinity,
+                                        child: Text(
+                                          tab.title,
+                                          maxLines: 1,
+                                          softWrap: false,
+                                        ),
+                                      ),
                                     ),
                                   ),
                                 ],
@@ -773,11 +924,16 @@ class _CustomTitleBarState extends State<CustomTitleBar>
                                     : tab.title;
                             return Tooltip(
                               message: tooltipMessage,
-                              child: Text(
-                                tab.title,
-                                overflow: TextOverflow.clip,
-                                maxLines: 1,
-                                softWrap: false,
+                              child: ClipRect(
+                                child: OverflowBox(
+                                  alignment: Alignment.centerRight,
+                                  maxWidth: double.infinity,
+                                  child: Text(
+                                    tab.title,
+                                    maxLines: 1,
+                                    softWrap: false,
+                                  ),
+                                ),
                               ),
                             );
                           },

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -671,9 +671,9 @@ class _CustomTitleBarState extends State<CustomTitleBar>
     Widget buildTabAppearance(StateSetter? setState) {
       return Container(
         constraints: const BoxConstraints(maxHeight: 32),
-        padding: EdgeInsets.only(
-            left: 2,
-            right: (index == 0 && settingsState.alignTabsToRight) ? 0 : 2,
+        padding: EdgeInsetsDirectional.only(
+            start: 2,
+            end: (index == 0 && settingsState.alignTabsToRight) ? 0 : 2,
             top: 0,
             bottom: 0),
         child: CustomPaint(

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -990,6 +990,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       },
       backgroundColor:
           Colors.white, // תמיד לבן - ה-ColorFilter יהפוך לשחור במצב כהה
+      // ignore: deprecated_member_use
       maxScale: 10,
       horizontalCacheExtent: 0,
       verticalCacheExtent: layoutMode == PdfLayoutMode.bookView

--- a/lib/widgets/navigation/scrollable_tab_bar.dart
+++ b/lib/widgets/navigation/scrollable_tab_bar.dart
@@ -125,7 +125,7 @@ class _ScrollableTabBarWithArrowsState
     return AlignmentDirectional.bottomStart;
   }
 
-  Widget _buildTabBar({bool shrinkWrap = false}) {
+  Widget _buildTabBar() {
     return NotificationListener<ScrollMetricsNotification>(
       onNotification: (metricsNotification) {
         final metrics = metricsNotification.metrics;
@@ -177,8 +177,7 @@ class _ScrollableTabBarWithArrowsState
 
             return Align(
               alignment: _tabBarAlignment(),
-              widthFactor: shrinkWrap ? 1.0 : null,
-              child: shrinkWrap ? IntrinsicWidth(child: tabBar) : tabBar,
+              child: tabBar,
             );
           },
         ),
@@ -232,9 +231,21 @@ class _ScrollableTabBarWithArrowsState
     final bool showArrows = !widget.hideArrowsWhenNotScrollable || hasOverflow;
 
     if (!hasOverflow) {
+      // כשיש tabWidth ידוע — חישוב רוחב כולל ישיר (ללא IntrinsicWidth)
+      // IntrinsicWidth גורם ל-Tooltip לנסות לעדכן overlay בזמן layout → assertion crash
+      if (widget.tabWidth != null && widget.tabs.isNotEmpty) {
+        final totalWidth = widget.tabWidth! * widget.tabs.length;
+        return Align(
+          alignment: _nonOverflowAlignment(),
+          child: SizedBox(
+            width: totalWidth,
+            child: _buildTabBar(),
+          ),
+        );
+      }
       return Align(
         alignment: _nonOverflowAlignment(),
-        child: _buildTabBar(shrinkWrap: true),
+        child: _buildTabBar(),
       );
     }
 

--- a/lib/widgets/navigation/scrollable_tab_bar.dart
+++ b/lib/widgets/navigation/scrollable_tab_bar.dart
@@ -10,6 +10,8 @@ class ScrollableTabBarWithArrows extends StatefulWidget {
   final ValueChanged<bool>? onOverflowChanged;
   // האם להסתיר את החיצים כשאין גלילה (לצמצום רווחים)
   final bool hideArrowsWhenNotScrollable;
+  // רוחב קבוע לכל טאב — null = auto
+  final double? tabWidth;
 
   const ScrollableTabBarWithArrows({
     super.key,
@@ -18,6 +20,7 @@ class ScrollableTabBarWithArrows extends StatefulWidget {
     this.tabAlignment,
     this.onOverflowChanged,
     this.hideArrowsWhenNotScrollable = false,
+    this.tabWidth,
   });
 
   @override
@@ -151,10 +154,17 @@ class _ScrollableTabBarWithArrowsState
                 _attachAndSyncPosition();
               });
             }
+            // כשיש tabWidth קבוע — עוטפים כל טאב ב-SizedBox
+            final List<Widget> resolvedTabs = widget.tabWidth != null
+                ? widget.tabs
+                    .map((t) => SizedBox(width: widget.tabWidth, child: t))
+                    .toList()
+                : widget.tabs;
+
             final tabBar = TabBar(
               controller: widget.controller,
               isScrollable: true,
-              tabs: widget.tabs,
+              tabs: resolvedTabs,
               tabAlignment: widget.tabAlignment ?? TabAlignment.start,
               padding: EdgeInsets.zero,
               labelPadding: EdgeInsets.zero,


### PR DESCRIPTION
## מה השתנה

### שינוי מרכזי — רוחב שווה לכל הטאבים
- כל הטאבים חולקים רוחב שווה בהתאם לשטח הפנוי — סדר ועקביות ויזואלית
- כשיש מקום — הטאבים מתפרסים עד 200px כל אחד
- כשאין מקום — גלילה אופקית מתחת ל-72px (כמו קודם)
- פתיחת טאב: שינוי גודל מיידי
- סגירת הטאב האחרון: מיידי (כפתור X לא זז)
- סגירת טאב באמצע: המתנה של 3 שניות (מניעת קפיצות layout בסגירה מרובה)

### שיפורים ויזואליים
- אייקון הצמדה: מתכווץ לרוחב אפס כשלא רלוונטי — חוסך מקום אמיתי
- קו מפריד 1px אנכי בין טאבים לא-נבחרים לבהירות גבולות
- רווח קבוע בין הטאב האחרון לכפתור ההגדרות (במצב צמוד-לימין)
- ישור אנכי משופר — אייקון וטקסט ממורכזים
- הזחה קלה בטאב הנבחר להדגשת הבחירה

### תיקוני באגים
- מניעת overflow בפתיחת טאב חדש לפני עדכון ה-setState
- תיקון קריסת assertion של Tooltip בעת עדכון overlay בזמן layout