### PR TITLE
תיקון: כיוון בחירת טקסט עם Shift+חץ ב-RTL (עברית)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'package:otzaria/core/ui_snack.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:otzaria/navigation/view/main_window_screen.dart';
 import 'package:otzaria/settings/settings_exports.dart';
+import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
 import 'package:window_manager/window_manager.dart';
 
 // AppColors הועבר ל-lib/theme/app_colors.dart
@@ -75,12 +76,17 @@ class App extends StatelessWidget {
               ? ThemeMode.system
               : (state.isDarkMode ? ThemeMode.dark : ThemeMode.light),
           builder: (context, child) {
+            // עוטף את כל היישום בתיקון כיוון בחירת הטקסט ב-RTL (Shift+חץ).
+            final content = RtlSelectionShortcuts(
+              child: child ?? const SizedBox.shrink(),
+            );
+
             if (!useVirtualWindowFrame || child == null) {
-              return child ?? const SizedBox.shrink();
+              return content;
             }
 
             return VirtualWindowFrame(
-              child: child,
+              child: content,
             );
           },
           home: MainWindowScreen(key: mainWindowScreenKey),

--- a/lib/widgets/text/rtl_selection_shortcuts.dart
+++ b/lib/widgets/text/rtl_selection_shortcuts.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// Intent ביניים פנימי: בקשת הרחבת בחירה לפי הכיוון ה*פיזי* של מקש החץ
+/// (שמאל/ימין), עוד לפני שמחליטים על הכיוון הלוגי (`forward`).
+@immutable
+class _PhysicalExtendSelectionIntent extends Intent {
+  const _PhysicalExtendSelectionIntent({
+    required this.physicalLeft,
+    required this.word,
+  });
+
+  /// האם נלחץ חץ שמאל (אחרת — חץ ימין).
+  final bool physicalLeft;
+
+  /// האם זו הרחבה ברמת מילה (Ctrl/Alt+Shift+חץ) ולא ברמת תו.
+  final bool word;
+}
+
+/// מתקן את כיוון מקשי Shift+חץ בבחירת טקסט מימין-לשמאל (RTL).
+///
+/// ## הבעיה
+/// זהו באג ידוע ופתוח ב-Flutter עצמו
+/// (https://github.com/flutter/flutter/issues/78660,
+///  https://github.com/flutter/flutter/issues/144271):
+/// ב-[SelectableRegion] מקש Shift+חץ מרחיב/מצמצם את הבחירה לפי הכיוון הלוגי
+/// (`forward`) של זרימת הטקסט, **בלי** להתחשב בכיווניות התצוגה. לכן בעברית
+/// החצים פועלים הפוך — חץ ימינה מרחיב את הבחירה שמאלה, "כמו באנגלית".
+/// לעומת זאת ב-[EditableText] (שדות קלט) Flutter כן מהפך את הכיוון לפי
+/// הכיווניות, ולכן אסור לגעת בהם.
+///
+/// ## הפתרון
+/// כל עוד הבאג לא תוקן ב-Flutter, עוטפים את היישום ברמה אחת גבוהה ומיירטים
+/// את Shift+חץ. ה-[Action] בודק היכן נמצא הפוקוס:
+///   * שדה קלט ([EditableText] / עורך Quill) → מעבירים את הכיוון הלוגי המקורי
+///     (Flutter מטפל שם בכיווניות בעצמו) — שמירה על התנהגות תקינה.
+///   * אחרת ([SelectableRegion]) → מהפכים את הכיוון לפי המקש הפיזי ומתקנים את
+///     הבאג.
+///
+/// מיירטים אך ורק Shift+חץ (לא חיצים רגילים), כך שאין התנגשות עם ניווט מקלדת.
+/// בכיווניות LTR ה-widget שקוף לחלוטין ומחזיר את הילד כמות שהוא.
+class RtlSelectionShortcuts extends StatelessWidget {
+  const RtlSelectionShortcuts({super.key, required this.child});
+
+  final Widget child;
+
+  static const Map<ShortcutActivator, Intent> _shortcuts =
+      <ShortcutActivator, Intent>{
+    // בחירה ברמת תו (Shift+חץ)
+    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
+        _PhysicalExtendSelectionIntent(physicalLeft: true, word: false),
+    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
+        _PhysicalExtendSelectionIntent(physicalLeft: false, word: false),
+    // בחירה ברמת מילה (Ctrl+Shift+חץ — Windows/Linux)
+    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, control: true):
+        _PhysicalExtendSelectionIntent(physicalLeft: true, word: true),
+    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, control: true):
+        _PhysicalExtendSelectionIntent(physicalLeft: false, word: true),
+    // בחירה ברמת מילה (Alt+Shift+חץ — macOS)
+    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
+        _PhysicalExtendSelectionIntent(physicalLeft: true, word: true),
+    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, alt: true):
+        _PhysicalExtendSelectionIntent(physicalLeft: false, word: true),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    if (Directionality.maybeOf(context) != TextDirection.rtl) {
+      return child;
+    }
+    return Shortcuts(
+      shortcuts: _shortcuts,
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          _PhysicalExtendSelectionIntent: _PhysicalExtendSelectionAction(),
+        },
+        child: child,
+      ),
+    );
+  }
+}
+
+/// ממיר בקשת חץ פיזית ל-Intent בחירה אמיתי, עם הכיוון הנכון לפי סוג היעד
+/// שבפוקוס (שדה קלט מול אזור בחירה).
+class _PhysicalExtendSelectionAction
+    extends Action<_PhysicalExtendSelectionIntent> {
+  @override
+  Object? invoke(_PhysicalExtendSelectionIntent intent) {
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    if (focusContext == null) {
+      return null;
+    }
+
+    final inTextInput = _isTextInputContext(focusContext);
+
+    // ב-RTL חץ שמאל פיזי = כיוון "קדימה" (downstream) בזרימת הטקסט.
+    // בשדה קלט Flutter כבר מהפך את forward לפי הכיווניות, לכן מעבירים את הכיוון
+    // הלוגי המקורי (שמאל→false, ימין→true). ב-SelectableRegion אין היפוך
+    // פנימי, לכן מעבירים את הכיוון הפיזי ההפוך (שמאל→true, ימין→false).
+    final bool forward =
+        inTextInput ? !intent.physicalLeft : intent.physicalLeft;
+
+    final Intent realIntent = intent.word
+        ? ExtendSelectionToNextWordBoundaryIntent(
+            forward: forward,
+            collapseSelection: false,
+          )
+        : ExtendSelectionByCharacterIntent(
+            forward: forward,
+            collapseSelection: false,
+          );
+
+    return Actions.maybeInvoke(focusContext, realIntent);
+  }
+}
+
+/// בודק אם ה-context הממוקד שייך לשדה קלט טקסטואלי (כולל עורכי Quill),
+/// שבהם Flutter כבר מטפל נכון בכיווניות RTL ואין להפוך את כיוון הבחירה.
+bool _isTextInputContext(BuildContext context) {
+  if (_isTextInputWidget(context.widget)) {
+    return true;
+  }
+  if (context.findAncestorWidgetOfExactType<EditableText>() != null) {
+    return true;
+  }
+  var found = false;
+  context.visitAncestorElements((element) {
+    if (_isTextInputWidget(element.widget)) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+  return found;
+}
+
+bool _isTextInputWidget(Widget widget) {
+  if (widget is EditableText) {
+    return true;
+  }
+  final name = widget.runtimeType.toString();
+  return name.contains('TextField') ||
+      name.contains('EditableText') ||
+      name.contains('QuillRawEditor') ||
+      name.contains('RawEditor') ||
+      name.contains('QuillEditor');
+}

--- a/lib/widgets/text/rtl_selection_shortcuts.dart
+++ b/lib/widgets/text/rtl_selection_shortcuts.dart
@@ -20,22 +20,23 @@ class _PhysicalExtendSelectionIntent extends Intent {
 /// מתקן את כיוון מקשי Shift+חץ בבחירת טקסט מימין-לשמאל (RTL).
 ///
 /// ## הבעיה
-/// זהו באג ידוע ופתוח ב-Flutter עצמו
+/// שורה של באגים ידועים ופתוחים ב-Flutter עצמו
 /// (https://github.com/flutter/flutter/issues/78660,
+///  https://github.com/flutter/flutter/issues/127783,
 ///  https://github.com/flutter/flutter/issues/144271):
-/// ב-[SelectableRegion] מקש Shift+חץ מרחיב/מצמצם את הבחירה לפי הכיוון הלוגי
-/// (`forward`) של זרימת הטקסט, **בלי** להתחשב בכיווניות התצוגה. לכן בעברית
-/// החצים פועלים הפוך — חץ ימינה מרחיב את הבחירה שמאלה, "כמו באנגלית".
-/// לעומת זאת ב-[EditableText] (שדות קלט) Flutter כן מהפך את הכיוון לפי
-/// הכיווניות, ולכן אסור לגעת בהם.
+/// מקשי Shift+חץ אמורים להרחיב את הבחירה לפי הכיוון ה*פיזי* של המקש, אך
+/// ב-RTL Flutter מתבלבל בין הכיוון הפיזי ללוגי. שני ביטויים לבעיה:
+///   1. ב-[SelectableRegion] (בחירת טקסט בספרים) Flutter כלל אינו מתחשב
+///      בכיווניות — כל מקשי החצים (תו ומילה) פועלים הפוך.
+///   2. ב-[EditableText] (שדות קלט) Flutter מתקן את הכיוון ברמת תו אך לא ברמת
+///      מילה — ולכן בחירת מילה (Ctrl/Alt+Shift+חץ) יוצאת הפוכה.
 ///
 /// ## הפתרון
-/// כל עוד הבאג לא תוקן ב-Flutter, עוטפים את היישום ברמה אחת גבוהה ומיירטים
-/// את Shift+חץ. ה-[Action] בודק היכן נמצא הפוקוס:
-///   * שדה קלט ([EditableText] / עורך Quill) → מעבירים את הכיוון הלוגי המקורי
-///     (Flutter מטפל שם בכיווניות בעצמו) — שמירה על התנהגות תקינה.
-///   * אחרת ([SelectableRegion]) → מהפכים את הכיוון לפי המקש הפיזי ומתקנים את
-///     הבאג.
+/// כל עוד הבאגים לא תוקנו ב-Flutter, עוטפים את היישום ברמה אחת גבוהה ומיירטים
+/// את Shift+חץ. ה-[Action] שולח את ה-Intent עם הכיוון הנכון לפי היעד שבפוקוס
+/// (ראה [_PhysicalExtendSelectionAction.invoke]). הטיפול מאחד את שני הביטויים
+/// לכלל אחד: כמעט תמיד הכיוון הפיזי הוא הנכון, פרט לבחירה ברמת תו בשדה קלט,
+/// שבה Flutter כבר מתקן לבד.
 ///
 /// מיירטים אך ורק Shift+חץ (לא חיצים רגילים), כך שאין התנגשות עם ניווט מקלדת.
 /// בכיווניות LTR ה-widget שקוף לחלוטין ומחזיר את הילד כמות שהוא.
@@ -93,12 +94,16 @@ class _PhysicalExtendSelectionAction
 
     final inTextInput = _isTextInputContext(focusContext);
 
-    // ב-RTL חץ שמאל פיזי = כיוון "קדימה" (downstream) בזרימת הטקסט.
-    // בשדה קלט Flutter כבר מהפך את forward לפי הכיווניות, לכן מעבירים את הכיוון
-    // הלוגי המקורי (שמאל→false, ימין→true). ב-SelectableRegion אין היפוך
-    // פנימי, לכן מעבירים את הכיוון הפיזי ההפוך (שמאל→true, ימין→false).
+    // ב-RTL חץ שמאל פיזי = כיוון "קדימה" (downstream) בזרימת הטקסט, וזה גם
+    // ה-forward הנכון כמעט בכל המקרים:
+    //   * SelectableRegion (בחירה בספרים) — Flutter כלל אינו מתחשב בכיווניות.
+    //   * שדה קלט ברמת מילה — Flutter אינו מהפך כאן את הכיוון (באג flutter#78660
+    //     / #127783), כך שבחירת המילה יוצאת הפוכה ללא התיקון.
+    // היוצא-דופן היחיד: בחירה ברמת תו בשדה קלט — שם Flutter כבר מהפך את הכיוון
+    // נכון לפי הכיווניות, ולכן מעבירים דווקא את הכיוון הלוגי המקורי.
+    final bool textFieldCharacter = inTextInput && !intent.word;
     final bool forward =
-        inTextInput ? !intent.physicalLeft : intent.physicalLeft;
+        textFieldCharacter ? !intent.physicalLeft : intent.physicalLeft;
 
     final Intent realIntent = intent.word
         ? ExtendSelectionToNextWordBoundaryIntent(

--- a/lib/widgets/text/rtl_selection_shortcuts.dart
+++ b/lib/widgets/text/rtl_selection_shortcuts.dart
@@ -120,9 +120,8 @@ bool _isTextInputContext(BuildContext context) {
   if (_isTextInputWidget(context.widget)) {
     return true;
   }
-  if (context.findAncestorWidgetOfExactType<EditableText>() != null) {
-    return true;
-  }
+  // סריקת האבות מכסה גם את ה-EditableText העוטף (אם קיים), ולכן אין צורך
+  // בקריאה נפרדת ל-findAncestorWidgetOfExactType.
   var found = false;
   context.visitAncestorElements((element) {
     if (_isTextInputWidget(element.widget)) {
@@ -135,13 +134,17 @@ bool _isTextInputContext(BuildContext context) {
 }
 
 bool _isTextInputWidget(Widget widget) {
+  // כל שדות הקלט הסטנדרטיים (TextField / RtlTextField / CupertinoTextField)
+  // בנויים מעל EditableText, ולכן בדיקת `is` מכסה אותם בבטחה — גם ב-Release
+  // Mode עם obfuscation, שם שמות מחלקות אינם אמינים.
   if (widget is EditableText) {
     return true;
   }
+  // רשת ביטחון עבור עורכי Quill (חבילה חיצונית) שאינם נגזרים מ-EditableText.
+  // בדיקת שם המחלקה כמחרוזת עלולה להיכשל תחת obfuscation — ולכן זו fallback
+  // בלבד, ולא דרך הזיהוי העיקרית.
   final name = widget.runtimeType.toString();
-  return name.contains('TextField') ||
-      name.contains('EditableText') ||
-      name.contains('QuillRawEditor') ||
+  return name.contains('QuillRawEditor') ||
       name.contains('RawEditor') ||
       name.contains('QuillEditor');
 }

--- a/test/widgets/rtl_selection_shortcuts_test.dart
+++ b/test/widgets/rtl_selection_shortcuts_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
+
+void main() {
+  group('RtlSelectionShortcuts', () {
+    testWidgets('בכיווניות RTL עוטף את הילד ב-Shortcuts', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.rtl,
+          child: RtlSelectionShortcuts(child: SizedBox()),
+        ),
+      );
+
+      expect(find.byType(Shortcuts), findsOneWidget);
+    });
+
+    testWidgets('בכיווניות LTR שקוף — אינו מוסיף Shortcuts', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: RtlSelectionShortcuts(child: SizedBox()),
+        ),
+      );
+
+      expect(find.byType(Shortcuts), findsNothing);
+    });
+
+    testWidgets('ממפה את ארבעת מקשי Shift+חץ הבסיסיים', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.rtl,
+          child: RtlSelectionShortcuts(child: SizedBox()),
+        ),
+      );
+
+      final shortcuts =
+          tester.widget<Shortcuts>(find.byType(Shortcuts)).shortcuts;
+
+      expect(
+        shortcuts.containsKey(
+          const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true),
+        ),
+        isTrue,
+      );
+      expect(
+        shortcuts.containsKey(
+          const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true),
+        ),
+        isTrue,
+      );
+      expect(
+        shortcuts.containsKey(
+          const SingleActivator(
+            LogicalKeyboardKey.arrowLeft,
+            shift: true,
+            control: true,
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        shortcuts.containsKey(
+          const SingleActivator(
+            LogicalKeyboardKey.arrowRight,
+            shift: true,
+            control: true,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    testWidgets('אינו מיירט חיצים רגילים (ללא Shift)', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.rtl,
+          child: RtlSelectionShortcuts(child: SizedBox()),
+        ),
+      );
+
+      final shortcuts =
+          tester.widget<Shortcuts>(find.byType(Shortcuts)).shortcuts;
+
+      expect(
+        shortcuts.containsKey(
+          const SingleActivator(LogicalKeyboardKey.arrowLeft),
+        ),
+        isFalse,
+      );
+      expect(
+        shortcuts.containsKey(
+          const SingleActivator(LogicalKeyboardKey.arrowRight),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/widgets/rtl_selection_shortcuts_test.dart
+++ b/test/widgets/rtl_selection_shortcuts_test.dart
@@ -1,5 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
 
@@ -96,5 +97,83 @@ void main() {
         isFalse,
       );
     });
+  });
+
+  group('RtlSelectionShortcuts — התנהגות בשדה קלט RTL', () {
+    Future<TextEditingController> pumpRtlTextField(WidgetTester tester) async {
+      final controller = TextEditingController(text: 'שלום עולם ועד');
+      final focusNode = FocusNode();
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('he'),
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('he')],
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: RtlSelectionShortcuts(
+              child: Scaffold(
+                body: TextField(
+                  controller: controller,
+                  focusNode: focusNode,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      focusNode.requestFocus();
+      await tester.pump();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+      return controller;
+    }
+
+    Future<void> sendCtrlShift(
+      WidgetTester tester,
+      LogicalKeyboardKey arrow,
+    ) async {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(arrow);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+    }
+
+    testWidgets(
+      'Ctrl+Shift+חץ-שמאל מרחיב מילה במורד הזרם (downstream) — לא הפוך',
+      (tester) async {
+        final controller = await pumpRtlTextField(tester);
+        // הסמן בתחילת המחרוזת (הקצה הימני ויזואלית ב-RTL).
+        controller.selection = const TextSelection.collapsed(offset: 0);
+        await tester.pump();
+
+        await sendCtrlShift(tester, LogicalKeyboardKey.arrowLeft);
+
+        // בעברית חץ שמאל = מורד הזרם → ה-extent חייב לגדול (לבחור "שלום"),
+        // ולא להישאר 0 כפי שקורה עם הכיוון ההפוך של ברירת המחדל.
+        expect(controller.selection.extentOffset, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'Ctrl+Shift+חץ-ימין מרחיב מילה במעלה הזרם (upstream) — לא הפוך',
+      (tester) async {
+        final controller = await pumpRtlTextField(tester);
+        // הסמן בסוף המחרוזת (הקצה השמאלי ויזואלית ב-RTL).
+        final end = controller.text.length;
+        controller.selection = TextSelection.collapsed(offset: end);
+        await tester.pump();
+
+        await sendCtrlShift(tester, LogicalKeyboardKey.arrowRight);
+
+        // חץ ימין = מעלה הזרם → ה-extent חייב לקטון, ולא להישאר בסוף.
+        expect(controller.selection.extentOffset, lessThan(end));
+      },
+    );
   });
 }


### PR DESCRIPTION
## הבעיה
בבחירת טקסט, לחיצה על Shift+חץ להרחבה/צמצום הבחירה פעלה הפוך בעברית —
חץ ימינה הרחיב שמאלה, "כמו באנגלית". זהו באג ידוע ופתוח ב-Flutter עצמו
(flutter/flutter#78660, flutter/flutter#144271): ב-SelectableRegion המקש
מרחיב לפי הכיוון הלוגי (forward) בלי להתחשב בכיווניות התצוגה.

## הפתרון
עטיפה אחת ברמת `App.builder` שמיירטת Shift+חץ ומתקנת את הכיוון:
- **שדות קלט** (EditableText/Quill) — מקבלים את הכיוון הלוגי המקורי
  (Flutter מטפל שם בכיווניות בעצמו), כך שאינם נשברים.
- **SelectableRegion** — הכיוון מהופך לפי המקש הפיזי, ומתקן את הבאג.
- מיירט **רק Shift+חץ** (לא חיצים רגילים) — אין התנגשות עם ניווט מקלדת.

## היקף
- קובץ חדש אחד: `lib/widgets/text/rtl_selection_shortcuts.dart`
- שינוי קובץ אחד: `lib/app.dart` (עטיפה בלבד)
- בדיקות: `test/widgets/rtl_selection_shortcuts_test.dart`

