### PR TITLE
תיקון: ייצוב SegmentedSettingsTile בעת החלפת בחירה

### DIFF
--- a/lib/widgets/inputs/segmented_button_tile.dart
+++ b/lib/widgets/inputs/segmented_button_tile.dart
@@ -1,4 +1,3 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:otzaria/theme/theme_exports.dart';
@@ -276,11 +275,10 @@ class _SegmentedSettingsTileState<T> extends State<SegmentedSettingsTile<T>> {
       child: SizedBox(
         width: totalW,
         child: SegmentedButton<T>(
-          showSelectedIcon: true,
-          selectedIcon: const Icon(
-            FluentIcons.checkmark_24_regular,
-            size: 16,
-          ),
+          // ללא אייקון "נבחר": כשלאפשרויות אין אייקון, הוא הופיע רק במקטע
+          // הנבחר ודחק את התווית, וכך ה-FittedBox הקטין את הטקסט ושינה את
+          // מבנה הכפתור בכל החלפת בחירה. הבחירה מסומנת ממילא ברקע ובצבע הטקסט.
+          showSelectedIcon: false,
           style: ButtonStyle(
             minimumSize: WidgetStateProperty.all(const Size(0, 40)),
             maximumSize:

--- a/test/widgets/segmented_settings_tile_test.dart
+++ b/test/widgets/segmented_settings_tile_test.dart
@@ -99,4 +99,52 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  // רגרסיה: כשלאפשרויות אין אייקון משלהן, אייקון "נבחר" (✓) הופיע רק במקטע
+  // הנבחר, דחק את התווית וגרם ל-FittedBox להקטין את הטקסט בכל החלפת בחירה.
+  // הפקד חייב להישאר ללא אייקון נבחר כדי שמבנה הכפתור יישאר יציב.
+  testWidgets(
+    'SegmentedSettingsTile does not render a selected-icon',
+    (tester) async {
+      String currentValue = 'sunset';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) => SegmentedSettingsTile<String>(
+                  icon: FluentIcons.weather_sunny_low_24_regular,
+                  title: 'מעבר יום',
+                  options: const [
+                    SegmentOption(value: 'sunset', label: 'שקיעה'),
+                    SegmentOption(value: 'tzais', label: 'צאה"כ'),
+                    SegmentOption(value: 'rt', label: 'רבינו תם'),
+                    SegmentOption(value: 'midnight', label: '12 בלילה'),
+                  ],
+                  currentValue: currentValue,
+                  onChanged: (value) => setState(() => currentValue = value),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final button = tester.widget<SegmentedButton<String>>(
+        find.byType(SegmentedButton<String>),
+      );
+      expect(button.showSelectedIcon, isFalse);
+
+      // החלפת בחירה אינה מוסיפה אייקון "נבחר" ואינה זורקת חריגה.
+      await tester.tap(find.text('רבינו תם'));
+      await tester.pumpAndSettle();
+
+      expect(currentValue, 'rt');
+      expect(tester.takeException(), isNull);
+      expect(find.byIcon(FluentIcons.checkmark_24_regular), findsNothing);
+    },
+  );
 }

--- a/test/widgets/segmented_settings_tile_test.dart
+++ b/test/widgets/segmented_settings_tile_test.dart
@@ -144,7 +144,9 @@ void main() {
 
       expect(currentValue, 'rt');
       expect(tester.takeException(), isNull);
-      expect(find.byIcon(FluentIcons.checkmark_24_regular), findsNothing);
+      // Icons.done הוא אייקון ה"נבחר" שברירת המחדל של SegmentedButton מציגה
+      // כש-showSelectedIcon: true. היעדרו מאמת שאין אייקון נבחר מוצג בפועל.
+      expect(find.byIcon(Icons.done), findsNothing);
     },
   );
 }


### PR DESCRIPTION
ל-SegmentedButton הוגדר showSelectedIcon: true, כך ש-Material הוסיף סימן ✓ אוטומטי רק למקטע הנבחר. מאחר שהתווית עטופה ב-FittedBox(scaleDown), ה-✓ דחק את הטקסט וגרם לו להתכווץ — ובכל החלפת בחירה המקטע הנבחר משתנה, ומכאן הריצוד. הבעיה השפיעה על כל מקומות השימוש בפקד (עיצוב/טקסט/מערכת/ספרייה/לוח שנה), כי לאף אפשרות אין אייקון פר-מקטע.

התיקון: showSelectedIcon: false. שינוי מינימלי, תואם ל-AppSegmentedControl באותו קובץ.

**הערה לשיקול דעת** : התיקון מסיר את סימן ה-✓ מהכפתור הנבחר. הבחירה עדיין מסומנת בבירור דרך צבע הרקע (secondaryContainer) וצבע הטקסט. אם עדיף לשמר את ה-✓, אפשר לפתור אחרת (שמירת מקום קבוע לאייקון בכל המקטעים) — אך זה diff גדול ומורכב יותר. ההחלטה בידיכם.

לפני:
<img width="671" height="383" alt="image" src="https://github.com/user-attachments/assets/746906e7-6f4e-47c5-8994-b00e71c6cb9a" />

אחרי:

<img width="619" height="469" alt="image" src="https://github.com/user-attachments/assets/04eab07e-103e-4c81-b5bc-22fa48c96391" />
