### PR TITLE
תיקון ניווט קטע קודם/הבא בפאנל המפרשים: חצייה בין פרקים

### DIFF
--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -154,6 +154,66 @@ CommentatorsNavSelection reduceSubItemTap(
   );
 }
 
+/// יעד ניווט 'קטע קודם/הבא': אינדקס הפרק ברשימת הפרקים והקטע בתוכו
+/// ([verseIdx] = [_kAllChapter] כשהפרק השכן ריק מקטעים ניתנים לבחירה).
+@immutable
+@visibleForTesting
+class CommentatorsVerseStep {
+  final int chapterIndex;
+  final int verseIdx;
+  const CommentatorsVerseStep(this.chapterIndex, this.verseIdx);
+
+  @override
+  bool operator ==(Object other) =>
+      other is CommentatorsVerseStep &&
+      other.chapterIndex == chapterIndex &&
+      other.verseIdx == verseIdx;
+
+  @override
+  int get hashCode => Object.hash(chapterIndex, verseIdx);
+}
+
+/// חישוב טהור של יעד 'קטע קודם' (forward=false) או 'קטע הבא' (forward=true).
+///
+/// [selectablePerChapter] — הקטעים הניתנים לבחירה בכל פרק (לפי סדר הפרקים).
+/// [chapterIndex]/[verseIdx] — המיקום הנוכחי. הניווט חוצה גבולות פרקים:
+/// מתחילת פרק ל'קטע האחרון' של הפרק הקודם, ומסופו ל'קטע הראשון' של הבא.
+/// מחזיר null כשאין יעד (קצה הספר).
+@visibleForTesting
+CommentatorsVerseStep? computeVerseStep(
+  List<List<int>> selectablePerChapter,
+  int chapterIndex,
+  int verseIdx, {
+  required bool forward,
+}) {
+  if (chapterIndex < 0 || chapterIndex >= selectablePerChapter.length) {
+    return null;
+  }
+  final selectable = selectablePerChapter[chapterIndex];
+  // "כל הפרק" ממוקם לפני הקטע הראשון (קדימה) ואחרי האחרון (אחורה).
+  final pos = verseIdx == _kAllChapter
+      ? (forward ? -1 : selectable.length)
+      : selectable.indexOf(verseIdx);
+  if (verseIdx != _kAllChapter && pos < 0) return null;
+
+  final target = forward ? pos + 1 : pos - 1;
+  if (target >= 0 && target < selectable.length) {
+    return CommentatorsVerseStep(chapterIndex, selectable[target]);
+  }
+
+  // חצייה לפרק השכן.
+  final neighborIndex = forward ? chapterIndex + 1 : chapterIndex - 1;
+  if (neighborIndex < 0 || neighborIndex >= selectablePerChapter.length) {
+    return null;
+  }
+  final neighbor = selectablePerChapter[neighborIndex];
+  if (neighbor.isEmpty) {
+    return CommentatorsVerseStep(neighborIndex, _kAllChapter);
+  }
+  return CommentatorsVerseStep(
+      neighborIndex, forward ? neighbor.first : neighbor.last);
+}
+
 class CommentatorsTabScreen extends StatefulWidget {
   final CommentatorsTab tab;
   final Function(OpenedTab) openBookCallback;
@@ -492,7 +552,13 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     if (pos.chapter == null) return;
 
     _initialChapterResolved = true;
-    _onChapterSelected(pos.chapter!, chapters);
+    // בחירת הקטע הספציפי שנפתח (ולא "כל הפרק"), כדי שניווט 'קטע קודם'
+    // יתחיל מהקטע הנוכחי ולא מקצה הפרק.
+    if (pos.verseIdx == _kAllChapter) {
+      _onChapterSelected(pos.chapter!, chapters);
+    } else {
+      _selectInChapter(pos.verseIdx, pos.chapter!, chapters);
+    }
   }
 
   /// גוללת את רשימת הניווט לפרק הנבחר. נקראת בעת פתיחת הפאנל ומעבר
