### PR TITLE
plugin packager: דלג על תיקיות פיתוח בעת ארוז

### DIFF
--- a/lib/plugins/services/plugin_packager.dart
+++ b/lib/plugins/services/plugin_packager.dart
@@ -134,28 +134,25 @@ class PluginPackager {
       '.git', '.svn', '.hg', '.idea', '.vscode',
       'node_modules', '__pycache__', '.claude',
     };
-    bool isInSkippedDir(String relativePath) {
-      for (final part in p.split(relativePath)) {
-        if (skipDirs.contains(part)) return true;
-      }
-      return false;
-    }
 
     // נאסוף את הקבצים *לפני* יצירת ארכיון הפלט, כדי שהקובץ החדש לא
     // יופיע ב-listSync. (גיבוי בנוסף לבדיקת הנתיב למטה.)
+    // סריקה ידנית (לא רקורסיבית ב-OS) כדי לדלג לחלוטין על תיקיות מוחרגות
+    // ולא לבזבז זמן על סריקת תוכנן (node_modules יכולה להכיל עשרות אלפי קבצים).
     final filesToPack = <File>[];
-    for (final entity in dir.listSync(recursive: true)) {
-      if (entity is! File) continue;
-      final entityAbs = p.normalize(p.absolute(entity.path));
-      if (entityAbs == normalizedOutPath) {
-        // אם הפלט הופנה במפורש אל תוך תיקיית התוסף — דלג עליו.
-        continue;
+    void collectFiles(Directory currentDir) {
+      for (final entity in currentDir.listSync(recursive: false)) {
+        if (skipDirs.contains(p.basename(entity.path))) continue;
+        if (entity is Directory) {
+          collectFiles(entity);
+        } else if (entity is File) {
+          final entityAbs = p.normalize(p.absolute(entity.path));
+          if (entityAbs == normalizedOutPath) continue;
+          filesToPack.add(entity);
+        }
       }
-      if (isInSkippedDir(p.relative(entity.path, from: dir.path))) {
-        continue;
-      }
-      filesToPack.add(entity);
     }
+    collectFiles(dir);
 
     final encoder = ZipFileEncoder();
     encoder.create(resolvedOutPath);

--- a/lib/plugins/services/plugin_packager.dart
+++ b/lib/plugins/services/plugin_packager.dart
@@ -107,6 +107,32 @@ class PluginPackager {
       throw PluginPackagerException(lines.join('\n'));
     }
 
+    // תיקיות פיתוח שאין צורך לארוז — שומרות על חבילה רזה ומונעות הדלפת
+    // היסטוריית git/הגדרות IDE לתוך ה-‎.otzplugin שמופץ.
+    const skipDirs = <String>{
+      '.git', '.svn', '.hg', '.idea', '.vscode',
+      'node_modules', '__pycache__', '.claude',
+    };
+
+    // בדיקת תקינות: ה-entrypoint לא יכול לשבת בתוך תיקייה מוחרגת —
+    // אחרת הקובץ לא ייכלל ב-.otzplugin והפלאגין יישבר בשקט.
+    // resolve מוחלט ואז relative מבטיח טיפול נכון בנתיבים כמו ./node_modules/...
+    // חשוב: בדיקה זו רצה לפני יצירת תיקיות הפלט, כדי שלא ישארו תיקיות ריקות
+    // בדיסק אם הבדיקה נכשלת.
+    final entrypointRelativePath = p.relative(
+      p.normalize(p.absolute(p.join(dir.path, manifest.entrypoint))),
+      from: dir.path,
+    );
+    final blockedDir =
+        p.split(entrypointRelativePath).where(skipDirs.contains).firstOrNull;
+    if (blockedDir != null) {
+      throw PluginPackagerException(
+        'קובץ הכניסה "${manifest.entrypoint}" נמצא בתוך תיקייה מוחרגת מאריזה '
+        '("$blockedDir"). העבר את ה-entrypoint מחוץ לתיקיות: '
+        '${skipDirs.join(', ')}',
+      );
+    }
+
     final resolvedOutPath = outputPath ??
         p.join(dir.parent.path, '${manifest.id}-${manifest.version}.otzplugin');
     final outFile = File(resolvedOutPath);
@@ -127,13 +153,6 @@ class PluginPackager {
     // התוסף, צריך להחריג אותו מהקבצים שמתווספים לארכיון כדי שהארכיון לא
     // יכיל את עצמו (במיוחד כש-force מאפשר דריסה תוך כדי כתיבה).
     final normalizedOutPath = p.normalize(p.absolute(resolvedOutPath));
-
-    // תיקיות פיתוח שאין צורך לארוז — שומרות על חבילה רזה ומונעות הדלפת
-    // היסטוריית git/הגדרות IDE לתוך ה-‎.otzplugin שמופץ.
-    const skipDirs = <String>{
-      '.git', '.svn', '.hg', '.idea', '.vscode',
-      'node_modules', '__pycache__', '.claude',
-    };
 
     // נאסוף את הקבצים *לפני* יצירת ארכיון הפלט, כדי שהקובץ החדש לא
     // יופיע ב-listSync. (גיבוי בנוסף לבדיקת הנתיב למטה.)

--- a/lib/plugins/services/plugin_packager.dart
+++ b/lib/plugins/services/plugin_packager.dart
@@ -128,6 +128,19 @@ class PluginPackager {
     // יכיל את עצמו (במיוחד כש-force מאפשר דריסה תוך כדי כתיבה).
     final normalizedOutPath = p.normalize(p.absolute(resolvedOutPath));
 
+    // תיקיות פיתוח שאין צורך לארוז — שומרות על חבילה רזה ומונעות הדלפת
+    // היסטוריית git/הגדרות IDE לתוך ה-‎.otzplugin שמופץ.
+    const skipDirs = <String>{
+      '.git', '.svn', '.hg', '.idea', '.vscode',
+      'node_modules', '__pycache__', '.claude',
+    };
+    bool isInSkippedDir(String relativePath) {
+      for (final part in p.split(relativePath)) {
+        if (skipDirs.contains(part)) return true;
+      }
+      return false;
+    }
+
     // נאסוף את הקבצים *לפני* יצירת ארכיון הפלט, כדי שהקובץ החדש לא
     // יופיע ב-listSync. (גיבוי בנוסף לבדיקת הנתיב למטה.)
     final filesToPack = <File>[];
@@ -136,6 +149,9 @@ class PluginPackager {
       final entityAbs = p.normalize(p.absolute(entity.path));
       if (entityAbs == normalizedOutPath) {
         // אם הפלט הופנה במפורש אל תוך תיקיית התוסף — דלג עליו.
+        continue;
+      }
+      if (isInSkippedDir(p.relative(entity.path, from: dir.path))) {
         continue;
       }
       filesToPack.add(entity);

--- a/test/plugins/services/plugin_packager_test.dart
+++ b/test/plugins/services/plugin_packager_test.dart
@@ -253,5 +253,115 @@ void main() {
         isTrue,
       );
     });
+
+    // ── בדיקות entrypoint בתוך תיקייה מוחרגת ──────────────────────────────
+
+    test('throws when entrypoint is inside node_modules/', () async {
+      // רגרסיה: בלי הולידציה, האריזה הייתה עוברת בהצלחה אך ה-.otzplugin
+      // יוצא שבור — הקובץ הכניסי מוחרג ולא נכלל בארכיון.
+      final manifest = _minimalManifest(
+        entrypoint: 'node_modules/some-pkg/index.html',
+      );
+      final pluginDir = _writePluginDir(
+        tempDir,
+        manifestOverride: manifest,
+        // יוצרים את הקובץ כדי שולידטור המניפסט יעבור את בדיקת הקיום שלו.
+        extraFiles: {'node_modules/some-pkg/index.html': '<html></html>'},
+      );
+
+      await expectLater(
+        () => PluginPackager.packDirectory(directoryPath: pluginDir),
+        throwsA(isA<PluginPackagerException>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('node_modules'), contains('מוחרגת')),
+        )),
+      );
+    });
+
+    test('throws when entrypoint is nested inside .git/', () async {
+      final manifest = _minimalManifest(entrypoint: '.git/hooks/index.html');
+      final pluginDir = _writePluginDir(
+        tempDir,
+        manifestOverride: manifest,
+        extraFiles: {'.git/hooks/index.html': '<html></html>'},
+      );
+
+      await expectLater(
+        () => PluginPackager.packDirectory(directoryPath: pluginDir),
+        throwsA(isA<PluginPackagerException>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('.git'), contains('מוחרגת')),
+        )),
+      );
+    });
+
+    test('throws when entrypoint uses ./ prefix into a skipped dir', () async {
+      // וריאנט נתיב עם ./ — normalize+absolute חייב לתפוס גם את זה.
+      final manifest =
+          _minimalManifest(entrypoint: './node_modules/pkg/index.html');
+      final pluginDir = _writePluginDir(
+        tempDir,
+        manifestOverride: manifest,
+        extraFiles: {'node_modules/pkg/index.html': '<html></html>'},
+      );
+
+      await expectLater(
+        () => PluginPackager.packDirectory(directoryPath: pluginDir),
+        throwsA(isA<PluginPackagerException>()),
+      );
+    });
+
+    test('files inside skipped dirs are silently excluded; entrypoint is safe',
+        () async {
+      // תיקיית .git קיימת עם קבצים, אבל ה-entrypoint עצמו בשורש — תקין.
+      final pluginDir = _writePluginDir(
+        tempDir,
+        extraFiles: {
+          '.git/config': '[core]',
+          '.git/HEAD': 'ref: refs/heads/main',
+          'node_modules/lib/util.js': 'export default {}',
+        },
+      );
+
+      final result = await PluginPackager.packDirectory(
+        directoryPath: pluginDir,
+        outputPath: p.join(tempDir.path, 'out.otzplugin'),
+      );
+
+      // רק 2 קבצים — קבצי .git ו-node_modules לא אמורים להיכלל.
+      expect(result.fileCount, 2);
+
+      final bytes = File(result.outputPath).readAsBytesSync();
+      final archive = ZipDecoder().decodeBytes(bytes);
+      final names = archive.files.map((f) => f.name).toSet();
+      expect(names, containsAll(<String>['manifest.json', 'index.html']));
+      expect(names.any((n) => n.startsWith('.git/')), isFalse);
+      expect(names.any((n) => n.startsWith('node_modules/')), isFalse);
+    });
+
+    test('entrypoint in a normal (non-skipped) subdirectory packs correctly',
+        () async {
+      final manifest = _minimalManifest(entrypoint: 'src/app/index.html');
+      final pluginDir = _writePluginDir(
+        tempDir,
+        manifestOverride: manifest,
+        extraFiles: {'src/app/index.html': '<html></html>'},
+      );
+
+      final result = await PluginPackager.packDirectory(
+        directoryPath: pluginDir,
+        outputPath: p.join(tempDir.path, 'out.otzplugin'),
+      );
+
+      expect(result.fileCount, 3); // manifest.json + index.html (root) + src/app/index.html
+      final bytes = File(result.outputPath).readAsBytesSync();
+      final archive = ZipDecoder().decodeBytes(bytes);
+      expect(
+        archive.files.map((f) => f.name),
+        contains('src/app/index.html'),
+      );
+    });
   });
 }


### PR DESCRIPTION
מונע הדלפת היסטוריית git, הגדרות IDE וכו' לתוך
קובץ ה-.otzplugin שמופץ.

תיקיות מוחרגות: .git .svn .hg .idea .vscode
                  node_modules __pycache__ .claude