### PR TITLE
תחילת שיפור מנוע היבוא ותצוגה של קבצי וורד

### DIFF
--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -26,6 +26,7 @@ import 'package:otzaria/migration/models/alt_toc_entry.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
 import 'package:otzaria/utils/file/toc_parser.dart';
 import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+import 'package:otzaria/utils/file/docx_cache.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:pdfrx/pdfrx.dart';
@@ -154,7 +155,10 @@ Future<void> _collectBookFilesRecursive(
 
         // ── DB existence check ─────────────────────────────────────────────
         // Perform BEFORE any expensive IO (TOC parse) so unchanged books are
-        // skipped entirely without reading file content.
+        // skipped entirely without reading file content. A *changed* file
+        // falls through to re-parse its TOC (so the navigation stays in sync
+        // with the edited content), keeping its existing book id.
+        int? existingBookId;
         if (db != null) {
           final rows = db.select(
             'SELECT id, fileSize, lastModified FROM book WHERE filePath = ? LIMIT 1',
@@ -168,23 +172,12 @@ Future<void> _collectBookFilesRecursive(
               // Unchanged — skip entirely, no work needed.
               continue;
             }
-            // File has changed — report for metadata-only update.
-            books.add(_DiscoveredBook(
-              path: entity.path,
-              title: title,
-              fileType: fileType,
-              fileSize: fileSize,
-              lastModified: lastModified,
-              categoryPath: categoryPath,
-              tocEntries: null, // no re-parse on metadata update
-              existingBookId: row['id'] as int,
-            ));
-            continue;
+            existingBookId = row['id'] as int; // changed — re-parse TOC below
           }
         }
         // ──────────────────────────────────────────────────────────────────
 
-        // Genuinely new book — parse TOC for TXT / DOCX.
+        // New or changed book — parse TOC for TXT / DOCX.
         List<_RawTocEntry>? rawToc;
         String? conversionError;
         if (fileType == 'txt') {
@@ -221,6 +214,7 @@ Future<void> _collectBookFilesRecursive(
           categoryPath: categoryPath,
           tocEntries: rawToc,
           conversionError: conversionError,
+          existingBookId: existingBookId,
         ));
       }
     } catch (e) {
@@ -1167,6 +1161,11 @@ class DatabaseLibraryProvider implements LibraryProvider {
         if (book.isFileBacked && book.filePath != null) {
           final file = File(book.filePath!);
           if (await file.exists()) {
+            // DOCX הוא בינארי — חובה להמיר, לא readAsString (שמחזיר זבל/זורק).
+            if ((book.fileType ?? '').toLowerCase() == 'docx' ||
+                file.path.toLowerCase().endsWith('.docx')) {
+              return await convertDocxWithCache(file, title);
+            }
             return await file.readAsString();
           }
         }
@@ -1187,9 +1186,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           final file = File(book.filePath!);
           if (await file.exists()) {
             if ((book.fileType ?? '').toLowerCase() == 'docx') {
-              final bytes = await file.readAsBytes();
-              final t = title;
-              return await Isolate.run(() => docxToText(bytes, t));
+              return await convertDocxWithCache(file, title);
             }
             return await file.readAsString();
           }
@@ -1880,15 +1877,12 @@ class DatabaseLibraryProvider implements LibraryProvider {
           _userBooksCategoryIds.add(pickedFolder.id);
 
           // ספרים בתוך התיקייה הנבחרת עצמה — לשורש הספרייה.
-          final booksInPickedFolder =
-              (booksByCategory[pickedFolder.id] ?? [])
-                ..sort((a, b) {
-                  final orderA =
-                      (a['orderIndex'] as num?)?.toDouble() ?? 999.0;
-                  final orderB =
-                      (b['orderIndex'] as num?)?.toDouble() ?? 999.0;
-                  return orderA.compareTo(orderB);
-                });
+          final booksInPickedFolder = (booksByCategory[pickedFolder.id] ?? [])
+            ..sort((a, b) {
+              final orderA = (a['orderIndex'] as num?)?.toDouble() ?? 999.0;
+              final orderB = (b['orderIndex'] as num?)?.toDouble() ?? 999.0;
+              return orderA.compareTo(orderB);
+            });
           for (final dbBook in booksInPickedFolder) {
             final book = _convertMinimalBookMapToBook(
               dbBook,
@@ -1949,8 +1943,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           final created = Category(
             title: 'ספרים אישיים',
             description: metadata['ספרים אישיים']?['heDesc'] ?? '',
-            shortDescription:
-                metadata['ספרים אישיים']?['heShortDesc'] ?? '',
+            shortDescription: metadata['ספרים אישיים']?['heShortDesc'] ?? '',
             order: personalRootInUserDb.orderIndex,
             subCategories: [],
             books: [],
@@ -2609,13 +2602,21 @@ class DatabaseLibraryProvider implements LibraryProvider {
         }
         try {
           if (book.existingBookId != null) {
-            // Metadata-only update (file changed since last scan).
+            // File changed since last scan — update metadata, and refresh the
+            // TOC if it was re-parsed (so navigation matches the new content).
             await repository.updateExternalBookMetadata(
               book.existingBookId!,
               book.fileSize,
               book.lastModified,
             );
-            debugPrint('📁 Updated external book metadata: ${book.title}');
+            if (book.tocEntries != null) {
+              await repository.replaceExternalBookToc(
+                book.existingBookId!,
+                _rawTocToDbEntries(book.tocEntries!),
+              );
+            }
+            debugPrint(
+                '📁 Updated external book (metadata+TOC): ${book.title}');
             updated++;
             continue;
           }

--- a/lib/data/data_providers/file_system_library_provider.dart
+++ b/lib/data/data_providers/file_system_library_provider.dart
@@ -9,7 +9,7 @@ import 'package:otzaria/data/data_providers/library_provider.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/library/models/library.dart';
-import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+import 'package:otzaria/utils/file/docx_cache.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
 import 'package:otzaria/utils/file/toc_parser.dart';
 import 'package:otzaria/settings/settings_exports.dart';
@@ -285,8 +285,7 @@ class FileSystemLibraryProvider implements LibraryProvider {
     }
 
     if (path.endsWith('.docx')) {
-      final bytes = await file.readAsBytes();
-      return Isolate.run(() => docxToText(bytes, title));
+      return convertDocxWithCache(file, title);
     } else {
       return file.readAsString();
     }

--- a/lib/migration/database/daos/database.dart
+++ b/lib/migration/database/daos/database.dart
@@ -6,6 +6,7 @@ import 'book_dao.dart';
 import 'book_has_links_dao.dart';
 import 'category_dao.dart';
 import 'connection_type_dao.dart';
+import 'docx_text_cache_dao.dart';
 import 'generation_dao.dart';
 import 'line_dao.dart';
 import 'link_dao.dart';
@@ -42,6 +43,7 @@ class MyDatabase {
   BookHasLinksDao? _bookHasLinksDao;
   CategoryDao? _categoryDao;
   ConnectionTypeDao? _connectionTypeDao;
+  DocxTextCacheDao? _docxTextCacheDao;
   GenerationDao? _generationDao;
   LineDao? _lineDao;
   LinkDao? _linkDao;
@@ -81,6 +83,11 @@ class MyDatabase {
   ConnectionTypeDao get connectionTypeDao {
     _ensureDaosInitialized();
     return _connectionTypeDao!;
+  }
+
+  DocxTextCacheDao get docxTextCacheDao {
+    _ensureDaosInitialized();
+    return _docxTextCacheDao!;
   }
 
   GenerationDao get generationDao {
@@ -203,6 +210,7 @@ class MyDatabase {
     _bookHasLinksDao = BookHasLinksDao(this);
     _categoryDao = CategoryDao(this);
     _connectionTypeDao = ConnectionTypeDao(this);
+    _docxTextCacheDao = DocxTextCacheDao(this);
     _generationDao = GenerationDao(this);
     _lineDao = LineDao(this);
     _linkDao = LinkDao(this);
@@ -480,6 +488,20 @@ class MyDatabase {
         );
         ''',
       'CREATE INDEX IF NOT EXISTS idx_pdf_outline_cache_accessed_at ON pdf_outline_cache(accessedAt);',
+
+      // Persistent cache of converted external DOCX text (populated in cache.db)
+      '''
+        CREATE TABLE IF NOT EXISTS docx_text_cache (
+          filePath TEXT PRIMARY KEY,
+          fileSize INTEGER NOT NULL,
+          lastModified INTEGER NOT NULL,
+          converterVersion INTEGER NOT NULL DEFAULT 0,
+          text TEXT NOT NULL,
+          createdAt INTEGER NOT NULL,
+          accessedAt INTEGER NOT NULL
+        );
+        ''',
+      'CREATE INDEX IF NOT EXISTS idx_docx_text_cache_accessed_at ON docx_text_cache(accessedAt);',
 
       // Links table
       '''

--- a/lib/migration/database/daos/docx_text_cache_dao.dart
+++ b/lib/migration/database/daos/docx_text_cache_dao.dart
@@ -1,0 +1,55 @@
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+import '../../models/docx_text_cache_entry.dart';
+import '../sql/query_loader.dart';
+import '../sql/sqlite3_utils.dart';
+import 'database.dart';
+
+/// DAO למטמון התוכן הממומר של קובצי docx חיצוניים (טבלת `docx_text_cache`,
+/// מאוכלסת ב-`cache.db`). מקביל ל-[PdfOutlineCacheDao].
+class DocxTextCacheDao {
+  final MyDatabase _db;
+  late final Map<String, String> _queries;
+
+  DocxTextCacheDao(this._db) {
+    _queries = QueryLoader.loadQueries('DocxTextCacheQueries.sq');
+  }
+
+  Future<sqlite3.Database> get database => _db.database;
+
+  Future<DocxTextCacheEntry?> selectByFilePath(String filePath) async {
+    final db = await database;
+    final result =
+        db.select(_queries['selectByFilePath']!, [filePath]).toMapList();
+    if (result.isEmpty) return null;
+    return DocxTextCacheEntry.fromMap(result.first);
+  }
+
+  Future<void> upsert(DocxTextCacheEntry entry) async {
+    final db = await database;
+    db.execute(_queries['upsert']!, [
+      entry.filePath,
+      entry.fileSize,
+      entry.lastModified,
+      entry.converterVersion,
+      entry.text,
+      entry.createdAt,
+      entry.accessedAt,
+    ]);
+  }
+
+  Future<void> updateAccessedAt(String filePath, int accessedAt) async {
+    final db = await database;
+    db.execute(_queries['updateAccessedAt']!, [accessedAt, filePath]);
+  }
+
+  Future<void> deleteByFilePath(String filePath) async {
+    final db = await database;
+    db.execute(_queries['deleteByFilePath']!, [filePath]);
+  }
+
+  Future<void> deleteAccessedBefore(int cutoffMillis) async {
+    final db = await database;
+    db.execute(_queries['deleteAccessedBefore']!, [cutoffMillis]);
+  }
+}

--- a/lib/migration/database/repository/seforim_repository.dart
+++ b/lib/migration/database/repository/seforim_repository.dart
@@ -5,6 +5,7 @@ import '../../../utils/text/text_manipulation.dart';
 import '../../models/author.dart';
 import '../../models/book.dart';
 import '../../models/category.dart';
+import '../../models/docx_text_cache_entry.dart';
 import '../../models/line.dart';
 import '../../models/link.dart';
 import '../../models/pdf_outline_cache_entry.dart';
@@ -854,6 +855,17 @@ class SeforimRepository {
         .updateExternalMetadata(bookId, fileSize, lastModified);
   }
 
+  /// מחליף את ה-TOC של ספר חיצוני קיים (מחיקת הישן + הוספת החדש). נדרש
+  /// כשקובץ DOCX/TXT נערך — כדי שהניווט יתעדכן לפי התוכן החדש, ולא יישאר
+  /// לפי הגרסה הישנה.
+  Future<void> replaceExternalBookToc(
+      int bookId, List<TocEntry> tocEntries) async {
+    await deleteBookTocEntries(bookId);
+    if (tocEntries.isNotEmpty) {
+      await _insertTocEntriesForExternalBook(bookId, tocEntries);
+    }
+  }
+
   /// Updates a book's storage details (file path, file size, last modified).
   /// Required when a book transitions between being stored externally and within the DB.
   Future<void> updateBookStorage(
@@ -1064,6 +1076,28 @@ class SeforimRepository {
 
   Future<void> prunePdfOutlineCacheAccessedBefore(int cutoffMillis) async {
     await _database.pdfOutlineCacheDao.deleteAccessedBefore(cutoffMillis);
+  }
+
+  // --- Persistent external DOCX text cache ---
+
+  Future<DocxTextCacheEntry?> getDocxTextCacheEntry(String filePath) async {
+    return _database.docxTextCacheDao.selectByFilePath(filePath);
+  }
+
+  Future<void> upsertDocxTextCacheEntry(DocxTextCacheEntry entry) async {
+    await _database.docxTextCacheDao.upsert(entry);
+  }
+
+  Future<void> deleteDocxTextCacheEntry(String filePath) async {
+    await _database.docxTextCacheDao.deleteByFilePath(filePath);
+  }
+
+  Future<void> touchDocxTextCacheEntry(String filePath, int accessedAt) async {
+    await _database.docxTextCacheDao.updateAccessedAt(filePath, accessedAt);
+  }
+
+  Future<void> pruneDocxTextCacheAccessedBefore(int cutoffMillis) async {
+    await _database.docxTextCacheDao.deleteAccessedBefore(cutoffMillis);
   }
 
   Future<void> prunePdfOutlineCacheExceptFilePaths(

--- a/lib/migration/database/sql/Database.sq
+++ b/lib/migration/database/sql/Database.sq
@@ -241,6 +241,19 @@ CREATE TABLE IF NOT EXISTS pdf_outline_cache (
 
 CREATE INDEX IF NOT EXISTS idx_pdf_outline_cache_accessed_at ON pdf_outline_cache(accessedAt);
 
+-- Persistent cache of converted external DOCX text
+CREATE TABLE IF NOT EXISTS docx_text_cache (
+    filePath TEXT PRIMARY KEY,
+    fileSize INTEGER NOT NULL,
+    lastModified INTEGER NOT NULL,
+    converterVersion INTEGER NOT NULL DEFAULT 0,
+    text TEXT NOT NULL,
+    createdAt INTEGER NOT NULL,
+    accessedAt INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_docx_text_cache_accessed_at ON docx_text_cache(accessedAt);
+
 -- Links table
 CREATE TABLE IF NOT EXISTS link (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/lib/migration/database/sql/DocxTextCacheQueries.sq
+++ b/lib/migration/database/sql/DocxTextCacheQueries.sq
@@ -1,0 +1,42 @@
+-- Queries for persistent cache of converted external DOCX text
+
+selectByFilePath:
+SELECT *
+FROM docx_text_cache
+WHERE filePath = ?
+LIMIT 1;
+
+selectAllFilePaths:
+SELECT filePath
+FROM docx_text_cache;
+
+upsert:
+INSERT INTO docx_text_cache (
+  filePath,
+  fileSize,
+  lastModified,
+  converterVersion,
+  text,
+  createdAt,
+  accessedAt
+)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(filePath) DO UPDATE SET
+  fileSize = excluded.fileSize,
+  lastModified = excluded.lastModified,
+  converterVersion = excluded.converterVersion,
+  text = excluded.text,
+  accessedAt = excluded.accessedAt;
+
+updateAccessedAt:
+UPDATE docx_text_cache
+SET accessedAt = ?
+WHERE filePath = ?;
+
+deleteByFilePath:
+DELETE FROM docx_text_cache
+WHERE filePath = ?;
+
+deleteAccessedBefore:
+DELETE FROM docx_text_cache
+WHERE accessedAt < ?;

--- a/lib/migration/database/sql/query_loader.dart
+++ b/lib/migration/database/sql/query_loader.dart
@@ -34,6 +34,7 @@ class QueryLoader {
       'CategoryQueries.sq',
       'ConnectionTypeQueries.sq',
       'Database.sq',
+      'DocxTextCacheQueries.sq',
       'GenerationQueries.sq',
       'LineQueries.sq',
       'LineTocQueries.sq',

--- a/lib/migration/models/docx_text_cache_entry.dart
+++ b/lib/migration/models/docx_text_cache_entry.dart
@@ -1,0 +1,56 @@
+/// רשומת מטמון מתמשך לתוכן הממומר של קובץ Word (docx) חיצוני.
+///
+/// ההמרה של docx ל-HTML של אוצריא היא יקרה (פירוק XML מלא בכל פתיחה).
+/// המטמון נשמר ב-`cache.db` (כתיב), ומפתח-התוקף שלו הוא שילוב של
+/// [fileSize] + [lastModified] של קובץ ה-docx: אם המשתמש עורך את הקובץ
+/// (ספרים אישיים), הערכים משתנים, ההתאמה נכשלת, והתוכן מומר מחדש — כך
+/// הטריות נשמרת תמיד, בלי להקפיא תוכן ישן.
+class DocxTextCacheEntry {
+  final String filePath;
+  final int fileSize;
+  final int lastModified;
+
+  /// גרסת הממיר שיצרה את הרשומה (`kDocxConverterVersion`). חלק ממפתח-התוקף:
+  /// שדרוג הממיר פוסל רשומות ישנות גם אם הקובץ עצמו לא השתנה.
+  final int converterVersion;
+
+  /// הטקסט הממומר המלא (פלט [docxToText]) — HTML שורות מופרדות ב-`\n`.
+  final String text;
+  final int createdAt;
+  final int accessedAt;
+
+  const DocxTextCacheEntry({
+    required this.filePath,
+    required this.fileSize,
+    required this.lastModified,
+    required this.converterVersion,
+    required this.text,
+    required this.createdAt,
+    required this.accessedAt,
+  });
+
+  factory DocxTextCacheEntry.fromMap(Map<String, dynamic> map) {
+    return DocxTextCacheEntry(
+      filePath: map['filePath'] as String,
+      fileSize: map['fileSize'] as int? ?? 0,
+      lastModified: map['lastModified'] as int? ?? 0,
+      converterVersion: map['converterVersion'] as int? ?? 0,
+      text: map['text'] as String? ?? '',
+      createdAt: map['createdAt'] as int? ?? 0,
+      accessedAt: map['accessedAt'] as int? ?? 0,
+    );
+  }
+
+  /// האם הרשומה תקפה: זהות הקובץ (גודל + זמן-שינוי) **וגם** התאמת גרסת
+  /// הממיר. אי-התאמה באחד מהם — הרשומה נפסלת והתוכן מומר מחדש.
+  bool isValidFor(int size, int modified, int version) =>
+      fileSize == size &&
+      lastModified == modified &&
+      converterVersion == version;
+
+  @override
+  String toString() =>
+      'DocxTextCacheEntry(filePath: $filePath, fileSize: $fileSize, '
+      'lastModified: $lastModified, v: $converterVersion, '
+      'textLen: ${text.length})';
+}

--- a/lib/text_book/text_book_repository.dart
+++ b/lib/text_book/text_book_repository.dart
@@ -5,7 +5,7 @@ import 'package:otzaria/data/data_providers/database_library_provider.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/data/book_locator.dart';
-import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+import 'package:otzaria/utils/file/docx_cache.dart';
 import 'package:otzaria/utils/file/toc_parser.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'dart:io';
@@ -68,8 +68,7 @@ class TextBookRepository {
         if (await file.exists()) {
           final ext = (dbBook.fileType ?? '').toLowerCase();
           if (ext == 'docx') {
-            final bytes = await file.readAsBytes();
-            return await Isolate.run(() => docxToText(bytes, title));
+            return await convertDocxWithCache(file, title);
           }
           if (ext == 'pdf') return '';
           return await file.readAsString();
@@ -224,8 +223,7 @@ class TextBookRepository {
           final ext = (dbBook.fileType ?? '').toLowerCase();
           final String content;
           if (ext == 'docx') {
-            final bytes = await file.readAsBytes();
-            content = await Isolate.run(() => docxToText(bytes, title));
+            content = await convertDocxWithCache(file, title);
           } else if (ext == 'pdf') {
             content = '';
           } else {

--- a/lib/utils/file/docx_cache.dart
+++ b/lib/utils/file/docx_cache.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:otzaria/data/data_providers/cache_database_holder.dart';
+import 'package:otzaria/migration/models/docx_text_cache_entry.dart';
+import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+
+/// משך חיים של רשומת מטמון docx ללא גישה. רשומות של ספרים שלא נפתחו
+/// מעבר לפרק זמן זה מנוקות — כדי ש-`cache.db` לא יגדל ללא הגבלה (כל
+/// רשומה מכילה את טקסט הספר המלא, כולל base64 של תמונות).
+const Duration _docxCacheTtl = Duration(days: 90);
+
+/// תדירות מקסימלית לעדכון `accessedAt` (יום). מונע כתיבת WAL בכל פתיחה.
+const int _touchThrottleMs = 24 * 60 * 60 * 1000;
+
+final Random _pruneSampler = Random();
+
+/// האם להריץ ניקוי אופורטוניסטי בנתיב cache-hit (הסתברות ~5%). כך מטמון
+/// של ספרים שנמחקו/לא-נפתחו מתנקה גם כשאין המרות חדשות, בלי overhead
+/// בכל פתיחה.
+bool _shouldOpportunisticPrune() => _pruneSampler.nextInt(20) == 0;
+
+/// המרות docx פעילות (מפתח: `path|size|mtime`) — מבטל המרה כפולה מקבילה
+/// כשגם `getBookContent` וגם `getBookToc` פותחים את אותו ספר *לפני*
+/// שהמטמון נכתב (פתיחה ראשונה ממש).
+final Map<String, Future<String>> _inFlight = {};
+
+/// ממיר קובץ docx חיצוני לטקסט של אוצריא, עם מטמון מתמשך ב-`cache.db`.
+///
+/// ההמרה (פירוק XML מלא ב-[docxToText]) יקרה — לאלפי דפים מדובר בשניות בכל
+/// פתיחה. המטמון נמנע מכך: מפתח-התוקף הוא גודל הקובץ + זמן-השינוי + גרסת
+/// הממיר. אם הקובץ לא השתנה — מחזיר את הטקסט השמור מיידית; אם המשתמש ערך
+/// את הקובץ (ספרים אישיים) — הערכים משתנים וההמרה מתבצעת מחדש. כך הטריות
+/// נשמרת. כשל מטמון אינו פוגע — נופלים להמרה רגילה.
+///
+/// הכותרת ([title]) אינה חלק ממפתח המטמון — היא מוזרקת מחדש בכל קריאה
+/// (ראו [_withFreshTitle]), כך ששינוי שם הספר אינו פוסל את המטמון אך
+/// הכותרת המוצגת תמיד עדכנית.
+Future<String> convertDocxWithCache(File file, String title) async {
+  final stat = await file.stat();
+  final size = stat.size;
+  final mtime = stat.modified.millisecondsSinceEpoch;
+  final path = file.path;
+
+  // ── נתיב cache-hit ──────────────────────────────────────────────────────
+  try {
+    final repo = await CacheDatabaseHolder.instance.repository;
+    final entry = await repo.getDocxTextCacheEntry(path);
+    if (entry != null && entry.isValidFor(size, mtime, kDocxConverterVersion)) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      // throttle: touch לכל היותר פעם ביום (מונע כתיבת WAL בכל פתיחה).
+      if (now - entry.accessedAt > _touchThrottleMs) {
+        unawaited(repo.touchDocxTextCacheEntry(path, now).catchError((_) {}));
+      }
+      if (_shouldOpportunisticPrune()) {
+        unawaited(repo
+            .pruneDocxTextCacheAccessedBefore(
+                now - _docxCacheTtl.inMilliseconds)
+            .catchError((_) {}));
+      }
+      return _withFreshTitle(entry.text, title);
+    }
+  } catch (e) {
+    debugPrint('⚠️ docx cache read failed (falling back to convert): $e');
+  }
+
+  // ── נתיב המרה ──────────────────────────────────────────────────────────
+  // דה-דופ המרות מקבילות: אם כבר רצה המרה לאותו קובץ, נצרף אליה.
+  final key = '$path|$size|$mtime';
+  final pending = _inFlight[key];
+  if (pending != null) return _withFreshTitle(await pending, title);
+
+  final future = _convert(path, title);
+  _inFlight[key] = future;
+  final String text;
+  try {
+    text = await future;
+  } finally {
+    _inFlight.remove(key);
+  }
+
+  // שמירה ברקע (fire-and-forget): הטקסט כבר מוכן, אין צורך להמתין ל-DB.
+  unawaited(_persist(path, size, mtime, text));
+  return text;
+}
+
+/// ההמרה עצמה. ה-bytes נקראים *בתוך* ה-[Isolate.run] (לא לפניו) כדי לא
+/// להעתיק buffer גדול (עשרות MB) בין ה-main isolate ל-worker — רק הנתיב
+/// והכותרת (מחרוזות קטנות) עוברים.
+Future<String> _convert(String path, String title) {
+  return Isolate.run(() {
+    final bytes = File(path).readAsBytesSync();
+    return docxToText(bytes, title);
+  });
+}
+
+/// שמירת התוצאה במטמון + ניקוי TTL. best-effort — כשל אינו פוגע בטקסט שכבר
+/// הוחזר למשתמש.
+Future<void> _persist(String path, int size, int mtime, String text) async {
+  try {
+    final repo = await CacheDatabaseHolder.instance.repository;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await repo.upsertDocxTextCacheEntry(DocxTextCacheEntry(
+      filePath: path,
+      fileSize: size,
+      lastModified: mtime,
+      converterVersion: kDocxConverterVersion,
+      text: text,
+      createdAt: now,
+      accessedAt: now,
+    ));
+    await repo
+        .pruneDocxTextCacheAccessedBefore(now - _docxCacheTtl.inMilliseconds);
+  } catch (e) {
+    debugPrint('⚠️ docx cache write failed (text still returned): $e');
+  }
+}
+
+/// מחליף את שורת הכותרת (h1, שורה 0 ש-[docxToText] תמיד מייצר) ב-[title]
+/// הנוכחי. כך המטמון נשמר לפי הקובץ ולא לפי שם הספר — שינוי-שם אינו פוסל
+/// את המטמון, אך הכותרת המוצגת מתעדכנת מיד. אם הפלט אינו פותח ב-`<h1>`
+/// (לא אמור לקרות) — מוחזר כפי שהוא.
+@visibleForTesting
+String withFreshDocxTitle(String cachedText, String title) =>
+    _withFreshTitle(cachedText, title);
+
+String _withFreshTitle(String cachedText, String title) {
+  final nl = cachedText.indexOf('\n');
+  final head = nl < 0 ? cachedText : cachedText.substring(0, nl);
+  if (!head.startsWith('<h1>')) return cachedText;
+  final rest = nl < 0 ? '' : cachedText.substring(nl);
+  // escape כדי ששם קובץ עם `<`/`&` לא ישבור את ה-HTML.
+  return '<h1>${escapeHtmlText(title)}</h1>$rest';
+}

--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -3,6 +3,16 @@ import 'package:archive/archive.dart';
 import 'package:xml/xml.dart' as xml;
 import 'dart:convert';
 
+/// גרסת הממיר [docxToText]. **חובה להעלות ערך זה בכל שינוי שמשפיע על הפלט**
+/// (עיצוב, כותרות, תמונות, טבלאות…). מטמון התוכן ([convertDocxWithCache])
+/// כולל את הגרסה במפתח-התוקף: העלאה כאן פוסלת אוטומטית את כל הרשומות שנוצרו
+/// ע"י גרסה ישנה, וגורמת להמרה מחדש — כך משתמש שכבר פתח ספר יקבל את התצוגה
+/// המשופרת בלי לגעת בקובץ.
+/// v2: תמונות מוטמעות (data URI) וטבלאות עשירות. v3: רשימות ממוספרות
+/// מקוננות (decimal/רומי/אותיות לטיניות/עבריות/multilevel) לפי numbering.xml.
+/// v4: בקרות-תוכן (`w:sdt`) וטבלאות מקוננות בתאים — מניעת אובדן תוכן.
+const int kDocxConverterVersion = 4;
+
 // Windows-1255 Hebrew range: 0xC0–0xD8 and 0xE0–0xFA map to Unicode with offset 1264.
 // 0xE0 (224) + 1264 = 1488 = U+05D0 = א, ... 0xFA (250) + 1264 = 1514 = U+05EA = ת
 const _cp1255Offset = 1264;
@@ -27,56 +37,737 @@ String _decodeXmlBytes(List<int> bytes) {
 
 ZipDecoder? _zipDecoder;
 
-/// Processes a run element and returns HTML-formatted text with styling
-String _processRun(xml.XmlElement node, {double defaultFontSize = 12}) {
-  final rPr = node.getElement('w:rPr');
-  final text = node.getElement('w:t')?.innerText ?? '';
-  if (text.isEmpty) return '';
+/// מונה רץ לסימוני הערות שוליים (משותף לגוף ולתאי טבלה).
+class _FootnoteCounter {
+  int _value = 1;
+  int next() => _value++;
+}
 
-  var result = text;
+/// הגדרת רמה אחת ברשימה ממוספרת (`w:lvl` ב-numbering.xml).
+class _NumLevel {
+  /// `decimal` / `lowerRoman` / `upperLetter` / `hebrew1` / `bullet` …
+  final String numFmt;
 
-  if (rPr != null) {
-    // Font size
-    final sz = rPr.getElement('w:sz')?.getAttribute('w:val');
-    if (sz != null) {
-      final fontSize = double.parse(sz) / 2; // Word uses half-points
-      if (fontSize > defaultFontSize) {
-        result = '<big>$result</big>';
-      } else if (fontSize < defaultFontSize) {
-        result = '<small>$result</small>';
+  /// תבנית התצוגה, למשל `%1.` או `%1.%2.` (multilevel).
+  final String lvlText;
+
+  /// ערך התחלה (`w:start`, ברירת מחדל 1).
+  final int start;
+
+  const _NumLevel(this.numFmt, this.lvlText, this.start);
+}
+
+/// משאבי המסמך המשותפים לכל פונקציות העיבוד: הערות שוליים, תמונות מוטמעות,
+/// הגדרות רשימות, ומונים. מועבר במקום שורת פרמטרים ארוכה.
+class _DocxContext {
+  final Map<String, String> footnotes;
+
+  /// `r:embed`/`r:id` → `data:image/...;base64,...` מוכן להטמעה (offline).
+  final Map<String, String> images;
+
+  /// `numId` → (`ilvl` → הגדרת הרמה). מקובץ numbering.xml.
+  final Map<String, Map<int, _NumLevel>> numbering;
+
+  final _FootnoteCounter footnoteCounter = _FootnoteCounter();
+
+  /// מונים רצים לרשימות: `numId` → (`ilvl` → הערך הנוכחי).
+  final Map<String, Map<int, int>> _listCounters = {};
+
+  _DocxContext(this.footnotes, this.images, this.numbering);
+
+  /// מחזיר את תווית המספור/תבליט לפריט רשימה (למשל `1.`, `1.1.`, `א.`, `•`).
+  /// מקדם את המונה המתאים ומאפס רמות עמוקות יותר (מבנה multilevel תקין).
+  String listLabel(String? numId, int ilvl) {
+    final levels = numId != null ? numbering[numId] : null;
+    final lvl = levels?[ilvl];
+    if (lvl == null) return '•'; // אין הגדרה — תבליט ברירת מחדל
+    if (lvl.numFmt == 'bullet') return '•';
+
+    final counters = _listCounters.putIfAbsent(numId!, () => {});
+    counters[ilvl] = (counters[ilvl] ?? (lvl.start - 1)) + 1;
+    counters.removeWhere((k, _) => k > ilvl); // איפוס רמות עמוקות יותר
+
+    var label = lvl.lvlText;
+    for (var k = 0; k <= ilvl; k++) {
+      final kLvl = levels![k];
+      if (kLvl == null) continue;
+      final count = counters[k] ?? kLvl.start;
+      label = label.replaceAll('%${k + 1}', _formatNum(count, kLvl.numFmt));
+    }
+    return label.isEmpty ? '•' : label;
+  }
+}
+
+/// ממיר מספר לתצוגה לפי פורמט המספור של Word.
+String _formatNum(int n, String fmt) {
+  switch (fmt) {
+    case 'decimalZero':
+      return n < 10 ? '0$n' : '$n';
+    case 'lowerLetter':
+      return _toLetters(n, upper: false);
+    case 'upperLetter':
+      return _toLetters(n, upper: true);
+    case 'lowerRoman':
+      return _toRoman(n).toLowerCase();
+    case 'upperRoman':
+      return _toRoman(n);
+    case 'hebrew1':
+    case 'hebrew2':
+      return _toHebrewNumeral(n);
+    case 'none':
+      return '';
+    case 'decimal':
+    default:
+      return '$n';
+  }
+}
+
+/// 1→a, 26→z, 27→aa … (bijective base-26).
+String _toLetters(int n, {required bool upper}) {
+  if (n <= 0) return '$n';
+  final base = upper ? 65 : 97;
+  final chars = <int>[];
+  var x = n;
+  while (x > 0) {
+    x--;
+    chars.add(base + (x % 26));
+    x ~/= 26;
+  }
+  return String.fromCharCodes(chars.reversed);
+}
+
+/// ממיר מספר למספרה רומית (1–3999), אחרת מחזיר ספרות.
+String _toRoman(int n) {
+  if (n <= 0 || n > 3999) return '$n';
+  const vals = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
+  const syms = [
+    'M',
+    'CM',
+    'D',
+    'CD',
+    'C',
+    'XC',
+    'L',
+    'XL',
+    'X',
+    'IX',
+    'V',
+    'IV',
+    'I'
+  ];
+  final buf = StringBuffer();
+  var x = n;
+  for (var i = 0; i < vals.length; i++) {
+    while (x >= vals[i]) {
+      buf.write(syms[i]);
+      x -= vals[i];
+    }
+  }
+  return buf.toString();
+}
+
+/// ממיר מספר לאות עברית (גימטרייה) ללא גרשיים — למספור רשימות `hebrew1`.
+/// מדויק עד 499; מעבר לכך נופל לספרות (רשימות ארוכות כאלה נדירות).
+String _toHebrewNumeral(int n) {
+  if (n <= 0 || n > 499) return '$n';
+  const ones = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+  const tens = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+  const hundreds = ['', 'ק', 'ר', 'ש', 'ת'];
+  final buf = StringBuffer();
+  var x = n;
+  if (x >= 100) {
+    buf.write(hundreds[x ~/ 100]);
+    x %= 100;
+  }
+  if (x == 15) {
+    buf.write('טו');
+  } else if (x == 16) {
+    buf.write('טז');
+  } else {
+    if (x >= 10) {
+      buf.write(tens[x ~/ 10]);
+      x %= 10;
+    }
+    if (x > 0) buf.write(ones[x]);
+  }
+  return buf.toString();
+}
+
+/// בונה מפת `numId` → (`ilvl` → [_NumLevel]) מקובץ numbering.xml.
+Map<String, Map<int, _NumLevel>> _extractNumbering(Archive archive) {
+  ArchiveFile? numFile;
+  for (final f in archive) {
+    if (f.isFile && f.name == 'word/numbering.xml') {
+      numFile = f;
+      break;
+    }
+  }
+  if (numFile == null) return const {};
+
+  final xml.XmlDocument doc;
+  try {
+    doc = xml.XmlDocument.parse(_decodeXmlBytes(numFile.content));
+  } catch (_) {
+    return const {};
+  }
+
+  // abstractNumId → (ilvl → level)
+  final abstracts = <String, Map<int, _NumLevel>>{};
+  for (final an in doc.findAllElements('w:abstractNum')) {
+    final aid = an.getAttribute('w:abstractNumId');
+    if (aid == null) continue;
+    final levels = <int, _NumLevel>{};
+    for (final lvl in an.findElements('w:lvl')) {
+      final ilvl = int.tryParse(lvl.getAttribute('w:ilvl') ?? '');
+      if (ilvl == null) continue;
+      final fmt =
+          lvl.getElement('w:numFmt')?.getAttribute('w:val') ?? 'decimal';
+      final text = lvl.getElement('w:lvlText')?.getAttribute('w:val') ?? '';
+      final start = int.tryParse(
+              lvl.getElement('w:start')?.getAttribute('w:val') ?? '') ??
+          1;
+      levels[ilvl] = _NumLevel(fmt, text, start);
+    }
+    abstracts[aid] = levels;
+  }
+
+  // numId → abstractNumId → levels
+  final result = <String, Map<int, _NumLevel>>{};
+  for (final num in doc.findAllElements('w:num')) {
+    final numId = num.getAttribute('w:numId');
+    final aid = num.getElement('w:abstractNumId')?.getAttribute('w:val');
+    if (numId != null && aid != null && abstracts.containsKey(aid)) {
+      result[numId] = abstracts[aid]!;
+    }
+  }
+  return result;
+}
+
+/// מחזיר את ה-MIME של תמונה לפי סיומת, או `null` אם הקורא לא יודע לרנדר
+/// אותה (EMF/WMF/TIFF — פורמטים ישנים של Word שאינם נתמכים ב-HtmlWidget).
+String? _imageMime(String path) {
+  final p = path.toLowerCase();
+  if (p.endsWith('.png')) return 'image/png';
+  if (p.endsWith('.jpg') || p.endsWith('.jpeg')) return 'image/jpeg';
+  if (p.endsWith('.gif')) return 'image/gif';
+  if (p.endsWith('.bmp')) return 'image/bmp';
+  if (p.endsWith('.webp')) return 'image/webp';
+  return null;
+}
+
+/// בונה מפת `rId` → `data:` URI עבור כל התמונות המוטמעות בקובץ — קריאה
+/// אחת של ה-relationships + קבצי ה-media, והמרה ל-base64. הטמעה מלאה
+/// (offline) ולא קישור חיצוני. פורמטים שהקורא לא תומך בהם מדולגים בשקט.
+Map<String, String> _extractImages(Archive archive) {
+  // שלב 1: rId → target ("media/imageN.png"), רק יחסים מסוג image.
+  final rels = <String, String>{};
+  for (final file in archive) {
+    if (file.isFile && file.name == 'word/_rels/document.xml.rels') {
+      try {
+        final doc = xml.XmlDocument.parse(_decodeXmlBytes(file.content));
+        for (final rel in doc.findAllElements('Relationship')) {
+          if ((rel.getAttribute('Type') ?? '').endsWith('/image')) {
+            final id = rel.getAttribute('Id');
+            final target = rel.getAttribute('Target');
+            if (id != null && target != null) rels[id] = target;
+          }
+        }
+      } catch (_) {
+        // rels פגום — ממשיכים בלי תמונות.
       }
+      break;
     }
+  }
+  if (rels.isEmpty) return const {};
 
-    // Font color
-    final color = rPr.getElement('w:color')?.getAttribute('w:val');
-    if (color != null) {
-      result = '<span style="color:#$color">$result</span>';
-    }
-
-    // Font family
-    final fontFamily = rPr.getElement('w:rFonts')?.getAttribute('w:ascii') ??
-        rPr.getElement('w:rFonts')?.getAttribute('w:eastAsia');
-    if (fontFamily != null) {
-      result = '<span style="font-family:$fontFamily">$result</span>';
-    }
-
-    // Underline
-    if (rPr.getElement('w:u') != null) {
-      result = '<u>$result</u>';
-    }
-
-    // Italic
-    if (rPr.getElement('w:i') != null) {
-      result = '<i>$result</i>';
-    }
-
-    // Bold
-    if (rPr.getElement('w:b') != null) {
-      result = '<b>$result</b>';
+  // שלב 2: target → bytes → data URI. ממפים נתיב מלא בארכיב לתוכן.
+  final mediaByPath = <String, ArchiveFile>{};
+  for (final file in archive) {
+    if (file.isFile && file.name.startsWith('word/media/')) {
+      mediaByPath[file.name] = file;
     }
   }
 
+  final images = <String, String>{};
+  rels.forEach((id, target) {
+    final mime = _imageMime(target);
+    if (mime == null) return; // פורמט לא נתמך
+    final fullPath =
+        target.startsWith('/') ? target.substring(1) : 'word/$target';
+    final file = mediaByPath[fullPath];
+    if (file == null) return; // קובץ חסר
+    images[id] = 'data:$mime;base64,${base64Encode(file.content)}';
+  });
+  return images;
+}
+
+/// אם ה-run מכיל תמונה מוטמעת (DrawingML `a:blip` או VML `v:imagedata`)
+/// שיש לה data URI מוכן — מחזיר תג `<img>`; אחרת `null`.
+String? _imageHtmlFromRun(xml.XmlElement run, Map<String, String> images) {
+  if (images.isEmpty) return null;
+  for (final blip in run.findAllElements('a:blip')) {
+    final id = blip.getAttribute('r:embed') ?? blip.getAttribute('r:link');
+    final uri = id == null ? null : images[id];
+    if (uri != null) return '<img src="$uri" style="max-width: 100%;"/>';
+  }
+  for (final data in run.findAllElements('v:imagedata')) {
+    final id = data.getAttribute('r:id');
+    final uri = id == null ? null : images[id];
+    if (uri != null) return '<img src="$uri" style="max-width: 100%;"/>';
+  }
+  return null;
+}
+
+/// Escape של תווי HTML בתוכן *טקסט* (לא בתגיות שאנו מוסיפים), כדי שתוכן
+/// שמכיל `<`/`>`/`&` (נוסחאות, סוגריים מחודדים, "ר' & ...") לא ישבור את
+/// הרנדור — `HtmlWidget` היה מפרש `<` כתחילת תגית ומבלגן את כל המשך הפסקה.
+String _escapeHtml(String s) {
+  if (!s.contains('&') && !s.contains('<') && !s.contains('>')) return s;
+  return s
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+}
+
+/// גרסה ציבורית של [_escapeHtml] — לשימוש בהזרקת כותרת הספר במטמון
+/// (`docx_cache`), כדי ששם קובץ עם `<`/`&` לא ישבור את ה-HTML.
+String escapeHtmlText(String s) => _escapeHtml(s);
+
+/// בודק מאפיין on/off של Word (`CT_OnOff`, וכן `w:u`): קיים *ומופעל*.
+///
+/// `w:val="false"/"0"/"off"/"none"` = כבוי — Word משתמש בזה כדי לבטל עיצוב
+/// שעבר בירושה מהסגנון (למשל פסקה שמבטלת הדגשה של Heading). בלי הבדיקה הזו
+/// `<w:b w:val="0"/>` היה נחשב מודגש בטעות, ו-`<w:u w:val="none"/>` קו תחתי.
+bool _isOnOff(xml.XmlElement? el) {
+  if (el == null) return false;
+  final val = el.getAttribute('w:val');
+  if (val == null) return true; // קיום בלי val = מופעל
+  final v = val.toLowerCase();
+  return v != 'false' && v != '0' && v != 'off' && v != 'none';
+}
+
+/// ממיר ערך `w:highlight` (מרקר צבעוני) לצבע CSS, או `null` אם אין/לבטל.
+///
+/// רוב 16 ערכי ה-highlight של Word הם שמות צבע תקניים ב-CSS
+/// (`yellow`, `darkblue`, `lightgray`...). היוצא דופן הוא `darkYellow`
+/// שאין לו שם CSS — ממופה ל-HEX. `none` = ללא סימון.
+String? _highlightColor(String val) {
+  final v = val.toLowerCase();
+  if (v == 'none') return null;
+  if (v == 'darkyellow') return '#808000';
+  return v;
+}
+
+/// ממפה ערך `w:u w:val` (סוג הקו התחתי של Word) לערך `text-decoration-style`
+/// של CSS שהקורא תומך בו (`solid`/`double`/`dotted`/`dashed`/`wavy`).
+/// `single`/`thick`/`words` → `solid` (מוחזר `null` כדי לחסוך style מיותר).
+String? _underlineStyleCss(String val) {
+  final v = val.toLowerCase();
+  if (v == 'double') return 'double';
+  if (v.startsWith('wav')) return 'wavy'; // wave, wavyHeavy, wavyDouble
+  if (v.startsWith('dot')) return 'dotted'; // dotted, dottedHeavy, dotDash…
+  if (v.startsWith('dash')) return 'dashed'; // dash, dashLong, dashedHeavy…
+  return null; // single, thick, words, solid
+}
+
+/// בונה את ה-CSS של קו תחתי מותאם (סוג/צבע/עובי) עבור `<span>`, או `null`
+/// כשמדובר בקו פשוט (single) ללא צבע — שאז עדיף `<u>` (שניתן למזג).
+String? _underlineSpanStyle(xml.XmlElement u) {
+  final val = u.getAttribute('w:val') ?? 'single';
+  final color = u.getAttribute('w:color');
+  final styleCss = _underlineStyleCss(val);
+  final isThick = val.toLowerCase().contains('thick') ||
+      val.toLowerCase().endsWith('heavy');
+  final hasColor = color != null && color.toLowerCase() != 'auto';
+
+  if (styleCss == null && !isThick && !hasColor) return null; // קו פשוט → <u>
+
+  final css = StringBuffer('text-decoration: underline');
+  if (styleCss != null) css.write(' $styleCss');
+  css.write(';');
+  if (hasColor) css.write(' text-decoration-color: #$color;');
+  if (isThick) css.write(' text-decoration-thickness: 2px;');
+  return css.toString();
+}
+
+/// מקטע טקסט מעוצב בודד (run לאחר עיבוד). [open]/[close] הן תגיות העטיפה
+/// (למשל `<b><span style="color:#X">` ו-`</span></b>`), ו-[text] הטקסט הפנימי.
+///
+/// המבנה הזה מאפשר *מיזוג* מקטעים סמוכים בעלי עטיפה זהה לפני בניית ה-HTML —
+/// קריטי לביצועים: Word מפצל פסקה מעוצבת לעשרות runs זהים, ובלי מיזוג כל
+/// אחד היה מקבל עותק מלא של תגיות העיצוב (ניפוח HTML/זיכרון של פי עשרות).
+/// [raw] מסמן תוכן מוכן (סימון הערת שוליים) שאין לעטוף ואין למזג.
+class _Seg {
+  final String open;
+  final String close;
+  final String text;
+  final bool raw;
+  const _Seg(this.open, this.close, this.text) : raw = false;
+  const _Seg.raw(this.text)
+      : open = '',
+        close = '',
+        raw = true;
+}
+
+/// ממפה את *שם* סגנון הפסקה לרמת כותרת 1–6, או `null` אם אינו כותרת.
+///
+/// Word — וגם הייצוא של אוצריא עצמה — כותבים את הסגנון בשם (`Heading1`,
+/// `Heading 2`, `Title`, `כותרת 1`) ולא במספר. הזיהוי הקודם השתמש ב-
+/// `double.tryParse` ולכן פספס את *כל* הכותרות.
+int? _headingLevelFromStyleName(String? styleVal) {
+  if (styleVal == null) return null;
+  final lower = styleVal.toLowerCase();
+  if (lower == 'title') return 1;
+
+  final en = RegExp(r'heading\s*([1-6])').firstMatch(lower);
+  if (en != null) return int.parse(en.group(1)!);
+
+  final he = RegExp(r'כותרת\s*([1-6])').firstMatch(styleVal);
+  if (he != null) return int.parse(he.group(1)!);
+
+  return null;
+}
+
+/// מעבד run בודד ל-[_Seg] (עטיפה + טקסט), או `null` אם הוא ריק/מוסתר.
+///
+/// תומך ב-`w:br`/`w:tab` בתוך ה-run, ומזהה הדגשה/נטייה גם בווריאנט
+/// complex-script (`w:bCs`/`w:iCs`) — קריטי לעברית. גופן (`w:rFonts`)
+/// וצבע שחור/ברירת-מחדל מנוקים כדי לא לשבור את גופן הקריאה ואת מצב כהה.
+///
+/// תגיות העטיפה נבנות מבפנים החוצה (עילי/תחתי הכי פנימי, מודגש הכי חיצוני),
+/// כך שכל run בעל אותו עיצוב מקבל [open] זהה וניתן למיזוג.
+_Seg? _processRunSeg(xml.XmlElement node) {
+  final rPr = node.getElement('w:rPr');
+
+  // טקסט מוסתר (`w:vanish`) — לא מוצג (משמש לאינדקסים/הערות נסתרות).
+  if (rPr != null && _isOnOff(rPr.getElement('w:vanish'))) {
+    return null;
+  }
+
+  final buf = StringBuffer();
+  for (final child in node.childElements) {
+    switch (child.name.qualified) {
+      case 'w:t':
+        buf.write(_escapeHtml(child.innerText));
+      case 'w:br':
+        buf.write('<br>');
+      case 'w:tab':
+        buf.write(' ');
+    }
+  }
+  final text = buf.toString();
+  if (text.isEmpty) return null;
+  if (rPr == null) return _Seg('', '', text);
+
+  // נצבר מבפנים החוצה; ה-open נבנה הפוך (חיצוני קודם), ה-close כסדר הצבירה.
+  final opens = <String>[];
+  final closes = <String>[];
+  void wrap(String openTag, String closeTag) {
+    opens.add(openTag);
+    closes.add(closeTag);
+  }
+
+  // עילי/תחתי (`w:vertAlign`) — הכי פנימי, צמוד לטקסט.
+  final vertAlign = rPr.getElement('w:vertAlign')?.getAttribute('w:val');
+  if (vertAlign == 'superscript') {
+    wrap('<sup>', '</sup>');
+  } else if (vertAlign == 'subscript') {
+    wrap('<sub>', '</sub>');
+  }
+
+  // צבע: רק צבע אמיתי (לא שחור/auto) — שחור שובר מצב כהה.
+  final color = rPr.getElement('w:color')?.getAttribute('w:val');
+  if (color != null) {
+    final c = color.toLowerCase();
+    if (c != '000000' && c != 'auto') {
+      wrap('<span style="color:#$color">', '</span>');
+    }
+  }
+
+  // סימון/מרקר צבעוני (`w:highlight`) → רקע צבעוני.
+  final highlight = rPr.getElement('w:highlight')?.getAttribute('w:val');
+  if (highlight != null) {
+    final bg = _highlightColor(highlight);
+    if (bg != null) wrap('<span style="background-color:$bg">', '</span>');
+  }
+
+  // קו חוצה: כפול (`w:dstrike`) → line-through double; יחיד → `<s>`.
+  if (_isOnOff(rPr.getElement('w:dstrike'))) {
+    wrap('<span style="text-decoration: line-through double;">', '</span>');
+  } else if (_isOnOff(rPr.getElement('w:strike'))) {
+    wrap('<s>', '</s>');
+  }
+
+  // קו תחתי — `w:u w:val="none"` מבטל. קו פשוט → `<u>`; סוג מותאם
+  // (כפול/מנוקד/מקווקו/גלי/עבה/צבעוני) → `<span>` עם text-decoration.
+  final u = rPr.getElement('w:u');
+  if (_isOnOff(u)) {
+    final spanStyle = _underlineSpanStyle(u!);
+    wrap(spanStyle == null ? '<u>' : '<span style="$spanStyle">',
+        spanStyle == null ? '</u>' : '</span>');
+  }
+
+  // נטוי — כולל וריאנט complex-script של עברית
+  if (_isOnOff(rPr.getElement('w:i')) || _isOnOff(rPr.getElement('w:iCs'))) {
+    wrap('<i>', '</i>');
+  }
+
+  // מודגש — כולל וריאנט complex-script של עברית (הכי חיצוני)
+  if (_isOnOff(rPr.getElement('w:b')) || _isOnOff(rPr.getElement('w:bCs'))) {
+    wrap('<b>', '</b>');
+  }
+
+  return _Seg(opens.reversed.join(), closes.join(), text);
+}
+
+/// מרנדר את תוכן הפסקה (כל ה-runs לפי הסדר) כולל הערות שוליים inline
+/// בפורמט שהקורא של אוצריא מציג כמפרש בצד:
+///   `<sup class="footnote-marker">N</sup><i class="footnote">גוף</i>`
+String _renderParagraphInline(xml.XmlElement paragraph, _DocxContext ctx) {
+  // שלב 1: איסוף מקטעים (segments) מכל ה-runs לפי הסדר.
+  final segs = <_Seg>[];
+  for (final run in paragraph.findAllElements('w:r')) {
+    final footnoteRef = run.getElement('w:footnoteReference');
+    if (footnoteRef != null) {
+      final id = footnoteRef.getAttribute('w:id');
+      if (id != null && ctx.footnotes.containsKey(id)) {
+        final n = ctx.footnoteCounter.next();
+        segs.add(_Seg.raw('<sup class="footnote-marker">$n</sup>'
+            '<i class="footnote">${_escapeHtml(ctx.footnotes[id]!)}</i>'));
+      }
+      continue;
+    }
+
+    // תמונה מוטמעת (offline data URI) — מקטע raw שאינו ממוזג.
+    final imgHtml = _imageHtmlFromRun(run, ctx.images);
+    if (imgHtml != null) {
+      segs.add(_Seg.raw(imgHtml));
+      continue;
+    }
+
+    final seg = _processRunSeg(run);
+    if (seg != null) segs.add(seg);
+  }
+
+  // שלב 2: בנייה עם מיזוג מקטעים סמוכים בעלי עטיפה זהה — תגיות העיצוב
+  // נכתבות פעם אחת לכל רצף, במקום לכל run בנפרד (מונע ניפוח HTML/זיכרון
+  // מ-runs מפוצלים של Word). מקטע raw (הערת שוליים) אינו ממוזג.
+  final buf = StringBuffer();
+  var i = 0;
+  while (i < segs.length) {
+    final s = segs[i];
+    if (s.raw) {
+      buf.write(s.text);
+      i++;
+      continue;
+    }
+    buf.write(s.open);
+    buf.write(s.text);
+    var j = i + 1;
+    while (j < segs.length && !segs[j].raw && segs[j].open == s.open) {
+      buf.write(segs[j].text);
+      j++;
+    }
+    buf.write(s.close);
+    i = j;
+  }
+  return buf.toString();
+}
+
+/// מעבד פסקה בודדת ומוסיף אותה ל-[output] (אם אינה ריקה).
+/// מטפל בכותרות (לפי שם הסגנון/outlineLvl) וברשימות (קידומת תבליט).
+void _processParagraph(
+  xml.XmlElement paragraph,
+  _DocxContext ctx,
+  List<String> output,
+) {
+  var text = _renderParagraphInline(paragraph, ctx);
+  if (text.trim().isEmpty) return;
+
+  final pPr = paragraph.getElement('w:pPr');
+
+  // כותרת: קודם לפי שם הסגנון, אחרת גיבוי שפה-אגנוסטי דרך outlineLvl.
+  final styleVal = pPr?.getElement('w:pStyle')?.getAttribute('w:val');
+  var level = _headingLevelFromStyleName(styleVal);
+  if (level == null) {
+    final outline = pPr?.getElement('w:outlineLvl')?.getAttribute('w:val');
+    final o = outline != null ? int.tryParse(outline) : null;
+    if (o != null) level = o + 1;
+  }
+
+  if (level != null) {
+    final clamped = level.clamp(1, 6);
+    output.add('<h$clamped>$text</h$clamped>');
+    return;
+  }
+
+  // רשימה: קידומת תבליט עם הזחה לפי רמת הקינון — לא `<ul>` (שנשבר בין שורות).
+  final numPr = pPr?.getElement('w:numPr');
+  if (numPr != null) {
+    final numId = numPr.getElement('w:numId')?.getAttribute('w:val');
+    final ilvl =
+        int.tryParse(numPr.getElement('w:ilvl')?.getAttribute('w:val') ?? '') ??
+            0;
+    final label = ctx.listLabel(numId, ilvl);
+    final indent = '    ' * ilvl;
+    text = '$indent$label $text';
+  }
+
+  // יישור מפורש (`w:jc`) — center/right/left. `both`/`start`/`end` נופלים
+  // לברירת המחדל של אוצריא (justify ב-RTL) ולכן אינם נעטפים.
+  // חל רק על פסקת גוף: כותרות כבר חזרו ב-return למעלה, כדי לא לעטוף `<h>`
+  // ב-`<div>` (מה שהיה שובר את זיהוי הכותרות ב-TocParser).
+  final jc = pPr?.getElement('w:jc')?.getAttribute('w:val');
+  final align = switch (jc) {
+    'center' => 'center',
+    'right' => 'right',
+    'left' => 'left',
+    _ => null,
+  };
+  if (align != null) {
+    text = '<div style="text-align: $align;">$text</div>';
+  }
+
+  output.add(text);
+}
+
+/// מספר עמודות ה-grid שתא תופס (`w:gridSpan`, ברירת מחדל 1).
+int _gridSpanOf(xml.XmlElement cell) {
+  final v = cell
+      .getElement('w:tcPr')
+      ?.getElement('w:gridSpan')
+      ?.getAttribute('w:val');
+  return (v != null ? int.tryParse(v) : null) ?? 1;
+}
+
+/// האם התא הוא המשך מיזוג אנכי (`w:vMerge` ללא `restart`) — כלומר ממוזג
+/// עם התא שמעליו ואין לפלוט עבורו `<td>`.
+bool _isVMergeContinue(xml.XmlElement cell) {
+  final vm = cell.getElement('w:tcPr')?.getElement('w:vMerge');
+  return vm != null && vm.getAttribute('w:val') != 'restart';
+}
+
+/// אוסף ילדים ישירים מהסוגים שב-[tags], תוך פתיחה *שקופה* של בקרות-תוכן
+/// (`w:sdt`) רקורסיבית. ב-Word שורות/תאים/בלוקים עלולים להיות עטופים ב-sdt,
+/// ו-`findElements` ישיר היה מחמיץ אותם ומאבד תוכן.
+List<xml.XmlElement> _collectChildren(xml.XmlElement parent, Set<String> tags) {
+  final result = <xml.XmlElement>[];
+  for (final child in parent.childElements) {
+    final name = child.name.qualified;
+    if (tags.contains(name)) {
+      result.add(child);
+    } else if (name == 'w:sdt') {
+      final content = child.getElement('w:sdtContent');
+      if (content != null) result.addAll(_collectChildren(content, tags));
+    }
+  }
   return result;
+}
+
+/// מחזיר את התא שמתחיל בעמדת ה-grid [targetPos] בשורה [row], או `null`.
+xml.XmlElement? _cellAtGridPos(xml.XmlElement row, int targetPos) {
+  var pos = 0;
+  for (final cell in _collectChildren(row, const {'w:tc'})) {
+    if (pos == targetPos) return cell;
+    pos += _gridSpanOf(cell);
+    if (pos > targetPos) break;
+  }
+  return null;
+}
+
+/// מעבד טבלה ל-`<table>` אמיתי (שורה אחת ב-output, כי שורה=widget בקורא).
+/// תומך ב: מיזוג אופקי (`gridSpan`→colspan) ואנכי (`vMerge`→rowspan), רקע
+/// תאים (`w:shd`), יישור אנכי (`w:vAlign`), שורת כותרת (`w:tblHeader`→`<th>`),
+/// וכיוון RTL (`w:bidiVisual`). מסגרות נוצרות ב-CSS (border-collapse).
+void _processTable(
+  xml.XmlElement table,
+  _DocxContext ctx,
+  List<String> output,
+) {
+  final html = _buildTableHtml(table, ctx);
+  if (html != null) output.add(html);
+}
+
+/// בונה את ה-HTML של טבלה (`<table>…</table>`), או `null` אם ריקה. מופרד
+/// מ-[_processTable] כדי לאפשר הטמעת טבלה מקוננת בתוך תא (recursion).
+String? _buildTableHtml(xml.XmlElement table, _DocxContext ctx) {
+  final rowEls = _collectChildren(table, const {'w:tr'});
+  if (rowEls.isEmpty) return null;
+
+  final isRtl = table.getElement('w:tblPr')?.getElement('w:bidiVisual') != null;
+
+  final rows = StringBuffer();
+  for (var r = 0; r < rowEls.length; r++) {
+    final row = rowEls[r];
+    final isHeader =
+        row.getElement('w:trPr')?.getElement('w:tblHeader') != null;
+    final tag = isHeader ? 'th' : 'td';
+
+    final cellsBuf = StringBuffer();
+    var colPos = 0;
+    for (final cell in _collectChildren(row, const {'w:tc'})) {
+      final span = _gridSpanOf(cell);
+
+      // תא המשך-מיזוג-אנכי: מדולג (כלול ב-rowspan של התא העליון).
+      if (_isVMergeContinue(cell)) {
+        colPos += span;
+        continue;
+      }
+
+      final tcPr = cell.getElement('w:tcPr');
+      final vMergeVal = tcPr?.getElement('w:vMerge')?.getAttribute('w:val');
+
+      // rowspan: אם זה restart, סופרים תאי-המשך בשורות הבאות באותה עמדה.
+      var rowspan = 1;
+      if (vMergeVal == 'restart') {
+        for (var rr = r + 1; rr < rowEls.length; rr++) {
+          final below = _cellAtGridPos(rowEls[rr], colPos);
+          if (below != null && _isVMergeContinue(below)) {
+            rowspan++;
+          } else {
+            break;
+          }
+        }
+      }
+
+      final shd = tcPr?.getElement('w:shd')?.getAttribute('w:fill');
+      final vAlign = tcPr?.getElement('w:vAlign')?.getAttribute('w:val');
+
+      final attrs = StringBuffer();
+      if (span > 1) attrs.write(' colspan="$span"');
+      if (rowspan > 1) attrs.write(' rowspan="$rowspan"');
+      final styles = <String>['border: 1px solid #999', 'padding: 4px 8px'];
+      if (shd != null) {
+        final f = shd.toLowerCase();
+        if (f != 'auto' && f != 'ffffff') styles.add('background-color: #$shd');
+      }
+      if (vAlign != null) styles.add('vertical-align: $vAlign');
+      attrs.write(' style="${styles.join('; ')}"');
+
+      // תוכן התא: פסקאות וטבלאות מקוננות לפי הסדר (גם אם עטופות ב-sdt),
+      // כדי לא לאבד תוכן מקונן.
+      final parts = <String>[];
+      for (final child in _collectChildren(cell, const {'w:p', 'w:tbl'})) {
+        if (child.name.qualified == 'w:p') {
+          final inline = _renderParagraphInline(child, ctx);
+          if (inline.trim().isNotEmpty) parts.add(inline.trim());
+        } else {
+          final nested = _buildTableHtml(child, ctx);
+          if (nested != null) parts.add(nested);
+        }
+      }
+
+      cellsBuf.write('<$tag$attrs>${parts.join('<br>')}</$tag>');
+      colPos += span;
+    }
+
+    if (cellsBuf.isNotEmpty) rows.write('<tr>$cellsBuf</tr>');
+  }
+
+  if (rows.isEmpty) return null;
+  final dir = isRtl ? ' dir="rtl"' : '';
+  return '<table$dir style="border-collapse: collapse; '
+      'border: 1px solid #999;">$rows</table>';
 }
 
 /// Extracts footnotes from the document
@@ -85,18 +776,24 @@ Map<String, String> _extractFootnotes(Archive archive) {
 
   for (final file in archive) {
     if (file.isFile && file.name == 'word/footnotes.xml') {
-      final content = _decodeXmlBytes(file.content);
-      final document = xml.XmlDocument.parse(content);
+      try {
+        final content = _decodeXmlBytes(file.content);
+        final document = xml.XmlDocument.parse(content);
 
-      final footnoteNodes = document.findAllElements('w:footnote');
-      for (final footnote in footnoteNodes) {
-        final id = footnote.getAttribute('w:id');
-        if (id != null && id != '-1' && id != '0') {
-          // Skip automatic footnotes
-          final text =
-              footnote.findAllElements('w:t').map((e) => e.innerText).join('');
-          footnotes[id] = text;
+        final footnoteNodes = document.findAllElements('w:footnote');
+        for (final footnote in footnoteNodes) {
+          final id = footnote.getAttribute('w:id');
+          if (id != null && id != '-1' && id != '0') {
+            // Skip automatic footnotes
+            final text = footnote
+                .findAllElements('w:t')
+                .map((e) => e.innerText)
+                .join('');
+            footnotes[id] = text;
+          }
         }
+      } catch (_) {
+        // footnotes.xml פגום — ממשיכים בלי הערות במקום לקרוס.
       }
       break;
     }
@@ -106,79 +803,59 @@ Map<String, String> _extractFootnotes(Archive archive) {
 }
 
 /// Converts a docx file to text.
-/// Marks up headings, lists, text styling, and includes footnotes after their respective paragraphs
+/// Marks up headings, lists, text styling, and includes footnotes inline.
 String docxToText(Uint8List bytes, String title) {
   _zipDecoder ??= ZipDecoder();
 
   final archive = _zipDecoder!.decodeBytes(bytes);
-  final footnotes = _extractFootnotes(archive);
-  final List<String> list = ['<h1>$title</h1>'];
+  final ctx = _DocxContext(
+    _extractFootnotes(archive),
+    _extractImages(archive),
+    _extractNumbering(archive),
+  );
+  final List<String> list = ['<h1>${_escapeHtml(title)}</h1>'];
 
   for (final file in archive) {
     if (file.isFile && file.name == 'word/document.xml') {
       final fileContent = _decodeXmlBytes(file.content);
-      final document = xml.XmlDocument.parse(fileContent);
-
-      final paragraphNodes = document.findAllElements('w:p');
-      var footnoteCounter = 1;
-      var paragraphFootnotes = <String>[];
-
-      for (final paragraph in paragraphNodes) {
-        final textNodes = paragraph.findAllElements('w:r');
-        var text = '';
-        paragraphFootnotes.clear();
-
-        for (final node in textNodes) {
-          // Check for footnote reference
-          final footnoteRef = node.getElement('w:footnoteReference');
-          if (footnoteRef != null) {
-            final footnoteId = footnoteRef.getAttribute('w:id');
-            if (footnoteId != null && footnotes.containsKey(footnoteId)) {
-              text += '<sup>$footnoteCounter</sup>';
-              paragraphFootnotes
-                  .add('$footnoteCounter) ${footnotes[footnoteId]}');
-              footnoteCounter++;
-            }
-          } else {
-            text += _processRun(node);
-          }
-        }
-
-        // Process paragraph style
-        var style = paragraph
-            .getElement('w:pPr')
-            ?.getElement('w:pStyle')
-            ?.getAttribute('w:val');
-
-        // Handle headings
-        if (style != null && double.tryParse(style) != null) {
-          int styleNum = int.parse(style) + 1;
-          text = '<h$styleNum>$text</h$styleNum>';
-        }
-
-        // Handle lists
-        var numbering = paragraph.getElement('w:pPr')?.getElement('w:numPr');
-        if (numbering != null) {
-          String? level = numbering.getElement('w:ilvl')?.getAttribute('w:val');
-          if (level != null) {
-            int levelInt = int.parse(level);
-            for (int i = 0; i <= levelInt; i++) {
-              text = '<ul><li>$text</li></ul>';
-            }
-          }
-        }
-
-        // Add paragraph with its footnotes
-        if (text.trim().isNotEmpty) {
-          list.add(text);
-          if (paragraphFootnotes.isNotEmpty) {
-            list.add(
-                '<div class="footnotes"><small>${paragraphFootnotes.join('<br>')}</small></div>');
-          }
-        }
+      final xml.XmlDocument document;
+      try {
+        document = xml.XmlDocument.parse(fileContent);
+      } catch (_) {
+        // document.xml פגום — מחזירים לפחות את כותרת הספר במקום לקרוס.
+        break;
       }
+
+      final body = document.rootElement.getElement('w:body');
+      if (body == null) break;
+
+      _processBlockChildren(body.childElements, ctx, list);
+      break;
     }
   }
 
   return list.join('\n');
+}
+
+/// מעבד רצף אלמנטי-בלוק (ילדי body / sdtContent) *לפי הסדר*: פסקאות,
+/// טבלאות, ובקרות-תוכן (`w:sdt`). ה-sdt עטיפה שקופה — יורדים ל-`w:sdtContent`
+/// ומעבדים את ילדיו רקורסיבית, כדי לא לאבד תוכן שעטוף בבקרת-תוכן (טפסים).
+void _processBlockChildren(
+  Iterable<xml.XmlElement> children,
+  _DocxContext ctx,
+  List<String> output,
+) {
+  for (final element in children) {
+    switch (element.name.qualified) {
+      case 'w:p':
+        _processParagraph(element, ctx, output);
+      case 'w:tbl':
+        _processTable(element, ctx, output);
+      case 'w:sdt':
+        final content = element.getElement('w:sdtContent');
+        if (content != null) {
+          _processBlockChildren(content.childElements, ctx, output);
+        }
+    }
+  }
 }

--- a/test/data_providers/docx_text_cache_test.dart
+++ b/test/data_providers/docx_text_cache_test.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/migration/database/daos/database.dart';
+import 'package:otzaria/migration/database/repository/seforim_repository.dart';
+import 'package:otzaria/migration/models/docx_text_cache_entry.dart';
+import 'package:path/path.dart' as path;
+
+/// בדיקות שכבת המטמון של תוכן docx (גישה B): שמירה, קריאה, וקריטית —
+/// זיהוי-שינוי (קובץ שנערך אינו תקף, כדי שלא יוצג תוכן מיושן).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late MyDatabase database;
+  late SeforimRepository repository;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('docx-text-cache-');
+    database = MyDatabase.withPath(path.join(tempDir.path, 'cache.db'));
+    repository = SeforimRepository(database);
+    await repository.ensureInitialized();
+  });
+
+  tearDown(() async {
+    database.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  DocxTextCacheEntry entry({
+    String filePath = '/lib/ספר.docx',
+    int fileSize = 1000,
+    int lastModified = 5000,
+    int converterVersion = 1,
+    String text = '<h1>ספר</h1>\nתוכן',
+  }) =>
+      DocxTextCacheEntry(
+        filePath: filePath,
+        fileSize: fileSize,
+        lastModified: lastModified,
+        converterVersion: converterVersion,
+        text: text,
+        createdAt: 1,
+        accessedAt: 1,
+      );
+
+  group('DocxTextCache - שמירה וקריאה', () {
+    test('רשומה שנשמרה נקראת חזרה עם אותו טקסט', () async {
+      await repository.upsertDocxTextCacheEntry(entry());
+      final got = await repository.getDocxTextCacheEntry('/lib/ספר.docx');
+      expect(got, isNotNull);
+      expect(got!.text, '<h1>ספר</h1>\nתוכן');
+      expect(got.fileSize, 1000);
+      expect(got.lastModified, 5000);
+    });
+
+    test('נתיב שלא נשמר מחזיר null', () async {
+      final got = await repository.getDocxTextCacheEntry('/lib/אחר.docx');
+      expect(got, isNull);
+    });
+  });
+
+  group('DocxTextCache - זיהוי-שינוי (invalidation)', () {
+    test('isValidFor תקף רק כשגודל, זמן-שינוי וגרסת-ממיר זהים', () async {
+      await repository.upsertDocxTextCacheEntry(entry(converterVersion: 1));
+      final got = (await repository.getDocxTextCacheEntry('/lib/ספר.docx'))!;
+
+      expect(got.isValidFor(1000, 5000, 1), isTrue, reason: 'ללא שינוי → תקף');
+      expect(got.isValidFor(1000, 9999, 1), isFalse,
+          reason: 'זמן-שינוי שונה (הקובץ נערך) → לא תקף');
+      expect(got.isValidFor(2222, 5000, 1), isFalse,
+          reason: 'גודל שונה → לא תקף');
+      expect(got.isValidFor(1000, 5000, 2), isFalse,
+          reason: 'גרסת-ממיר חדשה (שודרג הממיר) → לא תקף, יומר מחדש');
+    });
+
+    test('עריכת הקובץ (upsert עם זמן/גודל חדשים) דורסת את התוכן הישן',
+        () async {
+      await repository.upsertDocxTextCacheEntry(
+          entry(text: 'תוכן ישן', lastModified: 5000));
+      await repository.upsertDocxTextCacheEntry(
+          entry(text: 'תוכן חדש', fileSize: 1500, lastModified: 8000));
+
+      final got = (await repository.getDocxTextCacheEntry('/lib/ספר.docx'))!;
+      expect(got.text, 'תוכן חדש');
+      expect(got.lastModified, 8000);
+      expect(got.fileSize, 1500);
+    });
+
+    test('מחיקת רשומה מסירה אותה מהמטמון', () async {
+      await repository.upsertDocxTextCacheEntry(entry());
+      await repository.deleteDocxTextCacheEntry('/lib/ספר.docx');
+      final got = await repository.getDocxTextCacheEntry('/lib/ספר.docx');
+      expect(got, isNull);
+    });
+
+    test('שדרוג גרסת-ממיר דורס תוכן, ו-createdAt נשמר מהיצירה הראשונה',
+        () async {
+      await repository.upsertDocxTextCacheEntry(const DocxTextCacheEntry(
+        filePath: '/x.docx',
+        fileSize: 1,
+        lastModified: 1,
+        converterVersion: 1,
+        text: 'ישן',
+        createdAt: 111,
+        accessedAt: 111,
+      ));
+      // שדרוג הממיר (גרסה 2) + עדכון זמני הקובץ
+      await repository.upsertDocxTextCacheEntry(const DocxTextCacheEntry(
+        filePath: '/x.docx',
+        fileSize: 2,
+        lastModified: 2,
+        converterVersion: 2,
+        text: 'חדש',
+        createdAt: 999,
+        accessedAt: 999,
+      ));
+
+      final got = (await repository.getDocxTextCacheEntry('/x.docx'))!;
+      expect(got.text, 'חדש');
+      expect(got.converterVersion, 2);
+      expect(got.accessedAt, 999, reason: 'accessedAt מתעדכן');
+      expect(got.createdAt, 111,
+          reason: 'createdAt נשמר מהיצירה הראשונה (לא נדרס)');
+    });
+  });
+
+  group('DocxTextCache - ניקוי מטמון (TTL)', () {
+    test('touch מעדכן את זמן-הגישה (כדי שספר בשימוש לא ייכחד)', () async {
+      await repository.upsertDocxTextCacheEntry(
+          entry(filePath: '/lib/ב.docx').copyWithAccessed(100));
+      await repository.touchDocxTextCacheEntry('/lib/ב.docx', 999999);
+      final got = (await repository.getDocxTextCacheEntry('/lib/ב.docx'))!;
+      expect(got.accessedAt, 999999);
+    });
+
+    test('prune מוחק רשומות ישנות ושומר רשומות שנגעו בהן לאחרונה', () async {
+      await repository.upsertDocxTextCacheEntry(
+          entry(filePath: '/lib/ישן.docx').copyWithAccessed(1000));
+      await repository.upsertDocxTextCacheEntry(
+          entry(filePath: '/lib/חדש.docx').copyWithAccessed(50000));
+
+      // מוחק כל מה שנגעו בו לפני 10000
+      await repository.pruneDocxTextCacheAccessedBefore(10000);
+
+      expect(await repository.getDocxTextCacheEntry('/lib/ישן.docx'), isNull);
+      expect(
+          await repository.getDocxTextCacheEntry('/lib/חדש.docx'), isNotNull);
+    });
+  });
+}
+
+extension on DocxTextCacheEntry {
+  DocxTextCacheEntry copyWithAccessed(int accessedAt) => DocxTextCacheEntry(
+        filePath: filePath,
+        fileSize: fileSize,
+        lastModified: lastModified,
+        converterVersion: converterVersion,
+        text: text,
+        createdAt: createdAt,
+        accessedAt: accessedAt,
+      );
+}

--- a/test/utils/file/docx_cache_test.dart
+++ b/test/utils/file/docx_cache_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/utils/file/docx_cache.dart';
+
+/// בדיקות ללוגיקת הזרקת-הכותרת של מטמון ה-docx. המטמון מפתוח לפי הקובץ
+/// (לא לפי שם הספר), כך ששינוי-שם אינו פוסל את המטמון אך הכותרת מתעדכנת.
+void main() {
+  group('withFreshDocxTitle', () {
+    test('מחליף את שורת הכותרת בשם הנוכחי, שומר את שאר התוכן', () {
+      const cached = '<h1>שם ישן</h1>\n<p>תוכן הספר</p>\nעוד שורה';
+      final result = withFreshDocxTitle(cached, 'שם חדש');
+      expect(result, '<h1>שם חדש</h1>\n<p>תוכן הספר</p>\nעוד שורה');
+    });
+
+    test('טקסט עם h1 בלבד (בלי שורות נוספות) מתעדכן', () {
+      const cached = '<h1>ישן</h1>';
+      expect(withFreshDocxTitle(cached, 'חדש'), '<h1>חדש</h1>');
+    });
+
+    test('טקסט שאינו פותח ב-h1 מוחזר כפי שהוא', () {
+      const cached = '<p>בלי כותרת</p>\nשורה';
+      expect(withFreshDocxTitle(cached, 'שם'), cached);
+    });
+
+    test('כותרת זהה משאירה את התוכן ללא שינוי מהותי', () {
+      const cached = '<h1>אותו שם</h1>\nתוכן';
+      expect(withFreshDocxTitle(cached, 'אותו שם'), cached);
+    });
+  });
+}

--- a/test/utils/file/docx_to_otzaria_benchmark.dart
+++ b/test/utils/file/docx_to_otzaria_benchmark.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+
+/// בנצ'מרק ביצועים *וזיכרון* ל-docxToText על היקף של "אלפי דפים".
+///
+/// אינו טסט תקינות — מודד זמן, תפוקה וצריכת זיכרון (RSS) ומדפיס דו"ח.
+/// מסומן `skip` כדי לא להאט את החבילה הרגילה. להרצה ידנית:
+///   flutter test test/utils/file/docx_to_otzaria_benchmark.dart --run-skipped
+///
+/// אומדן היקף: דף ≈ 30 שורות, כך ש-30,000 פסקאות ≈ ~1,000 עמודים.
+void main() {
+  const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+  const imgNs = '$ns '
+      'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" '
+      'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"';
+
+  // פסקת גוף "רגילה": 4 runs, עיצוב פשוט.
+  String simplePara(int i) => '<w:p><w:pPr><w:jc w:val="both"/></w:pPr>'
+      '<w:r><w:rPr><w:bCs/></w:rPr><w:t>מילה מודגשת </w:t></w:r>'
+      '<w:r><w:rPr><w:iCs/></w:rPr><w:t>ונטויה </w:t></w:r>'
+      '<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>וקו תחתי </w:t></w:r>'
+      '<w:r><w:t>וטקסט רגיל בשורה זו לבדיקת אורך פסקה סביר. </w:t></w:r></w:p>';
+
+  // פסקת גוף "מורכבת": ~16 runs, כל אחד עם 2–3 שכבות עיצוב מקוננות + צבע.
+  String complexPara(int i) {
+    final b = StringBuffer('<w:p><w:pPr><w:jc w:val="both"/></w:pPr>');
+    for (var k = 0; k < 16; k++) {
+      b.write('<w:r><w:rPr><w:bCs/><w:iCs/>'
+          '<w:u w:val="wave" w:color="FF0000"/>'
+          '<w:color w:val="1F3B6D"/><w:vertAlign w:val="superscript"/>'
+          '<w:highlight w:val="yellow"/></w:rPr>'
+          '<w:t>מקטע$k </w:t></w:r>');
+    }
+    b.write('</w:p>');
+    return b.toString();
+  }
+
+  // פסקת "עשירה": רשימה ממוספרת מקוננת + טבלה 2x3 מדי 5 פסקאות.
+  String richPara(int i) {
+    final lvl = i % 3;
+    final item = '<w:p><w:pPr><w:numPr><w:ilvl w:val="$lvl"/>'
+        '<w:numId w:val="1"/></w:numPr></w:pPr>'
+        '<w:r><w:t>פריט רשימה ברמה $lvl בפסקה $i</w:t></w:r></w:p>';
+    if (i % 5 != 0) return item;
+    final cells = StringBuffer();
+    for (var r = 0; r < 2; r++) {
+      cells.write('<w:tr>');
+      for (var c = 0; c < 3; c++) {
+        cells.write('<w:tc><w:tcPr><w:shd w:fill="EEEEEE"/></w:tcPr>'
+            '<w:p><w:r><w:t>תא $r,$c</w:t></w:r></w:p></w:tc>');
+      }
+      cells.write('</w:tr>');
+    }
+    return '$item<w:tbl><w:tblPr><w:bidiVisual/></w:tblPr>$cells</w:tbl>';
+  }
+
+  String numberingXml() =>
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+      '<w:numbering $ns><w:abstractNum w:abstractNumId="0">'
+      '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>'
+      '<w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="hebrew1"/><w:lvlText w:val="%2."/></w:lvl>'
+      '<w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="lowerRoman"/><w:lvlText w:val="%3."/></w:lvl>'
+      '</w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>'
+      '</w:numbering>';
+
+  Uint8List buildDocx(int paragraphs, {required String mode}) {
+    final useImgNs = mode == 'images';
+    final doc = StringBuffer()
+      ..write('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>')
+      ..write('<w:document ${useImgNs ? imgNs : ns}><w:body>');
+
+    for (var i = 0; i < paragraphs; i++) {
+      if (i % 30 == 0) {
+        doc.write('<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr>'
+            '<w:r><w:t>פרק מספר $i</w:t></w:r></w:p>');
+        continue;
+      }
+      switch (mode) {
+        case 'simple':
+          doc.write(simplePara(i));
+        case 'complex':
+          doc.write(complexPara(i));
+        case 'rich':
+          doc.write(richPara(i));
+        case 'images':
+          doc.write(simplePara(i));
+          if (i % 20 == 0) {
+            doc.write('<w:p><w:r><w:drawing>'
+                '<a:blip r:embed="rId1"/></w:drawing></w:r></w:p>');
+          }
+      }
+    }
+    doc.write('</w:body></w:document>');
+
+    final archive = Archive();
+    final docBytes = utf8.encode(doc.toString());
+    archive
+        .addFile(ArchiveFile('word/document.xml', docBytes.length, docBytes));
+
+    if (mode == 'rich') {
+      final n = utf8.encode(numberingXml());
+      archive.addFile(ArchiveFile('word/numbering.xml', n.length, n));
+    }
+    if (mode == 'images') {
+      // תמונת PNG אחת (~3KB) משותפת לכל ההפניות.
+      final png = List<int>.generate(3000, (k) => k % 256);
+      final rels = utf8.encode(
+          '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+          '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/i.png"/></Relationships>');
+      archive.addFile(
+          ArchiveFile('word/_rels/document.xml.rels', rels.length, rels));
+      archive.addFile(ArchiveFile('word/media/i.png', png.length, png));
+    }
+    return Uint8List.fromList(ZipEncoder().encode(archive));
+  }
+
+  int mb(int bytes) => (bytes / (1024 * 1024)).round();
+
+  void runCase(int paragraphs, String mode) {
+    final xmlBytes = buildDocx(paragraphs, mode: mode);
+    final rssBefore = ProcessInfo.currentRss;
+    final sw = Stopwatch()..start();
+    final out = docxToText(xmlBytes, 'בנצ\'מרק');
+    sw.stop();
+    final rssAfter = ProcessInfo.currentRss;
+    // ignore: avoid_print
+    print('━━ ${mode.padRight(8)}| פסקאות=$paragraphs '
+        '(~${(paragraphs / 30).round()} עמ\') '
+        '| המרה=${sw.elapsedMilliseconds}ms '
+        '| פלט=${mb(out.length * 2)}MB '
+        '| RSS Δ=${mb(rssAfter - rssBefore)}MB '
+        '| RSS peak=${mb(ProcessInfo.maxRss)}MB');
+    expect(out, contains('<h1>'));
+  }
+
+  group('docxToText benchmark', () {
+    test('זמן + זיכרון: כל סוגי התוכן, עד ~2000 עמ\'', () {
+      // ignore: avoid_print
+      print('\n=== ביצועים (debug/JIT, isolate) — פלט/RSS ב-MB ===');
+      runCase(30000, 'simple'); // ~1000 עמ' טקסט רגיל
+      runCase(60000, 'simple'); // ~2000 עמ'
+      runCase(30000, 'rich'); // ~1000 עמ' רשימות+טבלאות
+      runCase(30000, 'images'); // ~1000 עמ' עם תמונות מוטמעות
+      runCase(30000, 'complex'); // ~1000 עמ' עיצוב כבד
+    }, timeout: const Timeout(Duration(minutes: 6)));
+  }, skip: 'בנצ\'מרק ידני — הרץ עם --run-skipped');
+}

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -211,12 +211,774 @@ void main() {
       );
       final result = docxToText(docx, 'בדיקה');
 
-      expect(result, contains('<sup>1</sup>'));
-      expect(result, contains('הערת שוליים'));
-      // footnote div comes after the paragraph that references it
+      // פורמט הערות אוצריא: <sup class="footnote-marker"> + <i class="footnote">
+      expect(result, contains('<sup class="footnote-marker">1</sup>'));
+      expect(result, contains('<i class="footnote">הערת שוליים</i>'));
+      // ה-<sup> וגוף ההערה צמודים, באותה שורה, אחרי הטקסט המפנה
       final paraIdx = result.indexOf('טקסט');
       final noteIdx = result.indexOf('הערת שוליים');
       expect(noteIdx, greaterThan(paraIdx));
+    });
+  });
+
+  group('docxToText - כותרות לפי שם הסגנון', () {
+    String docWithStyle(String styleVal, String text) => '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr><w:pStyle w:val="$styleVal"/></w:pPr>
+      <w:r><w:t>$text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+
+    test('Heading1 (שם) מומר ל-<h1>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(docWithStyle('Heading1', 'פרק'))), 'ב');
+      expect(result, contains('<h1>פרק</h1>'));
+    });
+
+    test('"Heading 3" עם רווח מומר ל-<h3>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(docWithStyle('Heading 3', 'סעיף'))), 'ב');
+      expect(result, contains('<h3>סעיף</h3>'));
+    });
+
+    test('Title מומר ל-<h1>', () {
+      final result =
+          docxToText(_buildDocx(_utf8Xml(docWithStyle('Title', 'שער'))), 'ב');
+      expect(result, contains('<h1>שער</h1>'));
+    });
+
+    test('סגנון לא-כותרת נשאר פסקה רגילה (בלי <h>)', () {
+      final result =
+          docxToText(_buildDocx(_utf8Xml(docWithStyle('Normal', 'רגיל'))), 'ב');
+      expect(result, contains('רגיל'));
+      expect(result, isNot(contains('<h2>רגיל')));
+    });
+
+    test('כותרת מזוהה דרך outlineLvl כשאין שם סגנון תואם', () {
+      final xml = '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr><w:outlineLvl w:val="0"/></w:pPr>
+      <w:r><w:t>כותרת מתאר</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<h1>כותרת מתאר</h1>'));
+    });
+  });
+
+  group('docxToText - הדגשה עברית (complex-script)', () {
+    String runWithProps(String props, String text) => '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p><w:r><w:rPr>$props</w:rPr><w:t>$text</w:t></w:r></w:p>
+  </w:body>
+</w:document>''';
+
+    test('w:bCs בלבד (בלי w:b) מומר ל-<b>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:bCs/>', 'מודגש'))), 'ב');
+      expect(result, contains('<b>מודגש</b>'));
+    });
+
+    test('w:iCs בלבד (בלי w:i) מומר ל-<i>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:iCs/>', 'נטוי'))), 'ב');
+      expect(result, contains('<i>נטוי</i>'));
+    });
+
+    test('w:strike מומר ל-<s>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:strike/>', 'חוצה'))), 'ב');
+      expect(result, contains('<s>חוצה</s>'));
+    });
+  });
+
+  group('docxToText - ניקוי תגים לא נתמכים', () {
+    String runWithProps(String props, String text) => '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p><w:r><w:rPr>$props</w:rPr><w:t>$text</w:t></w:r></w:p>
+  </w:body>
+</w:document>''';
+
+    test('צבע שחור (000000) לא נפלט כ-span', () {
+      final result = docxToText(
+          _buildDocx(
+              _utf8Xml(runWithProps('<w:color w:val="000000"/>', 'טקסט'))),
+          'ב');
+      expect(result, contains('טקסט'));
+      expect(result, isNot(contains('color')));
+    });
+
+    test('גופן (rFonts) לא נפלט כ-font-family', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps(
+              '<w:rFonts w:ascii="David" w:cs="David"/>', 'טקסט'))),
+          'ב');
+      expect(result, contains('טקסט'));
+      expect(result, isNot(contains('font-family')));
+    });
+
+    test('צבע אמיתי (לא שחור) כן נשמר', () {
+      final result = docxToText(
+          _buildDocx(
+              _utf8Xml(runWithProps('<w:color w:val="FF0000"/>', 'אדום'))),
+          'ב');
+      expect(result, contains('color:#FF0000'));
+    });
+  });
+
+  group('docxToText - מעברי שורה ורשימות', () {
+    test('w:br בתוך פסקה מומר ל-<br>', () {
+      final xml = '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p><w:r><w:t>שורה א</w:t><w:br/><w:t>שורה ב</w:t></w:r></w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('שורה א<br>שורה ב'));
+    });
+
+    test('פריט רשימה מקבל קידומת תבליט בלי <ul>', () {
+      final xml = '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>
+      <w:r><w:t>פריט</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('• פריט'));
+      expect(result, isNot(contains('<ul>')));
+      expect(result, isNot(contains('<li>')));
+    });
+  });
+
+  group('docxToText - טבלאות ועמידות', () {
+    test('תוכן טבלה אינו זולג ומתערבב עם הזרם הרגיל', () {
+      final xml = '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p><w:r><w:t>פסקת גוף</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr>
+        <w:tc><w:p><w:r><w:t>תא1</w:t></w:r></w:p></w:tc>
+        <w:tc><w:p><w:r><w:t>תא2</w:t></w:r></w:p></w:tc>
+      </w:tr>
+    </w:tbl>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      // הטבלה נפלטת כ-<table> אחד (שורה אחת), עם תאים, ולא זולגת לזרם.
+      expect(result, contains('<table'));
+      expect(result, contains('<td'));
+      expect(result, contains('תא1'));
+      expect(result, contains('תא2'));
+      expect(result, contains('פסקת גוף'));
+      // כל הטבלה בשורה לוגית אחת (כי שורה = widget בקורא).
+      final tableLine =
+          result.split('\n').firstWhere((l) => l.contains('<table'));
+      expect(tableLine, contains('</table>'));
+    });
+
+    test('XML פגום לא מקריס את היבוא ומחזיר לפחות את הכותרת', () {
+      final docx = _buildDocx(_utf8Xml('<w:document not-closed'));
+      final result = docxToText(docx, 'כותרת');
+      expect(result, contains('<h1>כותרת</h1>'));
+    });
+  });
+
+  group('docxToText - טבלאות עשירות', () {
+    String cell(String text, {String tcPr = ''}) =>
+        '<w:tc><w:tcPr>$tcPr</w:tcPr><w:p><w:r><w:t>$text</w:t></w:r></w:p></w:tc>';
+    String table(String inner, {String tblPr = ''}) =>
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document $_xmlNs><w:body><w:tbl><w:tblPr>$tblPr</w:tblPr>'
+        '$inner</w:tbl></w:body></w:document>';
+
+    test('מיזוג אופקי (gridSpan) → colspan', () {
+      final xml = table('<w:tr>'
+          '${cell("ממוזג", tcPr: "<w:gridSpan w:val=\"2\"/>")}'
+          '</w:tr>');
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('colspan="2"'));
+      expect(result, contains('ממוזג'));
+    });
+
+    test('מיזוג אנכי (vMerge) → rowspan', () {
+      final xml = table('<w:tr>'
+          '${cell("גובה", tcPr: "<w:vMerge w:val=\"restart\"/>")}'
+          '${cell("ימין1")}</w:tr>'
+          '<w:tr>'
+          '${cell("", tcPr: "<w:vMerge/>")}'
+          '${cell("ימין2")}</w:tr>');
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('rowspan="2"'));
+      // תא ההמשך אינו נפלט בנפרד (אין td ריק שני)
+      expect('גובה'.allMatches(result), hasLength(1));
+    });
+
+    test('רקע תא (w:shd) → background-color', () {
+      final xml = table('<w:tr>'
+          '${cell("צבעוני", tcPr: "<w:shd w:fill=\"FFFF00\"/>")}'
+          '</w:tr>');
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('background-color: #FFFF00'));
+    });
+
+    test('שורת כותרת (tblHeader) → <th>', () {
+      final xml = table('<w:tr><w:trPr><w:tblHeader/></w:trPr>'
+          '${cell("כותרת")}</w:tr>');
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<th'));
+      expect(result, contains('כותרת'));
+    });
+
+    test('טבלה RTL (bidiVisual) → dir="rtl"', () {
+      final xml =
+          table('<w:tr>${cell("ימני")}</w:tr>', tblPr: '<w:bidiVisual/>');
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<table dir="rtl"'));
+    });
+  });
+
+  group('docxToText - תמונות מוטמעות (offline)', () {
+    // ה-namespaces הדרושים לזיהוי a:blip ו-r:embed.
+    const imgNs = '$_xmlNs '
+        'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" '
+        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"';
+
+    Uint8List buildWithImage(String target, List<int> imageBytes) {
+      final docXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $imgNs><w:body><w:p><w:r><w:drawing>'
+          '<a:blip r:embed="rId1"/></w:drawing></w:r></w:p></w:body>'
+          '</w:document>';
+      final relsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+          '<Relationship Id="rId1" '
+          'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" '
+          'Target="$target"/></Relationships>';
+      final encoder = ZipEncoder();
+      final archive = Archive();
+      final doc = utf8.encode(docXml);
+      final rels = utf8.encode(relsXml);
+      archive.addFile(ArchiveFile('word/document.xml', doc.length, doc));
+      archive.addFile(
+          ArchiveFile('word/_rels/document.xml.rels', rels.length, rels));
+      archive.addFile(ArchiveFile(
+          'word/${target.startsWith('/') ? target.substring(1) : target}',
+          imageBytes.length,
+          imageBytes));
+      return Uint8List.fromList(encoder.encode(archive));
+    }
+
+    test('תמונת PNG מוטמעת → <img> עם data URI (base64, ללא אינטרנט)', () {
+      final png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]; // חתימת PNG
+      final result = docxToText(buildWithImage('media/image1.png', png), 'ב');
+      expect(result, contains('<img src="data:image/png;base64,'));
+      // לא קישור חיצוני — הכל מוטמע
+      expect(result, isNot(contains('http')));
+    });
+
+    test('תמונת JPEG → data:image/jpeg', () {
+      final jpg = [0xFF, 0xD8, 0xFF];
+      final result = docxToText(buildWithImage('media/pic.jpeg', jpg), 'ב');
+      expect(result, contains('data:image/jpeg;base64,'));
+    });
+
+    test('פורמט לא נתמך (EMF) אינו נפלט כתמונה', () {
+      final emf = [0x01, 0x00, 0x00, 0x00];
+      final result = docxToText(buildWithImage('media/image1.emf', emf), 'ב');
+      expect(result, isNot(contains('<img')));
+    });
+  });
+
+  group('docxToText - רשימות ממוספרות מקוננות', () {
+    // בונה numbering.xml עם רמות נתונות (כולן numId=1 → abstractNumId=0).
+    String numberingXml(List<List<String>> levels, {String start = '1'}) {
+      final lvls = <String>[];
+      for (var i = 0; i < levels.length; i++) {
+        lvls.add('<w:lvl w:ilvl="$i"><w:start w:val="$start"/>'
+            '<w:numFmt w:val="${levels[i][0]}"/>'
+            '<w:lvlText w:val="${levels[i][1]}"/></w:lvl>');
+      }
+      return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:numbering $_xmlNs><w:abstractNum w:abstractNumId="0">'
+          '${lvls.join()}</w:abstractNum>'
+          '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>'
+          '</w:numbering>';
+    }
+
+    String item(int ilvl, String text) =>
+        '<w:p><w:pPr><w:numPr><w:ilvl w:val="$ilvl"/>'
+        '<w:numId w:val="1"/></w:numPr></w:pPr>'
+        '<w:r><w:t>$text</w:t></w:r></w:p>';
+
+    Uint8List build(String body, String numbering) {
+      final docXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body>$body</w:body></w:document>';
+      final encoder = ZipEncoder();
+      final archive = Archive();
+      final d = utf8.encode(docXml);
+      final n = utf8.encode(numbering);
+      archive.addFile(ArchiveFile('word/document.xml', d.length, d));
+      archive.addFile(ArchiveFile('word/numbering.xml', n.length, n));
+      return Uint8List.fromList(encoder.encode(archive));
+    }
+
+    test('מספור decimal רץ: 1. 2. 3.', () {
+      final num = numberingXml([
+        ['decimal', '%1.']
+      ]);
+      final result = docxToText(
+          build('${item(0, "ראשון")}${item(0, "שני")}${item(0, "שלישי")}', num),
+          'ב');
+      expect(result, contains('1. ראשון'));
+      expect(result, contains('2. שני'));
+      expect(result, contains('3. שלישי'));
+    });
+
+    test('multilevel מקונן: 1. ואז 1.1. ואז 1.1.1.', () {
+      final num = numberingXml([
+        ['decimal', '%1.'],
+        ['decimal', '%1.%2.'],
+        ['decimal', '%1.%2.%3.'],
+      ]);
+      final result = docxToText(
+          build('${item(0, "א")}${item(1, "ב")}${item(2, "ג")}${item(1, "ד")}',
+              num),
+          'ב');
+      expect(result, contains('1. א'));
+      expect(result, contains('1.1. ב'));
+      expect(result, contains('1.1.1. ג'));
+      expect(result, contains('1.2. ד'), reason: 'חזרה לרמה 1 ממשיכה ל-1.2');
+    });
+
+    test('אותיות לטיניות (lowerLetter): a. b.', () {
+      final num = numberingXml([
+        ['lowerLetter', '%1.']
+      ]);
+      final result =
+          docxToText(build('${item(0, "x")}${item(0, "y")}', num), 'ב');
+      expect(result, contains('a. x'));
+      expect(result, contains('b. y'));
+    });
+
+    test('אותיות רומיות (upperRoman): I. II. III.', () {
+      final num = numberingXml([
+        ['upperRoman', '%1.']
+      ]);
+      final result = docxToText(
+          build('${item(0, "a")}${item(0, "b")}${item(0, "c")}', num), 'ב');
+      expect(result, contains('I. a'));
+      expect(result, contains('II. b'));
+      expect(result, contains('III. c'));
+    });
+
+    test('אותיות עבריות (hebrew1): א. ב. ג.', () {
+      final num = numberingXml([
+        ['hebrew1', '%1.']
+      ]);
+      final result = docxToText(
+          build('${item(0, "x")}${item(0, "y")}${item(0, "z")}', num), 'ב');
+      expect(result, contains('א. x'));
+      expect(result, contains('ב. y'));
+      expect(result, contains('ג. z'));
+    });
+
+    test('רשימה שמתחילה ממספר נתון (start=5): 5. 6.', () {
+      final num = numberingXml([
+        ['decimal', '%1.']
+      ], start: '5');
+      final result =
+          docxToText(build('${item(0, "x")}${item(0, "y")}', num), 'ב');
+      expect(result, contains('5. x'));
+      expect(result, contains('6. y'));
+    });
+
+    test('תבליט (bullet) נשאר •', () {
+      final num = numberingXml([
+        ['bullet', '']
+      ]);
+      final result = docxToText(build(item(0, "פריט"), num), 'ב');
+      expect(result, contains('• פריט'));
+    });
+
+    test('רשימה בלי numbering.xml נופלת לתבליט (לא קורסת)', () {
+      final docXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body>${item(0, "פריט")}</w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(docXml)), 'ב');
+      expect(result, contains('• פריט'));
+    });
+  });
+
+  group('docxToText - escaping של תוכן', () {
+    test('שם ספר עם < / & מקבל escape בכותרת (לא שובר HTML)', () {
+      final result =
+          docxToText(_buildDocx(_utf8Xml(_simpleDocXml('תוכן'))), 'א < ב & ג');
+      expect(result, contains('<h1>א &lt; ב &amp; ג</h1>'));
+      expect(result, isNot(contains('<h1>א < ב')));
+    });
+
+    test('תווי < ו-> בתוכן הופכים ל-entity ולא שוברים את ה-HTML', () {
+      // ב-Word התו "<" מקודד כ-&lt; ב-XML; innerText מחזיר "<" גולמי.
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p><w:r><w:t>a &lt; b &gt; c</w:t>'
+          '</w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('a &lt; b &gt; c'));
+      // אין "<" גולמי שיתפרש כתגית פתיחה שבורה
+      expect(result, isNot(contains('a < b')));
+    });
+
+    test('תו & בתוכן הופך ל-&amp;', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p><w:r><w:t>ר&apos; &amp; כו&apos;</w:t>'
+          '</w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('&amp;'));
+    });
+  });
+
+  group('docxToText - מיזוג runs מפוצלים', () {
+    test('שני runs מודגשים סמוכים ממוזגים ל-<b> אחד', () {
+      // Word מפצל "שלום" לשני runs מודגשים — הפלט צריך להיות <b>שלום</b> אחד.
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:r><w:rPr><w:b/></w:rPr><w:t>של</w:t></w:r>'
+          '<w:r><w:rPr><w:b/></w:rPr><w:t>ום</w:t></w:r>'
+          '</w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<b>שלום</b>'));
+      expect(result, isNot(contains('</b><b>')));
+    });
+
+    test('runs בעיצוב שונה אינם ממוזגים', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:r><w:rPr><w:b/></w:rPr><w:t>מודגש</w:t></w:r>'
+          '<w:r><w:rPr><w:i/></w:rPr><w:t>נטוי</w:t></w:r>'
+          '</w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<b>מודגש</b>'));
+      expect(result, contains('<i>נטוי</i>'));
+    });
+
+    test('runs סמוכים עם עיצוב זהה (צבע) ממוזגים ל-span אחד', () {
+      // מבחן ביצועים: ניפוח HTML מ-runs מפוצלים של Word עם אותו עיצוב.
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>אב</w:t></w:r>'
+          '<w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>גד</w:t></w:r>'
+          '</w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<span style="color:#FF0000">אבגד</span>'));
+      // span יחיד — לא עותק לכל run
+      expect('color:#FF0000'.allMatches(result), hasLength(1));
+    });
+
+    test('עטיפה מורכבת זהה (מודגש+צבע+מרקר) ממוזגת פעם אחת', () {
+      final props = '<w:rPr><w:bCs/><w:color w:val="1F3B6D"/>'
+          '<w:highlight w:val="yellow"/></w:rPr>';
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:r>$props<w:t>חלק </w:t></w:r>'
+          '<w:r>$props<w:t>שני </w:t></w:r>'
+          '<w:r>$props<w:t>שלישי</w:t></w:r>'
+          '</w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      // <b> אחד, span-צבע אחד, span-מרקר אחד — לא שלושה עותקים
+      expect('<b>'.allMatches(result), hasLength(1));
+      expect('background-color:yellow'.allMatches(result), hasLength(1));
+      expect(result, contains('חלק שני שלישי'));
+    });
+  });
+
+  group('docxToText - מאפייני on/off ומעלית/מורד', () {
+    String runWithProps(String props, String text) =>
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document $_xmlNs><w:body><w:p><w:r><w:rPr>$props</w:rPr>'
+        '<w:t>$text</w:t></w:r></w:p></w:body></w:document>';
+
+    test('w:b w:val="0" (ביטול ירושה) אינו מודגש', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:b w:val="0"/>', 'רגיל'))), 'ב');
+      expect(result, contains('רגיל'));
+      expect(result, isNot(contains('<b>')));
+    });
+
+    test('w:b w:val="false" אינו מודגש', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:b w:val="false"/>', 'רגיל'))),
+          'ב');
+      expect(result, isNot(contains('<b>')));
+    });
+
+    test('w:u w:val="none" (ביטול קו תחתי) אינו עוטף ב-<u>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="none"/>', 'טקסט'))),
+          'ב');
+      expect(result, isNot(contains('<u>')));
+    });
+
+    test('w:u w:val="single" כן עוטף ב-<u>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="single"/>', 'קו'))),
+          'ב');
+      expect(result, contains('<u>קו</u>'));
+    });
+
+    test('w:vertAlign superscript מומר ל-<sup>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(
+              runWithProps('<w:vertAlign w:val="superscript"/>', 'מעלית'))),
+          'ב');
+      expect(result, contains('<sup>מעלית</sup>'));
+    });
+
+    test('w:vertAlign subscript מומר ל-<sub>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(
+              runWithProps('<w:vertAlign w:val="subscript"/>', 'מורד'))),
+          'ב');
+      expect(result, contains('<sub>מורד</sub>'));
+    });
+
+    test('טקסט מוסתר (w:vanish) אינו מוצג', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:r><w:t>גלוי</w:t></w:r>'
+          '<w:r><w:rPr><w:vanish/></w:rPr><w:t>מוסתר</w:t></w:r>'
+          '</w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('גלוי'));
+      expect(result, isNot(contains('מוסתר')));
+    });
+  });
+
+  group('docxToText - מרקר ויישור', () {
+    String runWithProps(String props, String text) =>
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document $_xmlNs><w:body><w:p><w:r><w:rPr>$props</w:rPr>'
+        '<w:t>$text</w:t></w:r></w:p></w:body></w:document>';
+
+    test('w:highlight=yellow מומר לרקע צבעוני', () {
+      final result = docxToText(
+          _buildDocx(
+              _utf8Xml(runWithProps('<w:highlight w:val="yellow"/>', 'מסומן'))),
+          'ב');
+      expect(result, contains('background-color:yellow'));
+      expect(result, contains('מסומן'));
+    });
+
+    test('w:highlight=darkYellow ממופה ל-HEX (אין שם CSS)', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(
+              runWithProps('<w:highlight w:val="darkYellow"/>', 'כהה'))),
+          'ב');
+      expect(result, contains('background-color:#808000'));
+    });
+
+    test('w:highlight=none אינו יוצר רקע', () {
+      final result = docxToText(
+          _buildDocx(
+              _utf8Xml(runWithProps('<w:highlight w:val="none"/>', 'רגיל'))),
+          'ב');
+      expect(result, isNot(contains('background-color')));
+    });
+
+    test('פסקת גוף עם jc=center מתקבלת מיושרת למרכז', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:pPr><w:jc w:val="center"/></w:pPr>'
+          '<w:r><w:t>שירת הים</w:t></w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('text-align: center'));
+      expect(result, contains('שירת הים'));
+    });
+
+    test('כותרת ממורכזת לא נעטפת ב-div (נשמר זיהוי <h>)', () {
+      // כותרת עם jc=center חייבת להישאר <h..> בתחילת השורה כדי ש-TocParser יזהה.
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:pPr><w:pStyle w:val="Heading1"/><w:jc w:val="center"/></w:pPr>'
+          '<w:r><w:t>פרק</w:t></w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<h1>פרק</h1>'));
+      expect(result, isNot(contains('text-align')));
+    });
+
+    test('jc=right מתקבל מיושר לימין', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:pPr><w:jc w:val="right"/></w:pPr>'
+          '<w:r><w:t>ימין</w:t></w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('text-align: right'));
+    });
+
+    test('jc=left מתקבל מיושר לשמאל', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:p>'
+          '<w:pPr><w:jc w:val="left"/></w:pPr>'
+          '<w:r><w:t>שמאל</w:t></w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('text-align: left'));
+    });
+  });
+
+  group('docxToText - סוגי קווים תחתונים וקו חוצה', () {
+    String runWithProps(String props, String text) =>
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document $_xmlNs><w:body><w:p><w:r><w:rPr>$props</w:rPr>'
+        '<w:t>$text</w:t></w:r></w:p></w:body></w:document>';
+
+    test('קו תחתי כפול → text-decoration underline double', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="double"/>', 'כפול'))),
+          'ב');
+      expect(result, contains('text-decoration: underline double'));
+    });
+
+    test('קו תחתי מנוקד (dotted) → dotted', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="dotted"/>', 'מנוקד'))),
+          'ב');
+      expect(result, contains('underline dotted'));
+    });
+
+    test('קו תחתי מקווקו (dash) → dashed', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="dash"/>', 'מקווקו'))),
+          'ב');
+      expect(result, contains('underline dashed'));
+    });
+
+    test('קו תחתי גלי (wave) → wavy', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="wave"/>', 'גלי'))),
+          'ב');
+      expect(result, contains('underline wavy'));
+    });
+
+    test('קו תחתי עבה (thick) → thickness', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="thick"/>', 'עבה'))),
+          'ב');
+      expect(result, contains('text-decoration-thickness'));
+    });
+
+    test('קו תחתי צבעוני → text-decoration-color', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps(
+              '<w:u w:val="single" w:color="FF0000"/>', 'צבעוני'))),
+          'ב');
+      expect(result, contains('text-decoration-color: #FF0000'));
+    });
+
+    test('קו תחתי single רגיל נשאר <u> (ניתן למיזוג)', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:u w:val="single"/>', 'רגיל'))),
+          'ב');
+      expect(result, contains('<u>רגיל</u>'));
+    });
+
+    test('קו חוצה כפול (dstrike) → line-through double', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:dstrike/>', 'חוצה כפול'))), 'ב');
+      expect(result, contains('text-decoration: line-through double'));
+    });
+
+    test('קו חוצה יחיד (strike) נשאר <s>', () {
+      final result = docxToText(
+          _buildDocx(_utf8Xml(runWithProps('<w:strike/>', 'חוצה'))), 'ב');
+      expect(result, contains('<s>חוצה</s>'));
+    });
+  });
+
+  group('docxToText - מבנים מקוננים (sdt וטבלאות מקוננות)', () {
+    test('פסקה בתוך w:sdt (בקרת תוכן) אינה נשמטת', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body>'
+          '<w:p><w:r><w:t>לפני</w:t></w:r></w:p>'
+          '<w:sdt><w:sdtContent>'
+          '<w:p><w:r><w:t>בתוך בקרת תוכן</w:t></w:r></w:p>'
+          '</w:sdtContent></w:sdt>'
+          '<w:p><w:r><w:t>אחרי</w:t></w:r></w:p>'
+          '</w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('לפני'));
+      expect(result, contains('בתוך בקרת תוכן'),
+          reason: 'תוכן עטוף ב-sdt לא נאבד');
+      expect(result, contains('אחרי'));
+    });
+
+    test('טבלה בתוך w:sdt אינה נשמטת', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:sdt><w:sdtContent>'
+          '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>תא-בסדט</w:t></w:r></w:p></w:tc>'
+          '</w:tr></w:tbl>'
+          '</w:sdtContent></w:sdt></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<table'));
+      expect(result, contains('תא-בסדט'));
+    });
+
+    test('טבלה מקוננת בתוך תא — תוכנה הפנימי נשמר', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:tbl><w:tr><w:tc>'
+          '<w:p><w:r><w:t>חיצוני</w:t></w:r></w:p>'
+          '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>פנימי</w:t></w:r></w:p></w:tc>'
+          '</w:tr></w:tbl>'
+          '</w:tc></w:tr></w:tbl></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('חיצוני'));
+      expect(result, contains('פנימי'), reason: 'תוכן טבלה מקוננת לא נאבד');
+      // שתי טבלאות (חיצונית + מקוננת)
+      expect('<table'.allMatches(result).length, greaterThanOrEqualTo(2));
+    });
+
+    test('שורת טבלה עטופה ב-w:sdt אינה נשמטת', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:tbl>'
+          '<w:tr><w:tc><w:p><w:r><w:t>רגילה</w:t></w:r></w:p></w:tc></w:tr>'
+          '<w:sdt><w:sdtContent>'
+          '<w:tr><w:tc><w:p><w:r><w:t>בתוך-סדט</w:t></w:r></w:p></w:tc></w:tr>'
+          '</w:sdtContent></w:sdt>'
+          '</w:tbl></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('רגילה'));
+      expect(result, contains('בתוך-סדט'),
+          reason: 'שורת טבלה עטופה ב-sdt לא נאבדת');
+    });
+
+    test('תא טבלה עטוף ב-w:sdt אינו נשמט', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body><w:tbl><w:tr>'
+          '<w:tc><w:p><w:r><w:t>תא-א</w:t></w:r></w:p></w:tc>'
+          '<w:sdt><w:sdtContent>'
+          '<w:tc><w:p><w:r><w:t>תא-סדט</w:t></w:r></w:p></w:tc>'
+          '</w:sdtContent></w:sdt>'
+          '</w:tr></w:tbl></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('תא-א'));
+      expect(result, contains('תא-סדט'), reason: 'תא עטוף ב-sdt לא נאבד');
     });
   });
 }