@@ -713,18 +779,6 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     );
   }
 
-  void _selectVerseAndLoad(int verseIdx, List<TocEntry> chapters) {
-    final chapter = _selectedChapter;
-    if (chapter == null) return;
-    _selectVerseInChapter(verseIdx, chapter, chapters);
-  }
-
-  void _selectParaAndLoad(int paraIdx, List<TocEntry> chapters) {
-    final chapter = _selectedChapter;
-    if (chapter == null) return;
-    _selectParaInChapter(paraIdx, chapter, chapters);
-  }
-
   // ── ניווט בין פרקים ────────────────────────────────────────────────────────
 
   void _navigateToPrevChapter(List<TocEntry> chapters) {
@@ -741,69 +795,51 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     }
   }
 
-  void _navigateToPrevVerse(List<TocEntry> chapters) {
-    if (_selectedChapter == null) return;
-    final currentState = widget.tab.bloc.state;
-    final content = currentState is TextBookLoaded
-        ? currentState.content
-        : const <String>[];
-    final hasVerses = _selectedChapter?.children.isNotEmpty ?? false;
-    if (hasVerses) {
-      final selectable = _selectableVerseIndices(_selectedChapter!, content);
-      final currentPos = _selectedVerseIdx == _kAllChapter
-          ? -1
-          : selectable.indexOf(_selectedVerseIdx);
-      if (currentPos <= -1) return;
-      if (currentPos == 0) {
-        _selectVerseAndLoad(_kAllChapter, chapters);
-        return;
-      }
-      _selectVerseAndLoad(selectable[currentPos - 1], chapters);
+  /// הקטעים הניתנים לבחירה בפרק (פסוקים אם יש children, אחרת היסטי פסקאות).
+  List<int> _selectableForChapter(
+      TocEntry chapter, List<TocEntry> chapters, List<String> content) {
+    return chapter.children.isNotEmpty
+        ? _selectableVerseIndices(chapter, content)
+        : _selectableParagraphOffsets(chapters, chapter, content);
+  }
+
+  /// בוחר קטע (פסוק/פסקה) בפרק כלשהו, בהתאם לסוג הפרק.
+  void _selectInChapter(int idx, TocEntry chapter, List<TocEntry> chapters) {
+    if (chapter.children.isNotEmpty) {
+      _selectVerseInChapter(idx, chapter, chapters);
     } else {
-      final selectable =
-          _selectableParagraphOffsets(chapters, _selectedChapter!, content);
-      final currentPos = _selectedVerseIdx == _kAllChapter
-          ? -1
-          : selectable.indexOf(_selectedVerseIdx);
-      if (currentPos <= -1) return;
-      if (currentPos == 0) {
-        _selectParaAndLoad(_kAllChapter, chapters);
-        return;
-      }
-      _selectParaAndLoad(selectable[currentPos - 1], chapters);
+      _selectParaInChapter(idx, chapter, chapters);
     }
   }
 
-  void _navigateToNextVerse(List<TocEntry> chapters) {
-    if (_selectedChapter == null) return;
+  void _navigateVerse(List<TocEntry> chapters, {required bool forward}) {
+    final chapter = _selectedChapter;
+    if (chapter == null) return;
+    final ci = chapters.indexOf(chapter);
+    if (ci < 0) return;
     final currentState = widget.tab.bloc.state;
     final content = currentState is TextBookLoaded
         ? currentState.content
         : const <String>[];
-    final hasVerses = _selectedChapter?.children.isNotEmpty ?? false;
-    if (hasVerses) {
-      final selectable = _selectableVerseIndices(_selectedChapter!, content);
-      if (selectable.isEmpty) return;
-      if (_selectedVerseIdx == _kAllChapter) {
-        _selectVerseAndLoad(selectable.first, chapters);
-        return;
-      }
-      final currentPos = selectable.indexOf(_selectedVerseIdx);
-      if (currentPos < 0 || currentPos + 1 >= selectable.length) return;
-      _selectVerseAndLoad(selectable[currentPos + 1], chapters);
+    final selectablePerChapter = [
+      for (final ch in chapters) _selectableForChapter(ch, chapters, content),
+    ];
+    final step = computeVerseStep(selectablePerChapter, ci, _selectedVerseIdx,
+        forward: forward);
+    if (step == null) return;
+    final target = chapters[step.chapterIndex];
+    if (step.verseIdx == _kAllChapter) {
+      _onChapterSelected(target, chapters);
     } else {
-      final selectable =
-          _selectableParagraphOffsets(chapters, _selectedChapter!, content);
-      if (selectable.isEmpty) return;
-      if (_selectedVerseIdx == _kAllChapter) {
-        _selectParaAndLoad(selectable.first, chapters);
-        return;
-      }
-      final currentPos = selectable.indexOf(_selectedVerseIdx);
-      if (currentPos < 0 || currentPos + 1 >= selectable.length) return;
-      _selectParaAndLoad(selectable[currentPos + 1], chapters);
+      _selectInChapter(step.verseIdx, target, chapters);
     }
   }
+
+  void _navigateToPrevVerse(List<TocEntry> chapters) =>
+      _navigateVerse(chapters, forward: false);
+
+  void _navigateToNextVerse(List<TocEntry> chapters) =>
+      _navigateVerse(chapters, forward: true);
 
   void _openSearchPane() {
     setState(() => _navPaneOpen = true);

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -554,10 +554,22 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     _initialChapterResolved = true;
     // בחירת הקטע הספציפי שנפתח (ולא "כל הפרק"), כדי שניווט 'קטע קודם'
     // יתחיל מהקטע הנוכחי ולא מקצה הפרק.
-    if (pos.verseIdx == _kAllChapter) {
-      _onChapterSelected(pos.chapter!, chapters);
+    final chapter = pos.chapter!;
+    var verseIdx = pos.verseIdx;
+    // בפרק ללא תת-פרקים _findPos מחזיר תמיד "כל הפרק"; נגזור את היסט הפסקה
+    // הנפתחת, אך רק אם הוא ניתן לבחירה (אחרת נשאר "כל הפרק").
+    if (verseIdx == _kAllChapter && chapter.children.isEmpty) {
+      final content = state.content;
+      final paraIdx = lineIndex - chapter.index;
+      if (_selectableParagraphOffsets(chapters, chapter, content)
+          .contains(paraIdx)) {
+        verseIdx = paraIdx;
+      }
+    }
+    if (verseIdx == _kAllChapter) {
+      _onChapterSelected(chapter, chapters);
     } else {
-      _selectInChapter(pos.verseIdx, pos.chapter!, chapters);
+      _selectInChapter(verseIdx, chapter, chapters);
     }
   }
 
@@ -821,9 +833,15 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     final content = currentState is TextBookLoaded
         ? currentState.content
         : const <String>[];
-    final selectablePerChapter = [
-      for (final ch in chapters) _selectableForChapter(ch, chapters, content),
-    ];
+    // computeVerseStep נוגע רק בפרק הנוכחי ובשכן בכיוון — שאר הפרקים ריקים
+    // כדי לא לחשב selectable לכל הספר בכל לחיצה (חוסך O(N) בספרים גדולים).
+    final neighborIndex = forward ? ci + 1 : ci - 1;
+    final selectablePerChapter = List<List<int>>.generate(
+      chapters.length,
+      (i) => (i == ci || i == neighborIndex)
+          ? _selectableForChapter(chapters[i], chapters, content)
+          : const [],
+    );
     final step = computeVerseStep(selectablePerChapter, ci, _selectedVerseIdx,
         forward: forward);
     if (step == null) return;

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -154,6 +154,28 @@ CommentatorsNavSelection reduceSubItemTap(
   );
 }
 
+/// קובע את הקטע שייבחר בפתיחת טאב המפרשים על [lineIndex].
+///
+/// [posVerseIdx] — התוצאה של איתור המיקום (`_findPos`): אינדקס הפסוק בפרק,
+/// או [_kAllChapter] כשלא זוהה קטע ספציפי (למשל בפרק ללא תת-פרקים).
+/// [chapterIndex] — אינדקס תחילת הפרק בתוכן. [hasChildren] — האם לפרק
+/// יש תת-פרקים. [selectableParagraphOffsets] — היסטי הפסקאות הניתנים לבחירה.
+///
+/// בפרק ללא תת-פרקים גוזר את היסט הפסקה שנפתחה, אך רק אם הוא ניתן לבחירה —
+/// כך שניווט 'קטע קודם' יתחיל מהקטע הנוכחי ולא ייתקע על היסט מסונן.
+@visibleForTesting
+int resolveOpenedVerseIdx({
+  required int posVerseIdx,
+  required int lineIndex,
+  required int chapterIndex,
+  required bool hasChildren,
+  required List<int> selectableParagraphOffsets,
+}) {
+  if (posVerseIdx != _kAllChapter || hasChildren) return posVerseIdx;
+  final paraIdx = lineIndex - chapterIndex;
+  return selectableParagraphOffsets.contains(paraIdx) ? paraIdx : _kAllChapter;
+}
+
 /// יעד ניווט 'קטע קודם/הבא': אינדקס הפרק ברשימת הפרקים והקטע בתוכו
 /// ([verseIdx] = [_kAllChapter] כשהפרק השכן ריק מקטעים ניתנים לבחירה).
 @immutable
@@ -552,20 +574,16 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     if (pos.chapter == null) return;
 
     _initialChapterResolved = true;
-    // בחירת הקטע הספציפי שנפתח (ולא "כל הפרק"), כדי שניווט 'קטע קודם'
-    // יתחיל מהקטע הנוכחי ולא מקצה הפרק.
     final chapter = pos.chapter!;
-    var verseIdx = pos.verseIdx;
-    // בפרק ללא תת-פרקים _findPos מחזיר תמיד "כל הפרק"; נגזור את היסט הפסקה
-    // הנפתחת, אך רק אם הוא ניתן לבחירה (אחרת נשאר "כל הפרק").
-    if (verseIdx == _kAllChapter && chapter.children.isEmpty) {
-      final content = state.content;
-      final paraIdx = lineIndex - chapter.index;
-      if (_selectableParagraphOffsets(chapters, chapter, content)
-          .contains(paraIdx)) {
-        verseIdx = paraIdx;
-      }
-    }
+    final verseIdx = resolveOpenedVerseIdx(
+      posVerseIdx: pos.verseIdx,
+      lineIndex: lineIndex,
+      chapterIndex: chapter.index,
+      hasChildren: chapter.children.isNotEmpty,
+      selectableParagraphOffsets: chapter.children.isEmpty
+          ? _selectableParagraphOffsets(chapters, chapter, state.content)
+          : const [],
+    );
     if (verseIdx == _kAllChapter) {
       _onChapterSelected(chapter, chapters);
     } else {

--- a/test/text_book/view/commentators_tab_nav_test.dart
+++ b/test/text_book/view/commentators_tab_nav_test.dart
@@ -169,4 +169,139 @@ void main() {
       expect(next.navExpandedChapter, equals(chA));
     });
   });
+
+  group('computeVerseStep — ניווט קטע קודם/הבא (חוצה פרקים)', () {
+    // שני פרקים: פרק 0 עם קטעים [0,1,2], פרק 1 עם קטעים [0,1].
+    final twoChapters = [
+      [0, 1, 2],
+      [0, 1],
+    ];
+
+    test('קטע הבא בתוך אותו פרק', () {
+      expect(computeVerseStep(twoChapters, 0, 0, forward: true),
+          equals(const CommentatorsVerseStep(0, 1)));
+    });
+
+    test('קטע קודם בתוך אותו פרק', () {
+      expect(computeVerseStep(twoChapters, 0, 2, forward: false),
+          equals(const CommentatorsVerseStep(0, 1)));
+    });
+
+    test('מהקטע האחרון בפרק — קטע הבא חוצה לפרק הבא (קטע ראשון)', () {
+      expect(computeVerseStep(twoChapters, 0, 2, forward: true),
+          equals(const CommentatorsVerseStep(1, 0)));
+    });
+
+    test('מהקטע הראשון בפרק — קטע קודם חוצה לפרק הקודם (קטע אחרון)', () {
+      // ליבת הבאג: פעם הניווט "נתקע" בתחילת הפרק. כעת חוצה אחורה.
+      expect(computeVerseStep(twoChapters, 1, 0, forward: false),
+          equals(const CommentatorsVerseStep(0, 2)));
+    });
+
+    test('"כל הפרק" — קטע קודם יורד לקטע האחרון של אותו פרק', () {
+      expect(computeVerseStep(twoChapters, 0, -1, forward: false),
+          equals(const CommentatorsVerseStep(0, 2)));
+    });
+
+    test('"כל הפרק" — קטע הבא עולה לקטע הראשון של אותו פרק', () {
+      expect(computeVerseStep(twoChapters, 0, -1, forward: true),
+          equals(const CommentatorsVerseStep(0, 0)));
+    });
+
+    test('קצה הספר — קטע קודם מהקטע הראשון בפרק הראשון מחזיר null', () {
+      expect(computeVerseStep(twoChapters, 0, 0, forward: false), isNull);
+    });
+
+    test('קצה הספר — קטע הבא מהקטע האחרון בפרק האחרון מחזיר null', () {
+      expect(computeVerseStep(twoChapters, 1, 1, forward: true), isNull);
+    });
+
+    test('חצייה קדימה לפרק שכן ריק מקטעים — מחזיר "כל הפרק"', () {
+      final withEmpty = [
+        [0, 1],
+        <int>[],
+      ];
+      expect(computeVerseStep(withEmpty, 0, 1, forward: true),
+          equals(const CommentatorsVerseStep(1, -1)));
+    });
+
+    test('חצייה אחורה לפרק שכן ריק מקטעים — מחזיר "כל הפרק"', () {
+      final withEmpty = [
+        <int>[],
+        [0, 1],
+      ];
+      expect(computeVerseStep(withEmpty, 1, 0, forward: false),
+          equals(const CommentatorsVerseStep(0, -1)));
+    });
+
+    test('"כל הפרק" בפרק ריק — קטע קודם חוצה אחורה לקטע האחרון של הקודם', () {
+      final withEmpty = [
+        [0, 1],
+        <int>[],
+      ];
+      expect(computeVerseStep(withEmpty, 1, -1, forward: false),
+          equals(const CommentatorsVerseStep(0, 1)));
+    });
+
+    test('"כל הפרק" בפרק ריק — קטע הבא חוצה קדימה לקטע הראשון של הבא', () {
+      final withEmpty = [
+        <int>[],
+        [0, 1],
+      ];
+      expect(computeVerseStep(withEmpty, 0, -1, forward: true),
+          equals(const CommentatorsVerseStep(1, 0)));
+    });
+
+    test('קצה הספר — "כל הפרק" בפרק יחיד ריק מחזיר null בשני הכיוונים', () {
+      final single = [<int>[]];
+      expect(computeVerseStep(single, 0, -1, forward: false), isNull);
+      expect(computeVerseStep(single, 0, -1, forward: true), isNull);
+    });
+
+    test('אינדקס פרק לא חוקי מחזיר null', () {
+      expect(computeVerseStep(twoChapters, 5, 0, forward: true), isNull);
+    });
+
+    test('verseIdx שאינו ברשימת הקטעים מחזיר null', () {
+      expect(computeVerseStep(twoChapters, 0, 99, forward: true), isNull);
+    });
+  });
+
+  group('computeVerseStep — תרחיש הבאג המקורי (פתיחה + חזרה אחורה)', () {
+    // הבאג: בפתיחה בקטע ספציפי, 'קטע קודם' נתקע בקטע שנפתח ולא ירד מתחתיו.
+    // הרצף מדמה: פתיחה בפרק 1, ואז לחיצות 'קודם' רצופות — עד חצייה לפרק 0,
+    // בלי היתקעות.
+    final book = [
+      [0, 1, 2],
+      [0, 1],
+    ];
+
+    test('פתיחה בקטע הראשון בפרק 1 — קטע קודם חוצה לפרק 0 ולא נתקע', () {
+      final back1 = computeVerseStep(book, 1, 0, forward: false);
+      expect(back1, equals(const CommentatorsVerseStep(0, 2)),
+          reason: 'מהקטע הראשון בפרק 1 יש לחצות לקטע האחרון בפרק 0');
+
+      final back2 = computeVerseStep(book, back1!.chapterIndex, back1.verseIdx,
+          forward: false);
+      expect(back2, equals(const CommentatorsVerseStep(0, 1)));
+
+      final back3 = computeVerseStep(book, back2!.chapterIndex, back2.verseIdx,
+          forward: false);
+      expect(back3, equals(const CommentatorsVerseStep(0, 0)));
+
+      // בקטע הראשון של הפרק הראשון — אין לאן לחזור.
+      expect(
+          computeVerseStep(book, back3!.chapterIndex, back3.verseIdx,
+              forward: false),
+          isNull);
+    });
+
+    test('הלוך-ושוב סימטרי: הבא ואז קודם חוזר לאותו מיקום', () {
+      final fwd = computeVerseStep(book, 0, 2, forward: true);
+      expect(fwd, equals(const CommentatorsVerseStep(1, 0)));
+      final back = computeVerseStep(book, fwd!.chapterIndex, fwd.verseIdx,
+          forward: false);
+      expect(back, equals(const CommentatorsVerseStep(0, 2)));
+    });
+  });
 }

--- a/test/text_book/view/commentators_tab_nav_test.dart
+++ b/test/text_book/view/commentators_tab_nav_test.dart
@@ -330,4 +330,76 @@ void main() {
           equals(const CommentatorsVerseStep(1, 2)));
     });
   });
