### PR TITLE
Feature/resume download

### DIFF
--- a/docs/plugin-sdk/API_REFERENCE.md
+++ b/docs/plugin-sdk/API_REFERENCE.md
@@ -406,6 +406,9 @@ if (res.success && res.data.ok) {
   ההורדות. **הנתיב חייב להיות בתוך תיקייה שהמשתמש בחר דרך `ui.pickFolder`**
   (ראו [`ui.pickFolder`](#uipickfolder)); אחרת מוחזרת `error.forbidden`.
   כאשר `destPath` סופק, תיקיית האב נוצרת במידת הצורך וקובץ קיים נדרס.
+- `resume` אופציונלי ורלוונטי רק יחד עם `destPath`. כאשר ערכו `true`, אוצריא
+  שומר הורדה חלקית וממשיך אותה בניסיון הבא באמצעות `Range` ו-`If-Range`.
+  המשך מתבצע רק כשיש `ETag` חזק שמוכיח שהמשאב לא השתנה; אחרת מתחילים מחדש.
 
 ```javascript
 const { data } = await Otzaria.call('network.download', {
@@ -419,7 +422,8 @@ const folder = await Otzaria.call('ui.pickFolder', { title: 'בחר תיקיית
 if (folder.success && folder.data.path) {
   await Otzaria.call('network.download', {
     url: 'https://github.com/Owner/Repo/releases/latest/download/books.zip',
-    destPath: folder.data.path + '/books.zip'
+    destPath: folder.data.path + '/books.zip',
+    resume: true
   });
 }
 ```

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -2827,7 +2827,9 @@ class PluginBridgeAdapter {
         // תיקיית ההורדות. הנתיב חייב להיות בתוך תיקייה שהמשתמש אישר דרך
         // ui.pickFolder — אותו גבול אבטחה של פעולות ה-fs.
         final destPath = args['destPath'] as String?;
-        final resume = args['resume'] as bool? ?? false;
+        // `== true` ולא `as bool?` — ערך לא-בוליאני מהתוסף (מחרוזת/מספר) לא
+        // יזרוק TypeError אלא פשוט ייחשב false.
+        final resume = args['resume'] == true;
         if (destPath != null && destPath.isNotEmpty) {
           if (!_isPathInGrantedFolder(destPath)) {
             throw Exception(

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -2827,8 +2827,6 @@ class PluginBridgeAdapter {
         // תיקיית ההורדות. הנתיב חייב להיות בתוך תיקייה שהמשתמש אישר דרך
         // ui.pickFolder — אותו גבול אבטחה של פעולות ה-fs.
         final destPath = args['destPath'] as String?;
-        // `== true` ולא `as bool?` — ערך לא-בוליאני מהתוסף (מחרוזת/מספר) לא
-        // יזרוק TypeError אלא פשוט ייחשב false.
         final resume = args['resume'] == true;
         if (destPath != null && destPath.isNotEmpty) {
           if (!_isPathInGrantedFolder(destPath)) {

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -2827,6 +2827,7 @@ class PluginBridgeAdapter {
         // תיקיית ההורדות. הנתיב חייב להיות בתוך תיקייה שהמשתמש אישר דרך
         // ui.pickFolder — אותו גבול אבטחה של פעולות ה-fs.
         final destPath = args['destPath'] as String?;
+        final resume = args['resume'] as bool? ?? false;
         if (destPath != null && destPath.isNotEmpty) {
           if (!_isPathInGrantedFolder(destPath)) {
             throw Exception(
@@ -2839,6 +2840,7 @@ class PluginBridgeAdapter {
             isAllowed: (candidate) => PluginNetworkAccessResolver.instance
                 .isUriAllowedForPlugin(candidate, plugin.manifest),
             isRedirectAllowed: isGithubReleaseRedirectAllowed,
+            resume: resume,
           );
           return {'path': result.path, 'filename': result.filename};
         }

--- a/lib/plugins/services/plugin_file_download_service.dart
+++ b/lib/plugins/services/plugin_file_download_service.dart
@@ -113,13 +113,24 @@ class PluginFileDownloadService {
   ///
   /// בשונה מ-[downloadToDownloads], היעד הוא קובץ ספציפי (ולא תיקיית
   /// ההורדות), המאפשר לתוסף לשמור את הקובץ למבנה תיקיות שהמשתמש בחר.
-  /// תיקיית האב נוצרת במידת הצורך, וקובץ קיים באותו נתיב נדרס.
+  /// תיקיית האב נוצרת במידת הצורך. ללא [resume] קובץ קיים באותו נתיב נדרס;
+  /// עם [resume] הוא עשוי להתווסף אליו (ראה למטה).
   ///
   /// כאשר [resume] הוא `true` ויש קובץ חלקי בנתיב [destPath], ההורדה ממשיכה
-  /// מנקודת הסיום של הקובץ הקיים באמצעות `Range: bytes=N-`. אם השרת מחזיר
-  /// 206 Partial Content — הנתונים מצורפים לקובץ; אם הוא מחזיר 200 (התעלם
-  /// מה-Range) — הקובץ נכתב מחדש. במצב resume כשל לא ימחק את הקובץ החלקי,
-  /// כך שניסיון נוסף יוכל להמשיך מאותה נקודה.
+  /// מנקודת הסיום של הקובץ הקיים באמצעות `Range: bytes=N-`:
+  ///  * **206 Partial Content** עם `Content-Range` שמתחיל בדיוק ב-offset
+  ///    המבוקש → הנתונים מצורפים לקובץ. offset שאינו תואם אינו מצורף בעיוור
+  ///    (היה יוצר קובץ פגום) — הקובץ החלקי נמחק ונזרקת שגיאה כדי שניסיון נקי
+  ///    יתחיל מ-0.
+  ///  * **200 OK** (השרת התעלם מה-Range) → הקובץ נכתב מחדש מ-0.
+  ///  * **416 Range Not Satisfiable** → אם ה-total ב-`Content-Range` שווה
+  ///    לגודל הקובץ הקיים, ההורדה כבר הושלמה בעבר ומוחזרת הצלחה; אחרת הקובץ
+  ///    החלקי אינו תואם לשרת, הוא נמחק ונזרקת שגיאה.
+  ///
+  /// אם ידוע הגודל הכולל (מ-`Content-Range`/`Content-Length`) ובסיום התקבלו
+  /// פחות בייטים — ההורדה נחשבת חלקית ונזרקת שגיאה (הקובץ אינו מדווח כהצלחה).
+  /// במצב [resume] כשל אינו מוחק את הקובץ החלקי, כך שניסיון נוסף יוכל להמשיך
+  /// מאותה נקודה.
   ///
   /// **גבול אבטחה:** השירות אינו מאמת את [destPath] — האחריות לוודא שהוא
   /// בתוך תיקייה שהמשתמש אישר מוטלת על הקורא (האדפטר). אכיפת ה-allowlist על
@@ -150,12 +161,55 @@ class PluginFileDownloadService {
       rangeStart: existingBytes,
     );
 
-    // 206 = השרת כיבד את ה-Range → צרף לקובץ קיים; 200 = כתוב מחדש
-    final shouldAppend = existingBytes > 0 && response.statusCode == 206;
-    final sink = outFile.openWrite(
-      mode: shouldAppend ? FileMode.append : FileMode.write,
-    );
+    final contentRange = response.headers['content-range'];
 
+    // 416 Range Not Satisfiable — נמסר מ-[_fetchFollowingAllowedRedirects]
+    // (במקום שגיאה) רק כשביקשנו Range. אם ה-total ב-Content-Range שווה בדיוק
+    // לגודל הקובץ הקיים → ההורדה כבר הושלמה בעבר; מחזירים הצלחה. אחרת הקובץ
+    // החלקי אינו תואם למה שבשרת (למשל שריד של קובץ אחר) — מוחקים אותו וזורקים,
+    // כדי שניסיון נוסף יתחיל נקי.
+    if (response.statusCode == 416) {
+      await response.stream.timeout(_stallTimeout).drain<void>();
+      final total = _contentRangeTotal(contentRange);
+      if (existingBytes > 0 && total == existingBytes) {
+        return PluginFileDownloadResult(outFile.path, p.basename(outFile.path));
+      }
+      if (await outFile.exists()) {
+        await outFile.delete();
+      }
+      throw Exception('שגיאה בהורדת הקובץ (416)');
+    }
+
+    // קביעת מצב הכתיבה — עם אימות ש-206 באמת ממשיך מ-existingBytes לפני
+    // צירוף (append עיוור על offset לא תואם יוצר קובץ פגום בשקט).
+    // expectedTotal = הגודל הסופי הצפוי של הקובץ על הדיסק, לבדיקת שלמות.
+    final FileMode writeMode;
+    int? expectedTotal;
+    if (response.statusCode == 206) {
+      final serverStart = _contentRangeStart(contentRange);
+      expectedTotal = _contentRangeTotal(contentRange);
+      if (existingBytes > 0 && serverStart == existingBytes) {
+        // השרת כיבד את ה-Range והמשיך בדיוק מהנקודה הנכונה → צירוף.
+        writeMode = FileMode.append;
+      } else if (serverStart == 0) {
+        // 206 שמתחיל מ-0 → הגוף מייצג את הקובץ המלא; כתיבה מחדש.
+        writeMode = FileMode.write;
+      } else {
+        // 206 עם offset שאינו תואם ל-existingBytes ואינו 0 → אי אפשר לצרף
+        // בבטחה. מנקזים, מוחקים את החלקי וזורקים כדי שניסיון נוסף יתחיל נקי.
+        await response.stream.timeout(_stallTimeout).drain<void>();
+        if (await outFile.exists()) {
+          await outFile.delete();
+        }
+        throw Exception('שגיאה בהורדת הקובץ (206 עם טווח לא תואם)');
+      }
+    } else {
+      // 200 — השרת התעלם מה-Range (או שלא ביקשנו); כתיבה מחדש מ-0.
+      writeMode = FileMode.write;
+      expectedTotal = response.contentLength;
+    }
+
+    final sink = outFile.openWrite(mode: writeMode);
     try {
       await sink.addStream(response.stream.timeout(_stallTimeout));
       await sink.flush();
@@ -171,6 +225,20 @@ class PluginFileDownloadService {
       rethrow;
     }
 
+    // בדיקת שלמות: אם ידוע הגודל הכולל וברשותנו פחות — ההורדה נקטעה (השרת
+    // סגר את החיבור נקי לפני שהסתיים). זורקים כדי שהתוסף לא יחשוב שההצלחה
+    // מלאה; במצב resume הקובץ החלקי נשמר להמשך.
+    if (expectedTotal != null) {
+      final finalBytes = await outFile.length();
+      if (finalBytes != expectedTotal) {
+        if (!resume && await outFile.exists()) {
+          await outFile.delete();
+        }
+        throw Exception(
+            'שגיאה בהורדת הקובץ (התקבלו $finalBytes מתוך $expectedTotal בייטים)');
+      }
+    }
+
     return PluginFileDownloadResult(outFile.path, p.basename(outFile.path));
   }
 
@@ -178,7 +246,9 @@ class PluginFileDownloadService {
   /// ועבור יעדי redirect גם מול [isRedirectAllowed] (בהינתן ה-hop הקודם).
   /// מחזירה את התשובה הסופית (2xx). מנקזת תשובות-ביניים כדי לשחרר sockets.
   /// [rangeStart] אופציונלי — אם גדול מ-0, מוסיף `Range: bytes=N-` לכל בקשה
-  /// בשרשרת ה-redirects כדי לתמוך בהמשך הורדה (resume).
+  /// בשרשרת ה-redirects כדי לתמוך בהמשך הורדה (resume). כאשר [rangeStart] > 0
+  /// גם תשובת **416** מוחזרת לקורא (במקום שגיאה), כדי שיוכל לזהות קובץ שכבר
+  /// הושלם או טווח לא-תואם ולטפל בהם.
   Future<http.StreamedResponse> _fetchFollowingAllowedRedirects(
     Uri initialUri,
     Future<bool> Function(Uri) isAllowed,
@@ -218,6 +288,11 @@ class PluginFileDownloadService {
       }
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
+        // 416 בעת resume נמסר לקורא לטיפול (קובץ שכבר הושלם / טווח לא תואם)
+        // במקום שגיאה. הגוף אינו מנוקז כאן — הקורא מנקז אותו.
+        if (rangeStart > 0 && response.statusCode == 416) {
+          return response;
+        }
         await response.stream.timeout(_stallTimeout).drain<void>();
         throw Exception('שגיאה בהורדת הקובץ (${response.statusCode})');
       }
@@ -225,6 +300,25 @@ class PluginFileDownloadService {
       return response;
     }
     throw Exception('שגיאה בהורדת הקובץ (יותר מדי redirects)');
+  }
+
+  /// מחלצת את ה-offset ההתחלתי (הבייט הראשון) מכותרת `Content-Range` בצורה
+  /// `bytes 12345-99999/123456`. מחזירה `null` אם הכותרת חסרה או בפורמט לא
+  /// מוכר (למשל `bytes */123456` בתשובת 416).
+  static int? _contentRangeStart(String? header) {
+    if (header == null) return null;
+    final match = RegExp(r'bytes\s+(\d+)-').firstMatch(header);
+    if (match == null) return null;
+    return int.tryParse(match.group(1)!);
+  }
+
+  /// מחלצת את האורך הכולל של המשאב (החלק שאחרי `/`) מכותרת `Content-Range`.
+  /// מחזירה `null` אם הכותרת חסרה או שהאורך אינו ידוע (`*`).
+  static int? _contentRangeTotal(String? header) {
+    if (header == null) return null;
+    final match = RegExp(r'/(\d+)\s*$').firstMatch(header);
+    if (match == null) return null;
+    return int.tryParse(match.group(1)!);
   }
 
   bool _isRedirect(int statusCode) =>

--- a/lib/plugins/services/plugin_file_download_service.dart
+++ b/lib/plugins/services/plugin_file_download_service.dart
@@ -113,24 +113,10 @@ class PluginFileDownloadService {
   ///
   /// בשונה מ-[downloadToDownloads], היעד הוא קובץ ספציפי (ולא תיקיית
   /// ההורדות), המאפשר לתוסף לשמור את הקובץ למבנה תיקיות שהמשתמש בחר.
-  /// תיקיית האב נוצרת במידת הצורך. ללא [resume] קובץ קיים באותו נתיב נדרס;
-  /// עם [resume] הוא עשוי להתווסף אליו (ראה למטה).
-  ///
-  /// כאשר [resume] הוא `true` ויש קובץ חלקי בנתיב [destPath], ההורדה ממשיכה
-  /// מנקודת הסיום של הקובץ הקיים באמצעות `Range: bytes=N-`:
-  ///  * **206 Partial Content** עם `Content-Range` שמתחיל בדיוק ב-offset
-  ///    המבוקש → הנתונים מצורפים לקובץ. offset שאינו תואם אינו מצורף בעיוור
-  ///    (היה יוצר קובץ פגום) — הקובץ החלקי נמחק ונזרקת שגיאה כדי שניסיון נקי
-  ///    יתחיל מ-0.
-  ///  * **200 OK** (השרת התעלם מה-Range) → הקובץ נכתב מחדש מ-0.
-  ///  * **416 Range Not Satisfiable** → אם ה-total ב-`Content-Range` שווה
-  ///    לגודל הקובץ הקיים, ההורדה כבר הושלמה בעבר ומוחזרת הצלחה; אחרת הקובץ
-  ///    החלקי אינו תואם לשרת, הוא נמחק ונזרקת שגיאה.
-  ///
-  /// אם ידוע הגודל הכולל (מ-`Content-Range`/`Content-Length`) ובסיום התקבלו
-  /// פחות בייטים — ההורדה נחשבת חלקית ונזרקת שגיאה (הקובץ אינו מדווח כהצלחה).
-  /// במצב [resume] כשל אינו מוחק את הקובץ החלקי, כך שניסיון נוסף יוכל להמשיך
-  /// מאותה נקודה.
+  /// תיקיית האב נוצרת במידת הצורך. ללא [resume] קובץ קיים נדרס. עם [resume]
+  /// השירות ממשיך רק חלקי שנוצר על ידו ושויך לאותו URL ול-ETag חזק בקובץ צד.
+  /// בקשת ההמשך משתמשת ב-`Range` וב-`If-Range`, כדי ששינוי במשאב יגרום להורדה
+  /// מלאה במקום לחיבור בייטים מגרסאות שונות.
   ///
   /// **גבול אבטחה:** השירות אינו מאמת את [destPath] — האחריות לוודא שהוא
   /// בתוך תיקייה שהמשתמש אישר מוטלת על הקורא (האדפטר). אכיפת ה-allowlist על
@@ -149,64 +135,98 @@ class PluginFileDownloadService {
   }) async {
     final outFile = File(destPath);
     await outFile.parent.create(recursive: true);
+    final resumeFile = File('$destPath.resume');
 
-    // אם resume=true ויש קובץ חלקי — שלח Range: bytes=N-
-    final existingBytes =
-        (resume && await outFile.exists()) ? await outFile.length() : 0;
+    var existingBytes = 0;
+    String? validator;
+    var hasResumeState = false;
+    if (resume && await outFile.exists()) {
+      final state = await _readResumeState(resumeFile);
+      validator = _strongEtag(state?.etag);
+      if (state?.url == downloadUri.toString() && validator != null) {
+        existingBytes = await outFile.length();
+        hasResumeState = existingBytes > 0;
+      }
+    }
+    if (!hasResumeState) await _deleteResumeState(resumeFile);
 
     final response = await _fetchFollowingAllowedRedirects(
       downloadUri,
       isAllowed,
       isRedirectAllowed,
       rangeStart: existingBytes,
+      ifRange: validator,
     );
 
     final contentRange = response.headers['content-range'];
 
-    // 416 Range Not Satisfiable — נמסר מ-[_fetchFollowingAllowedRedirects]
-    // (במקום שגיאה) רק כשביקשנו Range. אם ה-total ב-Content-Range שווה בדיוק
-    // לגודל הקובץ הקיים → ההורדה כבר הושלמה בעבר; מחזירים הצלחה. אחרת הקובץ
-    // החלקי אינו תואם למה שבשרת (למשל שריד של קובץ אחר) — מוחקים אותו וזורקים,
-    // כדי שניסיון נוסף יתחיל נקי.
     if (response.statusCode == 416) {
-      await response.stream.timeout(_stallTimeout).drain<void>();
-      final total = _contentRangeTotal(contentRange);
-      if (existingBytes > 0 && total == existingBytes) {
+      await _abandonBody(response);
+      final total = _unsatisfiedRangeTotal(contentRange);
+      if (hasResumeState && total == existingBytes) {
+        await _deleteResumeState(resumeFile);
         return PluginFileDownloadResult(outFile.path, p.basename(outFile.path));
       }
-      if (await outFile.exists()) {
-        await outFile.delete();
-      }
+      if (await outFile.exists()) await outFile.delete();
+      await _deleteResumeState(resumeFile);
       throw Exception('שגיאה בהורדת הקובץ (416)');
     }
 
-    // קביעת מצב הכתיבה — עם אימות ש-206 באמת ממשיך מ-existingBytes לפני
-    // צירוף (append עיוור על offset לא תואם יוצר קובץ פגום בשקט).
-    // expectedTotal = הגודל הסופי הצפוי של הקובץ על הדיסק, לבדיקת שלמות.
     final FileMode writeMode;
     int? expectedTotal;
+    int? expectedBodyBytes;
+    var bytesBeforeResponse = 0;
     if (response.statusCode == 206) {
-      final serverStart = _contentRangeStart(contentRange);
-      expectedTotal = _contentRangeTotal(contentRange);
-      if (existingBytes > 0 && serverStart == existingBytes) {
-        // השרת כיבד את ה-Range והמשיך בדיוק מהנקודה הנכונה → צירוף.
-        writeMode = FileMode.append;
-      } else if (serverStart == 0) {
-        // 206 שמתחיל מ-0 → הגוף מייצג את הקובץ המלא; כתיבה מחדש.
-        writeMode = FileMode.write;
-      } else {
-        // 206 עם offset שאינו תואם ל-existingBytes ואינו 0 → אי אפשר לצרף
-        // בבטחה. מנקזים, מוחקים את החלקי וזורקים כדי שניסיון נוסף יתחיל נקי.
-        await response.stream.timeout(_stallTimeout).drain<void>();
-        if (await outFile.exists()) {
-          await outFile.delete();
-        }
-        throw Exception('שגיאה בהורדת הקובץ (206 עם טווח לא תואם)');
+      final range = _parseContentRange(contentRange);
+      final matchingResume =
+          range != null && hasResumeState && range.start == existingBytes;
+      final restartFromZero = range != null && range.start == 0;
+      if (!matchingResume && !restartFromZero) {
+        await _rejectResponse(
+          response,
+          outFile,
+          resumeFile,
+          'שגיאה בהורדת הקובץ (206 עם טווח לא תואם)',
+        );
       }
+
+      final responseValidator = _strongEtag(response.headers['etag']);
+      if (matchingResume) {
+        if (responseValidator != null && responseValidator != validator) {
+          await _rejectResponse(
+            response,
+            outFile,
+            resumeFile,
+            'שגיאה בהורדת הקובץ (ETag לא תואם)',
+          );
+        }
+        writeMode = FileMode.append;
+        bytesBeforeResponse = existingBytes;
+      } else {
+        if (await outFile.exists()) await outFile.delete();
+        writeMode = FileMode.write;
+        validator = responseValidator;
+      }
+      expectedTotal = range.total;
+      expectedBodyBytes = range.end - range.start + 1;
     } else {
-      // 200 — השרת התעלם מה-Range (או שלא ביקשנו); כתיבה מחדש מ-0.
+      if (await outFile.exists()) await outFile.delete();
       writeMode = FileMode.write;
       expectedTotal = response.contentLength;
+      expectedBodyBytes = response.contentLength;
+      validator = _strongEtag(response.headers['etag']);
+    }
+
+    hasResumeState =
+        resume &&
+        validator != null &&
+        await _writeResumeState(
+          resumeFile,
+          downloadUri.toString(),
+          validator,
+        );
+    if (!hasResumeState) {
+      await _deleteResumeState(resumeFile);
     }
 
     final sink = outFile.openWrite(mode: writeMode);
@@ -218,42 +238,67 @@ class PluginFileDownloadService {
       try {
         await sink.close();
       } catch (_) {}
-      // במצב resume — שמור את הקובץ החלקי לניסיון הבא
-      if (!resume && await outFile.exists()) {
-        await outFile.delete();
-      }
+      final partialBytes = await outFile.exists()
+          ? await outFile.length()
+          : null;
+      final receivedBytes = partialBytes == null
+          ? null
+          : partialBytes - bytesBeforeResponse;
+      final safePartial =
+          hasResumeState &&
+          partialBytes != null &&
+          receivedBytes != null &&
+          receivedBytes >= 0 &&
+          (expectedBodyBytes == null || receivedBytes <= expectedBodyBytes) &&
+          (expectedTotal == null || partialBytes <= expectedTotal);
+      if (!safePartial && await outFile.exists()) await outFile.delete();
+      if (!await outFile.exists()) await _deleteResumeState(resumeFile);
       rethrow;
     }
 
-    // בדיקת שלמות: אם ידוע הגודל הכולל וברשותנו פחות — ההורדה נקטעה (השרת
-    // סגר את החיבור נקי לפני שהסתיים). זורקים כדי שהתוסף לא יחשוב שההצלחה
-    // מלאה; במצב resume הקובץ החלקי נשמר להמשך.
+    final finalBytes = await outFile.length();
+    final receivedBytes = finalBytes - bytesBeforeResponse;
+    if (expectedBodyBytes != null && receivedBytes != expectedBodyBytes) {
+      final resumableShortRead =
+          hasResumeState &&
+          receivedBytes >= 0 &&
+          receivedBytes < expectedBodyBytes;
+      if (!resumableShortRead) {
+        await outFile.delete();
+        await _deleteResumeState(resumeFile);
+      }
+      throw Exception(
+        'שגיאה בהורדת הקובץ (הטווח הצהיר $expectedBodyBytes בייטים, התקבלו $receivedBytes)',
+      );
+    }
+
     if (expectedTotal != null) {
-      final finalBytes = await outFile.length();
       if (finalBytes != expectedTotal) {
-        if (!resume && await outFile.exists()) {
+        final resumableShortRead = hasResumeState && finalBytes < expectedTotal;
+        if (!resumableShortRead && await outFile.exists()) {
           await outFile.delete();
+          await _deleteResumeState(resumeFile);
         }
         throw Exception(
-            'שגיאה בהורדת הקובץ (התקבלו $finalBytes מתוך $expectedTotal בייטים)');
+          'שגיאה בהורדת הקובץ (התקבלו $finalBytes מתוך $expectedTotal בייטים)',
+        );
       }
     }
 
+    await _deleteResumeState(resumeFile);
     return PluginFileDownloadResult(outFile.path, p.basename(outFile.path));
   }
 
   /// מבצעת GET תוך מעקב ידני אחרי redirects, כשכל יעד נבדק מול [isAllowed]
   /// ועבור יעדי redirect גם מול [isRedirectAllowed] (בהינתן ה-hop הקודם).
   /// מחזירה את התשובה הסופית (2xx). מנקזת תשובות-ביניים כדי לשחרר sockets.
-  /// [rangeStart] אופציונלי — אם גדול מ-0, מוסיף `Range: bytes=N-` לכל בקשה
-  /// בשרשרת ה-redirects כדי לתמוך בהמשך הורדה (resume). כאשר [rangeStart] > 0
-  /// גם תשובת **416** מוחזרת לקורא (במקום שגיאה), כדי שיוכל לזהות קובץ שכבר
-  /// הושלם או טווח לא-תואם ולטפל בהם.
+  /// [rangeStart] ו-[ifRange] נשמרים בכל שרשרת ה-redirects לצורך resume בטוח.
   Future<http.StreamedResponse> _fetchFollowingAllowedRedirects(
     Uri initialUri,
     Future<bool> Function(Uri) isAllowed,
     bool Function(Uri previous, Uri target)? isRedirectAllowed, {
     int rangeStart = 0,
+    String? ifRange,
   }) async {
     var current = initialUri;
     Uri? previous;
@@ -266,12 +311,15 @@ class PluginFileDownloadService {
               (isRedirectAllowed?.call(previous, current) ?? false));
       if (!permitted) {
         throw Exception(
-            'error.forbidden: הכתובת אינה ברשימת ההיתר לגישת רשת של תוספים');
+          'error.forbidden: הכתובת אינה ברשימת ההיתר לגישת רשת של תוספים',
+        );
       }
 
       final request = http.Request('GET', current)..followRedirects = false;
+      request.headers['Accept-Encoding'] = 'identity';
       if (rangeStart > 0) {
         request.headers['Range'] = 'bytes=$rangeStart-';
+        if (ifRange != null) request.headers['If-Range'] = ifRange;
       }
       final response = await _client.send(request).timeout(_stallTimeout);
 
@@ -288,8 +336,6 @@ class PluginFileDownloadService {
       }
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
-        // 416 בעת resume נמסר לקורא לטיפול (קובץ שכבר הושלם / טווח לא תואם)
-        // במקום שגיאה. הגוף אינו מנוקז כאן — הקורא מנקז אותו.
         if (rangeStart > 0 && response.statusCode == 416) {
           return response;
         }
@@ -302,23 +348,87 @@ class PluginFileDownloadService {
     throw Exception('שגיאה בהורדת הקובץ (יותר מדי redirects)');
   }
 
-  /// מחלצת את ה-offset ההתחלתי (הבייט הראשון) מכותרת `Content-Range` בצורה
-  /// `bytes 12345-99999/123456`. מחזירה `null` אם הכותרת חסרה או בפורמט לא
-  /// מוכר (למשל `bytes */123456` בתשובת 416).
-  static int? _contentRangeStart(String? header) {
-    if (header == null) return null;
-    final match = RegExp(r'bytes\s+(\d+)-').firstMatch(header);
+  static final _contentRangePattern = RegExp(
+    r'^bytes\s+(\d+)-(\d+)/(\d+)\s*$',
+    caseSensitive: false,
+  );
+  static final _unsatisfiedRangePattern = RegExp(
+    r'^bytes\s+\*/(\d+)\s*$',
+    caseSensitive: false,
+  );
+
+  static ({int start, int end, int total})? _parseContentRange(String? header) {
+    final match = header == null
+        ? null
+        : _contentRangePattern.firstMatch(header);
     if (match == null) return null;
-    return int.tryParse(match.group(1)!);
+    final start = int.tryParse(match.group(1)!);
+    final end = int.tryParse(match.group(2)!);
+    final total = int.tryParse(match.group(3)!);
+    if (start == null || end == null || total == null) return null;
+    if (start > end || end >= total) return null;
+    return (start: start, end: end, total: total);
   }
 
-  /// מחלצת את האורך הכולל של המשאב (החלק שאחרי `/`) מכותרת `Content-Range`.
-  /// מחזירה `null` אם הכותרת חסרה או שהאורך אינו ידוע (`*`).
-  static int? _contentRangeTotal(String? header) {
-    if (header == null) return null;
-    final match = RegExp(r'/(\d+)\s*$').firstMatch(header);
-    if (match == null) return null;
-    return int.tryParse(match.group(1)!);
+  static int? _unsatisfiedRangeTotal(String? header) {
+    final match = header == null
+        ? null
+        : _unsatisfiedRangePattern.firstMatch(header);
+    return match == null ? null : int.tryParse(match.group(1)!);
+  }
+
+  static String? _strongEtag(String? value) {
+    final etag = value?.trim();
+    if (etag == null || etag.isEmpty || etag.startsWith('W/')) return null;
+    return etag;
+  }
+
+  Future<({String url, String etag})?> _readResumeState(File file) async {
+    try {
+      if (!await file.exists()) return null;
+      final lines = (await file.readAsString()).split('\n');
+      if (lines.length < 2) return null;
+      return (url: lines.first, etag: lines[1]);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> _writeResumeState(
+    File file,
+    String url,
+    String etag,
+  ) async {
+    try {
+      await file.writeAsString('$url\n$etag', flush: true);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> _deleteResumeState(File file) async {
+    try {
+      if (await file.exists()) await file.delete();
+    } catch (_) {}
+  }
+
+  Future<void> _abandonBody(http.StreamedResponse response) async {
+    try {
+      await response.stream.listen((_) {}).cancel().timeout(_stallTimeout);
+    } catch (_) {}
+  }
+
+  Future<Never> _rejectResponse(
+    http.StreamedResponse response,
+    File outFile,
+    File resumeFile,
+    String message,
+  ) async {
+    await _abandonBody(response);
+    if (await outFile.exists()) await outFile.delete();
+    await _deleteResumeState(resumeFile);
+    throw Exception(message);
   }
 
   bool _isRedirect(int statusCode) =>

--- a/lib/plugins/services/plugin_file_download_service.dart
+++ b/lib/plugins/services/plugin_file_download_service.dart
@@ -115,6 +115,12 @@ class PluginFileDownloadService {
   /// ההורדות), המאפשר לתוסף לשמור את הקובץ למבנה תיקיות שהמשתמש בחר.
   /// תיקיית האב נוצרת במידת הצורך, וקובץ קיים באותו נתיב נדרס.
   ///
+  /// כאשר [resume] הוא `true` ויש קובץ חלקי בנתיב [destPath], ההורדה ממשיכה
+  /// מנקודת הסיום של הקובץ הקיים באמצעות `Range: bytes=N-`. אם השרת מחזיר
+  /// 206 Partial Content — הנתונים מצורפים לקובץ; אם הוא מחזיר 200 (התעלם
+  /// מה-Range) — הקובץ נכתב מחדש. במצב resume כשל לא ימחק את הקובץ החלקי,
+  /// כך שניסיון נוסף יוכל להמשיך מאותה נקודה.
+  ///
   /// **גבול אבטחה:** השירות אינו מאמת את [destPath] — האחריות לוודא שהוא
   /// בתוך תיקייה שהמשתמש אישר מוטלת על הקורא (האדפטר). אכיפת ה-allowlist על
   /// ה-URL ועל כל redirect זהה ל-[downloadToDownloads]: [isAllowed] נבדק על
@@ -128,17 +134,28 @@ class PluginFileDownloadService {
     String destPath, {
     required Future<bool> Function(Uri) isAllowed,
     bool Function(Uri previous, Uri target)? isRedirectAllowed,
+    bool resume = false,
   }) async {
+    final outFile = File(destPath);
+    await outFile.parent.create(recursive: true);
+
+    // אם resume=true ויש קובץ חלקי — שלח Range: bytes=N-
+    final existingBytes =
+        (resume && await outFile.exists()) ? await outFile.length() : 0;
+
     final response = await _fetchFollowingAllowedRedirects(
       downloadUri,
       isAllowed,
       isRedirectAllowed,
+      rangeStart: existingBytes,
     );
 
-    final outFile = File(destPath);
-    await outFile.parent.create(recursive: true);
+    // 206 = השרת כיבד את ה-Range → צרף לקובץ קיים; 200 = כתוב מחדש
+    final shouldAppend = existingBytes > 0 && response.statusCode == 206;
+    final sink = outFile.openWrite(
+      mode: shouldAppend ? FileMode.append : FileMode.write,
+    );
 
-    final sink = outFile.openWrite();
     try {
       await sink.addStream(response.stream.timeout(_stallTimeout));
       await sink.flush();
@@ -147,7 +164,8 @@ class PluginFileDownloadService {
       try {
         await sink.close();
       } catch (_) {}
-      if (await outFile.exists()) {
+      // במצב resume — שמור את הקובץ החלקי לניסיון הבא
+      if (!resume && await outFile.exists()) {
         await outFile.delete();
       }
       rethrow;
@@ -159,11 +177,14 @@ class PluginFileDownloadService {
   /// מבצעת GET תוך מעקב ידני אחרי redirects, כשכל יעד נבדק מול [isAllowed]
   /// ועבור יעדי redirect גם מול [isRedirectAllowed] (בהינתן ה-hop הקודם).
   /// מחזירה את התשובה הסופית (2xx). מנקזת תשובות-ביניים כדי לשחרר sockets.
+  /// [rangeStart] אופציונלי — אם גדול מ-0, מוסיף `Range: bytes=N-` לכל בקשה
+  /// בשרשרת ה-redirects כדי לתמוך בהמשך הורדה (resume).
   Future<http.StreamedResponse> _fetchFollowingAllowedRedirects(
     Uri initialUri,
     Future<bool> Function(Uri) isAllowed,
-    bool Function(Uri previous, Uri target)? isRedirectAllowed,
-  ) async {
+    bool Function(Uri previous, Uri target)? isRedirectAllowed, {
+    int rangeStart = 0,
+  }) async {
     var current = initialUri;
     Uri? previous;
     for (var hop = 0; hop <= _maxRedirects; hop++) {
@@ -179,6 +200,9 @@ class PluginFileDownloadService {
       }
 
       final request = http.Request('GET', current)..followRedirects = false;
+      if (rangeStart > 0) {
+        request.headers['Range'] = 'bytes=$rangeStart-';
+      }
       final response = await _client.send(request).timeout(_stallTimeout);
 
       if (_isRedirect(response.statusCode)) {

--- a/test/plugins/bridge/plugin_bridge_adapter_test.dart
+++ b/test/plugins/bridge/plugin_bridge_adapter_test.dart
@@ -1506,6 +1506,34 @@ void main() {
       expect(File(destPath).readAsBytesSync(), [7, 8, 9]);
     });
 
+    test('network.download מעביר resume לשירות ההורדה', () async {
+      final destPath = p.join(tempDir.path, 'resume.zip');
+      await File(destPath).writeAsBytes([7, 8]);
+      await File('$destPath.resume').writeAsString('$downloadUrl\n"v1"');
+      final client = MockClient((request) async {
+        expect(request.headers['range'], 'bytes=2-');
+        expect(request.headers['if-range'], '"v1"');
+        return http.Response.bytes(
+          [9],
+          206,
+          headers: {'content-range': 'bytes 2-2/3', 'etag': '"v1"'},
+        );
+      });
+      final adapter = buildAdapter(
+        pickFolder: ({title}) async => tempDir.path,
+        fileDownloadService: PluginFileDownloadService(client: client),
+      );
+      await adapter.execute('ui', 'pickFolder', {});
+
+      await adapter.execute('network', 'download', {
+        'url': downloadUrl,
+        'destPath': destPath,
+        'resume': true,
+      });
+
+      expect(File(destPath).readAsBytesSync(), [7, 8, 9]);
+    });
+
     test(
       'network.download עם destPath מחוץ לתיקייה מאושרת נחסם ואינו מוריד',
       () async {

--- a/test/plugins/services/plugin_file_download_service_test.dart
+++ b/test/plugins/services/plugin_file_download_service_test.dart
@@ -23,6 +23,14 @@ void main() {
 
   Future<bool> allowAll(Uri _) async => true;
 
+  Future<void> seedResumeState(
+    String destPath,
+    Uri uri, {
+    String etag = '"v1"',
+  }) async {
+    await File('$destPath.resume').writeAsString('$uri\n$etag');
+  }
+
   PluginFileDownloadService serviceReturning(
     List<int> body, {
     int status = 200,
@@ -99,7 +107,8 @@ void main() {
     expect(
       () => service.downloadToDownloads(
         Uri.parse(
-            'https://github.com/Owner/Repo/releases/latest/download/a.zip'),
+          'https://github.com/Owner/Repo/releases/latest/download/a.zip',
+        ),
         isAllowed: allowAll,
         targetDir: tempDir,
       ),
@@ -142,32 +151,38 @@ void main() {
     expect(result.filename, 'a.zip');
   });
 
-  test('חוסם redirect ליעד שאינו ב-allowlist (לא עוקף את ה-allowlist)',
-      () async {
-    var hitEvil = false;
-    final client = MockClient((request) async {
-      if (request.url.host == 'github.com') {
-        return http.Response('', 302,
-            headers: {'location': 'https://evil.example.com/a.zip'});
-      }
-      hitEvil = true;
-      return http.Response.bytes([0], 200);
-    });
-    final service = PluginFileDownloadService(client: client);
+  test(
+    'חוסם redirect ליעד שאינו ב-allowlist (לא עוקף את ה-allowlist)',
+    () async {
+      var hitEvil = false;
+      final client = MockClient((request) async {
+        if (request.url.host == 'github.com') {
+          return http.Response(
+            '',
+            302,
+            headers: {'location': 'https://evil.example.com/a.zip'},
+          );
+        }
+        hitEvil = true;
+        return http.Response.bytes([0], 200);
+      });
+      final service = PluginFileDownloadService(client: client);
 
-    await expectLater(
-      service.downloadToDownloads(
-        Uri.parse(
-            'https://github.com/Owner/Repo/releases/latest/download/a.zip'),
-        isAllowed: globalAllowsGithubOnly,
-        isRedirectAllowed: redirectAllowsCdnFromGithub,
-        targetDir: tempDir,
-      ),
-      throwsA(isA<Exception>()),
-    );
-    // ודא שהבקשה ליעד האסור מעולם לא יצאה.
-    expect(hitEvil, isFalse);
-  });
+      await expectLater(
+        service.downloadToDownloads(
+          Uri.parse(
+            'https://github.com/Owner/Repo/releases/latest/download/a.zip',
+          ),
+          isAllowed: globalAllowsGithubOnly,
+          isRedirectAllowed: redirectAllowsCdnFromGithub,
+          targetDir: tempDir,
+        ),
+        throwsA(isA<Exception>()),
+      );
+      // ודא שהבקשה ליעד האסור מעולם לא יצאה.
+      expect(hitEvil, isFalse);
+    },
+  );
 
   test('חוסם גישה ישירה ל-CDN ככתובת התחלתית (ללא redirect)', () async {
     var hit = false;
@@ -197,7 +212,8 @@ void main() {
 
       final result = await service.downloadToPath(
         Uri.parse(
-            'https://github.com/Owner/Repo/releases/latest/download/books.zip'),
+          'https://github.com/Owner/Repo/releases/latest/download/books.zip',
+        ),
         destPath,
         isAllowed: allowAll,
       );
@@ -214,7 +230,8 @@ void main() {
 
       await service.downloadToPath(
         Uri.parse(
-            'https://github.com/Owner/Repo/releases/latest/download/books.zip'),
+          'https://github.com/Owner/Repo/releases/latest/download/books.zip',
+        ),
         destPath,
         isAllowed: allowAll,
       );
@@ -227,7 +244,8 @@ void main() {
       await expectLater(
         service.downloadToPath(
           Uri.parse(
-              'https://github.com/Owner/Repo/releases/latest/download/a.zip'),
+            'https://github.com/Owner/Repo/releases/latest/download/a.zip',
+          ),
           p.join(tempDir.path, 'a.zip'),
           isAllowed: allowAll,
         ),
@@ -236,43 +254,62 @@ void main() {
     });
 
     group('resume', () {
-      test('מצרף ל-206 כשה-offset תואם (Content-Range) ושולח Range נכון',
-          () async {
-        final destPath = p.join(tempDir.path, 'big.zip');
-        await File(destPath).writeAsBytes([1, 2, 3]);
-        String? sentRange;
-        final client = MockClient((request) async {
-          sentRange = request.headers['range'];
-          return http.Response.bytes([4, 5], 206,
-              headers: {'content-range': 'bytes 3-4/5'});
-        });
-        final service = PluginFileDownloadService(client: client);
+      test(
+        'מצרף ל-206 כשה-offset תואם (Content-Range) ושולח Range נכון',
+        () async {
+          final destPath = p.join(tempDir.path, 'big.zip');
+          final uri = Uri.parse(
+            'https://github.com/Owner/Repo/releases/latest/download/big.zip',
+          );
+          await File(destPath).writeAsBytes([1, 2, 3]);
+          await seedResumeState(destPath, uri);
+          String? sentRange;
+          String? sentIfRange;
+          final client = MockClient((request) async {
+            sentRange = request.headers['range'];
+            sentIfRange = request.headers['if-range'];
+            return http.Response.bytes(
+              [4, 5],
+              206,
+              headers: {'content-range': 'bytes 3-4/5', 'etag': '"v1"'},
+            );
+          });
+          final service = PluginFileDownloadService(client: client);
 
-        final result = await service.downloadToPath(
-          Uri.parse(
-              'https://github.com/Owner/Repo/releases/latest/download/big.zip'),
-          destPath,
-          isAllowed: allowAll,
-          resume: true,
-        );
+          final result = await service.downloadToPath(
+            uri,
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          );
 
-        expect(sentRange, 'bytes=3-');
-        expect(result.path, destPath);
-        expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
-      });
+          expect(sentRange, 'bytes=3-');
+          expect(sentIfRange, '"v1"');
+          expect(result.path, destPath);
+          expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+          expect(await File('$destPath.resume').exists(), isFalse);
+        },
+      );
 
       test('416 על קובץ שכבר הושלם → הצלחה, הקובץ נשמר כמות שהוא', () async {
         final destPath = p.join(tempDir.path, 'done.zip');
+        final uri = Uri.parse(
+          'https://github.com/Owner/Repo/releases/latest/download/done.zip',
+        );
         await File(destPath).writeAsBytes([1, 2, 3, 4, 5]);
+        await seedResumeState(destPath, uri);
         final client = MockClient((request) async {
-          return http.Response.bytes([], 416,
-              headers: {'content-range': 'bytes */5'});
+          expect(request.headers['if-range'], '"v1"');
+          return http.Response.bytes(
+            [],
+            416,
+            headers: {'content-range': 'bytes */5'},
+          );
         });
         final service = PluginFileDownloadService(client: client);
 
         final result = await service.downloadToPath(
-          Uri.parse(
-              'https://github.com/Owner/Repo/releases/latest/download/done.zip'),
+          uri,
           destPath,
           isAllowed: allowAll,
           resume: true,
@@ -280,19 +317,25 @@ void main() {
 
         expect(result.path, destPath);
         expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+        expect(await File('$destPath.resume').exists(), isFalse);
       });
 
       test('200 (השרת מתעלם מ-Range) → כתיבה מחדש מ-0', () async {
         final destPath = p.join(tempDir.path, 'restart.zip');
+        final uri = Uri.parse(
+          'https://github.com/Owner/Repo/releases/latest/download/restart.zip',
+        );
         await File(destPath).writeAsBytes([9, 9]);
+        await seedResumeState(destPath, uri);
         final client = MockClient((request) async {
-          return http.Response.bytes([1, 2, 3], 200);
+          expect(request.headers['range'], 'bytes=2-');
+          expect(request.headers['if-range'], '"v1"');
+          return http.Response.bytes([1, 2, 3], 200, headers: {'etag': '"v2"'});
         });
         final service = PluginFileDownloadService(client: client);
 
         await service.downloadToPath(
-          Uri.parse(
-              'https://github.com/Owner/Repo/releases/latest/download/restart.zip'),
+          uri,
           destPath,
           isAllowed: allowAll,
           resume: true,
@@ -303,18 +346,24 @@ void main() {
 
       test('206 עם offset לא תואם → זריקה ומחיקת הקובץ החלקי', () async {
         final destPath = p.join(tempDir.path, 'bad.zip');
+        final uri = Uri.parse(
+          'https://github.com/Owner/Repo/releases/latest/download/bad.zip',
+        );
         await File(destPath).writeAsBytes([1, 2, 3]);
+        await seedResumeState(destPath, uri);
         final client = MockClient((request) async {
           // ביקשנו bytes=3- אך השרת מתחיל מ-1 (לא 3 ולא 0) — צירוף היה מקלקל.
-          return http.Response.bytes([2, 3, 4, 5], 206,
-              headers: {'content-range': 'bytes 1-4/5'});
+          return http.Response.bytes(
+            [2, 3, 4, 5],
+            206,
+            headers: {'content-range': 'bytes 1-4/5'},
+          );
         });
         final service = PluginFileDownloadService(client: client);
 
         await expectLater(
           service.downloadToPath(
-            Uri.parse(
-                'https://github.com/Owner/Repo/releases/latest/download/bad.zip'),
+            uri,
             destPath,
             isAllowed: allowAll,
             resume: true,
@@ -326,18 +375,24 @@ void main() {
 
       test('206 שנקטע לפני הסוף → זריקה, הקובץ החלקי נשמר להמשך', () async {
         final destPath = p.join(tempDir.path, 'partial.zip');
+        final uri = Uri.parse(
+          'https://github.com/Owner/Repo/releases/latest/download/partial.zip',
+        );
         await File(destPath).writeAsBytes([1, 2, 3]);
+        await seedResumeState(destPath, uri);
         final client = MockClient((request) async {
           // total=10 אך הגוף מכיל רק 2 בייטים → 5 מתוך 10 בסיום.
-          return http.Response.bytes([4, 5], 206,
-              headers: {'content-range': 'bytes 3-9/10'});
+          return http.Response.bytes(
+            [4, 5],
+            206,
+            headers: {'content-range': 'bytes 3-9/10', 'etag': '"v1"'},
+          );
         });
         final service = PluginFileDownloadService(client: client);
 
         await expectLater(
           service.downloadToPath(
-            Uri.parse(
-                'https://github.com/Owner/Repo/releases/latest/download/partial.zip'),
+            uri,
             destPath,
             isAllowed: allowAll,
             resume: true,
@@ -346,6 +401,7 @@ void main() {
         );
         // הקובץ נשמר עם מה שהתקבל, לניסיון resume נוסף.
         expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+        expect(await File('$destPath.resume').exists(), isTrue);
       });
 
       test('resume ללא קובץ קיים → הורדה רגילה מ-0 ללא כותרת Range', () async {
@@ -359,7 +415,8 @@ void main() {
 
         await service.downloadToPath(
           Uri.parse(
-              'https://github.com/Owner/Repo/releases/latest/download/fresh.zip'),
+            'https://github.com/Owner/Repo/releases/latest/download/fresh.zip',
+          ),
           destPath,
           isAllowed: allowAll,
           resume: true,
@@ -367,6 +424,262 @@ void main() {
 
         expect(sentRange, isNull);
         expect(await File(destPath).readAsBytes(), [1, 2, 3]);
+      });
+
+      test('כשל עם ETag נשמר וממשיך בבקשה הבאה עם Range ו-If-Range', () async {
+        final destPath = p.join(tempDir.path, 'retry.zip');
+        final uri = Uri.parse('https://github.com/Owner/Repo/retry.zip');
+        var requestCount = 0;
+        final client = MockClient.streaming((request, bodyStream) async {
+          requestCount++;
+          if (requestCount == 1) {
+            Stream<List<int>> interrupted() async* {
+              yield [1, 2];
+              await Future<void>.delayed(const Duration(seconds: 1));
+              yield [3];
+            }
+
+            return http.StreamedResponse(
+              interrupted(),
+              200,
+              contentLength: 5,
+              headers: {'etag': '"v1"'},
+            );
+          }
+          expect(request.headers['range'], 'bytes=2-');
+          expect(request.headers['if-range'], '"v1"');
+          return http.StreamedResponse(
+            Stream.value([3, 4, 5]),
+            206,
+            contentLength: 3,
+            headers: {
+              'content-range': 'bytes 2-4/5',
+              'etag': '"v1"',
+            },
+          );
+        });
+        final service = PluginFileDownloadService(
+          client: client,
+          stallTimeout: const Duration(milliseconds: 50),
+        );
+
+        await expectLater(
+          service.downloadToPath(
+            uri,
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+        expect(await File(destPath).readAsBytes(), [1, 2]);
+
+        await service.downloadToPath(
+          uri,
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+        expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+      });
+
+      test('כשל ללא ETag חזק אינו משאיר חלקי שאי אפשר לאמת', () async {
+        final destPath = p.join(tempDir.path, 'weak-etag.zip');
+        final client = MockClient.streaming((request, bodyStream) async {
+          Stream<List<int>> interrupted() async* {
+            yield [1, 2];
+            await Future<void>.delayed(const Duration(seconds: 1));
+            yield [3];
+          }
+
+          return http.StreamedResponse(
+            interrupted(),
+            200,
+            contentLength: 5,
+            headers: {'etag': 'W/"v1"'},
+          );
+        });
+        final service = PluginFileDownloadService(
+          client: client,
+          stallTimeout: const Duration(milliseconds: 50),
+        );
+
+        await expectLater(
+          service.downloadToPath(
+            Uri.parse('https://github.com/Owner/Repo/weak-etag.zip'),
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+        expect(await File(destPath).exists(), isFalse);
+        expect(await File('$destPath.resume').exists(), isFalse);
+      });
+
+      test('קובץ ללא מצב resume אינו מצורף למשאב', () async {
+        final destPath = p.join(tempDir.path, 'untrusted.zip');
+        await File(destPath).writeAsBytes([1, 1, 1]);
+        final client = MockClient((request) async {
+          expect(request.headers['range'], isNull);
+          expect(request.headers['if-range'], isNull);
+          return http.Response.bytes([2, 2, 2, 2, 2], 200);
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await service.downloadToPath(
+          Uri.parse('https://github.com/Owner/Repo/untrusted.zip'),
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(await File(destPath).readAsBytes(), [2, 2, 2, 2, 2]);
+      });
+
+      test('If-Range שהייצוג שלו השתנה גורם לכתיבה מלאה מ-0', () async {
+        final destPath = p.join(tempDir.path, 'changed.zip');
+        final uri = Uri.parse('https://github.com/Owner/Repo/changed.zip');
+        await File(destPath).writeAsBytes([1, 1, 1]);
+        await seedResumeState(destPath, uri, etag: '"old"');
+        final client = MockClient((request) async {
+          expect(request.headers['if-range'], '"old"');
+          return http.Response.bytes(
+            [2, 2, 2, 2, 2],
+            200,
+            headers: {'etag': '"new"'},
+          );
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await service.downloadToPath(
+          uri,
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(await File(destPath).readAsBytes(), [2, 2, 2, 2, 2]);
+      });
+
+      test('416 עם גוף שאינו נסגר מוחק שריד לא תואם בלי להיתקע', () async {
+        final destPath = p.join(tempDir.path, 'stale.zip');
+        final uri = Uri.parse('https://github.com/Owner/Repo/stale.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        await seedResumeState(destPath, uri);
+        final client = MockClient.streaming((request, bodyStream) async {
+          Stream<List<int>> stalled() async* {
+            await Future<void>.delayed(const Duration(seconds: 1));
+            yield [0];
+          }
+
+          return http.StreamedResponse(
+            stalled(),
+            416,
+            headers: {'content-range': 'bytes */5'},
+          );
+        });
+        final service = PluginFileDownloadService(
+          client: client,
+          stallTimeout: const Duration(milliseconds: 50),
+        );
+        final stopwatch = Stopwatch()..start();
+
+        await expectLater(
+          service.downloadToPath(
+            uri,
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<Exception>()),
+        );
+        stopwatch.stop();
+        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+        expect(await File(destPath).exists(), isFalse);
+      });
+
+      test('Content-Range מפוענח ללא תלות ברישיות range-unit', () async {
+        final destPath = p.join(tempDir.path, 'case.zip');
+        final uri = Uri.parse('https://github.com/Owner/Repo/case.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        await seedResumeState(destPath, uri);
+        final client = MockClient(
+          (request) async => http.Response.bytes(
+            [4, 5],
+            206,
+            headers: {'content-range': 'Bytes 3-4/5', 'etag': '"v1"'},
+          ),
+        );
+        final service = PluginFileDownloadService(client: client);
+
+        await service.downloadToPath(
+          uri,
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+      });
+
+      test('גוף 206 ארוך מהטווח המוצהר נדחה ונמחק', () async {
+        final destPath = p.join(tempDir.path, 'range-end.zip');
+        final uri = Uri.parse('https://github.com/Owner/Repo/range-end.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        await seedResumeState(destPath, uri);
+        final client = MockClient(
+          (request) async => http.Response.bytes(
+            [4, 5, 6, 7, 8, 9, 10],
+            206,
+            headers: {'content-range': 'bytes 3-4/10', 'etag': '"v1"'},
+          ),
+        );
+        final service = PluginFileDownloadService(client: client);
+
+        await expectLater(
+          service.downloadToPath(
+            uri,
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<Exception>()),
+        );
+        expect(await File(destPath).exists(), isFalse);
+        expect(await File('$destPath.resume').exists(), isFalse);
+      });
+
+      test('שגיאת stream אחרי חריגה מהטווח אינה משמרת חלקי פגום', () async {
+        final destPath = p.join(tempDir.path, 'range-error.zip');
+        final uri = Uri.parse('https://github.com/Owner/Repo/range-error.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        await seedResumeState(destPath, uri);
+        final client = MockClient.streaming((request, bodyStream) async {
+          Stream<List<int>> invalidBody() async* {
+            yield [4, 5, 6, 7, 8, 9, 10];
+            throw Exception('connection reset');
+          }
+
+          return http.StreamedResponse(
+            invalidBody(),
+            206,
+            headers: {'content-range': 'bytes 3-4/10', 'etag': '"v1"'},
+          );
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await expectLater(
+          service.downloadToPath(
+            uri,
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<Exception>()),
+        );
+        expect(await File(destPath).exists(), isFalse);
+        expect(await File('$destPath.resume').exists(), isFalse);
       });
     });
   });
@@ -389,7 +702,8 @@ void main() {
     await expectLater(
       service.downloadToDownloads(
         Uri.parse(
-            'https://github.com/Owner/Repo/releases/latest/download/a.zip'),
+          'https://github.com/Owner/Repo/releases/latest/download/a.zip',
+        ),
         isAllowed: allowAll,
         targetDir: tempDir,
       ),
@@ -422,7 +736,8 @@ void main() {
     await expectLater(
       service.downloadToDownloads(
         Uri.parse(
-            'https://github.com/Owner/Repo/releases/latest/download/a.zip'),
+          'https://github.com/Owner/Repo/releases/latest/download/a.zip',
+        ),
         isAllowed: allowAll,
         targetDir: tempDir,
       ),

--- a/test/plugins/services/plugin_file_download_service_test.dart
+++ b/test/plugins/services/plugin_file_download_service_test.dart
@@ -234,6 +234,141 @@ void main() {
         throwsA(isA<Exception>()),
       );
     });
+
+    group('resume', () {
+      test('מצרף ל-206 כשה-offset תואם (Content-Range) ושולח Range נכון',
+          () async {
+        final destPath = p.join(tempDir.path, 'big.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        String? sentRange;
+        final client = MockClient((request) async {
+          sentRange = request.headers['range'];
+          return http.Response.bytes([4, 5], 206,
+              headers: {'content-range': 'bytes 3-4/5'});
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        final result = await service.downloadToPath(
+          Uri.parse(
+              'https://github.com/Owner/Repo/releases/latest/download/big.zip'),
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(sentRange, 'bytes=3-');
+        expect(result.path, destPath);
+        expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+      });
+
+      test('416 על קובץ שכבר הושלם → הצלחה, הקובץ נשמר כמות שהוא', () async {
+        final destPath = p.join(tempDir.path, 'done.zip');
+        await File(destPath).writeAsBytes([1, 2, 3, 4, 5]);
+        final client = MockClient((request) async {
+          return http.Response.bytes([], 416,
+              headers: {'content-range': 'bytes */5'});
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        final result = await service.downloadToPath(
+          Uri.parse(
+              'https://github.com/Owner/Repo/releases/latest/download/done.zip'),
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(result.path, destPath);
+        expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+      });
+
+      test('200 (השרת מתעלם מ-Range) → כתיבה מחדש מ-0', () async {
+        final destPath = p.join(tempDir.path, 'restart.zip');
+        await File(destPath).writeAsBytes([9, 9]);
+        final client = MockClient((request) async {
+          return http.Response.bytes([1, 2, 3], 200);
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await service.downloadToPath(
+          Uri.parse(
+              'https://github.com/Owner/Repo/releases/latest/download/restart.zip'),
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(await File(destPath).readAsBytes(), [1, 2, 3]);
+      });
+
+      test('206 עם offset לא תואם → זריקה ומחיקת הקובץ החלקי', () async {
+        final destPath = p.join(tempDir.path, 'bad.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        final client = MockClient((request) async {
+          // ביקשנו bytes=3- אך השרת מתחיל מ-1 (לא 3 ולא 0) — צירוף היה מקלקל.
+          return http.Response.bytes([2, 3, 4, 5], 206,
+              headers: {'content-range': 'bytes 1-4/5'});
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await expectLater(
+          service.downloadToPath(
+            Uri.parse(
+                'https://github.com/Owner/Repo/releases/latest/download/bad.zip'),
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<Exception>()),
+        );
+        expect(await File(destPath).exists(), isFalse);
+      });
+
+      test('206 שנקטע לפני הסוף → זריקה, הקובץ החלקי נשמר להמשך', () async {
+        final destPath = p.join(tempDir.path, 'partial.zip');
+        await File(destPath).writeAsBytes([1, 2, 3]);
+        final client = MockClient((request) async {
+          // total=10 אך הגוף מכיל רק 2 בייטים → 5 מתוך 10 בסיום.
+          return http.Response.bytes([4, 5], 206,
+              headers: {'content-range': 'bytes 3-9/10'});
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await expectLater(
+          service.downloadToPath(
+            Uri.parse(
+                'https://github.com/Owner/Repo/releases/latest/download/partial.zip'),
+            destPath,
+            isAllowed: allowAll,
+            resume: true,
+          ),
+          throwsA(isA<Exception>()),
+        );
+        // הקובץ נשמר עם מה שהתקבל, לניסיון resume נוסף.
+        expect(await File(destPath).readAsBytes(), [1, 2, 3, 4, 5]);
+      });
+
+      test('resume ללא קובץ קיים → הורדה רגילה מ-0 ללא כותרת Range', () async {
+        final destPath = p.join(tempDir.path, 'fresh.zip');
+        String? sentRange = 'unset';
+        final client = MockClient((request) async {
+          sentRange = request.headers['range'];
+          return http.Response.bytes([1, 2, 3], 200);
+        });
+        final service = PluginFileDownloadService(client: client);
+
+        await service.downloadToPath(
+          Uri.parse(
+              'https://github.com/Owner/Repo/releases/latest/download/fresh.zip'),
+          destPath,
+          isAllowed: allowAll,
+          resume: true,
+        );
+
+        expect(sentRange, isNull);
+        expect(await File(destPath).readAsBytes(), [1, 2, 3]);
+      });
+    });
   });
 
   test('זורק TimeoutException כשהזרם נתקע (אין בייטים בחלון התקיעה)', () async {


### PR DESCRIPTION
feat(network): הוספת resume מאומת ל-`network.download` דרך `downloadToPath`.

מחליף את #517 (החשבון שממנו נפתח ה-PR המקורי אינו נגיש עוד).

## מה זה עושה

כאשר תוסף מעביר `resume: true` יחד עם `destPath`, הורדה שנקטעה יכולה להמשיך מהבייט האחרון במקום להתחיל מחדש.

## הגנות תקינות

- קובץ חלקי נחשב ניתן להמשך רק אם אוצריא יצרה לידו מצב resume שקושר אותו ל-URL ול-ETag חזק.
- כל המשך שולח `Range` וגם `If-Range`; אם המשאב השתנה, השרת מחזיר 200 והקובץ נכתב מחדש מ-0.
- תגובת 206 מתקבלת רק לאחר אימות מלא של `Content-Range`: התחלה, סוף, total ואורך הגוף.
- 416 נחשב הצלחה רק כשמצב ה-resume מאומת וה-total שווה בדיוק לגודל המקומי.
- גוף שגוי, offset לא תואם או ETag סותר גורמים למחיקת החלקי במקום ליצירת קובץ מעורב.
- timeout או כשל רשת משמרים חלקי רק כשיש validator חזק; בלי validator מתחילים מחדש בבטחה.
- בקשות נשלחות עם `Accept-Encoding: identity`, כדי שטווחי הבייטים וגודל הגוף יתייחסו לאותו ייצוג.
- גופי שגיאה שאינם נסגרים מבוטלים עם timeout ואינם מונעים ניקוי.
- ה-allowlist, בדיקות redirect והרשאת `destPath` נשארו ללא שינוי.

## API

הפרמטר `resume` אופציונלי ורלוונטי רק כאשר סופק `destPath`. ערך שאינו `true` מטופל כ-`false`.

## בדיקות

נוספו 16 בדיקות שירות ואינטגרציה, ובהן:

- timeout ולאחריו resume אמיתי עם `Range` ו-`If-Range`
- שינוי ייצוג בין ניסיונות ללא יצירת franken-file
- ETag חלש או חסר
- 200, 206 ו-416
- offset, סוף טווח ואורך גוף לא תואמים
- גוף 416 תקוע
- case-insensitive `Content-Range`
- העברת `resume` דרך `PluginBridgeAdapter`

אימות שבוצע:

- `flutter analyze` — נקי
- `flutter test test/plugins/` — 646 בדיקות עברו
- `dart format` — נקי
