### PR TITLE
PDF: שיפור מהירות פתיחה + cap זיכרון + יציבות layout בעמודי יעד

### DIFF
--- a/lib/pdf_book/bloc/pdf_book_bloc.dart
+++ b/lib/pdf_book/bloc/pdf_book_bloc.dart
@@ -285,7 +285,11 @@ class PdfBookBloc extends Bloc<PdfBookEvent, PdfBookState> {
       searchMode: searchMode,
       searchDistance: searchDistance,
       layoutMode: layoutMode,
-      isLoading: false, // Document is ready, so no longer loading
+      // כל פתיחה לעמוד שאינו הראשון (היסטוריה, סימניות, דף יומי,
+      // חיפוש, קישור→PDF) צריכה overlay עד ש-stability tracking
+      // ב-screen מסיים. בפתיחה לעמוד הראשון אין סיכון לקפיצות —
+      // הספינר נסגר מיד.
+      isLoading: tab.requiresStableLayout || tab.pageNumber > 1,
       loadSucceeded: true,
     ));
 

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -234,6 +234,28 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   bool _pdfViewerSuspended = false;
   bool _readerFocusAndHideQueued = false;
   bool _bookHasCommentaryLinks = false;
+
+  /// פעיל רק בפתיחה לעמוד שאינו ראשון (דף יומי, חיפוש, היסטוריה,
+  /// קישור מטקסט). כשהדגל true:
+  ///   1. ה-overlay נשאר על המסך עד שה-layout מתייצב על עמוד היעד.
+  ///   2. `verticalCacheExtent` ירוד ל-0 כדי לחסוך עבודת רינדור בזמן
+  ///      שהמטא-דאטה של עמודי הרקע עוד נטענת.
+  bool _waitingForStableLayout = false;
+
+  /// טיימר debounce - מאופס בכל עדכון controller. כשנפסקים העדכונים
+  /// למשך [_kStableLayoutDebounce], נבדק תנאי היציבות.
+  Timer? _stableLayoutTimer;
+
+  /// העמוד שאליו ביקש המשתמש לפתוח. ה-stability check מוודא שאחרי
+  /// שה-layout התייצב, ה-controller באמת נמצא בעמוד זה (ולא נדחף
+  /// משם בגלל ממדי עמודי רקע שהתעדכנו).
+  int? _stableLayoutTargetPage;
+
+  /// אינדיקטור חזק שכל המטא-דאטה של המסמך נטענה. ללא הדגל הזה,
+  /// 800ms של debounce ריק מטעים — עמודי רקע שעדיין נטענים יכולים
+  /// לדחוף את עמוד היעד אחרי שהצהרנו יציבות ולגרום לקפיצה נראית
+  /// (בעיקר ב-bookView).
+  bool _documentFullyLoaded = false;
   // FIFO queue of page-turns that came in while another was already running.
   // Each click gets its own animation; rapid clicks accumulate and play in
   // order, instead of being collapsed into a single animation toward the
@@ -1037,18 +1059,36 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           const PdfViewerScrollInteractionDelegateProviderPhysics(),
       onDocumentLoadFinished: (documentRef, succeeded) {
         if (!mounted) return;
-        _bloc.add(pdf_events.SetLoadingState(
-          isLoading: false,
-          succeeded: succeeded,
-        ));
+        if (!succeeded) {
+          _bloc.add(const pdf_events.SetLoadingState(
+            isLoading: false,
+            succeeded: false,
+          ));
+          return;
+        }
+        // המטא-דאטה של כל המסמך נטענה — מסמנים את הדגל ומפעילים את
+        // בדיקת היציבות מיד (במקום להמתין ל-800ms של debounce ריק).
+        _documentFullyLoaded = true;
+        if (_waitingForStableLayout) {
+          _onLayoutMaybeStable();
+        } else {
+          _bloc.add(const pdf_events.SetLoadingState(isLoading: false));
+        }
       },
       backgroundColor:
           Colors.white, // תמיד לבן - ה-ColorFilter יהפוך לשחור במצב כהה
       sizeDelegateProvider: PdfViewerSizeDelegateProviderLegacy(maxScale: 10),