### PR DESCRIPTION
## מה בוצע

- זיהוי כותרות נכון (לפי שם הסגנון, לא מספר)
- תמיכה בהדגשה עברית (מודגש/נטוי גם בעברית)
- כל סוגי הקווים (תחתי כפול/מנוקד/מקווקו/גלי/צבעוני, וקו חוצה כפול)
- יישור (מרכז/ימין/שמאל) (יתכן שיוסר כדי לא לפגוע בגנון של אוצריא )ומרקר צבעוני
- מעלית/מורד וטקסט מוסתר
- רשימות ממוספרות מקוננות (ספרות, אותיות עבריות+לטיניות, רומיות, רב-רמתי)
- טבלאות עשירות (מיזוג תאים, רקע, כותרות, RTL, מקוננות)
- תמונות מוטמעות — (יכן שיוסר בגרסאות הקרובות ובקום יהיה כתוב קים תמונה כדי להגיע לביצועים טובים יותר)
- בקרות-תוכן של Word
- ניקוי תגיות זרות + הגנה מפני שבירת תצוגה
- מטמון תוכן: פתיחה מיידית, עם זיהוי-שינוי וגרסת-ממיר

## לא בוצע

- שינוי גופן לגופןשל וורד בגלל פגיעה בחווית שימוש באוצריא ואחידות המבנה