+
+  group('resolveOpenedVerseIdx — בחירת הקטע בפתיחת הטאב', () {
+    test('פרק עם תת-פרקים — נבחר הפסוק שזוהה (posVerseIdx נשמר)', () {
+      expect(
+        resolveOpenedVerseIdx(
+          posVerseIdx: 2,
+          lineIndex: 12,
+          chapterIndex: 10,
+          hasChildren: true,
+          selectableParagraphOffsets: const [],
+        ),
+        equals(2),
+      );
+    });
+
+    test('פרק עם תת-פרקים ו-posVerseIdx=-1 — נשאר "כל הפרק"', () {
+      // כשלא זוהה פסוק ספציפי בפרק שיש בו תת-פרקים, לא גוזרים היסט פסקה.
+      expect(
+        resolveOpenedVerseIdx(
+          posVerseIdx: -1,
+          lineIndex: 12,
+          chapterIndex: 10,
+          hasChildren: true,
+          selectableParagraphOffsets: const [],
+        ),
+        equals(-1),
+      );
+    });
+
+    test('פרק ללא תת-פרקים — נגזר היסט הפסקה שנפתחה כשהוא ניתן לבחירה', () {
+      // הפער שנסגר: פתיחה על שורה ספציפית בפרק-פסקאות בוחרת את הפסקה,
+      // ולא "כל הפרק" — כך ש'קטע קודם' מיד אחרי הפתיחה עובד.
+      expect(
+        resolveOpenedVerseIdx(
+          posVerseIdx: -1,
+          lineIndex: 13,
+          chapterIndex: 10,
+          hasChildren: false,
+          selectableParagraphOffsets: const [0, 1, 2, 3],
+        ),
+        equals(3),
+      );
+    });
+
+    test('פרק ללא תת-פרקים — היסט מסונן נשאר "כל הפרק" (לא נתקע)', () {
+      // הרגרסיה שנמנעה: לו היינו בוחרים היסט שמסונן מרשימת ה-selectable,
+      // ניווט 'קטע קודם' היה מקבל indexOf==-1 ונתקע.
+      expect(
+        resolveOpenedVerseIdx(
+          posVerseIdx: -1,
+          lineIndex: 10,
+          chapterIndex: 10,
+          hasChildren: false,
+          selectableParagraphOffsets: const [1, 2, 3], // 0 מסונן (כותרת)
+        ),
+        equals(-1),
+      );
+    });
+
+    test('פרק ללא תת-פרקים — הקטע הראשון (היסט 0) נבחר כשהוא ניתן לבחירה', () {
+      expect(
+        resolveOpenedVerseIdx(
+          posVerseIdx: -1,
+          lineIndex: 10,
+          chapterIndex: 10,
+          hasChildren: false,
+          selectableParagraphOffsets: const [0, 1, 2],
+        ),
+        equals(0),
+      );
+    });
+  });
 }

