### PR TITLE
המרת DOCX: דילוג על תמונות-רקע דקורטיביות ותמיכה בתיבות-טקסט

### DIFF
--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -11,7 +11,9 @@ import 'dart:convert';
 /// v2: תמונות מוטמעות (data URI) וטבלאות עשירות. v3: רשימות ממוספרות
 /// מקוננות (decimal/רומי/אותיות לטיניות/עבריות/multilevel) לפי numbering.xml.
 /// v4: בקרות-תוכן (`w:sdt`) וטבלאות מקוננות בתאים — מניעת אובדן תוכן.
-const int kDocxConverterVersion = 4;
+/// v5: תיבות-טקסט (`w:txbxContent`) — טקסט בתוך מסגרת, אולי על תמונת-רקע.
+/// v6: דילוג על מסגרות-רקע דקורטיביות (`behindDoc`) שאינן ניתנות לרינדור.
+const int kDocxConverterVersion = 6;
 
 // Windows-1255 Hebrew range: 0xC0–0xD8 and 0xE0–0xFA map to Unicode with offset 1264.
 // 0xE0 (224) + 1264 = 1488 = U+05D0 = א, ... 0xFA (250) + 1264 = 1514 = U+05EA = ת
@@ -301,20 +303,74 @@ Map<String, String> _extractImages(Archive archive) {
   return images;
 }
 