## בתכנון 

- אפשרות תצוגה 1:1 כלל שניתן לוורד כולל כל האפשריות עמודים  דפיםוכו'
---

## קבצים חדשים

- `lib/utils/file/docx_cache.dart` — שכבת מטמון לתוכן הממומר: פתיחה מיידית, זיהוי-שינוי, גרסת-ממיר, ניקוי.
- `lib/migration/models/docx_text_cache_entry.dart` — מודל רשומת המטמון.
- `lib/migration/database/sql/DocxTextCacheQueries.sq` — שאילתות ה-SQL של טבלת המטמון.
- `lib/migration/database/daos/docx_text_cache_dao.dart` — שכבת הגישה (DAO) לטבלת המטמון.
- `test/utils/file/docx_word_roundtrip_test.dart` — בדיקת round-trip: ייצוא ל-Word ויבוא חזרה.
- `test/utils/file/docx_to_otzaria_benchmark.dart` — בנצ'מרק ביצועים וזיכרון על אלפי דפים.
- `test/utils/file/docx_cache_test.dart` — בדיקות ללוגיקת המטמון (הזרקת כותרת רעננה).
- `test/data_providers/docx_text_cache_test.dart` — בדיקות שכבת המטמון: שמירה, זיהוי-שינוי, ניקוי.

## קבצים קיימים ששונו

- `lib/utils/file/docx_to_otzaria.dart` — שכתוב הממיר: כותרות, עיצובים, רשימות, טבלאות, תמונות, בקרות-תוכן.
- `lib/migration/database/daos/database.dart` — נוספה טבלת המטמון לסכמה ורישום ה-DAO.
- `lib/migration/database/sql/Database.sq` — נוספה הגדרת טבלת המטמון (סנכרון סכמה).
- `lib/migration/database/sql/query_loader.dart` — רישום קובץ השאילתות החדש לטעינה.
- `lib/migration/database/repository/seforim_repository.dart` — נוספו מתודות גישה למטמון (שמירה/שליפה/ניקוי).
- `lib/data/data_providers/database_library_provider.dart` — הפניית טעינת docx דרך המטמון.
- `lib/data/data_providers/file_system_library_provider.dart` — הפניית טעינת docx דרך המטמון.
- `lib/text_book/text_book_repository.dart` — הפניית מסלולי-הגיבוי של טעינת docx דרך המטמון.
- `test/utils/file/docx_to_otzaria_test.dart` — הורחב: בדיקות לכל סוגי העיצוב, הטבלאות, התמונות והרשימות.