+      // חסימת הזיכרון של ה-renderer: ברירת המחדל של pdfrx 2.4.3 היא
+      // 100MB; מהודק ל-48MB כדי לצמצם לחץ זיכרון במחשבים עם 8GB RAM
+      // (תרחיש ה-OOM ב-Microsoft Store).
+      maxImageBytesCachedOnMemory: 48 * 1024 * 1024,
       horizontalCacheExtent: 0,
-      verticalCacheExtent: layoutMode == PdfLayoutMode.bookView
-          ? 2
-          : 1, // במצב ספר: פריסה אחת קדימה/אחורה נוספת
+      // בזמן stability tracking לא מרנדרים שכנים — חוסך עבודה בזמן
+      // שהמטא-דאטה של עמודי הרקע עוד נטענת. אחרי שמתייצב חוזרים לערך
+      // הרגיל (2 בספר, 1 רגיל).
+      verticalCacheExtent: _waitingForStableLayout
+          ? 0
+          : (layoutMode == PdfLayoutMode.bookView ? 2 : 1),
       pageAnchor: PdfPageAnchor.top, // עיגון לראש הדף
       onInteractionStart: (_) {
         if (!(widget.tab.pinLeftPane.value ||
@@ -1139,6 +1179,9 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       },
       onViewerReady: (document, controller) async {
         if (!mounted) return;
+        // איפוס stability tracking של פתיחה קודמת (רלוונטי ב-retry).
+        _cancelStableLayoutTracking();
+
         // Only grab focus if neither of the pane text-fields is focused.
         // Unconditional requestFocus() here stole focus from open search/nav fields.
         if (!_searchFieldFocusNode.hasFocus &&
@@ -1150,32 +1193,34 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
         final documentRef = controller.documentRef;
         widget.tab.documentRef.value = documentRef;
-        final outline = await document.loadOutline();
-        if (!mounted) return;
-        widget.tab.outline.value = outline;
         final totalPages = document.pages.length;
         final initialTargetPage = widget.tab.pageNumber.clamp(1, totalPages);
         widget.tab.pageNumber = initialTargetPage;
 
+        // שולחים DocumentReady מיד כדי לשחרר את ה-UI. טעינת ה-outline
+        // ו-resolve של titles/line-numbers הם פעולות כבדות (DB+PDF
+        // bookmarks) ונדחקות לרקע — outline מתעדכן ב-tab.outline
+        // וב-state בעדכון שני, ו-titles מתעדכנים ב-ValueNotifier.
         _bloc.add(pdf_events.DocumentReady(
           documentRef: documentRef,
-          outline: outline,
           totalPages: totalPages,
         ));
 
-        // חישוב currentTextLineNumber אחרי טעינת ה-outline
-        final targetPage = initialTargetPage;
-        final targetTitles = await _resolveTitlesForPage(targetPage);
-        if (!mounted) return;
-        widget.tab.currentTitle.value = targetTitles.display;
-        final initialResolved = await _resolveTextLineNumberForPage(
-          targetPage,
-          resolvedTitle: targetTitles.single,
-        );
-        if (!mounted) return;
-        widget.tab.currentTextLineNumber = initialResolved.start;
-        widget.tab.currentTextLineNumberEnd = initialResolved.end;
-        setState(() {});
+        // פתיחה ל"עמוד יעד" (דף יומי/חיפוש/קישור/היסטוריה/סימניה) —
+        // progressive loading עלול לעדכן ממדי עמודים ברקע ולדחוף את
+        // עמוד היעד מהמסך. כל פתיחה לעמוד שאינו הראשון צריכה overlay
+        // עד שה-layout מתייצב, גם אם הקורא לא הגדיר requiresStableLayout
+        // במפורש (היסטוריה/סימניה לא מסמנים את הדגל הזה).
+        if (widget.tab.requiresStableLayout || initialTargetPage > 1) {
+          _beginStableLayoutTracking(initialTargetPage);
+        }
+
+        unawaited(_loadOutlineAndTitlesInBackground(
+          document: document,
+          documentRef: documentRef,
+          targetPage: initialTargetPage,
+          totalPages: totalPages,
+        ));
 
         if (!mounted) return;
         final enablePerBookSettings =
@@ -1268,7 +1313,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
   PdfDocumentRefFile _createDocumentRef() => PdfDocumentRefFile(
         widget.tab.book.path,
-        useProgressiveLoading: !widget.tab.requiresStableLayout,
+        // תמיד progressive: pdfrx מציג את העמוד הראשון מיד במקום
+        // להמתין למטא-דאטה של כל העמודים. המעבר ל"stable" מטופל ב-screen
+        // עם debounce timer, ולכן אין צורך לכבות progressive loading.
+        useProgressiveLoading: true,
         passwordProvider: () => passwordDialog(context),
       );
 
@@ -2424,6 +2472,142 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     });
   }
 
+  /// טוען את ה-outline ואת ה-titles ברקע, מבלי לחסום את onViewerReady.
+  /// outline נטען ראשון כי resolve של titles ו-line-numbers נסמך עליו.
+  /// בסוף נשלח DocumentReady שני עם ה-outline כדי לעדכן את ה-state.
+  Future<void> _loadOutlineAndTitlesInBackground({
+    required PdfDocument document,
+    required PdfDocumentRef documentRef,
+    required int targetPage,
+    required int totalPages,
+  }) async {
+    try {
+      final outline = await document.loadOutline();
+      if (!mounted) return;
+      widget.tab.outline.value = outline;
+      _bloc.add(pdf_events.DocumentReady(
+        documentRef: documentRef,
+        outline: outline,
+        totalPages: totalPages,
+      ));
+    } catch (e, stackTrace) {
+      debugPrint('❌ Failed to load PDF outline: $e\n$stackTrace');
+    }
+
+    // אם המשתמש כבר ניווט מ-targetPage לעמוד אחר לפני שטעינת ה-outline
+    // הסתיימה, אין טעם לכתוב metadata של עמוד ישן — `_onPdfViewerControllerUpdate`
+    // כבר טיפל בעמוד החדש, ועדכון נוסף ידרוס אותו.
+    if (!mounted || !_isPageStillCurrent(targetPage)) return;
+    final titles = await _resolveTitlesForPage(targetPage);
+    if (!mounted || !_isPageStillCurrent(targetPage)) return;
+    widget.tab.currentTitle.value = titles.display;
+    final resolved = await _resolveTextLineNumberForPage(
+      targetPage,
+      resolvedTitle: titles.single,
+    );
+    if (!mounted || !_isPageStillCurrent(targetPage)) return;
+    widget.tab.currentTextLineNumber = resolved.start;
+    widget.tab.currentTextLineNumberEnd = resolved.end;
+    if (mounted) setState(() {});
+  }
+
+  /// בודק אם [page] עדיין רלוונטי — האם המשתמש לא ניווט הלאה.
+  /// במצב ספר ההשוואה ברמת ה-spread (עמוד 3 נחשב כ-spread שמתחיל ב-2).
+  bool _isPageStillCurrent(int page) {
+    final controller = widget.tab.pdfViewerController;
+    final viewerPage = controller.isReady
+        ? (controller.pageNumber ?? widget.tab.pageNumber)
+        : widget.tab.pageNumber;
+    if (_isBookViewModeActive()) {
+      return pdfSpreadStartPage(page) == pdfSpreadStartPage(viewerPage);
+    }
+    return page == viewerPage;
+  }
+
+  // ============ Stable-layout tracking ============
+  //
+  // ב-`requiresStableLayout: true` (דף יומי, חיפוש, קישור→PDF) פותחים
+  // PDF עם `useProgressiveLoading: true` כדי שה-PDF יופיע מיד, אבל
+  // משאירים overlay טעינה עד שה-layout מתייצב על עמוד היעד. הזיהוי
+  // מבוצע ב-debounce של [_kStableLayoutDebounce] על עדכוני ה-controller.
+
+  static const Duration _kStableLayoutDebounce = Duration(milliseconds: 800);
+
+  void _beginStableLayoutTracking(int targetPage) {
+    if (!mounted) return;
+    _stableLayoutTargetPage = targetPage;
+    _documentFullyLoaded = false;
+    if (!_waitingForStableLayout) {
+      setState(() {
+        _waitingForStableLayout = true;
+      });
+    }
+    _restartStableLayoutDebounce();
+  }
+
+  void _restartStableLayoutDebounce() {
+    _stableLayoutTimer?.cancel();
+    _stableLayoutTimer = Timer(_kStableLayoutDebounce, _onLayoutMaybeStable);
+  }
+
+  void _onLayoutMaybeStable() {
+    if (!mounted || !_waitingForStableLayout) return;
+    final controller = widget.tab.pdfViewerController;
+    if (!controller.isReady) {
+      _restartStableLayoutDebounce();
+      return;
+    }
+    // אינדיקטור חזק נדרש: בלי ש-onDocumentLoadFinished ירה (= כל
+    // המטא-דאטה נטענה), 800ms של debounce ריק עדיין משאיר אפשרות
+    // שעמודי רקע ימשיכו להידחק ולדחוף את עמוד היעד. בלי הבדיקה הזו
+    // נראו קפיצות גלויות אחרי שה-overlay הוסר ב-bookView.
+    if (!_documentFullyLoaded) {
+      _restartStableLayoutDebounce();
+      return;
+    }
+    final target = _stableLayoutTargetPage;
+    if (target != null) {
+      // במצב ספר עמודים מצומדים לזוגות (2,3), (4,5) — ה-controller
+      // מחזיר את עמוד התחילה של ה-spread. אילו השווינו ברמת עמוד,
+      // יעד=3 מול ה-controller=2 היה נראה כסטייה והיינו נכנסים
+      // ללולאת ייצוב אינסופית. ההשוואה ברמת ה-spread.
+      final currentPage = controller.pageNumber ?? target;
+      final inBookView = _isBookViewModeActive();
+      final targetKey = inBookView ? pdfSpreadStartPage(target) : target;
+      final currentKey =
+          inBookView ? pdfSpreadStartPage(currentPage) : currentPage;
+      if (currentKey != targetKey) {
+        controller.goToPage(pageNumber: target, duration: Duration.zero);
+        _restartStableLayoutDebounce();
+        return;
+      }
+    }
+    _completeStableLayoutTracking();
+  }
+
+  void _completeStableLayoutTracking() {
+    _stableLayoutTimer?.cancel();
+    _stableLayoutTimer = null;
+    _stableLayoutTargetPage = null;
+    if (!_waitingForStableLayout) return;
+    if (mounted) {
+      setState(() {
+        _waitingForStableLayout = false;
+      });
+      _bloc.add(const pdf_events.SetLoadingState(isLoading: false));
+    } else {
+      _waitingForStableLayout = false;
+    }
+  }
+
+  void _cancelStableLayoutTracking() {
+    _stableLayoutTimer?.cancel();
+    _stableLayoutTimer = null;
+    _stableLayoutTargetPage = null;
+    _waitingForStableLayout = false;
+    _documentFullyLoaded = false;
+  }
+
   Future<void> _loadPdfHeadingsAndLinks() async {
     final bookTitle = widget.tab.book.title;
     final categoryId = widget.tab.book.categoryId;
@@ -2534,6 +2718,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     _pendingPageTurns.clear();
     _pageTurnController.dispose();
     textSearcher?.removeListener(_onTextSearcherUpdated);
+    textSearcher?.dispose();
+    textSearcher = null;
+    _stableLayoutTimer?.cancel();
+    _stableLayoutTimer = null;
     pdfController.removeListener(_onPdfViewerControllerUpdate);
     _leftPaneTabController?.removeListener(_leftPaneTabControllerListener);
     widget.tab.showLeftPane.removeListener(_showLeftPaneListener);
@@ -2570,6 +2758,12 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
   void _onPdfViewerControllerUpdate() async {
     if (!widget.tab.pdfViewerController.isReady) return;
+
+    // ה-debounce של stability tracking מאופס בכל עדכון. כשהעדכונים
+    // נפסקים למשך _kStableLayoutDebounce, נחשב הציר כיציב.
+    if (_waitingForStableLayout) {
+      _restartStableLayoutDebounce();
+    }
 
     // Keep adjacent-spread pre-renders warm so page-turn animations can
     // open the cached snapshot instantly without waiting on goToPage + tile
@@ -2669,8 +2863,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
             _zoomIn,
         LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.add):
             _zoomIn,
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.add):
-            _zoomIn,
+        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.add): _zoomIn,
         LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.numpadAdd):
             _zoomIn,
         LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.numpadAdd):

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -251,10 +251,21 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   /// משם בגלל ממדי עמודי רקע שהתעדכנו).
   int? _stableLayoutTargetPage;
 
