### PR TITLE
עוגני-מילה בתצוגת הטקסט: אות סימון והדגשת ציטוטים

### DIFF
--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -280,6 +280,10 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
   final types = LinkTypes.dependentTextTypes.toList();
   final typePlaceholders = List.filled(types.length, '?').join(', ');
   final hasRange = startLineIndex != null && endLineIndex != null;
+  // בשאילתה ההפוכה השורה המוצגת היא צד היעד של הקישור השמור.
+  final hasLinkAnchor = _hasLinkAnchorTable(db);
+  final anchorSelect = _anchorSelectColumns(hasLinkAnchor);
+  final anchorJoin = _anchorJoinClause(hasLinkAnchor, displayedSide: 1);
 
   if (hasRange) {
     // כשיש טווח: מוצאים תחילה את ה-line IDs בטווח דרך idx_line_book_index,
@@ -301,12 +305,14 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
           sb.title as targetBookTitle,
           sb.categoryId as targetCategoryId,
           NULL as targetFileType,
+          $anchorSelect
           'SOURCE' as connectionTypeName
         FROM link l
         JOIN line tl ON l.targetLineId = tl.id
         JOIN line sl ON l.sourceLineId = sl.id
         JOIN book sb ON l.sourceBookId = sb.id
         JOIN connection_type ct ON l.connectionTypeId = ct.id
+        $anchorJoin
         WHERE l.targetLineId IN (
           SELECT id FROM line WHERE bookId = ? AND lineIndex BETWEEN ? AND ?
         )
@@ -326,12 +332,14 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
         sb.title as targetBookTitle,
         sb.categoryId as targetCategoryId,
         NULL as targetFileType,
+        $anchorSelect
         'SOURCE' as connectionTypeName
       FROM link l
       JOIN line tl ON l.targetLineId = tl.id
       JOIN line sl ON l.sourceLineId = sl.id
       JOIN book sb ON l.sourceBookId = sb.id
       JOIN connection_type ct ON l.connectionTypeId = ct.id
+      $anchorJoin
       WHERE l.targetBookId = ?
         AND ct.name IN ($typePlaceholders)
         AND l.sourceBookId != l.targetBookId
@@ -340,7 +348,9 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
 }
 
 /// עוגני-מילה (link_anchor) — קיים רק במסדים חדשים; במסד ישן השאילתות חוזרות
-/// לעמודות NULL. side=0 = העוגן יושב בשורת המקור (צד הבסיס).
+/// לעמודות NULL. side=0 = העוגן יושב בשורת המקור של הקישור, side=1 = בשורת
+/// היעד. `displayedSide` הוא הצד שהשורה שלו מוצגת בגוף הטקסט (הסמן/הטווח
+/// מוזרקים אליה), והצד הנגדי הוא קטע-הפאנל (anchorLinked*).
 bool _hasLinkAnchorTable(sqlite3.Database db) => db
     .select(
       "SELECT 1 FROM sqlite_master WHERE type='table' AND name='link_anchor' LIMIT 1",
@@ -350,19 +360,28 @@ bool _hasLinkAnchorTable(sqlite3.Database db) => db
 String _anchorSelectColumns(bool hasLinkAnchor) => hasLinkAnchor
     ? '''la.charStart as anchorCharStart,
           la.charEnd as anchorCharEnd,
-          la.label as anchorLabel,'''
+          la.label as anchorLabel,
+          lal.charStart as anchorLinkedCharStart,
+          lal.charEnd as anchorLinkedCharEnd,'''
     : '''NULL as anchorCharStart,
           NULL as anchorCharEnd,
-          NULL as anchorLabel,''';
+          NULL as anchorLabel,
+          NULL as anchorLinkedCharStart,
+          NULL as anchorLinkedCharEnd,''';
 
-/// עוגן אחד לכל קישור (MIN(charStart)) — קישור עם עוגן כפול (נדיר) לא יכפיל
-/// את שורת הקישור בפאנל.
-String _anchorJoinClause(bool hasLinkAnchor) => hasLinkAnchor
-    ? '''LEFT JOIN (
+/// עוגן אחד לכל קישור וצד (MIN(charStart)) — קישור עם עוגן כפול (נדיר) לא
+/// יכפיל את שורת הקישור בפאנל.
+String _anchorJoinClause(bool hasLinkAnchor, {required int displayedSide}) =>
+    hasLinkAnchor
+        ? '''LEFT JOIN (
           SELECT linkId, MIN(charStart) AS charStart, charEnd, label
-          FROM link_anchor WHERE side = 0 GROUP BY linkId
-        ) la ON la.linkId = l.id'''
-    : '';
+          FROM link_anchor WHERE side = $displayedSide GROUP BY linkId
+        ) la ON la.linkId = l.id
+        LEFT JOIN (
+          SELECT linkId, MIN(charStart) AS charStart, charEnd
+          FROM link_anchor WHERE side = ${1 - displayedSide} GROUP BY linkId
+        ) lal ON lal.linkId = l.id'''
+        : '';
 
 List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
   required String dbPath,
@@ -403,7 +422,7 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
         JOIN line tl ON l.targetLineId = tl.id
         JOIN book tb ON l.targetBookId = tb.id
         LEFT JOIN connection_type ct ON l.connectionTypeId = ct.id
-        ${_anchorJoinClause(hasLinkAnchor)}
+        ${_anchorJoinClause(hasLinkAnchor, displayedSide: 0)}
         WHERE l.sourceBookId = ?
         ORDER BY sl.lineIndex
       ''', [bookId]).toMapList();
@@ -481,7 +500,7 @@ List<Map<String, dynamic>> _loadBookLinksRowsInRangeInIsolate({
         JOIN line tl ON l.targetLineId = tl.id
         JOIN book tb ON l.targetBookId = tb.id
         LEFT JOIN connection_type ct ON l.connectionTypeId = ct.id
-        ${_anchorJoinClause(hasLinkAnchor)}
+        ${_anchorJoinClause(hasLinkAnchor, displayedSide: 0)}
         WHERE l.sourceBookId = ?
           AND sl.lineIndex BETWEEN ? AND ?
           $commentaryFilterClause
@@ -2529,6 +2548,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
           anchorStart: row['anchorCharStart'] as int?,
           anchorEnd: row['anchorCharEnd'] as int?,
           anchorLabel: row['anchorLabel'] as String?,
+          linkedAnchorStart: row['anchorLinkedCharStart'] as int?,
+          linkedAnchorEnd: row['anchorLinkedCharEnd'] as int?,
         );
       }).toList();
 
@@ -2591,6 +2612,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
           anchorStart: row['anchorCharStart'] as int?,
           anchorEnd: row['anchorCharEnd'] as int?,
           anchorLabel: row['anchorLabel'] as String?,
+          linkedAnchorStart: row['anchorLinkedCharStart'] as int?,
+          linkedAnchorEnd: row['anchorLinkedCharEnd'] as int?,
         );
       }).toList();
       return links;

--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -374,6 +374,9 @@ String _anchorSelectColumns(bool hasLinkAnchor) => hasLinkAnchor
 /// עוגני הקישור מקובצים לשורה אחת לכל קישור וצד: העוגן הראשון (MIN) לאות
 /// שבפאנל, ו-spans מקודד את כולם ("start:end:label;...", ראו
 /// [_parseAnchorSpans]) כך שקישור עם כמה עוגנים באותה שורה מציג את כולם.
+/// דטרמיניזם: charEnd/label הלא-אגרגטיביים מגיעים לפי חוזה SQLite משורת
+/// ה-MIN, ושורת ה-MIN יחידה — (linkId, side, charStart) הוא ה-PK של
+/// link_anchor, כך שאין שני עוגנים לאותו קישור/צד עם אותו charStart.
 String _anchorJoinClause(bool hasLinkAnchor, {required int displayedSide}) =>
     hasLinkAnchor
         ? '''LEFT JOIN (

--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -339,6 +339,31 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
     ''', params).toMapList();
 }
 
+/// עוגני-מילה (link_anchor) — קיים רק במסדים חדשים; במסד ישן השאילתות חוזרות
+/// לעמודות NULL. side=0 = העוגן יושב בשורת המקור (צד הבסיס).
+bool _hasLinkAnchorTable(sqlite3.Database db) => db
+    .select(
+      "SELECT 1 FROM sqlite_master WHERE type='table' AND name='link_anchor' LIMIT 1",
+    )
+    .isNotEmpty;
+
+String _anchorSelectColumns(bool hasLinkAnchor) => hasLinkAnchor
+    ? '''la.charStart as anchorCharStart,
+          la.charEnd as anchorCharEnd,
+          la.label as anchorLabel,'''
+    : '''NULL as anchorCharStart,
+          NULL as anchorCharEnd,
+          NULL as anchorLabel,''';
+
+/// עוגן אחד לכל קישור (MIN(charStart)) — קישור עם עוגן כפול (נדיר) לא יכפיל
+/// את שורת הקישור בפאנל.
+String _anchorJoinClause(bool hasLinkAnchor) => hasLinkAnchor
+    ? '''LEFT JOIN (
+          SELECT linkId, MIN(charStart) AS charStart, charEnd, label
+          FROM link_anchor WHERE side = 0 GROUP BY linkId
+        ) la ON la.linkId = l.id'''
+    : '';
+
 List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
   required String dbPath,
   required String title,
@@ -359,6 +384,7 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
     }
 
     final bookId = bookResults.first['id'] as int;
+    final hasLinkAnchor = _hasLinkAnchorTable(db);
 
     final forwardRows = db.select('''
         SELECT
@@ -370,12 +396,14 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
           tb.title as targetBookTitle,
           tb.categoryId as targetCategoryId,
           NULL as targetFileType,
+          ${_anchorSelectColumns(hasLinkAnchor)}
           ct.name as connectionTypeName
         FROM link l
         JOIN line sl ON l.sourceLineId = sl.id
         JOIN line tl ON l.targetLineId = tl.id
         JOIN book tb ON l.targetBookId = tb.id
         LEFT JOIN connection_type ct ON l.connectionTypeId = ct.id
+        ${_anchorJoinClause(hasLinkAnchor)}
         WHERE l.sourceBookId = ?
         ORDER BY sl.lineIndex
       ''', [bookId]).toMapList();
@@ -437,6 +465,7 @@ List<Map<String, dynamic>> _loadBookLinksRowsInRangeInIsolate({
             ? 'AND (ct.name IS NULL OR ct.name NOT IN ($depTypesIn) OR tb.title IN ($targetBookPlaceholders))'
             : 'AND (ct.name IS NULL OR ct.name NOT IN ($depTypesIn))';
 
+    final hasLinkAnchor = _hasLinkAnchorTable(db);
     final rows = db.select('''
         SELECT
           sl.lineIndex as sourceLineIndex,
@@ -445,12 +474,14 @@ List<Map<String, dynamic>> _loadBookLinksRowsInRangeInIsolate({
           tb.title as targetBookTitle,
           tb.categoryId as targetCategoryId,
           NULL as targetFileType,
+          ${_anchorSelectColumns(hasLinkAnchor)}
           ct.name as connectionTypeName
         FROM link l
         JOIN line sl ON l.sourceLineId = sl.id
         JOIN line tl ON l.targetLineId = tl.id
         JOIN book tb ON l.targetBookId = tb.id
         LEFT JOIN connection_type ct ON l.connectionTypeId = ct.id
+        ${_anchorJoinClause(hasLinkAnchor)}
         WHERE l.sourceBookId = ?
           AND sl.lineIndex BETWEEN ? AND ?
           $commentaryFilterClause
@@ -2495,6 +2526,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
           connectionType: connectionType,
           targetCategoryId: row['targetCategoryId'] as int?,
           targetFileType: row['targetFileType'] as String?,
+          anchorStart: row['anchorCharStart'] as int?,
+          anchorEnd: row['anchorCharEnd'] as int?,
+          anchorLabel: row['anchorLabel'] as String?,
         );
       }).toList();
 
@@ -2554,6 +2588,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
           connectionType: connectionType,
           targetCategoryId: row['targetCategoryId'] as int?,
           targetFileType: row['targetFileType'] as String?,
+          anchorStart: row['anchorCharStart'] as int?,
+          anchorEnd: row['anchorCharEnd'] as int?,
+          anchorLabel: row['anchorLabel'] as String?,
         );
       }).toList();
       return links;

