### PR TITLE
כפתורי החלון בפינה לפי מוסכמת מערכת ההפעלה ב-Windows

### DIFF
--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -81,9 +81,7 @@ final ButtonStyle _kIconButtonStyle = IconButton.styleFrom(
   minimumSize: const Size(32, 32),
   padding: EdgeInsets.zero,
   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-  shape: RoundedRectangleBorder(
-    borderRadius: AppTokens.borderRadiusAll,
-  ),
+  shape: RoundedRectangleBorder(borderRadius: AppTokens.borderRadiusAll),
 );
 
 class _CustomTitleBarState extends State<CustomTitleBar> {
@@ -113,8 +111,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   /// בלי להסתמך על gesture arena.
   bool _hitTestTab(BuildContext context, Offset globalPosition) {
     final result = HitTestResult();
-    WidgetsBinding.instance
-        .hitTestInView(result, globalPosition, View.of(context).viewId);
+    WidgetsBinding.instance.hitTestInView(
+      result,
+      globalPosition,
+      View.of(context).viewId,
+    );
     for (final entry in result.path) {
       final target = entry.target;
       if (target is RenderMetaData && target.metaData == _kTabHitMarker) {
@@ -130,8 +131,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   /// לפני שה-onPressed שלו יורה, כך שהטאב מתחלף במקום להיסגר.
   bool _hitTestCloseButton(BuildContext context, Offset globalPosition) {
     final result = HitTestResult();
-    WidgetsBinding.instance
-        .hitTestInView(result, globalPosition, View.of(context).viewId);
+    WidgetsBinding.instance.hitTestInView(
+      result,
+      globalPosition,
+      View.of(context).viewId,
+    );
     for (final entry in result.path) {
       final target = entry.target;
       if (target is RenderMetaData &&
@@ -155,7 +159,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   }
 
   bool _useStackedTabs(BuildContext context, NavigationState navState) {
-    final isReading = navState.currentScreen == Screen.reading ||
+    final isReading =
+        navState.currentScreen == Screen.reading ||
         navState.currentScreen == Screen.search;
     if (!isReading) return false;
     return MediaQuery.of(context).orientation == Orientation.portrait;
@@ -171,9 +176,106 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             // במסך עיון ללא טאבים פתוחים אין תוכן קריאה אמיתי, ולכן המסגרת
             // העליונה נצבעת כשאר מסכי הלוח (רקע לוח + גבול תחתון) במקום ברקע
             // מסך העיון. בחיפוש תמיד קיים טאב, לכן נשאר בסגנון הקריאה.
-            final useReaderStyle = navState.currentScreen == Screen.search ||
+            final useReaderStyle =
+                navState.currentScreen == Screen.search ||
                 (navState.currentScreen == Screen.reading &&
                     context.select((TabsBloc bloc) => bloc.state.hasOpenTabs));
+
+            final bool windowsNativeControls = !kIsWeb && Platform.isWindows;
+            final bool showWindowCaption =
+                !kIsWeb &&
+                (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
+
+            final Widget actionSegment = SizedBox(
+              height: 40,
+              child: Stack(
+                children: [
+                  Center(child: _buildActionButtons(context)),
+                  if (useReaderStyle)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      child: Align(
+                        alignment: AlignmentDirectional.bottomStart,
+                        child: Container(
+                          width: 74,
+                          height: 1,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.outlineVariant.withValues(alpha: 0.6),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            );
+
+            final Widget contentSegment = Expanded(
+              child: _buildContent(context, navState),
+            );
+
+            Widget? windowCaptionSegment;
+            if (showWindowCaption) {
+              Widget caption = SizedBox(
+                height: 50,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const ManagedUpdateTitleBarIndicator(),
+                    _buildFullscreenCaptionButton(context, settingsState),
+                    if (settingsState.isFullscreen)
+                      _CaptionActionButton(
+                        brightness: Theme.of(context).brightness,
+                        tooltip: 'מזער',
+                        icon: FluentIcons.subtract_24_regular,
+                        onPressed: () async {
+                          await FullscreenHelper.toggleFullscreen(
+                            context,
+                            false,
+                          );
+                          await windowManager.minimize();
+                        },
+                      ),
+                    if (settingsState.isFullscreen)
+                      _CaptionActionButton(
+                        brightness: Theme.of(context).brightness,
+                        tooltip: 'סגור',
+                        icon: FluentIcons.dismiss_24_regular,
+                        onPressed: () => windowManager.close(),
+                      ),
+                    if (!settingsState.isFullscreen)
+                      SizedBox(
+                        width: _kWindowCaptionButtonsWidth,
+                        height: 50,
+                        child: WindowCaption(
+                          brightness: Theme.of(context).brightness,
+                          backgroundColor: Colors.transparent,
+                        ),
+                      ),
+                  ],
+                ),
+              );
+              // ב-Windows הכפתורים בסדר LTR (מזעור→הגדלה→סגירה) בפינה הימנית כמו
+              // בכל חלון מערכת, במקום להתהפך עם כיווניות ה-RTL של האפליקציה.
+              if (windowsNativeControls) {
+                caption = Directionality(
+                  textDirection: TextDirection.ltr,
+                  child: caption,
+                );
+              }
+              windowCaptionSegment = caption;
+            }
+
+            // ב-Windows כפתורי החלון בפינה הימנית וכפתורי הפעולה בשמאלית, כמו
+            // חלון Windows רגיל; בשאר המערכות להפך, לפי ברירת ה-RTL של האפליקציה.
+            final List<Widget> topBarChildren = windowsNativeControls
+                ? [windowCaptionSegment!, contentSegment, actionSegment]
+                : [
+                    actionSegment,
+                    contentSegment,
+                    if (windowCaptionSegment != null) windowCaptionSegment,
+                  ];
             final topBar = SizedBox(
               height: 40,
               child: Stack(
@@ -197,87 +299,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                               ),
                             ),
                     ),
-                    child: Row(
-                      children: [
-                        // כפתורי פעולה (היסטוריה וכו') - תמיד מוצגים
-                        SizedBox(
-                          height: 40,
-                          child: Stack(
-                            children: [
-                              Center(
-                                child: _buildActionButtons(context),
-                              ),
-                              if (useReaderStyle)
-                                Positioned(
-                                  bottom: 0,
-                                  left: 0,
-                                  right: 0,
-                                  child: Align(
-                                    alignment: AlignmentDirectional.bottomStart,
-                                    child: Container(
-                                      width: 74,
-                                      height: 1,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outlineVariant
-                                          .withValues(alpha: 0.6),
-                                    ),
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ),
-
-                        // תוכן הכותרת (טאבים או כותרת רגילה)
-                        Expanded(
-                          child: _buildContent(context, navState),
-                        ),
-
-                        // כפתורי חלון (רק בדסקטופ)
-                        if (!kIsWeb &&
-                            (Platform.isWindows ||
-                                Platform.isLinux ||
-                                Platform.isMacOS))
-                          SizedBox(
-                            height: 50,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const ManagedUpdateTitleBarIndicator(),
-                                _buildFullscreenCaptionButton(
-                                    context, settingsState),
-                                if (settingsState.isFullscreen)
-                                  _CaptionActionButton(
-                                    brightness: Theme.of(context).brightness,
-                                    tooltip: 'מזער',
-                                    icon: FluentIcons.subtract_24_regular,
-                                    onPressed: () async {
-                                      await FullscreenHelper.toggleFullscreen(
-                                          context, false);
-                                      await windowManager.minimize();
-                                    },
-                                  ),
-                                if (settingsState.isFullscreen)
-                                  _CaptionActionButton(
-                                    brightness: Theme.of(context).brightness,
-                                    tooltip: 'סגור',
-                                    icon: FluentIcons.dismiss_24_regular,
-                                    onPressed: () => windowManager.close(),
-                                  ),
-                                if (!settingsState.isFullscreen)
-                                  SizedBox(
-                                    width: _kWindowCaptionButtonsWidth,
-                                    height: 50,
-                                    child: WindowCaption(
-                                      brightness: Theme.of(context).brightness,
-                                      backgroundColor: Colors.transparent,
-                                    ),
-                                  ),
-                              ],
-                            ),
-                          ),
-                      ],
-                    ),
+                    child: Row(children: topBarChildren),
                   ),
                 ],
               ),
@@ -287,10 +309,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
 
             return Column(
               mainAxisSize: MainAxisSize.min,
-              children: [
-                topBar,
-                _buildNarrowTabsRow(context),
-              ],
+              children: [topBar, _buildNarrowTabsRow(context)],
             );
           },
         );
@@ -303,7 +322,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         Settings.getValue<String>('key-shortcut-open-history') ?? 'ctrl+h';
     final bookmarksShortcut =
         Settings.getValue<String>('key-shortcut-open-bookmarks') ??
-            'ctrl+shift+b';
+        'ctrl+shift+b';
     final workspaceShortcut =
         Settings.getValue<String>('key-shortcut-switch-workspace') ?? 'ctrl+k';
 
@@ -311,9 +330,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
       width: _kAppBarControlsWidth,
       child: Stack(
         children: [
-          const DragToMoveArea(
-            child: SizedBox.expand(),
-          ),
+          const DragToMoveArea(child: SizedBox.expand()),
           Center(
             child: Row(
               mainAxisSize: MainAxisSize.min,
@@ -396,8 +413,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
     return _buildPanelTitle(context, title);
   }
 
-  Widget _buildPanelTitle(BuildContext context, String title,
-      {String? subtitle}) {
+  Widget _buildPanelTitle(
+    BuildContext context,
+    String title, {
+    String? subtitle,
+  }) {
     final color = Theme.of(context).colorScheme.onSurfaceVariant;
     final textStyle = TextStyle(
       color: color,
@@ -496,7 +516,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
     // בדסקטופ גרירת-עכבר על טאב מסדרת אותו מיד (כמו כרום); בנייד נדרשת לחיצה
     // ארוכה כדי שהחלקה/גלילה במגע לא תזיז טאב בטעות.
     final platform = Theme.of(context).platform;
-    final isDesktop = platform == TargetPlatform.windows ||
+    final isDesktop =
+        platform == TargetPlatform.windows ||
         platform == TargetPlatform.linux ||
         platform == TargetPlatform.macOS;
 
@@ -569,10 +590,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         onDoubleTapDown: (details) =>
             _doubleTapOnTab = _hitTestTab(context, details.globalPosition),
         onDoubleTap: _onTabsAreaDoubleTap,
-        child: KeyedSubtree(
-          key: tourReadingTabsTargetKey,
-          child: reorderList,
-        ),
+        child: KeyedSubtree(key: tourReadingTabsTargetKey, child: reorderList),
       ),
     );
   }
@@ -590,7 +608,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             size: 18,
           ),
           tooltip: 'הגדרות תצוגת הספרים',
-          onPressed: widget.onReadingSettingsPressed ??
+          onPressed:
+              widget.onReadingSettingsPressed ??
               () => showReadingSettingsDialog(context),
           style: _kIconButtonStyle,
         ),
@@ -614,17 +633,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   // --- Helper Methods ---
 
   void _showHistoryDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => const HistoryDialog(),
-    );
+    showDialog(context: context, builder: (context) => const HistoryDialog());
   }
 
   void _showBookmarksDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => const BookmarksDialog(),
-    );
+    showDialog(context: context, builder: (context) => const BookmarksDialog());
   }
 
   void _showSaveWorkspaceDialog(BuildContext context) {
@@ -636,7 +649,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   }
 
   Widget _buildFullscreenCaptionButton(
-      BuildContext context, SettingsState settingsState) {
+    BuildContext context,
+    SettingsState settingsState,
+  ) {
     // הכפתור מוצג רק בהקשר שמתיר מסך מלא (עיון/כלים).
     if (!FullscreenHelper.isAllowedInContext(context)) {
       return const SizedBox.shrink();
@@ -691,7 +706,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   }
 
   Widget _buildTab(
-      BuildContext context, OpenedTab tab, TabsState state, double tabWidth) {
+    BuildContext context,
+    OpenedTab tab,
+    TabsState state,
+    double tabWidth,
+  ) {
     final index = state.tabs.indexOf(tab);
     final isSelected = index == state.currentTabIndex;
     final closeTabShortcut =
@@ -766,7 +785,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                 ? '${tab.title}, $currentTitleValue'
                 : tab.title;
             return Tooltip(
-                message: tooltipMessage, child: fadedTitle(tab.title));
+              message: tooltipMessage,
+              child: fadedTitle(tab.title),
+            );
           },
         );
       }
@@ -779,7 +800,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                 ? '${tab.title}, $currentTitleValue'
                 : tab.title;
             return Tooltip(
-                message: tooltipMessage, child: fadedTitle(tab.title));
+              message: tooltipMessage,
+              child: fadedTitle(tab.title),
+            );
           },
         );
       }