-/// אם ה-run מכיל תמונה מוטמעת (DrawingML `a:blip` או VML `v:imagedata`)
-/// שיש לה data URI מוכן — מחזיר תג `<img>`; אחרת `null`.
-String? _imageHtmlFromRun(xml.XmlElement run, Map<String, String> images) {
+/// מחזיר את ה-data URI של תמונה מוטמעת ב-run (DrawingML `a:blip` או VML
+/// `v:imagedata`), או `null`.
+String? _imageUriFromRun(xml.XmlElement run, Map<String, String> images) {
   if (images.isEmpty) return null;
   for (final blip in run.findAllElements('a:blip')) {
     final id = blip.getAttribute('r:embed') ?? blip.getAttribute('r:link');
     final uri = id == null ? null : images[id];
-    if (uri != null) return '<img src="$uri" style="max-width: 100%;"/>';
+    if (uri != null) return uri;
   }
   for (final data in run.findAllElements('v:imagedata')) {
     final id = data.getAttribute('r:id');
     final uri = id == null ? null : images[id];
-    if (uri != null) return '<img src="$uri" style="max-width: 100%;"/>';
+    if (uri != null) return uri;
   }
+  return null;
+}
+
+/// האם הגרפיקה היא תמונה צפה *מאחורי* הטקסט (`wp:anchor behindDoc="1"`) —
+/// מסגרת/סימן-מים דקורטיבי שנועד לרקע-עמוד. במודל שורה-אחר-שורה של הקורא
+/// אי אפשר לרנדר רקע-עמוד, וזה מופיע כבלוק ריק מבלבל — ולכן מדולג.
+bool _isBehindDocDrawing(xml.XmlElement run) {
+  for (final anchor in run.findAllElements('wp:anchor')) {
+    final bd = anchor.getAttribute('behindDoc');
+    if (bd == '1' || bd == 'true') return true;
+  }
+  return false;
+}
+
+/// מעבד גרפיקה ב-run ומחזיר HTML, או `null` אם אין.
+///
+/// - **תיבת-טקסט / שייפ עם טקסט** (`w:txbxContent`): הטקסט נעטף במסגרת
+///   (`<div>` עם border). אם לשייפ יש גם תמונת-רקע — היא מוטמעת כ-
+///   `background-image` (טקסט *על* התמונה). כך טקסט בתוך מסגרת לא נאבד.
+/// - **תמונה בלבד**: `<img>` (data URI, offline).
+/// - **מסגרת-רקע דקורטיבית** (`behindDoc`): מדולגת (ראו [_isBehindDocDrawing]).
+String? _drawingHtmlFromRun(xml.XmlElement run, _DocxContext ctx) {
+  // תמונת-רקע מאחורי הטקסט — לא ניתנת לרינדור כרקע-עמוד; מדלגים על התמונה
+  // (אך עדיין מעבדים טקסט-בתיבה אם קיים, כדי לא לאבד תוכן).
+  final imgUri =
+      _isBehindDocDrawing(run) ? null : _imageUriFromRun(run, ctx.images);
+
+  xml.XmlElement? txbx;
+  for (final t in run.findAllElements('w:txbxContent')) {
+    txbx = t;
+    break;
+  }
+
+  if (txbx != null) {
+    final parts = <String>[];
+    for (final child in _collectChildren(txbx, const {'w:p', 'w:tbl'})) {
+      if (child.name.qualified == 'w:p') {
+        final inline = _renderParagraphInline(child, ctx);
+        if (inline.trim().isNotEmpty) parts.add(inline.trim());
+      } else {
+        final nested = _buildTableHtml(child, ctx);
+        if (nested != null) parts.add(nested);
+      }
+    }
+    if (parts.isEmpty && imgUri == null) return null;
+    final bg = imgUri != null
+        ? 'background-image: url($imgUri); background-size: contain; '
+            'background-repeat: no-repeat; background-position: center; '
+        : '';
+    return '<div style="${bg}border: 1px solid #999; '
+        'padding: 8px; margin: 4px 0;">${parts.join('<br>')}</div>';
+  }
+
+  if (imgUri != null) return '<img src="$imgUri" style="max-width: 100%;"/>';
   return null;
 }
 
@@ -524,9 +580,19 @@ _Seg? _processRunSeg(xml.XmlElement node) {
 /// בפורמט שהקורא של אוצריא מציג כמפרש בצד:
 ///   `<sup class="footnote-marker">N</sup><i class="footnote">גוף</i>`
 String _renderParagraphInline(xml.XmlElement paragraph, _DocxContext ctx) {
+  // runs שבתוך תיבות-טקסט (`w:txbxContent`) מעובדים *בתוך* התיבה (ב-
+  // _drawingHtmlFromRun), לא inline — אחרת findAllElements היה תופס אותם
+  // פעמיים. אוספים אותם לדילוג.
+  final txbxRuns = <xml.XmlElement>{};
+  for (final tb in paragraph.findAllElements('w:txbxContent')) {
+    txbxRuns.addAll(tb.findAllElements('w:r'));
+  }
+
   // שלב 1: איסוף מקטעים (segments) מכל ה-runs לפי הסדר.
   final segs = <_Seg>[];
   for (final run in paragraph.findAllElements('w:r')) {
+    if (txbxRuns.contains(run)) continue; // מעובד בתוך תיבת-הטקסט
+
     final footnoteRef = run.getElement('w:footnoteReference');
     if (footnoteRef != null) {
       final id = footnoteRef.getAttribute('w:id');
@@ -538,10 +604,10 @@ String _renderParagraphInline(xml.XmlElement paragraph, _DocxContext ctx) {
       continue;
     }
 
-    // תמונה מוטמעת (offline data URI) — מקטע raw שאינו ממוזג.
-    final imgHtml = _imageHtmlFromRun(run, ctx.images);
-    if (imgHtml != null) {
-      segs.add(_Seg.raw(imgHtml));
+    // גרפיקה: תיבת-טקסט (במסגרת, אולי על תמונת-רקע) או תמונה — מקטע raw.
+    final drawingHtml = _drawingHtmlFromRun(run, ctx);
+    if (drawingHtml != null) {
+      segs.add(_Seg.raw(drawingHtml));
       continue;
     }
 

--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -361,13 +361,17 @@ String? _drawingHtmlFromRun(xml.XmlElement run, _DocxContext ctx) {
         if (nested != null) parts.add(nested);
       }
     }
-    if (parts.isEmpty && imgUri == null) return null;
-    final bg = imgUri != null
-        ? 'background-image: url($imgUri); background-size: contain; '
-            'background-repeat: no-repeat; background-position: center; '
-        : '';
-    return '<div style="${bg}border: 1px solid #999; '
-        'padding: 8px; margin: 4px 0;">${parts.join('<br>')}</div>';
+    // תיבה עם טקסט: עוטפים במסגרת (`<div>`), עם תמונת-הרקע אם קיימת.
+    // תיבה ריקה מטקסט: נופלים לרינדור `<img>` הרגיל בהמשך — `<div>` ריק חסר
+    // גובה ולא היה מציג את תמונת-הרקע ממילא.
+    if (parts.isNotEmpty) {
+      final bg = imgUri != null
+          ? 'background-image: url($imgUri); background-size: contain; '
+              'background-repeat: no-repeat; background-position: center; '
+          : '';
+      return '<div style="${bg}border: 1px solid #999; '
+          'padding: 8px; margin: 4px 0;">${parts.join('<br>')}</div>';
+    }
   }
 
   if (imgUri != null) return '<img src="$imgUri" style="max-width: 100%;"/>';

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -1058,5 +1058,33 @@ void main() {
       expect(result, contains('background-image: url(data:image/png;base64,'),
           reason: 'הטקסט על תמונת-רקע מוטמעת');
     });
+
+    test('תיבת-טקסט ריקה עם תמונה → <img> רגיל ולא div ריק', () {
+      final docXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $drawNs><w:body><w:p><w:r><w:drawing>'
+          '<a:blip r:embed="rId1"/>'
+          '<w:txbxContent><w:p></w:p></w:txbxContent>'
+          '</w:drawing></w:r></w:p></w:body></w:document>';
+      final relsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+          '<Relationship Id="rId1" '
+          'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" '
+          'Target="media/i.png"/></Relationships>';
+      final encoder = ZipEncoder();
+      final archive = Archive();
+      final d = utf8.encode(docXml);
+      final rels = utf8.encode(relsXml);
+      final png = [0x89, 0x50, 0x4E, 0x47];
+      archive.addFile(ArchiveFile('word/document.xml', d.length, d));
+      archive.addFile(
+          ArchiveFile('word/_rels/document.xml.rels', rels.length, rels));
+      archive.addFile(ArchiveFile('word/media/i.png', png.length, png));
+      final result =
+          docxToText(Uint8List.fromList(encoder.encode(archive)), 'ב');
+      expect(result, contains('<img src="data:image/png;base64,'),
+          reason: 'תיבה ריקה מטקסט → התמונה כ-<img> רגיל');
+      expect(result, isNot(contains('background-image')),
+          reason: 'לא div ריק עם background-image (חסר גובה, לא מציג)');
+    });
   });
 }

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -981,4 +981,82 @@ void main() {
       expect(result, contains('תא-סדט'), reason: 'תא עטוף ב-sdt לא נאבד');
     });
   });
