### PR TITLE
חיסכון בסטארטאפ למנוע דילוג של כל הספרים שאונדקסו

### DIFF
--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -71,9 +71,10 @@ class IndexingRepository {
     // Fast path: if all books are already indexed and the catalogue is unchanged,
     // skip the expensive isolate creation and the full iteration loop.
     final fastPathBooks = library.getAllBooks();
-    if (fastPathBooks.isNotEmpty) {
-      final booksDoneSet = Set<String>.from(_tantivyDataProvider.booksDone);
-      final allIndexed = fastPathBooks.every(
+    final indexableBooks = fastPathBooks.where(isIndexableBook);
+    if (indexableBooks.isNotEmpty) {
+      final booksDoneSet = _tantivyDataProvider.booksDone.toSet();
+      final allIndexed = indexableBooks.every(
         (book) => booksDoneSet.contains(catalogueOrderKey(book)),
       );
       if (allIndexed) {

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -68,6 +68,25 @@ class IndexingRepository {
     void Function()? onActualIndexingStarted,
     required void Function(int processed, int total) onProgress,
   }) async {
+    // Fast path: if all books are already indexed and the catalogue is unchanged,
+    // skip the expensive isolate creation and the full iteration loop.
+    final fastPathBooks = library.getAllBooks();
+    if (fastPathBooks.isNotEmpty) {
+      final booksDoneSet = Set<String>.from(_tantivyDataProvider.booksDone);
+      final allIndexed = fastPathBooks.every(
+        (book) => booksDoneSet.contains(catalogueOrderKey(book)),
+      );
+      if (allIndexed) {
+        final currentSig = buildCatalogueOrderSignature(library);
+        if (!_tantivyDataProvider.requiresManualReindex(
+          currentCatalogueOrderSignature: currentSig,
+        )) {
+          debugPrint('⚡ Fast path: כל הספרים מאונדקסים והקטלוג לא השתנה – מדלג על האינדוקס');
+          return true;
+        }
+      }
+    }
+
     _tantivyDataProvider.isIndexing.value = true;
     final isolateService =
         _isolateService ?? await IndexingIsolateService.create();

--- a/lib/library/view/book_preview_panel.dart
+++ b/lib/library/view/book_preview_panel.dart
@@ -389,6 +389,7 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
           controller: _pdfController!,
           params: PdfViewerParams(
             backgroundColor: Theme.of(context).colorScheme.surface,
+            // ignore: deprecated_member_use
             maxScale: 10,
             horizontalCacheExtent: 0,
             verticalCacheExtent: 1,

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -990,6 +990,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       },
       backgroundColor:
           Colors.white, // תמיד לבן - ה-ColorFilter יהפוך לשחור במצב כהה
+      // ignore: deprecated_member_use
       maxScale: 10,
       horizontalCacheExtent: 0,
       verticalCacheExtent: layoutMode == PdfLayoutMode.bookView


### PR DESCRIPTION
אם כל הספרים כבר נמצאים ב-booksDone וחתימת הקטלוג לא השתנתה, indexAllBooks מחזיר true מיד ללא יצירת Isolate, buildKeyOrderMap, או לולאת 5000+ ספרים עם await Future.delayed בכל איטרציה.

חשבתי לעשות את זה אחרי שראיתי בדיבאג שזה מאוד מעסיק את התוכנה בהפעלתה לדלג על 7000 ספרים, ותכלס קלוד אמר שזה נראה לו רעיון טוב
אם אתה חושב שזה לא טוב פשוט תסגור את הPR