### PR TITLE
הסרת קוד מת של חתימת סדר הקטלוג

### DIFF
--- a/lib/data/data_providers/tantivy_data_provider.dart
+++ b/lib/data/data_providers/tantivy_data_provider.dart
@@ -13,8 +13,6 @@ import 'package:otzaria/core/app_paths.dart';
 class TantivyDataProvider {
   static const SearchEngineGateway _searchGateway = SearchEngineGateway();
   static const String _booksDoneKey = 'key-books-done';
-  static const String _catalogueOrderSignatureKey =
-      'key-catalogue-order-signature';
 
   /// Instance of the search engine pointing to the index directory
   late Future<SearchEngine> engine;
@@ -39,7 +37,6 @@ class TantivyDataProvider {
   /// שמזהה את גרסת סכמת האינדקס שעל הדיסק ומשווה אותה לגרסה שהמנוע דורש.
   /// כל עוד אין אינדקס קיים הערך נשאר true (אין מה לבדוק).
   bool _indexCompatible = true;
-  String? _catalogueOrderSignature;
 
   Box? _hiveBox;
   String? _hiveBoxDirectory;
@@ -56,8 +53,8 @@ class TantivyDataProvider {
   /// Indicates whether the indexing process is currently running
   ValueNotifier<bool> isIndexing = ValueNotifier(false);
 
-  /// מסמן שהטעינה האסינכרונית של מצב האינדקס מהדיסק (booksDone, חתימת קטלוג וכו')
-  /// הסתיימה. עד שהערך הופך ל-true, אסור להסיק "אין אינדקס" מ-booksDone.isEmpty.
+  /// מסמן שהטעינה האסינכרונית של מצב האינדקס מהדיסק (booksDone) הסתיימה.
+  /// עד שהערך הופך ל-true, אסור להסיק "אין אינדקס" מ-booksDone.isEmpty.
   final ValueNotifier<bool> isInitialized = ValueNotifier(false);
 
   /// Maintains a list of processed books to avoid reindexing
@@ -211,9 +208,6 @@ class TantivyDataProvider {
     try {
       final lockPath = await AppPaths.getTantivyLockPath();
       booksDone = await _readBooksDoneFromBox(lockPath);
-
-      final box = await _openBox(lockPath);
-      _catalogueOrderSignature = _readCatalogueOrderSignatureFromBox(box);
     } catch (e) {
       debugPrint('⚠️ Error loading books done: $e');
       booksDone = [];
@@ -227,12 +221,6 @@ class TantivyDataProvider {
       return value.map<String>((e) => e.toString()).toList();
     }
     return [];
-  }
-
-  String? _readCatalogueOrderSignatureFromBox(Box box) {
-    final dynamic value = box.get(_catalogueOrderSignatureKey);
-    if (value is String && value.isNotEmpty) return value;
-    return null;
   }
 
   /// בודק אם האינדקס הקיים בנתיב [indexPath] תואם לגרסת מנוע החיפוש הנוכחית.
@@ -292,21 +280,17 @@ class TantivyDataProvider {
     return true;
   }
 
-  Future<void> prepareForManualReindex(
-    String currentCatalogueOrderSignature,
-  ) async {
+  Future<void> prepareForManualReindex() async {
     final lockPath = await AppPaths.getTantivyLockPath();
     booksDone = [];
     // לאחר האיפוס והבנייה מחדש המנוע יכתוב מטא-נתונים תואמים לאינדקס החדש.
     _indexCompatible = true;
-    _catalogueOrderSignature = currentCatalogueOrderSignature;
     await _persistIndexState(lockPath);
   }
 
   Future<void> _persistIndexState(String directory) async {
     final box = await _openBox(directory);
     await box.put(_booksDoneKey, booksDone);
-    await box.put(_catalogueOrderSignatureKey, _catalogueOrderSignature ?? '');
   }
 
   Future<void> _handleSchemaError() async {

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
-import 'package:crypto/crypto.dart';
 import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
@@ -75,11 +73,9 @@ class IndexingRepository {
     return _tantivyDataProvider.requiresManualReindex();
   }
 
-  Future<void> prepareForManualReindex(Library library) async {
+  Future<void> prepareForManualReindex() async {
     await _tantivyDataProvider.engine;
-    await _tantivyDataProvider.prepareForManualReindex(
-      buildCatalogueOrderSignature(library),
-    );
+    await _tantivyDataProvider.prepareForManualReindex();
   }
 
   /// Indexes all books in the provided library.
@@ -558,14 +554,6 @@ class IndexingRepository {
       return -1;
     }
     return encodedCatalogueOrder - 1;
-  }
-
-  static String buildCatalogueOrderSignature(Library library) {
-    final orderedKeys = SearchCatalogueOrderHelper.buildOrderedKeys(
-      library,
-      keyOf: (book) => catalogueOrderKey(book as Book),
-    );
-    return sha1.convert(utf8.encode(orderedKeys.join('\n'))).toString();
   }
 
   static String catalogueOrderKey(Book book) {

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -597,7 +597,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
 
     switch (decision) {
       case StartupIndexingDecision.autoReindexThenStart:
-        await _indexingRepository.prepareForManualReindex(library);
+        await _indexingRepository.prepareForManualReindex();
         if (!mounted || !context.mounted) {
           return;
         }
@@ -646,7 +646,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
         return;
       }
 
-      await _indexingRepository.prepareForManualReindex(library);
+      await _indexingRepository.prepareForManualReindex();
       if (!mounted || !context.mounted) {
         return;
       }

--- a/lib/settings/tabs/library_settings_tab.dart
+++ b/lib/settings/tabs/library_settings_tab.dart
@@ -489,9 +489,7 @@ class _LibrarySettingsTabState extends State<LibrarySettingsTab> {
                                     context.read<IndexingBloc>();
 
                                 await _indexingRepository
-                                    .prepareForManualReindex(
-                                  library,
-                                );
+                                    .prepareForManualReindex();
                                 if (!mounted) {
                                   return;
                                 }

--- a/test/indexing/repository/indexing_repository_test.dart
+++ b/test/indexing/repository/indexing_repository_test.dart
@@ -312,30 +312,6 @@ void main() {
     });
   });
 
-  group('IndexingRepository.buildCatalogueOrderSignature', () {
-    test('משתנה כשסדר הקטלוג משתנה', () {
-      final firstLibrary = _buildLibrary(
-        bavliBooks: const [
-          ('שבת', 1),
-          ('חגיגה', 2),
-        ],
-      );
-      final secondLibrary = _buildLibrary(
-        bavliBooks: const [
-          ('שבת', 2),
-          ('חגיגה', 1),
-        ],
-      );
-
-      expect(
-        IndexingRepository.buildCatalogueOrderSignature(firstLibrary),
-        isNot(
-          IndexingRepository.buildCatalogueOrderSignature(secondLibrary),
-        ),
-      );
-    });
-  });
-
   group('IndexingRepository.isIndexableBook', () {
     test('DocxBook נכלל באינדוקס דרך מיפוי ל-TextBook', () {
       // רגרסיה: לפני התיקון `isIndexableBook` החזיר false ל-DocxBook,


### PR DESCRIPTION
## רקע

ב-PR #421 הוחלף מנגנון זיהוי האינדקס הלא-מעודכן מקבוע גרסה בצד Dart לבדיקת `checkIndexCompatibility` של מנוע החיפוש. בעקבות זאת, חתימת סדר הקטלוג (`_catalogueOrderSignature`) הפכה לקוד מת — היא נטענת מ-Hive, נשמרת ונכתבת חזרה, אך **אינה משתתפת בשום השוואה או החלטה**.

זאת בדיוק ההערה שהעלה Gemini בסקירת #421 (אפשרות 2 — ניקוי קוד מת).

> הערה: החתימה הייתה רדומה כבר לפני #421 — ההשוואה היחידה שלה (`shouldInvalidateStoredIndexState`) מעולם לא נקראה מקוד lib אלא מטסטים בלבד. כלומר שינוי בסדר הקטלוג מעולם לא הפעיל אינדוקס מחדש, וזה אינו שינוי התנהגות שה-PR הזה מכניס.

## מה השתנה

הסרת כל הקוד הקשור ל-`_catalogueOrderSignature`:

- השדה `_catalogueOrderSignature`, הקבוע `_catalogueOrderSignatureKey`, והפונקציה `_readCatalogueOrderSignatureFromBox`
- הקריאה/כתיבה ל-Hive ב-`_loadBooksDone` וב-`_persistIndexState`
- הפרמטר `currentCatalogueOrderSignature` ב-`prepareForManualReindex` (גם בספק וגם בריפו) ובשלושת הקוראים (`main_window_screen`, `library_settings_tab`)
- `buildCatalogueOrderSignature` והטסט שלו, וייבוא `crypto`/`dart:convert` שנעשו יתומים

ללא שינוי התנהגות. מנגנון זיהוי התאימות (`checkIndexCompatibility`) ופונקציות מיון הקטלוג (`catalogueOrderKey`, `buildCatalogueDocumentId`, `SearchCatalogueOrderHelper`) נשארים כמות שהם.

סך הכל: 8 הוספות, 62 מחיקות.

## בדיקות

⚠️ לא הצלחתי להריץ `flutter analyze`/`flutter test` בסביבת הפיתוח (אין dart/flutter מותקנים). מומלץ לאמת מקומית:
```bash
flutter analyze
flutter test test/indexing/repository/indexing_repository_test.dart test/data/data_providers/tantivy_data_provider_test.dart
```

https://claude.ai/code/session_019ayE9oPYGLeMD1gjCWuapY

---
_Generated by [Claude Code](https://claude.ai/code/session_019ayE9oPYGLeMD1gjCWuapY)_