+
+  group('docxToText - תיבות-טקסט (textbox / shape)', () {
+    const drawNs = '$_xmlNs '
+        'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" '
+        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"';
+
+    test('טקסט בתוך תיבת-טקסט מוצג במסגרת (div) ולא נכפל', () {
+      final xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $drawNs><w:body><w:p><w:r><w:drawing>'
+          '<w:txbxContent>'
+          '<w:p><w:r><w:t>טקסט בתוך מסגרת</w:t></w:r></w:p>'
+          '</w:txbxContent></w:drawing></w:r></w:p></w:body></w:document>';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('טקסט בתוך מסגרת'));
+      expect(result, contains('border:'), reason: 'נעטף במסגרת');
+      // לא מופיע פעמיים (פעם inline ופעם בתיבה)
+      expect('טקסט בתוך מסגרת'.allMatches(result), hasLength(1));
+    });
+
+    test('מסגרת-רקע דקורטיבית (behindDoc) מדולגת — לא בלוק ריק', () {
+      final docXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $drawNs '
+          'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">'
+          '<w:body>'
+          '<w:p><w:r><w:drawing>'
+          '<wp:anchor behindDoc="1"><a:blip r:embed="rId1"/></wp:anchor>'
+          '</w:drawing></w:r></w:p>'
+          '<w:p><w:r><w:t>כותרת הספר</w:t></w:r></w:p>'
+          '</w:body></w:document>';
+      final relsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+          '<Relationship Id="rId1" '
+          'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" '
+          'Target="media/i.png"/></Relationships>';
+      final encoder = ZipEncoder();
+      final archive = Archive();
+      final d = utf8.encode(docXml);
+      final rels = utf8.encode(relsXml);
+      final png = [0x89, 0x50, 0x4E, 0x47];
+      archive.addFile(ArchiveFile('word/document.xml', d.length, d));
+      archive.addFile(
+          ArchiveFile('word/_rels/document.xml.rels', rels.length, rels));
+      archive.addFile(ArchiveFile('word/media/i.png', png.length, png));
+      final result =
+          docxToText(Uint8List.fromList(encoder.encode(archive)), 'ב');
+      expect(result, contains('כותרת הספר'), reason: 'הטקסט נשמר');
+      expect(result, isNot(contains('<img')),
+          reason: 'מסגרת-הרקע מדולגת — לא מוצגת כבלוק ריק');
+    });
+
+    test('תיבת-טקסט עם תמונת-רקע → טקסט על background-image', () {
+      final docXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $drawNs><w:body><w:p><w:r><w:drawing>'
+          '<a:blip r:embed="rId1"/>'
+          '<w:txbxContent>'
+          '<w:p><w:r><w:t>על התמונה</w:t></w:r></w:p>'
+          '</w:txbxContent></w:drawing></w:r></w:p></w:body></w:document>';
+      final relsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+          '<Relationship Id="rId1" '
+          'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" '
+          'Target="media/i.png"/></Relationships>';
+      final encoder = ZipEncoder();
+      final archive = Archive();
+      final d = utf8.encode(docXml);
+      final rels = utf8.encode(relsXml);
+      final png = [0x89, 0x50, 0x4E, 0x47];
+      archive.addFile(ArchiveFile('word/document.xml', d.length, d));
+      archive.addFile(
+          ArchiveFile('word/_rels/document.xml.rels', rels.length, rels));
+      archive.addFile(ArchiveFile('word/media/i.png', png.length, png));
+      final result =
+          docxToText(Uint8List.fromList(encoder.encode(archive)), 'ב');
+      expect(result, contains('על התמונה'));
+      expect(result, contains('background-image: url(data:image/png;base64,'),
+          reason: 'הטקסט על תמונת-רקע מוטמעת');
+    });
+  });
 }