--- a/test/text_book/view/commentators_tab_nav_test.dart
+++ b/test/text_book/view/commentators_tab_nav_test.dart
@@ -304,4 +304,30 @@ void main() {
       expect(back, equals(const CommentatorsVerseStep(0, 2)));
     });
   });
+
+  group('computeVerseStep — חוזה חישוב עצל (רק הנוכחי והשכן מלאים)', () {
+    // _navigateVerse ממלא רק את הפרק הנוכחי ואת השכן בכיוון; שאר הפרקים
+    // ריקים לחיסכון. כאן מוודאים שהחישוב תקין תחת אילוץ זה.
+    test('קדימה: רק הפרק הנוכחי והבא מלאים — חצייה לפרק הבא', () {
+      final lazy = [
+        <int>[], // פרק לפני — לא רלוונטי לכיוון קדימה
+        [0, 1], // נוכחי
+        [0, 1, 2], // שכן בכיוון
+        <int>[], // אחרי — לא רלוונטי
+      ];
+      expect(computeVerseStep(lazy, 1, 1, forward: true),
+          equals(const CommentatorsVerseStep(2, 0)));
+    });
+
+    test('אחורה: רק הפרק הנוכחי והקודם מלאים — חצייה לפרק הקודם', () {
+      final lazy = [
+        <int>[], // לפני — לא רלוונטי
+        [0, 1, 2], // שכן בכיוון (קודם)
+        [0, 1], // נוכחי
+        <int>[], // אחרי — לא רלוונטי
+      ];
+      expect(computeVerseStep(lazy, 2, 0, forward: false),
+          equals(const CommentatorsVerseStep(1, 2)));
+    });
+  });
 }


### PR DESCRIPTION
הכפתורים "הקטע הקודם"/"הקטע הבא" ניווטו רק בתוך הפרק הנוכחי ונתקעו בגבולותיו. בנוסף, בפתיחה נבחר "כל הפרק" במקום הקטע שנפתח, ולכן לחיצה על "קודם" מיד לאחר הפתיחה לא עשתה כלום.

- חילוץ הליבה לפונקציה טהורה computeVerseStep החוצה גבולות פרקים
- איחוד _navigateToPrevVerse/_navigateToNextVerse ל-_navigateVerse
- בחירת הקטע הספציפי שנפתח ב-_resolveInitialChapter
- הסרת ה-wrappers המיותרים _selectVerseAndLoad/_selectParaAndLoad
- הוספת טסטים ל-computeVerseStep כולל תרחיש הבאג המקורי
@palmoni5 