### PR TITLE
החלפת בדיקת תאימות אינדקס מגרסה לבדיקת סכמה

### DIFF
--- a/lib/data/data_providers/tantivy_data_provider.dart
+++ b/lib/data/data_providers/tantivy_data_provider.dart
@@ -12,9 +12,7 @@ import 'package:otzaria/core/app_paths.dart';
 /// maintaining an index for full-text search capabilities.
 class TantivyDataProvider {
   static const SearchEngineGateway _searchGateway = SearchEngineGateway();
-  static const int currentIndexStateVersion = 5;
   static const String _booksDoneKey = 'key-books-done';
-  static const String _indexStateVersionKey = 'key-index-state-version';
   static const String _catalogueOrderSignatureKey =
       'key-catalogue-order-signature';
 
@@ -36,7 +34,11 @@ class TantivyDataProvider {
 
   // Track ongoing counts to prevent duplicates
   static final Set<String> _ongoingCounts = {};
-  int _storedIndexStateVersion = 0;
+  /// האם האינדקס הקיים על הדיסק תואם לגרסת מנוע החיפוש הנוכחית.
+  /// מחושב בעת האתחול באמצעות [checkIndexCompatibility] של מנוע החיפוש,
+  /// שמזהה את גרסת סכמת האינדקס שעל הדיסק ומשווה אותה לגרסה שהמנוע דורש.
+  /// כל עוד אין אינדקס קיים הערך נשאר true (אין מה לבדוק).
+  bool _indexCompatible = true;
   String? _catalogueOrderSignature;
 
   Box? _hiveBox;
@@ -72,6 +74,10 @@ class TantivyDataProvider {
     final indexPath = await AppPaths.getIndexPath();
     final indexExistedBefore = Directory(indexPath).existsSync();
     _indexExistedBeforeInit = indexExistedBefore;
+
+    // בדיקת תאימות האינדקס שעל הדיסק לפני פתיחת המנוע (שכותב מטא-נתונים
+    // מעודכנים לאינדקס תואם). כך נזהה אינדקס שנבנה בגרסת מנוע ישנה.
+    _indexCompatible = _evaluateIndexCompatibility(indexPath, indexExistedBefore);
 
     // Load persisted booksDone from disk.
     await _loadBooksDone();
@@ -207,7 +213,6 @@ class TantivyDataProvider {
       booksDone = await _readBooksDoneFromBox(lockPath);
 
       final box = await _openBox(lockPath);
-      _storedIndexStateVersion = _readIndexStateVersionFromBox(box);
       _catalogueOrderSignature = _readCatalogueOrderSignatureFromBox(box);
     } catch (e) {
       debugPrint('⚠️ Error loading books done: $e');
@@ -224,64 +229,64 @@ class TantivyDataProvider {
     return [];
   }
 
-  int _readIndexStateVersionFromBox(Box box) {
-    final dynamic value = box.get(_indexStateVersionKey, defaultValue: 0);
-    if (value is int) return value;
-    if (value is num) return value.toInt();
-    return 0;
-  }
-
   String? _readCatalogueOrderSignatureFromBox(Box box) {
     final dynamic value = box.get(_catalogueOrderSignatureKey);
     if (value is String && value.isNotEmpty) return value;
     return null;
   }
 
-  @visibleForTesting
-  static bool shouldInvalidateStoredIndexState({
-    required int storedIndexStateVersion,
-    required String? storedCatalogueOrderSignature,
-    required String currentCatalogueOrderSignature,
-  }) {
-    return storedIndexStateVersion != currentIndexStateVersion ||
-        storedCatalogueOrderSignature != currentCatalogueOrderSignature;
+  /// בודק אם האינדקס הקיים בנתיב [indexPath] תואם לגרסת מנוע החיפוש הנוכחית.
+  ///
+  /// משתמש ב-[checkIndexCompatibility] של מנוע החיפוש, שקורא את מטא-הנתונים
+  /// של האינדקס ומזהה את גרסת הסכמה שלו. מחזיר true כשאין אינדקס קיים
+  /// (אין מה לבדוק) או כשהאינדקס תואם. אם הבדיקה עצמה נכשלת לא מכריחים
+  /// בנייה מחדש כדי לא לפגוע במשתמש בלי סיבה ודאית.
+  bool _evaluateIndexCompatibility(String indexPath, bool indexExists) {
+    if (!indexExists) {
+      return true;
+    }
+    try {
+      final compatibility = checkIndexCompatibility(path: indexPath);
+      if (!compatibility.compatible) {
+        debugPrint(
+          '⚠️ אינדקס החיפוש אינו תואם לגרסת המנוע הנוכחית '
+          '(status=${compatibility.status}, '
+          'foundSchemaVersion=${compatibility.foundSchemaVersion}, '
+          'requiredSchemaVersion=${compatibility.requiredSchemaVersion}) '
+          '- נדרש איפוס ובנייה מחדש',
+        );
+      }
+      return compatibility.compatible;
+    } catch (e) {
+      debugPrint('⚠️ כשל בבדיקת תאימות האינדקס: $e');
+      return true;
+    }
   }
 
   @visibleForTesting
   static bool shouldPromptForManualReindex({
     required bool indexExistedBeforeInit,
-    required int storedIndexStateVersion,
-    required String? storedCatalogueOrderSignature,
-    required String currentCatalogueOrderSignature,
+    required bool indexCompatible,
   }) {
-    return indexExistedBeforeInit &&
-        storedIndexStateVersion != currentIndexStateVersion;
+    return indexExistedBeforeInit && !indexCompatible;
   }
 
-  bool requiresManualReindex({
-    required String currentCatalogueOrderSignature,
-  }) {
+  /// מחזיר האם נדרש איפוס ובנייה מחדש של האינדקס באישור המשתמש, כלומר כשקיים
+  /// על הדיסק אינדקס שאינו תואם לגרסת סכמת מנוע החיפוש הנוכחית.
+  bool requiresManualReindex() {
     return shouldPromptForManualReindex(
       indexExistedBeforeInit: _indexExistedBeforeInit,
-      storedIndexStateVersion: _storedIndexStateVersion,
-      storedCatalogueOrderSignature: _catalogueOrderSignature,
-      currentCatalogueOrderSignature: currentCatalogueOrderSignature,
+      indexCompatible: _indexCompatible,
     );
   }
 
-  Future<bool> ensureIndexStateMatchesCatalogue(
-    String currentCatalogueOrderSignature,
-  ) async {
-    if (!requiresManualReindex(
-      currentCatalogueOrderSignature: currentCatalogueOrderSignature,
-    )) {
+  Future<bool> ensureIndexStateMatchesCatalogue() async {
+    if (!requiresManualReindex()) {
       return false;
     }
 
     debugPrint(
-      '⚠️ מצב האינדקס לא תואם לקטלוג הנוכחי '
-      '(version=$_storedIndexStateVersion, '
-      'signatureMatch=${_catalogueOrderSignature == currentCatalogueOrderSignature}) '
+      '⚠️ אינדקס החיפוש אינו תואם לגרסת המנוע הנוכחית '
       '- נדרש איפוס ואינדוקס ידני באישור המשתמש',
     );
     return true;
@@ -292,7 +297,8 @@ class TantivyDataProvider {
   ) async {
     final lockPath = await AppPaths.getTantivyLockPath();
     booksDone = [];
-    _storedIndexStateVersion = currentIndexStateVersion;
+    // לאחר האיפוס והבנייה מחדש המנוע יכתוב מטא-נתונים תואמים לאינדקס החדש.
+    _indexCompatible = true;
     _catalogueOrderSignature = currentCatalogueOrderSignature;
     await _persistIndexState(lockPath);
   }
@@ -300,7 +306,6 @@ class TantivyDataProvider {
   Future<void> _persistIndexState(String directory) async {
     final box = await _openBox(directory);
     await box.put(_booksDoneKey, booksDone);
-    await box.put(_indexStateVersionKey, _storedIndexStateVersion);
     await box.put(_catalogueOrderSignatureKey, _catalogueOrderSignature ?? '');
   }
 
@@ -652,7 +657,8 @@ class TantivyDataProvider {
   Future<void> clear() async {
     isIndexing.value = false;
     booksDone.clear();
-    _storedIndexStateVersion = currentIndexStateVersion;
+    // האינדקס נמחק ונבנה מחדש מאפס, ולכן יהיה תואם לגרסת המנוע הנוכחית.
+    _indexCompatible = true;
 
     // שחרור משאבים לפני מחיקה פיזית של הקבצים (חשוב במיוחד ב-Windows
     // שבו קבצים פתוחים אינם ניתנים למחיקה).

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -72,9 +72,7 @@ class IndexingRepository {
       return false;
     }
     await _tantivyDataProvider.engine;
-    return _tantivyDataProvider.requiresManualReindex(
-      currentCatalogueOrderSignature: buildCatalogueOrderSignature(library),
-    );
+    return _tantivyDataProvider.requiresManualReindex();
   }
 
   Future<void> prepareForManualReindex(Library library) async {
@@ -96,9 +94,8 @@ class IndexingRepository {
   }) async {
     final allBooks = library.getAllBooks();
     final totalBooks = allBooks.length;
-    final catalogueOrderSignature = buildCatalogueOrderSignature(library);
-    final requiresManualReindex = await _tantivyDataProvider
-        .ensureIndexStateMatchesCatalogue(catalogueOrderSignature);
+    final requiresManualReindex =
+        await _tantivyDataProvider.ensureIndexStateMatchesCatalogue();
 
     if (shouldUseFastPath(
       books: allBooks,

--- a/test/data/data_providers/tantivy_data_provider_test.dart
+++ b/test/data/data_providers/tantivy_data_provider_test.dart
@@ -2,73 +2,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 
 void main() {
-  group('TantivyDataProvider.shouldInvalidateStoredIndexState', () {
-    test('מחזיר true כשגרסת מצב האינדקס השתנתה', () {
-      final shouldInvalidate =
-          TantivyDataProvider.shouldInvalidateStoredIndexState(
-        storedIndexStateVersion:
-            TantivyDataProvider.currentIndexStateVersion - 1,
-        storedCatalogueOrderSignature: 'same-signature',
-        currentCatalogueOrderSignature: 'same-signature',
-      );
-
-      expect(shouldInvalidate, isTrue);
-    });
-
-    test('מחזיר true כשחתימת הקטלוג השתנתה', () {
-      final shouldInvalidate =
-          TantivyDataProvider.shouldInvalidateStoredIndexState(
-        storedIndexStateVersion: TantivyDataProvider.currentIndexStateVersion,
-        storedCatalogueOrderSignature: 'old-signature',
-        currentCatalogueOrderSignature: 'new-signature',
-      );
-
-      expect(shouldInvalidate, isTrue);
-    });
-
-    test('מחזיר false כשהגרסה והחתימה תואמות', () {
-      final shouldInvalidate =
-          TantivyDataProvider.shouldInvalidateStoredIndexState(
-        storedIndexStateVersion: TantivyDataProvider.currentIndexStateVersion,
-        storedCatalogueOrderSignature: 'same-signature',
-        currentCatalogueOrderSignature: 'same-signature',
-      );
-
-      expect(shouldInvalidate, isFalse);
-    });
-  });
-
   group('TantivyDataProvider.shouldPromptForManualReindex', () {
-    test('מחזיר false כשאין אינדקס קיים גם אם הגרסה השתנתה', () {
+    test('מחזיר false כשאין אינדקס קיים גם אם האינדקס אינו תואם', () {
       final shouldPrompt = TantivyDataProvider.shouldPromptForManualReindex(
         indexExistedBeforeInit: false,
-        storedIndexStateVersion:
-            TantivyDataProvider.currentIndexStateVersion - 1,
-        storedCatalogueOrderSignature: 'same-signature',
-        currentCatalogueOrderSignature: 'same-signature',
+        indexCompatible: false,
       );
 
       expect(shouldPrompt, isFalse);
     });
 
-    test('מחזיר true כשיש אינדקס קיים והגרסה השתנתה', () {
+    test('מחזיר true כשיש אינדקס קיים שאינו תואם לגרסת המנוע', () {
       final shouldPrompt = TantivyDataProvider.shouldPromptForManualReindex(
         indexExistedBeforeInit: true,
-        storedIndexStateVersion:
-            TantivyDataProvider.currentIndexStateVersion - 1,
-        storedCatalogueOrderSignature: 'same-signature',
-        currentCatalogueOrderSignature: 'same-signature',
+        indexCompatible: false,
       );
 
       expect(shouldPrompt, isTrue);
     });
 
-    test('מחזיר false כשרק חתימת הקטלוג השתנתה והגרסה תואמת', () {
+    test('מחזיר false כשיש אינדקס קיים שתואם לגרסת המנוע', () {
       final shouldPrompt = TantivyDataProvider.shouldPromptForManualReindex(
         indexExistedBeforeInit: true,
-        storedIndexStateVersion: TantivyDataProvider.currentIndexStateVersion,
-        storedCatalogueOrderSignature: 'old-signature',
-        currentCatalogueOrderSignature: 'new-signature',
+        indexCompatible: true,
       );
 
       expect(shouldPrompt, isFalse);

--- a/test/indexing/repository/indexing_repository_test.dart
+++ b/test/indexing/repository/indexing_repository_test.dart
@@ -206,8 +206,6 @@ void main() {
           .where(IndexingRepository.isIndexableBook)
           .map(IndexingRepository.catalogueOrderKey)
           .toList();
-      final catalogueOrderSignature =
-          IndexingRepository.buildCatalogueOrderSignature(library);
       final provider = FakeTantivyDataProvider(
         booksDoneValue: indexedBookKeys,
         ensureIndexStateMatchesCatalogueValue: false,
@@ -235,10 +233,7 @@ void main() {
       expect(result, isTrue);
       expect(actualIndexingStarted, isFalse);
       expect(progressCalls, 0);
-      expect(
-        provider.ensureIndexStateMatchesCatalogueCalls,
-        [catalogueOrderSignature],
-      );
+      expect(provider.ensureIndexStateMatchesCatalogueCalls, 1);
       expect(isolateService.wasUsed, isFalse);
     });
 
@@ -249,8 +244,6 @@ void main() {
           .where(IndexingRepository.isIndexableBook)
           .map(IndexingRepository.catalogueOrderKey)
           .toList();
-      final catalogueOrderSignature =
-          IndexingRepository.buildCatalogueOrderSignature(library);
       final provider = FakeTantivyDataProvider(
         booksDoneValue: indexedBookKeys,
         ensureIndexStateMatchesCatalogueValue: true,
@@ -278,10 +271,7 @@ void main() {
       expect(result, isFalse);
       expect(actualIndexingStarted, isFalse);
       expect(progressCalls, 0);
-      expect(
-        provider.ensureIndexStateMatchesCatalogueCalls,
-        [catalogueOrderSignature],
-      );
+      expect(provider.ensureIndexStateMatchesCatalogueCalls, 1);
       expect(isolateService.wasUsed, isFalse);
     });
   });
@@ -455,16 +445,14 @@ class FakeTantivyDataProvider implements TantivyDataProvider {
 
   final List<String> booksDoneValue;
   final bool ensureIndexStateMatchesCatalogueValue;
-  final List<String> ensureIndexStateMatchesCatalogueCalls = [];
+  int ensureIndexStateMatchesCatalogueCalls = 0;
 
   @override
   List<String> get booksDone => booksDoneValue;
 
   @override
-  Future<bool> ensureIndexStateMatchesCatalogue(
-    String currentCatalogueOrderSignature,
-  ) async {
-    ensureIndexStateMatchesCatalogueCalls.add(currentCatalogueOrderSignature);
+  Future<bool> ensureIndexStateMatchesCatalogue() async {
+    ensureIndexStateMatchesCatalogueCalls++;
     return ensureIndexStateMatchesCatalogueValue;
   }
 


### PR DESCRIPTION
## סיכום
שינוי מנגנון בדיקת תאימות האינדקס מעקיבה אחר גרסה מאוחסנת לשימוש בבדיקת סכמה ישירה של מנוע החיפוש. הגישה החדשה מזהה אי-תאימות בעת ההאתחול על ידי קריאה למטא-נתונים של האינדקס, במקום להסתמך על ערך גרסה שמאוחסן בדיסק.

## שינויים עיקריים

- **הסרת מנגנון גרסה מאוחסן**: הוסרו `currentIndexStateVersion` ו-`_indexStateVersionKey` שלא היו מעודכנים כראוי
- **החלפה ב-`_indexCompatible`**: שדה בוליאני חדש המחזיק את תוצאת בדיקת התאימות שנעשית בעת ההאתחול
- **בדיקה בעת ההאתחול**: הוספת `_evaluateIndexCompatibility()` שקוראת ל-`checkIndexCompatibility()` של מנוע החיפוש לפני פתיחתו
- **פישוט ממשקים**: 
  - `requiresManualReindex()` כעת לא דורש פרמטר `currentCatalogueOrderSignature`
  - `ensureIndexStateMatchesCatalogue()` כעת לא דורש פרמטר `currentCatalogueOrderSignature`
  - `shouldPromptForManualReindex()` כעת מקבל `bool indexCompatible` במקום גרסה וחתימה
- **הסרת קוד מיותר**: הוסרה `_readIndexStateVersionFromBox()` ופעולות כתיבה/קריאה של גרסה מ-Hive
- **עדכון בדיקות**: פישוט בדיקות יחידה להשתמש בשדה `indexCompatible` החדש

## פרטי יישום

- בדיקת התאימות מתבצעת בשלב מוקדם של `initialize()`, לפני פתיחת מנוע החיפוש
- אם הבדיקה עצמה נכשלת, מחזירים `true` (תואם) כדי לא לכפות בנייה מחדש ללא סיבה ודאית
- הערך `_indexCompatible` נשאר `true` כל עוד אין אינדקס קיים (אין מה לבדוק)
- לאחר איפוס ובנייה מחדש, `_indexCompatible` מוגדר ל-`true` מכיוון שהאינדקס החדש תואם בהגדרה

https://claude.ai/code/session_019ayE9oPYGLeMD1gjCWuapY