### PR DESCRIPTION
## הבעיה
מנוע ההמרה `docxToText` טיפל בכל גרפיקה צפה כתמונת `<img>` inline. כתוצאה מכך:
- מסגרות-רקע דקורטיביות (סימני-מים, `behindDoc`) הופיעו כבלוק/תמונה ריקים ומבלבלים.
- טקסט שישב בתוך תיבת-טקסט (`w:txbxContent` / shape) נאבד לגמרי.

## התיקון
- **דילוג על רקע דקורטיבי (v6):** גרפיקה צפה *מאחורי* הטקסט (`wp:anchor behindDoc`) מדולגת — אי אפשר לרנדר רקע-עמוד במודל שורה-אחר-שורה של הקורא, ולכן אין טעם להציגה כתמונה ריקה.
- **תיבות-טקסט (v5):** הטקסט שבתוך תיבת-טקסט נשמר ונעטף ב-`div` עם מסגרת. אם לשייפ יש תמונת-רקע — היא מוטמעת כ-`background-image` (data URI, ללא תלות באינטרנט). ה-runs שבתוך התיבה מסומנים לדילוג ברינדור ה-inline כדי שלא ייכפלו.

## טסטים
3 בדיקות חדשות ב-`docx_to_otzaria_test.dart`: תיבה במסגרת ללא כפילות, דילוג `behindDoc`, וטקסט על `background-image`. כל 77 הבדיקות בקובץ עוברות.