+  /// הגנה מפני לולאת תיקון אינסופית: אם אחרי [_kStableLayoutMaxRetries]
+  /// נסיונות עוד לא הגענו לעמוד היעד, מסתפקים במה שיש ומסירים את
+  /// ה-overlay כדי לא לתקוע את המשתמש.
+  int _stableLayoutRetryCount = 0;
+
   /// אינדיקטור חזק שכל המטא-דאטה של המסמך נטענה. ללא הדגל הזה,
   /// 800ms של debounce ריק מטעים — עמודי רקע שעדיין נטענים יכולים
   /// לדחוף את עמוד היעד אחרי שהצהרנו יציבות ולגרום לקפיצה נראית
   /// (בעיקר ב-bookView).
+  ///
+  /// חשוב: הדגל מתאפס רק ב-[_createDocumentRef] (= מסמך חדש), לא ב-
+  /// [_cancelStableLayoutTracking] / [_beginStableLayoutTracking]. אילו
+  /// היינו מאפסים בהתחלת tracking, race condition שבו
+  /// onDocumentLoadFinished יורה לפני onViewerReady היה מאבד את
+  /// הסימון "המסמך נטען" ויוצר לולאה אינסופית של debounce.
   bool _documentFullyLoaded = false;
   // FIFO queue of page-turns that came in while another was already running.
   // Each click gets its own animation; rapid clicks accumulate and play in