@@ -818,7 +841,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
       // הכותרת תמיד ב-Expanded ומתכווצת לאפס בעת הצורך.
       final extrasBudget =
           tabWidth - 2 * (outerPad + innerPad) - (isSelected ? 4 : 0);
-      final showClose = extrasBudget >= 25 &&
+      final showClose =
+          extrasBudget >= 25 &&
           (tabWidth >= _kTabCloseHideBelowWidth || isSelected || isTabHovered);
       final showPin =
           tab.isPinned && (extrasBudget - (showClose ? 25 : 0)) >= 20;
@@ -844,11 +868,13 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
               child: CustomPaint(
                 painter: isSelected
                     ? _TabBackgroundPainter(
-                        AppSurfaces.topBarBackground(context))
+                        AppSurfaces.topBarBackground(context),
+                      )
                     : null,
                 foregroundPainter: isTabHovered && !isSelected
                     ? _TabBackgroundPainter(
-                        colorScheme.onSurface.withValues(alpha: 0.08))
+                        colorScheme.onSurface.withValues(alpha: 0.08),
+                      )
                     : null,
                 child: Tab(
                   child: Padding(
@@ -856,8 +882,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                     child: DefaultTextStyle(
                       style: TextStyle(
                         color: colorScheme.onSurface,
-                        fontWeight:
-                            isSelected ? FontWeight.w600 : FontWeight.normal,
+                        fontWeight: isSelected
+                            ? FontWeight.w600
+                            : FontWeight.normal,
                         fontSize: 14,
                       ),
                       child: Row(
@@ -925,8 +952,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         key: isSelected ? tourTabContextMenuTargetKey : null,
         menuBuilder: (menuCtx, _) =>
             _buildTabContextMenuEntries(menuCtx, tab, state),
-        menuItemKeysByLabel:
-            isSelected ? {'הצג לצד': tourTabSideBySideMenuItemTargetKey} : null,
+        menuItemKeysByLabel: isSelected
+            ? {'הצג לצד': tourTabSideBySideMenuItemTargetKey}
+            : null,
         child: StatefulBuilder(
           builder: (context, setLocalState) {
             return MouseRegion(
@@ -942,7 +970,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
 
   /// בונה פריט תפריט להעברת טאב לשולחן עבודה אחר
   AppContextMenuEntry _buildMoveToWorkspaceMenuEntry(
-      BuildContext context, OpenedTab tab) {
+    BuildContext context,
+    OpenedTab tab,
+  ) {
     final workspaceState = context.read<WorkspaceBloc>().state;
 
     final otherWorkspaces = workspaceState.workspaces
@@ -950,10 +980,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         .toList();
 
     if (otherWorkspaces.isEmpty) {
-      return AppContextMenuEntry(
-        label: 'העבר לשולחן עבודה',
-        enabled: false,
-      );
+      return AppContextMenuEntry(label: 'העבר לשולחן עבודה', enabled: false);
     }
 
     return AppContextMenuEntry(
@@ -971,14 +998,18 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
 
   /// מעביר טאב לשולחן עבודה אחר
   void _moveTabToWorkspace(
-      BuildContext context, OpenedTab tab, String targetWorkspaceId) {
+    BuildContext context,
+    OpenedTab tab,
+    String targetWorkspaceId,
+  ) {
     final tabsBloc = context.read<TabsBloc>();
     final workspaceBloc = context.read<WorkspaceBloc>();
     final tabsState = tabsBloc.state;
     final workspaceState = workspaceBloc.state;
 
-    final targetWorkspace =
-        workspaceState.workspaces.firstWhere((w) => w.id == targetWorkspaceId);
+    final targetWorkspace = workspaceState.workspaces.firstWhere(
+      (w) => w.id == targetWorkspaceId,
+    );
 
     tabsBloc.add(RemoveTab(tab));
 
@@ -987,12 +1018,14 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         ? 0
         : tabsState.currentTabIndex.clamp(0, currentTabs.length - 1);
 
-    workspaceBloc.add(MoveTabToWorkspace(
-      tab: tab,
-      targetWorkspaceId: targetWorkspaceId,
-      currentTabs: currentTabs,
-      currentTabIndex: newActiveIndex,
-    ));
+    workspaceBloc.add(
+      MoveTabToWorkspace(
+        tab: tab,
+        targetWorkspaceId: targetWorkspaceId,
+        currentTabs: currentTabs,
+        currentTabIndex: newActiveIndex,
+      ),
+    );
 
     UiSnack.show('הכרטיסיה הועברה לשולחן העבודה "${targetWorkspace.name}"');
   }
@@ -1007,10 +1040,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         label: tab.isPinned ? 'בטל הצמדת כרטיסיה' : 'הצמד כרטיסיה',
         onTap: () => context.read<TabsBloc>().add(TogglePinTab(tab)),
       ),
-      AppContextMenuEntry(
-        label: 'סגור',
-        onTap: () => closeTab(tab, context),
-      ),
+      AppContextMenuEntry(label: 'סגור', onTap: () => closeTab(tab, context)),
       AppContextMenuEntry(
         label: 'סגור הכל',
         onTap: () => closeAllTabs(state, context),
@@ -1028,8 +1058,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
 
     if (tab is! CombinedTab) {
       if (state.tabs.length > 1) {
-        final otherTabsList =
-            state.tabs.where((t) => t != tab && t is! CombinedTab).toList();
+        final otherTabsList = state.tabs
+            .where((t) => t != tab && t is! CombinedTab)
+            .toList();
         final otherTabs = otherTabsList.asMap().entries.map((mapEntry) {
           final isFirst = mapEntry.key == 0;
           final otherTab = mapEntry.value;
@@ -1038,23 +1069,14 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             label: otherTab.title,
             onTap: () {
               context.read<TabsBloc>().add(
-                    EnableSideBySideMode(
-                      rightTab: tab,
-                      leftTab: otherTab,
-                    ),
-                  );
+                EnableSideBySideMode(rightTab: tab, leftTab: otherTab),
+              );
             },
           );
         }).toList();
-        entries.add(AppContextMenuEntry(
-          label: 'הצג לצד',
-          children: otherTabs,
-        ));
+        entries.add(AppContextMenuEntry(label: 'הצג לצד', children: otherTabs));
       } else {
-        entries.add(AppContextMenuEntry(
-          label: 'הצג לצד',
-          enabled: false,
-        ));
+        entries.add(AppContextMenuEntry(label: 'הצג לצד', enabled: false));
       }
     }
 
@@ -1066,9 +1088,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         ),
         AppContextMenuEntry(
           label: 'חזרה לתצוגה רגילה',
-          onTap: () => context
-              .read<TabsBloc>()
-              .add(DisableSideBySideMode(state.tabs.indexOf(tab))),
+          onTap: () => context.read<TabsBloc>().add(
+            DisableSideBySideMode(state.tabs.indexOf(tab)),
+          ),
         ),
       ]);
     }
@@ -1212,8 +1234,9 @@ class _CaptionActionButtonState extends State<_CaptionActionButton> {
     final isDark = widget.brightness == Brightness.dark;
 
     Color bgColor = Colors.transparent;
-    Color iconColor =
-        isDark ? Colors.white : Colors.black.withValues(alpha: 0.8956);
+    Color iconColor = isDark
+        ? Colors.white
+        : Colors.black.withValues(alpha: 0.8956);
 
     if (_isHovering) {
       bgColor = isDark
@@ -1244,13 +1267,7 @@ class _CaptionActionButtonState extends State<_CaptionActionButton> {
             minHeight: 32,
           ),
           decoration: BoxDecoration(color: bgColor),
-          child: Center(
-            child: Icon(
-              widget.icon,
-              size: 16,
-              color: iconColor,
-            ),
-          ),
+          child: Center(child: Icon(widget.icon, size: 16, color: iconColor)),
         ),
       ),
     );

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -159,8 +159,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   }
 
   bool _useStackedTabs(BuildContext context, NavigationState navState) {
-    final isReading =
-        navState.currentScreen == Screen.reading ||
+    final isReading = navState.currentScreen == Screen.reading ||
         navState.currentScreen == Screen.search;
     if (!isReading) return false;
     return MediaQuery.of(context).orientation == Orientation.portrait;
@@ -176,14 +175,12 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             // במסך עיון ללא טאבים פתוחים אין תוכן קריאה אמיתי, ולכן המסגרת
             // העליונה נצבעת כשאר מסכי הלוח (רקע לוח + גבול תחתון) במקום ברקע
             // מסך העיון. בחיפוש תמיד קיים טאב, לכן נשאר בסגנון הקריאה.
-            final useReaderStyle =
-                navState.currentScreen == Screen.search ||
+            final useReaderStyle = navState.currentScreen == Screen.search ||
                 (navState.currentScreen == Screen.reading &&
                     context.select((TabsBloc bloc) => bloc.state.hasOpenTabs));
 
             final bool windowsNativeControls = !kIsWeb && Platform.isWindows;
-            final bool showWindowCaption =
-                !kIsWeb &&
+            final bool showWindowCaption = !kIsWeb &&
                 (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
 
             final Widget actionSegment = SizedBox(
@@ -197,7 +194,9 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                       left: 0,
                       right: 0,
                       child: Align(
-                        alignment: AlignmentDirectional.bottomStart,
+                        alignment: windowsNativeControls
+                            ? AlignmentDirectional.bottomEnd
+                            : AlignmentDirectional.bottomStart,
                         child: Container(
                           width: 74,
                           height: 1,
@@ -218,7 +217,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             Widget? windowCaptionSegment;
             if (showWindowCaption) {
               Widget caption = SizedBox(
-                height: 50,
+                height: 40,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -247,7 +246,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                     if (!settingsState.isFullscreen)
                       SizedBox(
                         width: _kWindowCaptionButtonsWidth,
-                        height: 50,
+                        height: 40,
                         child: WindowCaption(
                           brightness: Theme.of(context).brightness,
                           backgroundColor: Colors.transparent,
@@ -270,7 +269,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             // ב-Windows כפתורי החלון בפינה הימנית וכפתורי הפעולה בשמאלית, כמו
             // חלון Windows רגיל; בשאר המערכות להפך, לפי ברירת ה-RTL של האפליקציה.
             final List<Widget> topBarChildren = windowsNativeControls
-                ? [windowCaptionSegment!, contentSegment, actionSegment]
+                ? [
+                    if (windowCaptionSegment != null) windowCaptionSegment,
+                    contentSegment,
+                    actionSegment,
+                  ]
                 : [
                     actionSegment,
                     contentSegment,
@@ -322,7 +325,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         Settings.getValue<String>('key-shortcut-open-history') ?? 'ctrl+h';
     final bookmarksShortcut =
         Settings.getValue<String>('key-shortcut-open-bookmarks') ??
-        'ctrl+shift+b';
+            'ctrl+shift+b';
     final workspaceShortcut =
         Settings.getValue<String>('key-shortcut-switch-workspace') ?? 'ctrl+k';
 
@@ -516,8 +519,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
     // בדסקטופ גרירת-עכבר על טאב מסדרת אותו מיד (כמו כרום); בנייד נדרשת לחיצה
     // ארוכה כדי שהחלקה/גלילה במגע לא תזיז טאב בטעות.
     final platform = Theme.of(context).platform;
-    final isDesktop =
-        platform == TargetPlatform.windows ||
+    final isDesktop = platform == TargetPlatform.windows ||
         platform == TargetPlatform.linux ||
         platform == TargetPlatform.macOS;
 
@@ -608,8 +610,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             size: 18,
           ),
           tooltip: 'הגדרות תצוגת הספרים',
-          onPressed:
-              widget.onReadingSettingsPressed ??
+          onPressed: widget.onReadingSettingsPressed ??
               () => showReadingSettingsDialog(context),
           style: _kIconButtonStyle,
         ),
@@ -841,8 +842,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
       // הכותרת תמיד ב-Expanded ומתכווצת לאפס בעת הצורך.
       final extrasBudget =
           tabWidth - 2 * (outerPad + innerPad) - (isSelected ? 4 : 0);
-      final showClose =
-          extrasBudget >= 25 &&
+      final showClose = extrasBudget >= 25 &&
           (tabWidth >= _kTabCloseHideBelowWidth || isSelected || isTabHovered);
       final showPin =
           tab.isPinned && (extrasBudget - (showClose ? 25 : 0)) >= 20;
@@ -882,9 +882,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                     child: DefaultTextStyle(
                       style: TextStyle(
                         color: colorScheme.onSurface,
-                        fontWeight: isSelected
-                            ? FontWeight.w600
-                            : FontWeight.normal,
+                        fontWeight:
+                            isSelected ? FontWeight.w600 : FontWeight.normal,
                         fontSize: 14,
                       ),
                       child: Row(
@@ -952,9 +951,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         key: isSelected ? tourTabContextMenuTargetKey : null,
         menuBuilder: (menuCtx, _) =>
             _buildTabContextMenuEntries(menuCtx, tab, state),
-        menuItemKeysByLabel: isSelected
-            ? {'הצג לצד': tourTabSideBySideMenuItemTargetKey}
-            : null,
+        menuItemKeysByLabel:
+            isSelected ? {'הצג לצד': tourTabSideBySideMenuItemTargetKey} : null,
         child: StatefulBuilder(
           builder: (context, setLocalState) {
             return MouseRegion(
@@ -1058,9 +1056,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
 
     if (tab is! CombinedTab) {
       if (state.tabs.length > 1) {
-        final otherTabsList = state.tabs
-            .where((t) => t != tab && t is! CombinedTab)
-            .toList();
+        final otherTabsList =
+            state.tabs.where((t) => t != tab && t is! CombinedTab).toList();
         final otherTabs = otherTabsList.asMap().entries.map((mapEntry) {
           final isFirst = mapEntry.key == 0;
           final otherTab = mapEntry.value;
@@ -1069,8 +1066,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
             label: otherTab.title,
             onTap: () {
               context.read<TabsBloc>().add(
-                EnableSideBySideMode(rightTab: tab, leftTab: otherTab),
-              );
+                    EnableSideBySideMode(rightTab: tab, leftTab: otherTab),
+                  );
             },
           );
         }).toList();
@@ -1089,8 +1086,8 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         AppContextMenuEntry(
           label: 'חזרה לתצוגה רגילה',
           onTap: () => context.read<TabsBloc>().add(
-            DisableSideBySideMode(state.tabs.indexOf(tab)),
-          ),
+                DisableSideBySideMode(state.tabs.indexOf(tab)),
+              ),
         ),
       ]);
     }
@@ -1234,9 +1231,8 @@ class _CaptionActionButtonState extends State<_CaptionActionButton> {
     final isDark = widget.brightness == Brightness.dark;
 
     Color bgColor = Colors.transparent;
-    Color iconColor = isDark
-        ? Colors.white
-        : Colors.black.withValues(alpha: 0.8956);
+    Color iconColor =
+        isDark ? Colors.white : Colors.black.withValues(alpha: 0.8956);
 
     if (_isHovering) {
       bgColor = isDark


### PR DESCRIPTION
## מה זה עושה
ב-Windows כפתורי החלון (מזעור/הגדלה/סגירה) עוברים לפינה הימנית-עליונה בסדר המקורי של המערכת (מזעור → הגדלה → סגירה), במקום להתהפך לצד שמאל כתוצאה מכיווניות ה-RTL הגלובלית של האפליקציה. כפתורי הפעולה (היסטוריה/סימניות/שולחן עבודה) עוברים בהתאם לצד שמאל, כמו בכל חלון Windows רגיל.

## איך
- `custom_title_bar.dart`: סדר ה-`Row` של שורת הכותרת נקבע לפי הפלטפורמה. ב-Windows: `[כפתורי חלון, תוכן, כפתורי פעולה]` — תחת RTL זה מציב את כפתורי החלון בימין ואת כפתורי הפעולה בשמאל.
- בלוק כפתורי החלון עטוף ב-`Directionality(TextDirection.ltr)` ב-Windows בלבד, כדי שהכפתורים ירונדרו בסדר מקורי (מזעור→הגדלה→סגירה, סגירה בפינה הקיצונית).
- **macOS ו-Linux ללא שינוי** — נשארים בצד שמאל (תואם למוסכמת macOS).
- הטאבים והתוכן נשארים RTL; רק כרום החלון עוקב אחר מערכת ההפעלה.

## בדיקות
- `flutter analyze` על הקובץ: אין בעיות.
- `dart format`: תקין.
- ההתנהגות מותנית ב-`Platform.isWindows`, לכן בדיקות שרצות על מארח Linux עוברות במסלול ברירת המחדל ללא שינוי.
- ⚠️ לא אומת ויזואלית על Windows (בנייה מקומית נכשלה מסיבות סביבתיות לא קשורות — הורדת pdfium/toolchain). הלוגיקה אומתה ע"י אנלייזר והיגיון בלבד.

https://claude.ai/code/session_01Qtd3KLmdT6hfULi6qiVdrt