### PR TITLE
feat(network): add resume support to network.download

### DIFF
--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -2114,6 +2114,7 @@ class PluginBridgeAdapter {
         // תיקיית ההורדות. הנתיב חייב להיות בתוך תיקייה שהמשתמש אישר דרך
         // ui.pickFolder — אותו גבול אבטחה של פעולות ה-fs.
         final destPath = args['destPath'] as String?;
+        final resume = args['resume'] as bool? ?? false;
         if (destPath != null && destPath.isNotEmpty) {
           if (!_isPathInGrantedFolder(destPath)) {
             throw Exception(
@@ -2125,6 +2126,7 @@ class PluginBridgeAdapter {
             isAllowed: (candidate) => PluginNetworkAccessResolver.instance
                 .isUriAllowedForPlugin(candidate, plugin.manifest),
             isRedirectAllowed: isGithubReleaseRedirectAllowed,
+            resume: resume,
           );
           return {'path': result.path, 'filename': result.filename};
         }

--- a/lib/plugins/services/plugin_file_download_service.dart
+++ b/lib/plugins/services/plugin_file_download_service.dart
@@ -116,6 +116,12 @@ class PluginFileDownloadService {
   /// ההורדות), המאפשר לתוסף לשמור את הקובץ למבנה תיקיות שהמשתמש בחר.
   /// תיקיית האב נוצרת במידת הצורך, וקובץ קיים באותו נתיב נדרס.
   ///
+  /// כאשר [resume] הוא `true` ויש קובץ חלקי בנתיב [destPath], ההורדה ממשיכה
+  /// מנקודת הסיום של הקובץ הקיים באמצעות `Range: bytes=N-`. אם השרת מחזיר
+  /// 206 Partial Content — הנתונים מצורפים לקובץ; אם הוא מחזיר 200 (התעלם
+  /// מה-Range) — הקובץ נכתב מחדש. במצב resume כשל לא ימחק את הקובץ החלקי,
+  /// כך שניסיון נוסף יוכל להמשיך מאותה נקודה.
+  ///
   /// **גבול אבטחה:** השירות אינו מאמת את [destPath] — האחריות לוודא שהוא
   /// בתוך תיקייה שהמשתמש אישר מוטלת על הקורא (האדפטר). אכיפת ה-allowlist על
   /// ה-URL ועל כל redirect זהה ל-[downloadToDownloads]: [isAllowed] נבדק על
@@ -129,17 +135,28 @@ class PluginFileDownloadService {
     String destPath, {
     required Future<bool> Function(Uri) isAllowed,
     bool Function(Uri previous, Uri target)? isRedirectAllowed,
+    bool resume = false,
   }) async {
+    final outFile = File(destPath);
+    await outFile.parent.create(recursive: true);
+
+    // אם resume=true ויש קובץ חלקי — שלח Range: bytes=N-
+    final existingBytes =
+        (resume && await outFile.exists()) ? await outFile.length() : 0;
+
     final response = await _fetchFollowingAllowedRedirects(
       downloadUri,
       isAllowed,
       isRedirectAllowed,
+      rangeStart: existingBytes,
     );
 
-    final outFile = File(destPath);
-    await outFile.parent.create(recursive: true);
+    // 206 = השרת כיבד את ה-Range → צרף לקובץ קיים; 200 = כתוב מחדש
+    final shouldAppend = existingBytes > 0 && response.statusCode == 206;
+    final sink = outFile.openWrite(
+      mode: shouldAppend ? FileMode.append : FileMode.write,
+    );
 
-    final sink = outFile.openWrite();
     try {
       await sink.addStream(response.stream.timeout(_stallTimeout));
       await sink.flush();
@@ -148,7 +165,8 @@ class PluginFileDownloadService {
       try {
         await sink.close();
       } catch (_) {}
-      if (await outFile.exists()) {
+      // במצב resume — שמור את הקובץ החלקי לניסיון הבא
+      if (!resume && await outFile.exists()) {
         await outFile.delete();
       }
       rethrow;
@@ -160,11 +178,14 @@ class PluginFileDownloadService {
   /// מבצעת GET תוך מעקב ידני אחרי redirects, כשכל יעד נבדק מול [isAllowed]
   /// ועבור יעדי redirect גם מול [isRedirectAllowed] (בהינתן ה-hop הקודם).
   /// מחזירה את התשובה הסופית (2xx). מנקזת תשובות-ביניים כדי לשחרר sockets.
+  /// [rangeStart] אופציונלי — אם גדול מ-0, מוסיף `Range: bytes=N-` לכל בקשה
+  /// בשרשרת ה-redirects כדי לתמוך בהמשך הורדה (resume).
   Future<http.StreamedResponse> _fetchFollowingAllowedRedirects(
     Uri initialUri,
     Future<bool> Function(Uri) isAllowed,
-    bool Function(Uri previous, Uri target)? isRedirectAllowed,
-  ) async {
+    bool Function(Uri previous, Uri target)? isRedirectAllowed, {
+    int rangeStart = 0,
+  }) async {
     var current = initialUri;
     Uri? previous;
     for (var hop = 0; hop <= _maxRedirects; hop++) {
@@ -178,6 +199,9 @@ class PluginFileDownloadService {
       }
 
       final request = http.Request('GET', current)..followRedirects = false;
+      if (rangeStart > 0) {
+        request.headers['Range'] = 'bytes=$rangeStart-';
+      }
       final response = await _client.send(request).timeout(_stallTimeout);
 
       if (_isRedirect(response.statusCode)) {


### PR DESCRIPTION
Add 
esume parameter to downloadToPath and _fetchFollowingAllowedRedirects to support resuming interrupted downloads via HTTP Range requests.

When 
esume: true is passed and a partial file exists at destPath:
- Sends Range: bytes=N- header (N = existing file size)
- If server returns 206 Partial Content: appends to existing file
- If server returns 200 (Range ignored): overwrites from scratch
- On failure: partial file is preserved for the next attempt

Also update plugin_bridge_adapter.dart to extract 
esume from RPC args and forward it to downloadToPath.

Motivation: large files (e.g. 164 MB ZIPs from GitHub Releases) can stall mid-download. Without resume, each retry starts from byte 0. With resume, retries continue from the last received byte, reducing total transfer time and making large-file downloads reliable despite transient CDN stalls.