@@ -1311,14 +1322,20 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     );
   }
 
-  PdfDocumentRefFile _createDocumentRef() => PdfDocumentRefFile(
-        widget.tab.book.path,
-        // תמיד progressive: pdfrx מציג את העמוד הראשון מיד במקום
-        // להמתין למטא-דאטה של כל העמודים. המעבר ל"stable" מטופל ב-screen
-        // עם debounce timer, ולכן אין צורך לכבות progressive loading.
-        useProgressiveLoading: true,
-        passwordProvider: () => passwordDialog(context),
-      );
+  PdfDocumentRefFile _createDocumentRef() {
+    // מסמך חדש = מחזור חיים חדש לדגל הטעינה. זה המקום הריכוזי והבטוח
+    // לאיפוס: נקרא בכל יצירת ref (initial load + retry) ולא רגיש
+    // לסדר ההפעלה של onViewerReady / onDocumentLoadFinished.
+    _documentFullyLoaded = false;
+    return PdfDocumentRefFile(
+      widget.tab.book.path,
+      // תמיד progressive: pdfrx מציג את העמוד הראשון מיד במקום
+      // להמתין למטא-דאטה של כל העמודים. המעבר ל"stable" מטופל ב-screen
+      // עם debounce timer, ולכן אין צורך לכבות progressive loading.
+      useProgressiveLoading: true,
+      passwordProvider: () => passwordDialog(context),
+    );
+  }
 
   Widget _buildPdfViewerFromFile(String filePath) {
     return BlocBuilder<PdfBookBloc, PdfBookState>(
@@ -2532,11 +2549,15 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   // מבוצע ב-debounce של [_kStableLayoutDebounce] על עדכוני ה-controller.
 
   static const Duration _kStableLayoutDebounce = Duration(milliseconds: 800);
+  static const int _kStableLayoutMaxRetries = 3;
 
   void _beginStableLayoutTracking(int targetPage) {
     if (!mounted) return;
     _stableLayoutTargetPage = targetPage;
-    _documentFullyLoaded = false;
+    _stableLayoutRetryCount = 0;
+    // לא מאפסים _documentFullyLoaded כאן — race: onDocumentLoadFinished
+    // יכול לירות לפני onViewerReady, ואיפוס היה מאבד את הסימון. הוא
+    // מנוהל ריכוזית ב-_createDocumentRef.
     if (!_waitingForStableLayout) {
       setState(() {
         _waitingForStableLayout = true;
@@ -2577,6 +2598,18 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       final currentKey =
           inBookView ? pdfSpreadStartPage(currentPage) : currentPage;
       if (currentKey != targetKey) {
+        // הגנה מפני לולאה אינסופית: אם controller.goToPage לא מצליח
+        // לקבע את עמוד היעד אחרי N נסיונות, מוותרים על ניווט נוסף
+        // ומסירים את ה-overlay. עדיף PDF במיקום קצת שגוי על overlay
+        // תקוע.
+        if (_stableLayoutRetryCount >= _kStableLayoutMaxRetries) {
+          debugPrint(
+              '⚠️ stable-layout: ויתור אחרי $_stableLayoutRetryCount נסיונות '
+              '(target=$target, current=$currentPage)');
+          _completeStableLayoutTracking();
+          return;
+        }
+        _stableLayoutRetryCount++;
         controller.goToPage(pageNumber: target, duration: Duration.zero);
         _restartStableLayoutDebounce();
         return;
@@ -2604,8 +2637,9 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     _stableLayoutTimer?.cancel();
     _stableLayoutTimer = null;
     _stableLayoutTargetPage = null;
+    _stableLayoutRetryCount = 0;
     _waitingForStableLayout = false;
-    _documentFullyLoaded = false;
+    // לא מאפסים _documentFullyLoaded כאן — ראה הסבר ב-_beginStableLayoutTracking.
   }
 
   Future<void> _loadPdfHeadingsAndLinks() async {

--- a/lib/tabs/models/pdf_tab.dart
+++ b/lib/tabs/models/pdf_tab.dart
@@ -152,10 +152,12 @@ class PdfBookTab extends OpenedTab {
     }
 
     final tab = PdfBookTab(
-        book: restoredBook,
-        pageNumber: pageNumber,
-        openLeftPane: shouldOpenLeftPane,
-        isPinned: json['isPinned'] ?? false);
+      book: restoredBook,
+      pageNumber: pageNumber,
+      openLeftPane: shouldOpenLeftPane,
+      isPinned: json['isPinned'] ?? false,
+      requiresStableLayout: json['requiresStableLayout'] ?? false,
+    );
 
     tab.savedLayoutMode = savedLayoutMode;
 
@@ -201,6 +203,7 @@ class PdfBookTab extends OpenedTab {
       'showLeftPane': showLeftPane.value,
       'isPinned': isPinned,
       'type': 'PdfBookTab',
+      'requiresStableLayout': requiresStableLayout,
       if (savedLayoutMode != null) 'savedLayoutMode': savedLayoutMode!.name,
     };
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   hive_ce: ^2.19.3
   path_provider: ^2.1.5
   html: ^0.15.6
-  pdfrx: ^2.4.2
+  pdfrx: ^2.4.3
   url_launcher: ^6.3.2
   flutter_widget_from_html: ^0.17.2
   scrollable_positioned_list: ^0.3.8


### PR DESCRIPTION
מהדיף המקורי (1612 שורות, 7 קבצים) הוחל רק החלק שמשפר בפועל ביצועים
או תיקן בעיות אמיתיות, ונוספו תיקונים נדרשים שלא היו בדיף.

== מה נכנס מהדיף ==

1. טעינת outline + titles אסינכרונית ב-onViewerReady
   - היום: await document.loadOutline() חוסם 1-5s בספרי PDF גדולים
   - אחרי: DocumentReady נשלח מיד, outline ו-DB lookups רצים ברקע
   - חיסכון: שניות בפתיחה של ספרי PDF גדולים (ש"ס, רמב"ם)

2. שדרוג pdfrx 2.4.2 -> 2.4.3 + cap זיכרון 48MB
   - ב-2.4.3 limitRenderingCache=true ברירת מחדל (לא היה ב-2.4.2)
   - הידוק ל-48MB (במקום 100MB default) למחשבי 8GB RAM
   - הקשר: תרחיש ה-OOM של Microsoft Store

3. useProgressiveLoading: true תמיד + stability tracking
   - מבטל המתנה למטא-דאטה של כל העמודים בפתיחה לעמוד יעד
   - overlay נשאר עד שה-layout מתייצב + onDocumentLoadFinished
   - verticalCacheExtent ירוד ל-0 בזמן tracking (חוסך עבודת רינדור)
   - חיסכון: outline נטען במקביל למטא-דאטה (max במקום sum)

4. שמירת requiresStableLayout ב-JSON (toJson/fromJson)
   - באג: workspaces שמורים איבדו את הדגל בטעינה מחדש

5. textSearcher.dispose() ב-dispose()
   - תיקון memory leak: PdfTextSearcher אחז משאבי native

== מה לא נכנס מהדיף ==

1. אינסטרומנטציית [PDF_PERF] (~400 שורות)
   Stopwatches, Timer.periodic לדגימת RAM כל 50ms, _PdfPerfSnapshot,
   12+ משתני מצב למעקב (_pageChangesBeforeStable וכו'), עשרות
   debugPrint. למה: זה ענף מדידת ביצועים של המהנדס המקורי, לא פיצ'ר.
   ה-Timers/Stopwatches רצים גם ב-release.

2. PdfMetadataLoadState enum + מכונת מצב metadata ב-BLoC
   למה: אינדיריקציה ארכיטקטונית בלי רווח מדיד. _loadPdfHeadingsAndLinks
   כבר רץ במקביל לטעינת PDF היום.

3. calculatePdfViewerCacheBudgetBytes דינמי (24-64MB לפי RSS+filesize)
   למה: השתמש ב-File().lengthSync() סינכרוני ב-UI thread, בכל rebuild.
   הוחלף בערך סטטי 48MB.

4. keepRange: 4 -> 2 בפינוי spread cache
   למה: אין מדידה שמראה שיפור; רק עוד re-renders בגלילה אחורה.

5. שינוי סמנטיקה: "_waitingForStable" overlay system של הדיף
   _pendingPerfSettlingOperations, _runTrackedPerfSettlingOperation,
   stability tracking מורכב עם 12 משתני מצב. הוחלף בגרסה נקייה
   עם 4 משתנים בלבד.

6. _setImmediateCurrentTitle, _resetMetadataUiForReload וכו'
   helpers שמשרתים את הזרימה החדשה ב-BLoC - לא נדרשים בפתרון הפשוט.

7. Tests של עזרי PERF (classifyPdfPerfTargetBucket וכו')
   בודקים פונקציות שלא הוחלו.

== מה התווסף שלא היה בדיף ==

1. stability tracking מורחב לכל פתיחה לעמוד שאינו ראשון
   הדיף הפעיל overlay רק ל-requiresStableLayout=true. גרם רגרסיה:
   פתיחה מהיסטוריה/סימניות (לא מסמנים את הדגל) הציגה קפיצות
   ויזואליות כי async-outline ביטל את "חלון ההסתרה" הטבעי של
   await loadOutline הישן. התיקון: gate על
   "requiresStableLayout || pageNumber > 1" גם ב-screen וגם ב-BLoC.

2. דרישה ש-onDocumentLoadFinished ירה לפני הצהרת יציבות
   _documentFullyLoaded flag. 800ms של debounce ריק לא מספיק -
   pdfrx יכול לשתוק 800ms ואז להמשיך לדחוף את עמוד היעד כשעמודי
   רקע מסיימים טעינת מטא-דאטה. בלי הדגל ראיתי קפיצות בתצוגת ספר
   אחרי שה-overlay נעלם.

3. השוואה ברמת spread ב-bookView
   ב-_onLayoutMaybeStable + _isPageStillCurrent. במצב ספר עמודים
   מצומדים לזוגות (2,3) (4,5) - ה-controller מחזיר את spread start.
   השוואה ברמת עמוד (controller.pageNumber != target) הייתה יוצרת
   לולאת ייצוב אינסופית עבור עמודי יעד אי-זוגיים.

4. הגנת race ב-_loadOutlineAndTitlesInBackground
   _isPageStillCurrent() לפני כתיבת currentTitle/currentTextLineNumber.
   בלי זה, אם המשתמש ניווט במהלך טעינת outline, היו נדרסים
   כותרת+טווח שורות במידע של עמוד ישן.

5. Fast-path ב-onDocumentLoadFinished -> _onLayoutMaybeStable מיד
   במקום להמתין ל-800ms של debounce ריק כש-pdfrx כבר סיים. ב-PDFs
   קטנים זה חוסך כמעט שנייה שלמה.

== נטו ==

- ~233 שורות הוספה (לעומת ~1000 בדיף המקורי)
- אפס Timers מיותרים (הדיף הוסיף 3)
- 5 משתני מצב חדשים (הדיף הוסיף 14+)
- אפס אינסטרומנטציה (הדיף הוסיף ~400 שורות)
- ולידציה: flutter analyze נקי, 282/282 טסטים עוברים