--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -361,20 +361,24 @@ String _anchorSelectColumns(bool hasLinkAnchor) => hasLinkAnchor
     ? '''la.charStart as anchorCharStart,
           la.charEnd as anchorCharEnd,
           la.label as anchorLabel,
+          la.spans as anchorSpans,
           lal.charStart as anchorLinkedCharStart,
           lal.charEnd as anchorLinkedCharEnd,'''
     : '''NULL as anchorCharStart,
           NULL as anchorCharEnd,
           NULL as anchorLabel,
+          NULL as anchorSpans,
           NULL as anchorLinkedCharStart,
           NULL as anchorLinkedCharEnd,''';
 
-/// עוגן אחד לכל קישור וצד (MIN(charStart)) — קישור עם עוגן כפול (נדיר) לא
-/// יכפיל את שורת הקישור בפאנל.
+/// עוגני הקישור מקובצים לשורה אחת לכל קישור וצד: העוגן הראשון (MIN) לאות
+/// שבפאנל, ו-spans מקודד את כולם ("start:end:label;...", ראו
+/// [_parseAnchorSpans]) כך שקישור עם כמה עוגנים באותה שורה מציג את כולם.
 String _anchorJoinClause(bool hasLinkAnchor, {required int displayedSide}) =>
     hasLinkAnchor
         ? '''LEFT JOIN (
-          SELECT linkId, MIN(charStart) AS charStart, charEnd, label
+          SELECT linkId, MIN(charStart) AS charStart, charEnd, label,
+                 GROUP_CONCAT(charStart || ':' || COALESCE(charEnd, '') || ':' || COALESCE(label, ''), ';') AS spans
           FROM link_anchor WHERE side = $displayedSide GROUP BY linkId
         ) la ON la.linkId = l.id
         LEFT JOIN (
@@ -382,6 +386,26 @@ String _anchorJoinClause(bool hasLinkAnchor, {required int displayedSide}) =>
           FROM link_anchor WHERE side = ${1 - displayedSide} GROUP BY linkId
         ) lal ON lal.linkId = l.id'''
         : '';
+
+/// מפענח את מחרוזת ה-spans מהשאילתה לרשימת עוגנים ממוינת לפי מיקום.
+List<LinkAnchorSpan> _parseAnchorSpans(String? spans) {
+  if (spans == null || spans.isEmpty) return const [];
+  final result = <LinkAnchorSpan>[];
+  for (final part in spans.split(';')) {
+    final fields = part.split(':');
+    final start = int.tryParse(fields.first);
+    if (start == null) continue;
+    final end = fields.length > 1 ? int.tryParse(fields[1]) : null;
+    final label = fields.length > 2 ? fields.sublist(2).join(':') : '';
+    result.add(LinkAnchorSpan(
+      start: start,
+      end: end,
+      label: label.isEmpty ? null : label,
+    ));
+  }
+  result.sort((a, b) => a.start.compareTo(b.start));
+  return result;
+}
 
 List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
   required String dbPath,
@@ -2550,6 +2574,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           anchorLabel: row['anchorLabel'] as String?,
           linkedAnchorStart: row['anchorLinkedCharStart'] as int?,
           linkedAnchorEnd: row['anchorLinkedCharEnd'] as int?,
+          anchorSpans: _parseAnchorSpans(row['anchorSpans'] as String?),
         );
       }).toList();
 
@@ -2614,6 +2639,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           anchorLabel: row['anchorLabel'] as String?,
           linkedAnchorStart: row['anchorLinkedCharStart'] as int?,
           linkedAnchorEnd: row['anchorLinkedCharEnd'] as int?,
+          anchorSpans: _parseAnchorSpans(row['anchorSpans'] as String?),
         );
       }).toList();
       return links;

--- a/lib/models/links.dart
+++ b/lib/models/links.dart
@@ -44,6 +44,17 @@ class Link {
   /// The end character position of the link in the text (optional, for character-based links).
   final int? end;
 
+  /// עוגן-מילה מטבלת link_anchor שבמסד: אופסט בתווים *גלויים* (תגי HTML לא
+  /// נספרים, entity = תו אחד — מוסכמת line.charCount) בשורת המקור שבה יושבת
+  /// ההערה. null כשאין לקישור עוגן-מילה.
+  final int? anchorStart;
+
+  /// סוף טווח העוגן (אקסקלוסיבי), באותה מוסכמה. null לעוגן-נקודה.
+  final int? anchorEnd;
+
+  /// אות הסימון המודפסת (למשל "א") כשהמקור סיפק אותה.
+  final String? anchorLabel;
+
   /// Creates a new instance of [Link] with the provided parameters.
   Link({
     required this.heRef,
@@ -56,6 +67,9 @@ class Link {
     this.targetIsUserBook = false,
     this.start,
     this.end,
+    this.anchorStart,
+    this.anchorEnd,
+    this.anchorLabel,
   });
 
   static final LinkedHashMap<String, Future<String>> _contentCache =
@@ -177,7 +191,11 @@ class Link {
         start = json['start'] != null
             ? int.tryParse(json['start'].toString())
             : null,
-        end = json['end'] != null ? int.tryParse(json['end'].toString()) : null;
+        end = json['end'] != null ? int.tryParse(json['end'].toString()) : null,
+        // עוגני-מילה מגיעים רק ממסד הנתונים (link_anchor), לא מקבצי JSON.
+        anchorStart = null,
+        anchorEnd = null,
+        anchorLabel = null;
 }
 
 /// Retrieves a list of [Link] objects for the given list of [indexes] and the [links] to be processed.

--- a/lib/models/links.dart
+++ b/lib/models/links.dart
@@ -8,6 +8,16 @@ import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/utils/text/ref_helper.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 
+/// עוגן-מילה בודד של קישור בשורה המוצגת. קישור יכול לשאת כמה עוגנים
+/// (למשל הערה אחת שמסומנת בשני מקומות בשורה).
+class LinkAnchorSpan {
+  final int start;
+  final int? end;
+  final String? label;
+
+  const LinkAnchorSpan({required this.start, this.end, this.label});
+}
+
 /// Represents a link between two books in the library.
 class Link {
   static const int _maxContentCacheEntries = 400;
@@ -60,6 +70,10 @@ class Link {
   final int? linkedAnchorStart;
   final int? linkedAnchorEnd;
 
+  /// כל עוגני הקישור בשורה המוצגת, ממוינים לפי מיקום. anchorStart/End/Label
+  /// הם הראשון שבהם (לתאימות ולאות שבפאנל); ההזרקה לטקסט עוברת על כולם.
+  final List<LinkAnchorSpan> anchorSpans;
+
   /// Creates a new instance of [Link] with the provided parameters.
   Link({
     required this.heRef,
@@ -77,6 +91,7 @@ class Link {
     this.anchorLabel,
     this.linkedAnchorStart,
     this.linkedAnchorEnd,
+    this.anchorSpans = const [],
   });
 
   static final LinkedHashMap<String, Future<String>> _contentCache =
@@ -204,7 +219,8 @@ class Link {
         anchorEnd = null,
         anchorLabel = null,
         linkedAnchorStart = null,
-        linkedAnchorEnd = null;
+        linkedAnchorEnd = null,
+        anchorSpans = const [];
 }
 
 /// Retrieves a list of [Link] objects for the given list of [indexes] and the [links] to be processed.

--- a/lib/models/links.dart
+++ b/lib/models/links.dart
@@ -55,6 +55,11 @@ class Link {
   /// אות הסימון המודפסת (למשל "א") כשהמקור סיפק אותה.
   final String? anchorLabel;
 
+  /// עוגן בצד המקושר (path2/index2) — הטווח המצוטט בתוך קטע-הפאנל, באותה
+  /// מוסכמת תווים-גלויים. משמש להדגשת הציטוט בתוך תוכן הקישור המוצג.
+  final int? linkedAnchorStart;
+  final int? linkedAnchorEnd;
+
   /// Creates a new instance of [Link] with the provided parameters.
   Link({
     required this.heRef,
@@ -70,6 +75,8 @@ class Link {
     this.anchorStart,
     this.anchorEnd,
     this.anchorLabel,
+    this.linkedAnchorStart,
+    this.linkedAnchorEnd,
   });
 
   static final LinkedHashMap<String, Future<String>> _contentCache =
@@ -195,7 +202,9 @@ class Link {
         // עוגני-מילה מגיעים רק ממסד הנתונים (link_anchor), לא מקבצי JSON.
         anchorStart = null,
         anchorEnd = null,
-        anchorLabel = null;
+        anchorLabel = null,
+        linkedAnchorStart = null,
+        linkedAnchorEnd = null;
 }
 
 /// Retrieves a list of [Link] objects for the given list of [indexes] and the [links] to be processed.

--- a/lib/text_book/utils/link_anchor_markers.dart
+++ b/lib/text_book/utils/link_anchor_markers.dart
@@ -1,0 +1,119 @@
+import 'package:otzaria/models/links.dart';
+
+/// סמני עוגן-מילה (טבלת link_anchor שבמסד): הזרקת אות סימון קטנה, למשל (א),
+/// בנקודה המדויקת בשורת המקור שבה יושבת הערת המפרש.
+///
+/// `anchorStart` שמור במסד באופסט של *תווים גלויים* — תגי HTML לא נספרים,
+/// entity (`&...;`) נספר כתו אחד — אותה מוסכמה של `line.charCount`. ההזרקה
+/// חייבת לכן להיעשות על שורת המקור *כפי שנשמרה*, לפני כל עיבוד שמוסיף תוכן
+/// גלוי (סימוני הערות אישיות וכד').
+
+/// מספר וריאנטי הטיפוגרפיה של הסמנים (ראו SmartTextWidget.customStylesBuilder).
+const int kLinkAnchorStyleCount = 6;
+
+/// אות הסימון של קישור מעוגן: התווית ששמורה במסד, ואם אין — הרכיב האחרון של
+/// ה-heRef של ההערה (מספר ההערה בגימטריה, כפי שמודפס). מחזיר null כשאין אות
+/// לתצוגה — קישור כזה לא מקבל סמן.
+String? anchorMarkerLetter(Link link) {
+  final label = link.anchorLabel?.trim();
+  if (label != null && label.isNotEmpty) return label;
+  final tail = link.heRef.split(',').last.trim();
+  final letters = tail.replaceAll(RegExp(r'["׳״]'), '');
+  if (letters.isEmpty || letters.length > 4) return null;
+  if (!RegExp(r'^[א-ת]+$').hasMatch(letters)) return null;
+  return tail;
+}
+
+/// הקצאת וריאנט טיפוגרפי קבוע לכל מפרש שיש לו עוגני-מילה: לפי סדר אלפביתי של
+/// כותרות המפרשים — דטרמיניסטי לאורך כל הספר, כך שכל מפרש שומר על עיצובו.
+Map<String, int> anchorStyleIndexByCommentator(Iterable<Link> links) {
+  final titles = links
+      .where((link) => link.anchorStart != null)
+      .map((link) => link.path2)
+      .toSet()
+      .toList()
+    ..sort();
+  return {
+    for (var i = 0; i < titles.length; i++)
+      titles[i]: i % kLinkAnchorStyleCount,
+  };
+}
+
+/// מזריק את סמני העוגן לשורת ה-HTML הגולמית. הליכה אחת על השורה ממירה את
+/// אופסט התווים-הגלויים לנקודת ההזרקה: לפני התו הגלוי הבא אחרי מיקום העוגן
+/// (כך שהסמן לא ייכנס לתוך תג פתוח).
+String injectLinkAnchorMarkers({
+  required String rawLine,
+  required List<Link> anchorLinks,
+  required Map<String, int> styleIndexByCommentator,
+}) {
+  final markers = <({int at, String html})>[];
+  for (final link in anchorLinks) {
+    final start = link.anchorStart;
+    if (start == null || start < 0) continue;
+    final letter = anchorMarkerLetter(link);
+    if (letter == null) continue;
+    final styleIndex = styleIndexByCommentator[link.path2] ?? 0;
+    markers.add((
+      at: start,
+      html: '<sup class="link-anchor link-anchor-$styleIndex">($letter)</sup>',
+    ));
+  }
+  if (markers.isEmpty) return rawLine;
+  markers.sort((a, b) => a.at.compareTo(b.at));
+
+  final out = StringBuffer();
+  var visible = 0;
+  var next = 0;
+  var i = 0;
+  final len = rawLine.length;
+
+  void flushMarkersAt(int visibleCount) {
+    while (next < markers.length && markers[next].at <= visibleCount) {
+      out.write(markers[next].html);
+      next++;
+    }
+  }
+
+  while (i < len) {
+    final c = rawLine[i];
+    if (c == '<') {
+      final close = rawLine.indexOf('>', i);
+      if (close < 0) {
+        out.write(rawLine.substring(i));
+        i = len;
+        break;
+      }
+      out.write(rawLine.substring(i, close + 1));
+      i = close + 1;
+    } else {
+      // תו גלוי (או entity שנספר כתו אחד) — סמנים שמקומם כאן נכנסים לפניו.
+      flushMarkersAt(visible);
+      if (c == '&') {
+        final end = (i + 10 < len) ? i + 10 : len;
+        var j = i + 1;
+        var terminated = false;
+        while (j < end) {
+          if (rawLine[j] == ';') {
+            terminated = true;
+            break;
+          }
+          j++;
+        }
+        final entityEnd = terminated ? j + 1 : i + 1;
+        out.write(rawLine.substring(i, entityEnd));
+        i = entityEnd;
+      } else {
+        out.write(c);
+        i++;
+      }
+      visible++;
+    }
+  }
+  // סמנים שנותרו (בסוף השורה או מעבר לאורכה) מוזרקים בסוף.
+  while (next < markers.length) {
+    out.write(markers[next].html);
+    next++;
+  }
+  return out.toString();
+}

--- a/lib/text_book/utils/link_anchor_markers.dart
+++ b/lib/text_book/utils/link_anchor_markers.dart
@@ -1,4 +1,5 @@
 import 'package:otzaria/models/links.dart';
+import 'package:otzaria/personal_notes/utils/note_anchor_utils.dart';
 
 /// סמני עוגן-מילה (טבלת link_anchor שבמסד): הזרקת אות סימון קטנה, למשל (א),
 /// בנקודה המדויקת בשורת המקור שבה יושבת הערת המפרש.
@@ -14,8 +15,10 @@ const int kLinkAnchorStyleCount = 6;
 /// אות הסימון של קישור מעוגן: התווית ששמורה במסד, ואם אין — הרכיב האחרון של
 /// ה-heRef של ההערה (מספר ההערה בגימטריה, כפי שמודפס). מחזיר null כשאין אות
 /// לתצוגה — קישור כזה לא מקבל סמן.
-String? anchorMarkerLetter(Link link) {
-  final label = link.anchorLabel?.trim();
+String? anchorMarkerLetter(Link link) => _letterFor(link, link.anchorLabel);
+
+String? _letterFor(Link link, String? storedLabel) {
+  final label = storedLabel?.trim();
   if (label != null && label.isNotEmpty) return label;
   final tail = link.heRef.split(',').last.trim();
   final letters = tail.replaceAll(RegExp(r'["׳״]'), '');
@@ -43,45 +46,64 @@ Map<String, int> anchorStyleIndexByCommentator(Iterable<Link> links) {
 /// אופסט התווים-הגלויים לנקודת ההזרקה: לפני התו הגלוי הבא אחרי מיקום העוגן
 /// (כך שהסמן לא ייכנס לתוך תג פתוח).
 ///
-/// שני סוגי עוגנים:
-///  - עוגן-נקודה (anchorEnd == null): סמן אות מורם, למשל (א).
-///  - עוגן-טווח (anchorEnd != null, ציטוטים מ-charLevelData): עטיפת הטווח
-///    ב-span עם קו תחתון, באותו וריאנט סגנון של המפרש.
+/// שני סוגי עוגנים (קישור יכול לשאת כמה, דרך anchorSpans):
+///  - עוגן-נקודה (end == null): סמן אות מורם, למשל (א).
+///  - עוגן-טווח (end != null, ציטוטים מ-charLevelData): עטיפת הטווח דרך
+///    [wrapHtmlRanges] — שסוגר/פותח סביב תגים לא-מאוזנים כדי לשמור קינון
+///    תקין — באותו וריאנט סגנון של המפרש.
 String injectLinkAnchorMarkers({
   required String rawLine,
   required List<Link> anchorLinks,
   required Map<String, int> styleIndexByCommentator,
 }) {
-  // order בתוך אותו אופסט: סגירת טווח (0) לפני סמני אות (1) לפני פתיחת טווח (2),
-  // כדי שטווחים צמודים לא יקוננו זה בזה.
-  final markers = <({int at, int order, String html})>[];
+  final points = <({int at, int order, String html})>[];
+  final ranges = <HtmlWrapRange>[];
   for (final link in anchorLinks) {
-    final start = link.anchorStart;
-    if (start == null || start < 0) continue;
+    final spans = link.anchorSpans.isNotEmpty
+        ? link.anchorSpans
+        : [
+            if (link.anchorStart != null)
+              LinkAnchorSpan(
+                start: link.anchorStart!,
+                end: link.anchorEnd,
+                label: link.anchorLabel,
+              ),
+          ];
     final styleIndex = styleIndexByCommentator[link.path2] ?? 0;
-    final end = link.anchorEnd;
-    if (end != null && end > start) {
-      markers.add((
-        at: start,
-        order: 2,
-        html: '<span class="link-anchor-range link-anchor-$styleIndex">',
-      ));
-      markers.add((at: end, order: 0, html: '</span>'));
-    } else {
-      final letter = anchorMarkerLetter(link);
-      if (letter == null) continue;
-      markers.add((
-        at: start,
-        order: 1,
-        html:
-            '<sup class="link-anchor link-anchor-$styleIndex">($letter)</sup>',
-      ));
+    for (final span in spans) {
+      if (span.start < 0) continue;
+      final end = span.end;
+      if (end != null && end > span.start) {
+        final rawStart = _rawStartOfVisible(rawLine, span.start);
+        final rawEnd = _rawEndOfVisible(rawLine, end);
+        if (rawStart < rawEnd) {
+          ranges.add(HtmlWrapRange(
+            start: rawStart,
+            end: rawEnd,
+            openTag: '<span class="link-anchor-range link-anchor-$styleIndex">',
+            closeTag: '</span>',
+          ));
+        }
+      } else {
+        final letter = _letterFor(link, span.label);
+        if (letter == null) continue;
+        points.add((
+          at: span.start,
+          order: 1,
+          html:
+              '<sup class="link-anchor link-anchor-$styleIndex">($letter)</sup>',
+        ));
+      }
     }
   }
-  return _injectAtVisibleOffsets(rawLine, markers);
+  // טווחים קודם (על אופסטים גולמיים של השורה המקורית); סמני הנקודה מוזרקים
+  // אחר-כך לפי אופסטים גלויים, שהתגים שנוספו לא משנים.
+  var result = ranges.isEmpty ? rawLine : wrapHtmlRanges(rawLine, ranges);
+  return _injectAtVisibleOffsets(result, points);
 }
 
-/// עוטף טווח תווים-גלויים [start, end) של שורת HTML בתגי פתיחה/סגירה.
+/// עוטף טווח תווים-גלויים [start, end) של שורת HTML בתגי פתיחה/סגירה, תוך
+/// שמירת קינון תקין סביב תגים לא-מאוזנים (דרך [wrapHtmlRanges]).
 /// משמש להדגשת הציטוט (linkedAnchor) בתוך קטע המפרש בפאנל.
 String wrapVisibleRange({
   required String html,
@@ -91,10 +113,70 @@ String wrapVisibleRange({
   required String closeTag,
 }) {
   if (start < 0 || end <= start) return html;
-  return _injectAtVisibleOffsets(html, [
-    (at: start, order: 2, html: openTag),
-    (at: end, order: 0, html: closeTag),
+  final rawStart = _rawStartOfVisible(html, start);
+  final rawEnd = _rawEndOfVisible(html, end);
+  if (rawStart >= rawEnd) return html;
+  return wrapHtmlRanges(html, [
+    HtmlWrapRange(
+      start: rawStart,
+      end: rawEnd,
+      openTag: openTag,
+      closeTag: closeTag,
+    ),
   ]);
+}
+
+/// אינדקס גולמי של תחילת התו הגלוי מספר [visibleOffset] (אחרי תגים קודמים);
+/// אורך המחרוזת כשהאופסט מעבר לסוף.
+int _rawStartOfVisible(String html, int visibleOffset) {
+  var visible = 0;
+  var i = 0;
+  final len = html.length;
+  while (i < len) {
+    if (html[i] == '<') {
+      final close = html.indexOf('>', i);
+      if (close < 0) return len;
+      i = close + 1;
+    } else {
+      if (visible == visibleOffset) return i;
+      if (html[i] == '&') {
+        final end = (i + 10 < len) ? i + 10 : len;
+        final j = html.indexOf(';', i + 1);
+        i = (j > 0 && j < end) ? j + 1 : i + 1;
+      } else {
+        i++;
+      }
+      visible++;
+    }
+  }
+  return len;
+}
+
+/// אינדקס גולמי מיד אחרי התו הגלוי מספר [visibleOffset]-1 — סוף טווח
+/// אקסקלוסיבי שאינו בולע תגים עוקבים.
+int _rawEndOfVisible(String html, int visibleOffset) {
+  if (visibleOffset <= 0) return 0;
+  var visible = 0;
+  var i = 0;
+  final len = html.length;
+  while (i < len) {
+    if (html[i] == '<') {
+      final close = html.indexOf('>', i);
+      if (close < 0) return len;
+      i = close + 1;
+    } else {
+      if (html[i] == '&') {
+        final end = (i + 10 < len) ? i + 10 : len;
+        final j = html.indexOf(';', i + 1);
+        i = (j > 0 && j < end) ? j + 1 : i + 1;
+      } else {
+        i++;
+      }
+      visible++;
+      if (visible == visibleOffset) return i;
+    }
+  }
+  return len;
 }
 
 String _injectAtVisibleOffsets(

--- a/lib/text_book/utils/link_anchor_markers.dart
+++ b/lib/text_book/utils/link_anchor_markers.dart
@@ -87,11 +87,13 @@ String injectLinkAnchorMarkers({
       } else {
         final letter = _letterFor(link, span.label);
         if (letter == null) continue;
+        // span ולא sup: HtmlWidget מממש sup כ-WidgetSpan, ושניים+ בפסקת RTL
+        // מוצגים בסדר תוכן הפוך. ההגבהה נעשית ב-CSS (customStylesBuilder).
         points.add((
           at: span.start,
           order: 1,
           html:
-              '<sup class="link-anchor link-anchor-$styleIndex">($letter)</sup>',
+              '<span class="link-anchor link-anchor-$styleIndex">($letter)</span>',
         ));
       }
     }
@@ -207,9 +209,12 @@ String _injectAtVisibleOffsets(
   while (i < len) {
     final c = rawLine[i];
     if (c == '<') {
-      // אירועים שהגיע זמנם נכנסים לפני התג — כך פתיחת/סגירת טווח לא חוצה
-      // תגים סמוכים (<b>, itags) והקינון נשאר תקין.
-      flushMarkersAt(visible);
+      // הסמן שייך לתו הגלוי *הבא*: לפני תג פתיחה הוא נכנס עכשיו, אבל תג
+      // סגירה נכתב קודם — אחרת הסמן נבלע בתוך האלמנט הנסגר ויורש את עיצובו.
+      final isClosingTag = i + 1 < len && rawLine[i + 1] == '/';
+      if (!isClosingTag) {
+        flushMarkersAt(visible);
+      }
       final close = rawLine.indexOf('>', i);
       if (close < 0) {
         out.write(rawLine.substring(i));

--- a/lib/text_book/utils/link_anchor_markers.dart
+++ b/lib/text_book/utils/link_anchor_markers.dart
@@ -42,25 +42,70 @@ Map<String, int> anchorStyleIndexByCommentator(Iterable<Link> links) {
 /// מזריק את סמני העוגן לשורת ה-HTML הגולמית. הליכה אחת על השורה ממירה את
 /// אופסט התווים-הגלויים לנקודת ההזרקה: לפני התו הגלוי הבא אחרי מיקום העוגן
 /// (כך שהסמן לא ייכנס לתוך תג פתוח).
+///
+/// שני סוגי עוגנים:
+///  - עוגן-נקודה (anchorEnd == null): סמן אות מורם, למשל (א).
+///  - עוגן-טווח (anchorEnd != null, ציטוטים מ-charLevelData): עטיפת הטווח
+///    ב-span עם קו תחתון, באותו וריאנט סגנון של המפרש.
 String injectLinkAnchorMarkers({
   required String rawLine,
   required List<Link> anchorLinks,
   required Map<String, int> styleIndexByCommentator,
 }) {
-  final markers = <({int at, String html})>[];
+  // order בתוך אותו אופסט: סגירת טווח (0) לפני סמני אות (1) לפני פתיחת טווח (2),
+  // כדי שטווחים צמודים לא יקוננו זה בזה.
+  final markers = <({int at, int order, String html})>[];
   for (final link in anchorLinks) {
     final start = link.anchorStart;
     if (start == null || start < 0) continue;
-    final letter = anchorMarkerLetter(link);
-    if (letter == null) continue;
     final styleIndex = styleIndexByCommentator[link.path2] ?? 0;
-    markers.add((
-      at: start,
-      html: '<sup class="link-anchor link-anchor-$styleIndex">($letter)</sup>',
-    ));
+    final end = link.anchorEnd;
+    if (end != null && end > start) {
+      markers.add((
+        at: start,
+        order: 2,
+        html: '<span class="link-anchor-range link-anchor-$styleIndex">',
+      ));
+      markers.add((at: end, order: 0, html: '</span>'));
+    } else {
+      final letter = anchorMarkerLetter(link);
+      if (letter == null) continue;
+      markers.add((
+        at: start,
+        order: 1,
+        html:
+            '<sup class="link-anchor link-anchor-$styleIndex">($letter)</sup>',
+      ));
+    }
   }
+  return _injectAtVisibleOffsets(rawLine, markers);
+}
+
+/// עוטף טווח תווים-גלויים [start, end) של שורת HTML בתגי פתיחה/סגירה.
+/// משמש להדגשת הציטוט (linkedAnchor) בתוך קטע המפרש בפאנל.
+String wrapVisibleRange({
+  required String html,
+  required int start,
+  required int end,
+  required String openTag,
+  required String closeTag,
+}) {
+  if (start < 0 || end <= start) return html;
+  return _injectAtVisibleOffsets(html, [
+    (at: start, order: 2, html: openTag),
+    (at: end, order: 0, html: closeTag),
+  ]);
+}
+
+String _injectAtVisibleOffsets(
+  String rawLine,
+  List<({int at, int order, String html})> markers,
+) {
   if (markers.isEmpty) return rawLine;
-  markers.sort((a, b) => a.at.compareTo(b.at));
+  markers.sort((a, b) {
+    final byAt = a.at.compareTo(b.at);
+    return byAt != 0 ? byAt : a.order.compareTo(b.order);
+  });
 
   final out = StringBuffer();
   var visible = 0;
@@ -78,6 +123,9 @@ String injectLinkAnchorMarkers({
   while (i < len) {
     final c = rawLine[i];
     if (c == '<') {
+      // אירועים שהגיע זמנם נכנסים לפני התג — כך פתיחת/סגירת טווח לא חוצה
+      // תגים סמוכים (<b>, itags) והקינון נשאר תקין.
+      flushMarkersAt(visible);
       final close = rawLine.indexOf('>', i);
       if (close < 0) {
         out.write(rawLine.substring(i));

--- a/lib/text_book/utils/link_anchor_markers.dart
+++ b/lib/text_book/utils/link_anchor_markers.dart
@@ -97,7 +97,9 @@ String injectLinkAnchorMarkers({
     }
   }
   // טווחים קודם (על אופסטים גולמיים של השורה המקורית); סמני הנקודה מוזרקים
-  // אחר-כך לפי אופסטים גלויים, שהתגים שנוספו לא משנים.
+  // אחר-כך לפי אופסטים גלויים, שהתגים שנוספו לא משנים. טווחים חופפים:
+  // wrapHtmlRanges שומר את הראשון ומדלג על החופף לו — ויתור מכוון על
+  // הדגשה כפולה כדי לא לייצר HTML מוצלב.
   var result = ranges.isEmpty ? rawLine : wrapHtmlRanges(rawLine, ranges);
   return _injectAtVisibleOffsets(result, points);
 }

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -55,6 +55,7 @@ import 'package:otzaria/plugins/services/plugin_runtime_dispatcher.dart';
 import 'package:otzaria/plugins/utils/fluent_icon_resolver.dart';
 import 'package:otzaria/text_book/utils/inline_notes_utils.dart'
     as inline_notes;
+import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
 import 'package:otzaria/text_book/utils/note_inline_render.dart';
 import 'package:otzaria/text_book/utils/reading_segments.dart';
 import 'package:otzaria/text_book/utils/reading_segment_navigation.dart';
@@ -229,6 +230,39 @@ class _CombinedViewState extends State<CombinedView> {
   late final TextBookBloc _textBookBloc;
 
   bool _hasScrolledToInitialPosition = false;
+
+  // הקצאת וריאנט טיפוגרפי קבוע לכל מפרש עם עוגני-מילה. ממוזכר לפי זהות
+  // רשימת הקישורים של ה-state (מתחלפת רק כשהקישורים נטענים מחדש).
+  List<Link>? _anchorStyleSourceLinks;
+  Map<String, int> _anchorStyleCache = const {};
+
+  Map<String, int> _anchorStyles(TextBookLoaded state) {
+    if (!identical(_anchorStyleSourceLinks, state.links)) {
+      _anchorStyleSourceLinks = state.links;
+      _anchorStyleCache = anchorStyleIndexByCommentator(state.links);
+    }
+    return _anchorStyleCache;
+  }
+
+  /// סמני עוגן-מילה, למשל (א), בנקודה המדויקת בשורה. מוזרקים על שורת המקור
+  /// כפי שנשמרה — לפני הזרקות שמוסיפות תוכן גלוי (הערות אישיות וכד'), כי
+  /// anchorStart נמדד בתווים גלויים של התוכן השמור.
+  String _injectAnchorMarkersForLine(
+    String rawLine,
+    int lineIndex0,
+    TextBookLoaded state,
+  ) {
+    final anchorLinks = state.links
+        .where(
+            (link) => link.index1 == lineIndex0 + 1 && link.anchorStart != null)
+        .toList();
+    if (anchorLinks.isEmpty) return rawLine;
+    return injectLinkAnchorMarkers(
+      rawLine: rawLine,
+      anchorLinks: anchorLinks,
+      styleIndexByCommentator: _anchorStyles(state),
+    );
+  }
 
   // האם להציג את שורת "יד הרמב"ם" מעל השורה הראשונה (נטען פעם אחת לכל ספר).
   bool _showSourceBanner = false;
@@ -1681,6 +1715,10 @@ class _CombinedViewState extends State<CombinedView> {
 
                         String data = widget.data[primaryLineIndex];
 
+                        // סמני עוגן-מילה — לפני כל עיבוד שמוסיף תוכן גלוי.
+                        data = _injectAnchorMarkersForLine(
+                            data, primaryLineIndex, state);
+
                         // איסוף קישורי inline (start/end מתייחסים לטקסט המקורי)
                         List<Link> linksForLine = const [];
                         if (settingsState.enableHtmlLinks) {
@@ -1907,7 +1945,9 @@ class _CombinedViewState extends State<CombinedView> {
     required TextBookLoaded state,
     required SettingsState settingsState,
   }) {
-    var textWithLinks = rawText;
+    // סמני עוגן-מילה — על הטקסט השמור, לפני קישורי ה-inline (שממילא לא
+    // מתקיימים יחד איתם: start/end מגיעים רק מקבצי ספרייה, עוגנים רק מהמסד).
+    var textWithLinks = _injectAnchorMarkersForLine(rawText, lineIndex, state);
     if (settingsState.enableHtmlLinks) {
       try {
         final linksForLine = state.links
@@ -1917,10 +1957,10 @@ class _CombinedViewState extends State<CombinedView> {
                 link.end != null)
             .toList();
         if (linksForLine.isNotEmpty) {
-          textWithLinks = addInlineLinksToText(rawText, linksForLine);
+          textWithLinks = addInlineLinksToText(textWithLinks, linksForLine);
         }
       } catch (_) {
-        textWithLinks = rawText;
+        // הזרקת קישורי inline נכשלה — נשארים עם הטקסט (כולל סמני העוגן).
       }
     }
 

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -252,9 +252,10 @@ class _CombinedViewState extends State<CombinedView> {
     int lineIndex0,
     TextBookLoaded state,
   ) {
-    final anchorLinks = state.links
-        .where(
-            (link) => link.index1 == lineIndex0 + 1 && link.anchorStart != null)
+    // linksByLine ולא state.links: סינון על כל קישורי הספר (עשרות אלפים)
+    // פר-שורה פר-build מקרטע את הגלילה.
+    final anchorLinks = (state.linksByLine[lineIndex0 + 1] ?? const <Link>[])
+        .where((link) => link.anchorStart != null)
         .toList();
     if (anchorLinks.isEmpty) return rawLine;
     return injectLinkAnchorMarkers(

--- a/lib/text_book/view/combined_view/commentary_content.dart
+++ b/lib/text_book/view/combined_view/commentary_content.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/widgets/feedback/app_future_builder.dart';
 import 'package:otzaria/widgets/smart_text/smart_text.dart';
 import 'package:otzaria/search/utils/snippet_builder.dart';
+import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
 import 'package:otzaria/text_book/view/selection/selected_text_restore.dart';
 
 class CommentaryContent extends StatefulWidget {
@@ -188,8 +189,25 @@ class _CommentaryContentState extends State<CommentaryContent> {
 
                     _reportRenderedText(data, renderSettings);
 
+                    // עוגן בצד המקושר (ציטוט מ-charLevelData): הדגשת הטווח
+                    // המצוטט בתוך קטע המפרש, באופסטים של תווים-גלויים.
+                    var displayData = data;
+                    final linkedStart = widget.link.linkedAnchorStart;
+                    final linkedEnd = widget.link.linkedAnchorEnd;
+                    if (linkedStart != null &&
+                        linkedEnd != null &&
+                        linkedEnd > linkedStart) {
+                      displayData = wrapVisibleRange(
+                        html: data,
+                        start: linkedStart,
+                        end: linkedEnd,
+                        openTag: '<span class="link-anchor-range">',
+                        closeTag: '</span>',
+                      );
+                    }
+
                     return SmartTextWidget(
-                      text: data,
+                      text: displayData,
                       settings: renderSettings,
                     );
                   },

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -15,6 +15,7 @@ import 'package:otzaria/text_book/widgets/text_book_state_builder.dart';
 import 'package:otzaria/text_book/view/combined_view/commentary_content.dart';
 import 'package:otzaria/text_book/models/commentator_group.dart';
 import 'package:otzaria/text_book/utils/commentator_group_builder.dart';
+import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
 import 'package:otzaria/text_book/view/commentators_list_screen.dart';
 import 'package:otzaria/widgets/misc/commentators_filter_button.dart';
 import 'package:otzaria/widgets/layout/commentators_filter_screen.dart';
@@ -1945,6 +1946,14 @@ class _CollapsibleCommentaryGroupState
                           builder: (context, snapshot) {
                             String displayTitle =
                                 snapshot.data ?? link.fallbackDisplayReference;
+                            // קישור עם עוגן-מילה: אות הסימון שמופיעה בגוף
+                            // הטקסט מוצגת גם לפני כותרת ההערה.
+                            if (link.anchorStart != null) {
+                              final markerLetter = anchorMarkerLetter(link);
+                              if (markerLetter != null) {
+                                displayTitle = '($markerLetter) $displayTitle';
+                              }
+                            }
                             if (settingsState.replaceHolyNames) {
                               displayTitle =
                                   utils.replaceHolyNames(displayTitle);

--- a/lib/text_book/view/selected_line_links_view.dart
+++ b/lib/text_book/view/selected_line_links_view.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/settings/services/nikud_display_service.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
 import 'package:otzaria/text_book/widgets/text_book_state_builder.dart';
 import 'package:otzaria/widgets/feedback/app_future_builder.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
@@ -405,13 +406,19 @@ class _SelectedLineLinksViewState extends State<SelectedLineLinksView> {
       ),
       subtitle: BlocBuilder<SettingsBloc, SettingsState>(
         builder: (context, settingsState) {
-          final fallbackSubtitle = settingsState.replaceHolyNames
+          // קישור עם עוגן-מילה: אות הסימון שבגוף הטקסט מוצגת לפני ההפניה.
+          var markerPrefix = '';
+          if (link.anchorStart != null) {
+            final markerLetter = anchorMarkerLetter(link);
+            if (markerLetter != null) markerPrefix = '($markerLetter) ';
+          }
+          final rawFallback = settingsState.replaceHolyNames
               ? utils.replaceHolyNames(link.fallbackDisplayReference)
               : link.fallbackDisplayReference;
 
           if (!isExpanded) {
             return Text(
-              fallbackSubtitle,
+              markerPrefix + rawFallback,
               style: TextStyle(
                 fontSize: settingsState.commentatorsFontSize - 4,
                 fontWeight: FontWeight.normal,
@@ -423,9 +430,10 @@ class _SelectedLineLinksViewState extends State<SelectedLineLinksView> {
 
           return FutureBuilder<String>(
             future: link.displayReference,
-            initialData: fallbackSubtitle,
+            initialData: rawFallback,
             builder: (context, snapshot) {
-              String displaySubtitle = snapshot.data ?? fallbackSubtitle;
+              String displaySubtitle =
+                  markerPrefix + (snapshot.data ?? rawFallback);
               if (settingsState.replaceHolyNames) {
                 displaySubtitle = utils.replaceHolyNames(displaySubtitle);
               }

--- a/lib/text_book/view/widgets/continuous_reading_paragraph.dart
+++ b/lib/text_book/view/widgets/continuous_reading_paragraph.dart
@@ -302,7 +302,8 @@ TextStyle _styleForElement(dom.Element element, TextStyle parentStyle) {
     style = style.copyWith(fontSize: inlineFontSize);
   }
   if (localName == 'sup' ||
-      element.classes.contains('footnote-marker-number')) {
+      element.classes.contains('footnote-marker-number') ||
+      element.classes.contains('link-anchor')) {
     style = style.copyWith(
       fontSize: (style.fontSize ?? 18) * 0.75,
       fontStyle: FontStyle.italic,

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -72,7 +72,7 @@ class SmartTextWidget extends StatelessWidget {
         // סמני עוגן-מילה (link_anchor): אות קטנה מורמת (עוגן-נקודה) או קו
         // תחתון על טווח מצוטט (עוגן-טווח), עם וריאנט טיפוגרפי קבוע לכל מפרש
         // (ראו anchorStyleIndexByCommentator).
-        if (element.localName == 'sup' &&
+        if (element.localName == 'span' &&
             element.classes.contains('link-anchor')) {
           return <String, String>{
             'font-size': '0.7em',

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -69,6 +69,33 @@ class SmartTextWidget extends StatelessWidget {
             'top': '-0.55em',
           };
         }
+        // סמני עוגן-מילה (link_anchor): אות קטנה מורמת, עם וריאנט טיפוגרפי
+        // קבוע לכל מפרש (ראו anchorStyleIndexByCommentator).
+        if (element.localName == 'sup' &&
+            element.classes.contains('link-anchor')) {
+          final style = <String, String>{
+            'font-size': '0.7em',
+            'position': 'relative',
+            'top': '-0.55em',
+            'white-space': 'nowrap',
+          };
+          if (element.classes.contains('link-anchor-0')) {
+            style['font-weight'] = 'bold';
+          } else if (element.classes.contains('link-anchor-1')) {
+            style['font-style'] = 'italic';
+          } else if (element.classes.contains('link-anchor-2')) {
+            style['font-weight'] = 'bold';
+            style['font-style'] = 'italic';
+          } else if (element.classes.contains('link-anchor-3')) {
+            style['font-family'] = 'NotoRashiHebrew';
+          } else if (element.classes.contains('link-anchor-4')) {
+            style['font-family'] = 'NotoRashiHebrew';
+            style['font-weight'] = 'bold';
+          } else if (element.classes.contains('link-anchor-5')) {
+            style['text-decoration'] = 'underline';
+          }
+          return style;
+        }
         return null;
       },
       onTapUrl: (onOpenBook != null || onNoteTap != null)

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -69,32 +69,25 @@ class SmartTextWidget extends StatelessWidget {
             'top': '-0.55em',
           };
         }
-        // סמני עוגן-מילה (link_anchor): אות קטנה מורמת, עם וריאנט טיפוגרפי
-        // קבוע לכל מפרש (ראו anchorStyleIndexByCommentator).
+        // סמני עוגן-מילה (link_anchor): אות קטנה מורמת (עוגן-נקודה) או קו
+        // תחתון על טווח מצוטט (עוגן-טווח), עם וריאנט טיפוגרפי קבוע לכל מפרש
+        // (ראו anchorStyleIndexByCommentator).
         if (element.localName == 'sup' &&
             element.classes.contains('link-anchor')) {
-          final style = <String, String>{
+          return <String, String>{
             'font-size': '0.7em',
             'position': 'relative',
             'top': '-0.55em',
             'white-space': 'nowrap',
+            ..._linkAnchorVariantStyle(element),
           };
-          if (element.classes.contains('link-anchor-0')) {
-            style['font-weight'] = 'bold';
-          } else if (element.classes.contains('link-anchor-1')) {
-            style['font-style'] = 'italic';
-          } else if (element.classes.contains('link-anchor-2')) {
-            style['font-weight'] = 'bold';
-            style['font-style'] = 'italic';
-          } else if (element.classes.contains('link-anchor-3')) {
-            style['font-family'] = 'NotoRashiHebrew';
-          } else if (element.classes.contains('link-anchor-4')) {
-            style['font-family'] = 'NotoRashiHebrew';
-            style['font-weight'] = 'bold';
-          } else if (element.classes.contains('link-anchor-5')) {
-            style['text-decoration'] = 'underline';
-          }
-          return style;
+        }
+        if (element.localName == 'span' &&
+            element.classes.contains('link-anchor-range')) {
+          return <String, String>{
+            'text-decoration': 'underline',
+            ..._linkAnchorVariantStyle(element),
+          };
         }
         return null;
       },
@@ -119,6 +112,29 @@ class SmartTextWidget extends StatelessWidget {
           : null,
     );
   }
+}
+
+/// הווריאנט הטיפוגרפי של סמן/טווח עוגן-מילה לפי מחלקת ה-style שהוקצתה למפרש.
+Map<String, String> _linkAnchorVariantStyle(dom.Element element) {
+  if (element.classes.contains('link-anchor-0')) {
+    return const {'font-weight': 'bold'};
+  }
+  if (element.classes.contains('link-anchor-1')) {
+    return const {'font-style': 'italic'};
+  }
+  if (element.classes.contains('link-anchor-2')) {
+    return const {'font-weight': 'bold', 'font-style': 'italic'};
+  }
+  if (element.classes.contains('link-anchor-3')) {
+    return const {'font-family': 'NotoRashiHebrew'};
+  }
+  if (element.classes.contains('link-anchor-4')) {
+    return const {'font-family': 'NotoRashiHebrew', 'font-weight': 'bold'};
+  }
+  if (element.classes.contains('link-anchor-5')) {
+    return const {'text-decoration': 'underline'};
+  }
+  return const {};
 }
 
 /// גרסה פשוטה יותר של SmartTextWidget שמקבלת פרמטרים בודדים

--- a/test/text_book/link_anchor_markers_test.dart
+++ b/test/text_book/link_anchor_markers_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
+
+Link _anchorLink({
+  required String heRef,
+  required String path2,
+  int? anchorStart,
+  String? anchorLabel,
+}) {
+  return Link(
+    heRef: heRef,
+    index1: 4,
+    path2: path2,
+    index2: 1,
+    connectionType: 'commentary',
+    anchorStart: anchorStart,
+    anchorEnd: null,
+    anchorLabel: anchorLabel,
+  );
+}
+
+void main() {
+  group('anchorMarkerLetter', () {
+    test('מעדיף את התווית השמורה במסד', () {
+      final link = _anchorLink(
+        heRef: 'באר הגולה על שולחן ערוך אורח חיים א, ב',
+        path2: 'באר הגולה על שולחן ערוך אורח חיים',
+        anchorStart: 35,
+        anchorLabel: 'א',
+      );
+      expect(anchorMarkerLetter(link), 'א');
+    });
+
+    test('נגזר מהרכיב האחרון של heRef כשאין תווית', () {
+      final link = _anchorLink(
+        heRef: 'טורי זהב על שולחן ערוך אורח חיים א, ז',
+        path2: 'טורי זהב על שולחן ערוך אורח חיים',
+        anchorStart: 35,
+      );
+      expect(anchorMarkerLetter(link), 'ז');
+    });
+
+    test('גרשיים בתוך האות נשמרים בתצוגה', () {
+      final link = _anchorLink(
+        heRef: 'משנה ברורה,  א, קכ"ט',
+        path2: 'משנה ברורה',
+        anchorStart: 10,
+      );
+      expect(anchorMarkerLetter(link), 'קכ"ט');
+    });
+
+    test('רכיב אחרון שאינו גימטריה — אין אות', () {
+      final link = _anchorLink(
+        heRef: 'פירוש כלשהו, פסקה ארוכה מאוד שאינה אות',
+        path2: 'פירוש כלשהו',
+        anchorStart: 5,
+      );
+      expect(anchorMarkerLetter(link), isNull);
+    });
+  });
+
+  group('injectLinkAnchorMarkers', () {
+    // שורת שולחן ערוך או"ח א:א כפי שהיא שמורה במסד (הקטע הרלוונטי): התגים
+    // המקוריים של ספריא אינם נספרים כתווים גלויים, והעוגן של באר הגולה יושב
+    // באופסט גלוי 35 — מיד לפני "יתגבר".
+    const saLine = '(א) <b>דין השכמת הבוקר. ובו ט סעיפים:</b> '
+        '<i data-commentator="Be\'er HaGolah" data-label="א" data-order="1"></i>'
+        '<i data-commentator="Turei Zahav" data-order="1"></i>יתגבר '
+        '<i data-commentator="Ba\'er Hetev" data-order="1"></i>כארי לעמוד בבוקר';
+
+    test('סמן מוזרק בדיוק לפני המילה המעוגנת, בתוך תוכן אמיתי', () {
+      final bhg = _anchorLink(
+        heRef: 'באר הגולה על שולחן ערוך אורח חיים א, א',
+        path2: 'באר הגולה על שולחן ערוך אורח חיים',
+        anchorStart: 35,
+        anchorLabel: 'א',
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: saLine,
+        anchorLinks: [bhg],
+        styleIndexByCommentator: const {
+          'באר הגולה על שולחן ערוך אורח חיים': 0,
+        },
+      );
+      expect(
+        result,
+        contains('<sup class="link-anchor link-anchor-0">(א)</sup>'),
+      );
+      // הסמן נכנס צמוד לפני "יתגבר" — אחרי תגי ה-itag הבלתי-נראים.
+      final markerIndex = result.indexOf('<sup class="link-anchor');
+      final wordIndex = result.indexOf('יתגבר');
+      expect(markerIndex, lessThan(wordIndex));
+      final between = result.substring(
+          markerIndex +
+              '<sup class="link-anchor link-anchor-0">(א)</sup>'.length,
+          wordIndex);
+      expect(between, isEmpty);
+    });
+
+    test('כמה מפרשים באותה שורה — סגנון שונה לכל אחד', () {
+      final bhg = _anchorLink(
+        heRef: 'באר הגולה על שולחן ערוך אורח חיים א, א',
+        path2: 'באר הגולה על שולחן ערוך אורח חיים',
+        anchorStart: 35,
+        anchorLabel: 'א',
+      );
+      final baerHetev = _anchorLink(
+        heRef: 'באר היטב אורח חיים א, א',
+        path2: 'באר היטב אורח חיים',
+        anchorStart: 41,
+      );
+      final styles = anchorStyleIndexByCommentator([bhg, baerHetev]);
+      expect(styles.values.toSet().length, 2);
+
+      final result = injectLinkAnchorMarkers(
+        rawLine: saLine,
+        anchorLinks: [bhg, baerHetev],
+        styleIndexByCommentator: styles,
+      );
+      expect(result, contains('link-anchor-${styles[bhg.path2]}">(א)</sup>'));
+      expect(
+        result,
+        contains('link-anchor-${styles[baerHetev.path2]}">(א)</sup>'),
+      );
+      // העוגן של באר היטב (41) יושב אחרי "יתגבר " — לפני "כארי".
+      final hetevMarker =
+          '<sup class="link-anchor link-anchor-${styles[baerHetev.path2]}">(א)</sup>';
+      expect(result.indexOf(hetevMarker), lessThan(result.indexOf('כארי')));
+      expect(result.indexOf(hetevMarker), greaterThan(result.indexOf('יתגבר')));
+    });
+
+    test('entity נספר כתו גלוי אחד', () {
+      const line = 'אב&nbsp;גד';
+      final link = _anchorLink(
+        heRef: 'ספר כלשהו א, ב',
+        path2: 'ספר כלשהו',
+        anchorStart: 3,
+        anchorLabel: 'ב',
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: line,
+        anchorLinks: [link],
+        styleIndexByCommentator: const {'ספר כלשהו': 1},
+      );
+      expect(
+        result,
+        'אב&nbsp;<sup class="link-anchor link-anchor-1">(ב)</sup>גד',
+      );
+    });
+
+    test('עוגן מעבר לאורך השורה נצמד לסוף', () {
+      final link = _anchorLink(
+        heRef: 'ספר כלשהו א, ג',
+        path2: 'ספר כלשהו',
+        anchorStart: 999,
+        anchorLabel: 'ג',
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: 'אבג',
+        anchorLinks: [link],
+        styleIndexByCommentator: const {'ספר כלשהו': 0},
+      );
+      expect(result, 'אבג<sup class="link-anchor link-anchor-0">(ג)</sup>');
+    });
+
+    test('שורה בלי עוגנים חוזרת כמות שהיא', () {
+      expect(
+        injectLinkAnchorMarkers(
+          rawLine: saLine,
+          anchorLinks: const [],
+          styleIndexByCommentator: const {},
+        ),
+        saLine,
+      );
+    });
+  });
+}

--- a/test/text_book/link_anchor_markers_test.dart
+++ b/test/text_book/link_anchor_markers_test.dart
@@ -85,16 +85,16 @@ void main() {
       );
       expect(
         result,
-        contains('<sup class="link-anchor link-anchor-0">(א)</sup>'),
+        contains('<span class="link-anchor link-anchor-0">(א)</span>'),
       );
       // הסמן נכנס צמוד לפני "יתגבר" — בלי אף תו גלוי בין הסמן למילה
       // (רק תגי itag בלתי-נראים מותרים בתווך).
-      final markerIndex = result.indexOf('<sup class="link-anchor');
+      final markerIndex = result.indexOf('<span class="link-anchor');
       final wordIndex = result.indexOf('יתגבר');
       expect(markerIndex, lessThan(wordIndex));
       final between = result.substring(
           markerIndex +
-              '<sup class="link-anchor link-anchor-0">(א)</sup>'.length,
+              '<span class="link-anchor link-anchor-0">(א)</span>'.length,
           wordIndex);
       expect(between.replaceAll(RegExp(r'<[^>]*>'), ''), isEmpty);
     });
@@ -119,14 +119,14 @@ void main() {
         anchorLinks: [bhg, baerHetev],
         styleIndexByCommentator: styles,
       );
-      expect(result, contains('link-anchor-${styles[bhg.path2]}">(א)</sup>'));
+      expect(result, contains('link-anchor-${styles[bhg.path2]}">(א)</span>'));
       expect(
         result,
-        contains('link-anchor-${styles[baerHetev.path2]}">(א)</sup>'),
+        contains('link-anchor-${styles[baerHetev.path2]}">(א)</span>'),
       );
       // העוגן של באר היטב (41) יושב אחרי "יתגבר " — לפני "כארי".
       final hetevMarker =
-          '<sup class="link-anchor link-anchor-${styles[baerHetev.path2]}">(א)</sup>';
+          '<span class="link-anchor link-anchor-${styles[baerHetev.path2]}">(א)</span>';
       expect(result.indexOf(hetevMarker), lessThan(result.indexOf('כארי')));
       expect(result.indexOf(hetevMarker), greaterThan(result.indexOf('יתגבר')));
     });
@@ -146,7 +146,7 @@ void main() {
       );
       expect(
         result,
-        'אב&nbsp;<sup class="link-anchor link-anchor-1">(ב)</sup>גד',
+        'אב&nbsp;<span class="link-anchor link-anchor-1">(ב)</span>גד',
       );
     });
 
@@ -162,7 +162,50 @@ void main() {
         anchorLinks: [link],
         styleIndexByCommentator: const {'ספר כלשהו': 0},
       );
-      expect(result, 'אבג<sup class="link-anchor link-anchor-0">(ג)</sup>');
+      expect(result, 'אבג<span class="link-anchor link-anchor-0">(ג)</span>');
+    });
+
+    test('סמן על גבול אלמנט נכנס אחרי תג הסגירה, לא בתוכו', () {
+      final link = _anchorLink(
+        heRef: 'ספר כלשהו א, א',
+        path2: 'ספר כלשהו',
+        anchorStart: 2,
+        anchorLabel: 'א',
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: '<b>אב</b>גד',
+        anchorLinks: [link],
+        styleIndexByCommentator: const {'ספר כלשהו': 0},
+      );
+      // הסמן שייך ל"ג" שמחוץ ל-<b> — בתוך התג הוא היה יורש את ההדגשה
+      // (או את הקליק, אם התג הסוגר הוא <a>).
+      expect(
+        result,
+        '<b>אב</b><span class="link-anchor link-anchor-0">(א)</span>גד',
+      );
+    });
+
+    test('הסמנים נפלטים כ-span ולא כ-sup (כמה sup בפסקת RTL מתהפכים)', () {
+      final first = _anchorLink(
+        heRef: 'ספר ראשון א, א',
+        path2: 'ספר ראשון',
+        anchorStart: 0,
+        anchorLabel: 'א',
+      );
+      final second = _anchorLink(
+        heRef: 'ספר שני א, ב',
+        path2: 'ספר שני',
+        anchorStart: 3,
+        anchorLabel: 'ב',
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: 'אב גד',
+        anchorLinks: [first, second],
+        styleIndexByCommentator: const {'ספר ראשון': 0, 'ספר שני': 1},
+      );
+      expect(result, isNot(contains('<sup')));
+      // סדר האותיות הלוגי נשמר: (א) לפני (ב).
+      expect(result.indexOf('(א)'), lessThan(result.indexOf('(ב)')));
     });
 
     test('עוגן-טווח (ציטוט) נעטף בקו תחתון בגבולות מדויקים', () {
@@ -232,7 +275,7 @@ void main() {
         },
       );
       expect(
-        RegExp('link-anchor-1">\\(א\\)</sup>').allMatches(result).length,
+        RegExp('link-anchor-1">\\(א\\)</span>').allMatches(result).length,
         2,
       );
     });

--- a/test/text_book/link_anchor_markers_test.dart
+++ b/test/text_book/link_anchor_markers_test.dart
@@ -186,7 +186,7 @@ void main() {
       );
     });
 
-    test('עוגן-טווח מדלג על תגים בספירת התווים הגלויים', () {
+    test('עוגן-טווח שחוצה גבול תג נסגר ונפתח מחדש (קינון תקין)', () {
       final quote = Link(
         heRef: 'תהלים פרק כג',
         index1: 4,
@@ -201,9 +201,39 @@ void main() {
         anchorLinks: [quote],
         styleIndexByCommentator: const {'תהלים': 0},
       );
+      // הטווח [1,3) מתחיל בתוך <b> ומסתיים אחריו — העטיפה נסגרת לפני </b>
+      // ונפתחת מחדש, כך שה-HTML נשאר מקונן כדין.
       expect(
         result,
-        'א<span class="link-anchor-range link-anchor-0"><b>ב</b>ג</span>ד',
+        'א<b><span class="link-anchor-range link-anchor-0">ב</span></b>'
+        '<span class="link-anchor-range link-anchor-0">ג</span>ד',
+      );
+    });
+
+    test('קישור עם כמה עוגנים (anchorSpans) מציג את כולם', () {
+      final link = Link(
+        heRef: 'שערי תשובה על שולחן ערוך אורח חיים רצ, א',
+        index1: 4,
+        path2: 'שערי תשובה על שולחן ערוך אורח חיים',
+        index2: 1,
+        connectionType: 'commentary',
+        anchorStart: 2,
+        anchorLabel: 'א',
+        anchorSpans: const [
+          LinkAnchorSpan(start: 2, label: 'א'),
+          LinkAnchorSpan(start: 5, label: 'א'),
+        ],
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: 'אב גד הו',
+        anchorLinks: [link],
+        styleIndexByCommentator: const {
+          'שערי תשובה על שולחן ערוך אורח חיים': 1,
+        },
+      );
+      expect(
+        RegExp('link-anchor-1">\\(א\\)</sup>').allMatches(result).length,
+        2,
       );
     });
 

--- a/test/text_book/link_anchor_markers_test.dart
+++ b/test/text_book/link_anchor_markers_test.dart
@@ -87,7 +87,8 @@ void main() {
         result,
         contains('<sup class="link-anchor link-anchor-0">(א)</sup>'),
       );
-      // הסמן נכנס צמוד לפני "יתגבר" — אחרי תגי ה-itag הבלתי-נראים.
+      // הסמן נכנס צמוד לפני "יתגבר" — בלי אף תו גלוי בין הסמן למילה
+      // (רק תגי itag בלתי-נראים מותרים בתווך).
       final markerIndex = result.indexOf('<sup class="link-anchor');
       final wordIndex = result.indexOf('יתגבר');
       expect(markerIndex, lessThan(wordIndex));
@@ -95,7 +96,7 @@ void main() {
           markerIndex +
               '<sup class="link-anchor link-anchor-0">(א)</sup>'.length,
           wordIndex);
-      expect(between, isEmpty);
+      expect(between.replaceAll(RegExp(r'<[^>]*>'), ''), isEmpty);
     });
 
     test('כמה מפרשים באותה שורה — סגנון שונה לכל אחד', () {
@@ -162,6 +163,62 @@ void main() {
         styleIndexByCommentator: const {'ספר כלשהו': 0},
       );
       expect(result, 'אבג<sup class="link-anchor link-anchor-0">(ג)</sup>');
+    });
+
+    test('עוגן-טווח (ציטוט) נעטף בקו תחתון בגבולות מדויקים', () {
+      final quote = Link(
+        heRef: 'בראשית פרק א פסוק א',
+        index1: 4,
+        path2: 'בראשית',
+        index2: 1,
+        connectionType: 'quotation',
+        anchorStart: 2,
+        anchorEnd: 5,
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: 'אבג דה',
+        anchorLinks: [quote],
+        styleIndexByCommentator: const {'בראשית': 1},
+      );
+      expect(
+        result,
+        'אב<span class="link-anchor-range link-anchor-1">ג ד</span>ה',
+      );
+    });
+
+    test('עוגן-טווח מדלג על תגים בספירת התווים הגלויים', () {
+      final quote = Link(
+        heRef: 'תהלים פרק כג',
+        index1: 4,
+        path2: 'תהלים',
+        index2: 1,
+        connectionType: 'quotation',
+        anchorStart: 1,
+        anchorEnd: 3,
+      );
+      final result = injectLinkAnchorMarkers(
+        rawLine: 'א<b>ב</b>גד',
+        anchorLinks: [quote],
+        styleIndexByCommentator: const {'תהלים': 0},
+      );
+      expect(
+        result,
+        'א<span class="link-anchor-range link-anchor-0"><b>ב</b>ג</span>ד',
+      );
+    });
+
+    test('wrapVisibleRange עוטף טווח בקטע פאנל (הדגשת ציטוט)', () {
+      final result = wrapVisibleRange(
+        html: 'אמר רבי ותלד בן ששי ליעקב',
+        start: 8,
+        end: 19,
+        openTag: '<span class="link-anchor-range">',
+        closeTag: '</span>',
+      );
+      expect(
+        result,
+        'אמר רבי <span class="link-anchor-range">ותלד בן ששי</span> ליעקב',
+      );
     });
 
     test('שורה בלי עוגנים חוזרת כמות שהיא', () {


### PR DESCRIPTION
עוגני-מילה בתצוגת הטקסט: אות סימון במיקום המדויק של הערת המפרש, והדגשת ציטוטים.

תלוי בטבלת `link_anchor` החדשה שמייצר SeforimLibrary (Otzaria/SeforimLibrary#13). קורא בהצטרפות שמאלית — מסד ישן שאין בו את הטבלה ממשיך לעבוד ללא סמנים.

## מה מוצג
- **עוגן-נקודה**: אות קטנה מורמת, למשל (א), בדיוק במילה שעליה ההערה. כמה מפרשים על אותה שורה (באר הגולה, ט"ז, מג"א, משנה ברורה…) — כל אחד בווריאנט טיפוגרפי קבוע משלו (מודגש/נטוי/כתב רש"י/קו תחתון, לפי סדר אלפביתי).
- **עוגן-טווח** (ציטוטים מ-charLevelData): הטווח המצוטט נעטף בקו תחתון בגוף הטקסט, ובפאנל המפרשים הפסוק המצוטט מודגש בתוך קטע המפרש.
- אות הסימון מוצגת גם לפני ההפניה בפאנל המפרשים ובתצוגת השורה הנבחרת.

## מימוש
- שאילתות `database_library_provider` מצרפות `link_anchor` (עם בדיקת קיום טבלה); כל עוגני הקישור נאספים ב-`GROUP_CONCAT` ל-`anchorSpans` כך שקישור עם כמה עוגנים מציג את כולם.
- ההזרקה על אופסטי תווים-גלויים (מוסכמת `charCount`); טווחים עוברים דרך `wrapHtmlRanges` הקיים ששומר קינון HTML תקין גם כשטווח חוצה גבול תג.
- 13 טסטי יחידה חדשים; `flutter analyze` נקי; כל סוויטת הטסטים עוברת.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
