### PR TITLE
תמיכה בקבצי EPUB: תצוגה, תוכן עניינים, אינדקס חיפוש ואיתור

### DIFF
--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -31,6 +31,7 @@ import 'package:otzaria/utils/text/text_manipulation.dart';
 import 'package:otzaria/utils/file/toc_parser.dart';
 import 'package:otzaria/utils/file/docx_to_otzaria.dart';
 import 'package:otzaria/utils/file/docx_cache.dart';
+import 'package:otzaria/utils/file/epub_to_otzaria.dart';
 import 'package:otzaria/utils/file/file_book_path_resolver.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
@@ -65,7 +66,7 @@ class _RawTocEntry {
 class _DiscoveredBook {
   final String path;
   final String title;
-  final String fileType; // 'txt' | 'docx' | 'pdf'
+  final String fileType; // 'txt' | 'docx' | 'epub' | 'pdf'
   final int fileSize;
   final int lastModified;
   final List<String> categoryPath;
@@ -100,7 +101,8 @@ class _DiscoveredBook {
 /// and parses TXT / DOCX TOC for genuinely NEW books.
 /// PDF TOC is intentionally skipped here (pdfrx uses platform channels).
 Future<List<_DiscoveredBook>> _scanExternalFolderInIsolate(
-    (String folderPath, String folderName, String dbPath) args) async {
+  (String folderPath, String folderName, String dbPath) args,
+) async {
   // Open a read-only sqlite3 connection to check existing books without
   // going through the Drift/sqflite layer (which requires platform channels).
   sqlite3.Database? db;
@@ -147,6 +149,8 @@ Future<void> _collectBookFilesRecursive(
           fileType = 'txt';
         } else if (lower.endsWith('.docx')) {
           fileType = 'docx';
+        } else if (lower.endsWith('.epub')) {
+          fileType = 'epub';
         } else if (lower.endsWith('.pdf')) {
           fileType = 'pdf';
         } else {
@@ -182,7 +186,7 @@ Future<void> _collectBookFilesRecursive(
         }
         // ──────────────────────────────────────────────────────────────────
 
-        // New or changed book — parse TOC for TXT / DOCX.
+        // New or changed book — parse TOC for TXT / DOCX / EPUB.
         List<_RawTocEntry>? rawToc;
         String? conversionError;
         if (fileType == 'txt') {
@@ -194,10 +198,12 @@ Future<void> _collectBookFilesRecursive(
           } catch (_) {
             // TOC parse failure is non-fatal.
           }
-        } else if (fileType == 'docx') {
+        } else if (fileType == 'docx' || fileType == 'epub') {
           try {
             final bytes = await entity.readAsBytes();
-            final content = docxToText(bytes, title);
+            final content = fileType == 'docx'
+                ? docxToText(bytes, title)
+                : epubToText(bytes, title);
             try {
               final parsed = TocParser.parseEntriesFromContent(content);
               rawToc = _flattenTocToRaw(parsed);
@@ -210,17 +216,19 @@ Future<void> _collectBookFilesRecursive(
         }
         // PDF: rawToc stays null — parsed on the main isolate.
 
-        books.add(_DiscoveredBook(
-          path: entity.path,
-          title: title,
-          fileType: fileType,
-          fileSize: fileSize,
-          lastModified: lastModified,
-          categoryPath: categoryPath,
-          tocEntries: rawToc,
-          conversionError: conversionError,
-          existingBookId: existingBookId,
-        ));
+        books.add(
+          _DiscoveredBook(
+            path: entity.path,
+            title: title,
+            fileType: fileType,
+            fileSize: fileSize,
+            lastModified: lastModified,
+            categoryPath: categoryPath,
+            tocEntries: rawToc,
+            conversionError: conversionError,
+            existingBookId: existingBookId,
+          ),
+        );
       }
     } catch (e) {
       debugPrint('⚠️ Skipping inaccessible entity: ${entity.path}: $e');
@@ -235,9 +243,15 @@ Future<void> _collectBookFilesRecursive(
 /// the list.
 @visibleForTesting
 Future<List<Map<String, Object?>>> scanExternalFolderForTest(
-    String folderPath, String folderName, String dbPath) async {
-  final result =
-      await _scanExternalFolderInIsolate((folderPath, folderName, dbPath));
+  String folderPath,
+  String folderName,
+  String dbPath,
+) async {
+  final result = await _scanExternalFolderInIsolate((
+    folderPath,
+    folderName,
+    dbPath,
+  ));
   return result
       .map((b) => {'path': b.path, 'existingBookId': b.existingBookId})
       .toList();
@@ -258,12 +272,14 @@ void _flattenRawRecursive(
 ) {
   for (final entry in entries) {
     final myIndex = flat.length;
-    flat.add(_RawTocEntry(
-      text: entry.text,
-      level: entry.level,
-      lineIndex: entry.index,
-      parentIndex: parentIndex,
-    ));
+    flat.add(
+      _RawTocEntry(
+        text: entry.text,
+        level: entry.level,
+        lineIndex: entry.index,
+        parentIndex: parentIndex,
+      ),
+    );
     if (entry.children.isNotEmpty) {
       _flattenRawRecursive(entry.children, flat, myIndex);
     }
@@ -428,9 +444,9 @@ String _rangeEndSelectColumns(bool hasLinkRanges) => hasLinkRanges
 /// JOIN לקצה-הטווח של צד-הפאנל (`panelSide`: 0 = צד המקור השמור, 1 = היעד).
 String _rangeEndJoinClause(bool hasLinkRanges, {required int panelSide}) =>
     hasLinkRanges
-        ? '''LEFT JOIN link_range lr ON lr.linkId = l.id AND lr.side = $panelSide
+    ? '''LEFT JOIN link_range lr ON lr.linkId = l.id AND lr.side = $panelSide
         LEFT JOIN line rl ON rl.id = lr.endLineId'''
-        : '';
+    : '';
 
 String _anchorSelectColumns(bool hasLinkAnchor) => hasLinkAnchor
     ? '''la.charStart as anchorCharStart,
@@ -458,8 +474,9 @@ String _anchorSelectColumns(bool hasLinkAnchor) => hasLinkAnchor
 /// שורת הפאנל היא תמיד שורת ההתחלה של הקישור.
 String _anchorJoinClause(bool hasLinkAnchor, {required int displayedSide}) {
   if (!hasLinkAnchor) return '';
-  final displayedSideLine =
-      displayedSide == 0 ? 'l.sourceLineId' : 'l.targetLineId';
+  final displayedSideLine = displayedSide == 0
+      ? 'l.sourceLineId'
+      : 'l.targetLineId';
   return '''LEFT JOIN (
           SELECT linkId, MIN(charStart) AS charStart, charEnd, label,
                  GROUP_CONCAT(charStart || ':' || COALESCE(charEnd, '') || ':' || COALESCE(label, ''), ';') AS spans
@@ -481,11 +498,13 @@ List<LinkAnchorSpan> _parseAnchorSpans(String? spans) {
     if (start == null) continue;
     final end = fields.length > 1 ? int.tryParse(fields[1]) : null;
     final label = fields.length > 2 ? fields.sublist(2).join(':') : '';
-    result.add(LinkAnchorSpan(
-      start: start,
-      end: end,
-      label: label.isEmpty ? null : label,
-    ));
+    result.add(
+      LinkAnchorSpan(
+        start: start,
+        end: end,
+        label: label.isEmpty ? null : label,
+      ),
+    );
   }
   result.sort((a, b) => a.start.compareTo(b.start));
   return result;
@@ -523,7 +542,9 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
           JOIN link cl ON cl.id = lc.linkId
           WHERE lc.side = 0 AND cl.sourceBookId = ?'''
         : '';
-    final forwardRows = db.select('''
+    final forwardRows = db
+        .select(
+          '''
         WITH anchors(linkId, anchorLineId) AS (
           SELECT id, sourceLineId FROM link WHERE sourceBookId = ?
           $coverageArm
@@ -549,7 +570,10 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
         ${_rangeEndJoinClause(hasLinkRanges, panelSide: 1)}
         ${_anchorJoinClause(hasLinkAnchor, displayedSide: 0)}
         ORDER BY sl.lineIndex
-      ''', [bookId, if (hasLinkRanges) bookId]).toMapList();
+      ''',
+          [bookId, if (hasLinkRanges) bookId],
+        )
+        .toMapList();
     return [...forwardRows, ..._loadInverseSourceRows(db, bookId)];
   } finally {
     db?.close();
@@ -559,7 +583,7 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
 /// Top-level worker לסיכום קישורי ספר לפי (ספר-יעד, סוג חיבור) — שאילתת
 /// GROUP BY זולה במקום למשוך עשרות אלפי שורות קישורים לדארט.
 ({List<Map<String, dynamic>> rows, int? maxSourceLineIndex})
-    _loadBookLinkTargetsSummaryRowsInIsolate({
+_loadBookLinkTargetsSummaryRowsInIsolate({
   required String dbPath,
   required String title,
   required int categoryId,
@@ -588,7 +612,9 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
           JOIN link cl ON cl.id = lc.linkId
           WHERE lc.side = 0 AND cl.sourceBookId = ?'''
         : '';
-    final forwardRows = db.select('''
+    final forwardRows = db
+        .select(
+          '''
         WITH anchors(linkId) AS (
           SELECT id FROM link WHERE sourceBookId = ?
           $coverageArm
@@ -601,13 +627,18 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
         JOIN book tb ON l.targetBookId = tb.id
         LEFT JOIN connection_type ct ON l.connectionTypeId = ct.id
         GROUP BY tb.title, ct.name
-      ''', [bookId, if (hasLinkRanges) bookId]).toMapList();
+      ''',
+          [bookId, if (hasLinkRanges) bookId],
+        )
+        .toMapList();
 
     // הזרוע ההפוכה — מפרשים ששמורים כקישור מהם אל הספר הזה (מוצגים כ-SOURCE),
     // כמו ב-_loadInverseSourceRows.
     final depTypes = LinkTypes.dependentTextTypes.toList();
     final typePlaceholders = List.filled(depTypes.length, '?').join(', ');
-    final inverseRows = db.select('''
+    final inverseRows = db
+        .select(
+          '''
         SELECT sb.title as targetBookTitle,
                'SOURCE' as connectionTypeName,
                COUNT(*) as linkCount
@@ -618,15 +649,19 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
           AND ct.name IN ($typePlaceholders)
           AND l.sourceBookId != l.targetBookId
         GROUP BY sb.title
-      ''', [bookId, ...depTypes]).toMapList();
+      ''',
+          [bookId, ...depTypes],
+        )
+        .toMapList();
 
     final maxRows = db.select(
       'SELECT MAX(sl.lineIndex) as maxIdx FROM link l '
       'JOIN line sl ON sl.id = l.sourceLineId WHERE l.sourceBookId = ?',
       [bookId],
     ).toMapList();
-    final maxSourceLineIndex =
-        maxRows.isEmpty ? null : maxRows.first['maxIdx'] as int?;
+    final maxSourceLineIndex = maxRows.isEmpty
+        ? null
+        : maxRows.first['maxIdx'] as int?;
 
     return (
       rows: [...forwardRows, ...inverseRows],
@@ -640,7 +675,7 @@ List<Map<String, dynamic>> _loadBookLinksRowsInIsolate({
 /// Top-level wrapper עבור סיכום קישורי ספר ב-isolate.
 /// ראה ההסבר ב-[_runAlternativeStructuresInIsolate].
 Future<({List<Map<String, dynamic>> rows, int? maxSourceLineIndex})>
-    _runBookLinkTargetsSummaryInIsolate({
+_runBookLinkTargetsSummaryInIsolate({
   required String dbPath,
   required String title,
   required int categoryId,
@@ -701,13 +736,14 @@ List<Map<String, dynamic>> _loadBookLinksRowsInRangeInIsolate({
     // null     → ללא פילטר (כל הקישורים)
     // ריק      → רק קישורים שאינם מפרשים (REFERENCE וכד׳)
     // לא ריק   → קישורים שאינם מפרשים + המפרשים הנבחרים
-    final depTypesIn =
-        LinkTypes.dependentTextTypes.map((t) => "'$t'").join(', ');
+    final depTypesIn = LinkTypes.dependentTextTypes
+        .map((t) => "'$t'")
+        .join(', ');
     final commentaryFilterClause = targetBookTitles == null
         ? ''
         : hasCommentaryFilter
-            ? 'AND (ct.name IS NULL OR ct.name NOT IN ($depTypesIn) OR tb.title IN ($targetBookPlaceholders))'
-            : 'AND (ct.name IS NULL OR ct.name NOT IN ($depTypesIn))';
+        ? 'AND (ct.name IS NULL OR ct.name NOT IN ($depTypesIn) OR tb.title IN ($targetBookPlaceholders))'
+        : 'AND (ct.name IS NULL OR ct.name NOT IN ($depTypesIn))';
 
     // שורות ה-anchors כוללות גם שורות מכוסות של קישורי-טווח (side=0). הזרוע
     // מסוננת לחלון כבר כאן דרך ה-PK של link_coverage (lineId ראשון) — שורות
@@ -751,8 +787,12 @@ List<Map<String, dynamic>> _loadBookLinksRowsInRangeInIsolate({
       ''', parameters).toMapList();
     return [
       ...rows,
-      ..._loadInverseSourceRows(db, bookId,
-          startLineIndex: startLineIndex, endLineIndex: endLineIndex),
+      ..._loadInverseSourceRows(
+        db,
+        bookId,
+        startLineIndex: startLineIndex,
+        endLineIndex: endLineIndex,
+      ),
     ];
   } catch (error) {
     rethrow;
@@ -852,7 +892,7 @@ Future<List<Map<String, Object?>>> _runBookLinksInRangeInIsolate({
 /// Top-level worker לטעינת טווח שורות על חיבור RO חדש ב-isolate; ה-join+split
 /// מתבצע כאן כדי לא לחסום את ה-UI thread. ראה [_runAlternativeStructuresInIsolate].
 ({int startLine, int endLine, int totalLines, List<String> lines})?
-    _loadBookTextRangeRowsInIsolate({
+_loadBookTextRangeRowsInIsolate({
   required String dbPath,
   required String title,
   required int categoryId,
@@ -894,14 +934,19 @@ Future<List<Map<String, Object?>>> _runBookLinksInRangeInIsolate({
       // מהדורה חלופית: שורות מבנה (heRef NULL — כותרות/מחברים) נשארות מהשלד;
       // שורת תוכן מקבלת את נוסח המהדורה, וסגמנט שחסר בה מוצג ריק — לעולם לא
       // נופלים בשקט לנוסח הממוזג.
-      rows = db.select('''
+      rows = db
+          .select(
+            '''
         SELECT CASE WHEN l.heRef IS NULL THEN l.content
                     ELSE COALESCE(vl.content, '') END AS content
         FROM line l
         LEFT JOIN version_line vl ON vl.versionId = ? AND vl.lineId = l.id
         WHERE l.bookId = ? AND l.lineIndex >= ? AND l.lineIndex <= ?
         ORDER BY l.lineIndex
-      ''', [versionId, bookId, normalizedStart, normalizedEnd]).toMapList();
+      ''',
+            [versionId, bookId, normalizedStart, normalizedEnd],
+          )
+          .toMapList();
     } else {
       rows = db.select(
         'SELECT content FROM line WHERE bookId = ? AND lineIndex >= ? AND lineIndex <= ? ORDER BY lineIndex',
@@ -927,7 +972,7 @@ Future<List<Map<String, Object?>>> _runBookLinksInRangeInIsolate({
 /// Top-level wrapper עבור טעינת טווח תוכן ב-isolate.
 /// ראה ההסבר ב-[_runAlternativeStructuresInIsolate].
 Future<({int startLine, int endLine, int totalLines, List<String> lines})?>
-    _runBookTextRangeInIsolate({
+_runBookTextRangeInIsolate({
   required String dbPath,
   required String title,
   required int categoryId,
@@ -968,13 +1013,18 @@ List<Map<String, dynamic>> _loadBookVersionsRowsInIsolate({
     if (bookResults.isEmpty) return const [];
     final bookId = bookResults.first['id'] as int;
 
-    return db.select('''
+    return db
+        .select(
+          '''
       SELECT versionTitle, heVersionTitle, versionSource, priority, license,
              versionNotes, heVersionNotes, hasContent
       FROM book_version
       WHERE bookId = ?
       ORDER BY hasContent DESC, priority DESC, versionTitle
-    ''', [bookId]).toMapList();
+    ''',
+          [bookId],
+        )
+        .toMapList();
   } finally {
     db?.close();
   }
@@ -1212,7 +1262,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   @visibleForTesting
   static ({List<Map<String, dynamic>> rows, int? maxSourceLineIndex})
-      loadBookLinkTargetsSummaryRowsForTesting({
+  loadBookLinkTargetsSummaryRowsForTesting({
     required String dbPath,
     required String title,
     required int categoryId,
@@ -1239,7 +1289,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   @visibleForTesting
   static ({int startLine, int endLine, int totalLines, List<String> lines})?
-      loadBookTextRangeRowsForTesting({
+  loadBookTextRangeRowsForTesting({
     required String dbPath,
     required String title,
     required int categoryId,
@@ -1373,11 +1423,13 @@ class DatabaseLibraryProvider implements LibraryProvider {
       targetCategory.books.add(pdfBook);
       existingPdfTitles.add(title);
       modifiedCategories.add(targetCategory);
-      _cachedKeys.add(BookCompositeKey.create(
-        title: title,
-        categoryId: targetCategoryId,
-        fileType: 'pdf',
-      ));
+      _cachedKeys.add(
+        BookCompositeKey.create(
+          title: title,
+          categoryId: targetCategoryId,
+          fileType: 'pdf',
+        ),
+      );
       _categoryIdToPath[targetCategoryId] =
           DatabaseConstants.talmudBavliFolderName;
     }
@@ -1440,7 +1492,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   @override
   Future<Map<String, List<Book>>> loadBooks(
-      Map<String, Map<String, dynamic>> metadata) async {
+    Map<String, Map<String, dynamic>> metadata,
+  ) async {
     final Map<String, List<Book>> booksByCategory = {};
 
     if (!_sqliteProvider.isInitialized || _sqliteProvider.repository == null) {
@@ -1457,7 +1510,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
       // Build category paths and caches
       final Map<int, db_models.Category> categoryMap = {
-        for (var c in categories) c.id: c
+        for (var c in categories) c.id: c,
       };
       final Map<int, String> categoryPaths = {};
 
@@ -1500,14 +1553,17 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
         final categoryPath = getPath(dbBook.categoryId);
         _categoryIdToPath[dbBook.categoryId] = categoryPath;
-        _cachedKeys.add(BookCompositeKey.create(
-          title: dbBook.title,
-          categoryId: dbBook.categoryId,
-          fileType: dbBook.fileType,
-        ));
+        _cachedKeys.add(
+          BookCompositeKey.create(
+            title: dbBook.title,
+            categoryId: dbBook.categoryId,
+            fileType: dbBook.fileType,
+          ),
+        );
 
-        final categoryName =
-            dbBook.topics.isNotEmpty ? dbBook.topics.first.name : 'ללא קטגוריה';
+        final categoryName = dbBook.topics.isNotEmpty
+            ? dbBook.topics.first.name
+            : 'ללא קטגוריה';
 
         final topics = _buildTopics(dbBook, categoryPath);
 
@@ -1516,10 +1572,12 @@ class DatabaseLibraryProvider implements LibraryProvider {
           title: dbBook.title,
           author: dbBook.authors.isNotEmpty ? dbBook.authors.first.name : null,
           heShortDesc: dbBook.heShortDesc,
-          pubDate:
-              dbBook.pubDates.isNotEmpty ? dbBook.pubDates.first.date : null,
-          pubPlace:
-              dbBook.pubPlaces.isNotEmpty ? dbBook.pubPlaces.first.name : null,
+          pubDate: dbBook.pubDates.isNotEmpty
+              ? dbBook.pubDates.first.date
+              : null,
+          pubPlace: dbBook.pubPlaces.isNotEmpty
+              ? dbBook.pubPlaces.first.name
+              : null,
           order: dbBook.order.toInt(),
           topics: topics,
           fileType: dbBook.fileType,
@@ -1534,7 +1592,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
       _titlesCached = true;
       debugPrint(
-          '💾 Database loaded ${dbBooks.length} books into ${booksByCategory.length} categories');
+        '💾 Database loaded ${dbBooks.length} books into ${booksByCategory.length} categories',
+      );
     } catch (e) {
       debugPrint('⚠️ Error loading books from database: $e');
     }
@@ -1680,7 +1739,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
       try {
         final repository = await UserBooksDatabaseHolder.instance.repository;
         final categoryPath = await BookDatabaseResolver.buildCategoryPath(
-            repository, categoryId);
+          repository,
+          categoryId,
+        );
         if (categoryPath.isNotEmpty && !fromUserBooks) {
           _categoryIdToPath[categoryId] = categoryPath;
         }
@@ -1803,15 +1864,22 @@ class DatabaseLibraryProvider implements LibraryProvider {
       try {
         final repo = await UserBooksDatabaseHolder.instance.repository;
         final book = await repo.getBookByTitleCategoryAndFileType(
-            title, categoryId, fileType);
+          title,
+          categoryId,
+          fileType,
+        );
         if (book == null) return null;
         if (book.isFileBacked && book.filePath != null) {
           final file = File(book.filePath!);
           if (await file.exists()) {
-            // DOCX הוא בינארי — חובה להמיר, לא readAsString (שמחזיר זבל/זורק).
+            // DOCX/EPUB הם בינאריים — חובה להמיר, לא readAsString (זבל/זורק).
             if ((book.fileType ?? '').toLowerCase() == 'docx' ||
                 file.path.toLowerCase().endsWith('.docx')) {
               return await convertDocxWithCache(file, title);
+            }
+            if ((book.fileType ?? '').toLowerCase() == 'epub' ||
+                file.path.toLowerCase().endsWith('.epub')) {
+              return await convertEpubWithCache(file, title);
             }
             // קבצים אישיים ישנים עשויים להיות ב-Windows-1255/UTF-16 ולא UTF-8.
             return await readTextFileSmart(file);
@@ -1819,7 +1887,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
         }
         // נופל לטעינה מתוך ה-DB עצמו (טבלת `line`).
         return await _readBookTextFromUserBooksDb(
-            repo, book.id, book.totalLines);
+          repo,
+          book.id,
+          book.totalLines,
+        );
       } catch (e) {
         debugPrint('⚠️ Error reading user book text: $e');
         return null;
@@ -1836,6 +1907,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
           if (await file.exists()) {
             if ((book.fileType ?? '').toLowerCase() == 'docx') {
               return await convertDocxWithCache(file, title);
+            }
+            if ((book.fileType ?? '').toLowerCase() == 'epub') {
+              return await convertEpubWithCache(file, title);
             }
             return await readTextFileSmart(file);
           }
@@ -1858,7 +1932,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   /// קורא את תוכן הספר משורות ה-`line` של `user_books.db` ומחזיר טקסט מאוחד.
   Future<String?> _readBookTextFromUserBooksDb(
-      SeforimRepository repo, int bookId, int totalLines) async {
+    SeforimRepository repo,
+    int bookId,
+    int totalLines,
+  ) async {
     try {
       if (totalLines <= 0) return null;
       final lines = await repo.getLines(bookId, 0, totalLines - 1);
@@ -1886,7 +1963,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
       try {
         final repo = await UserBooksDatabaseHolder.instance.repository;
         final book = await repo.getBookByTitleCategoryAndFileType(
-            title, categoryId, fileType);
+          title,
+          categoryId,
+          fileType,
+        );
         if (book == null) return null;
         return await _loadTocFromUserBooksRepo(repo, book.id);
       } catch (e) {
@@ -1906,7 +1986,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
   /// משתמש ב-`getBookTocs` של ה-repository (שכבר עושה JOIN ל-tocText
   /// ומחזיר רשומות migration עם `text` מאוכלס).
   Future<List<TocEntry>?> _loadTocFromUserBooksRepo(
-      SeforimRepository repo, int bookId) async {
+    SeforimRepository repo,
+    int bookId,
+  ) async {
     final tocEntries = await repo.getBookTocs(bookId);
     if (tocEntries.isEmpty) return null;
     final idToEntry = <int, TocEntry>{};
@@ -1963,7 +2045,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
       _categoriesById
         ..clear()
         ..addEntries(
-            categories.map((category) => MapEntry(category.id, category)));
+          categories.map((category) => MapEntry(category.id, category)),
+        );
 
       for (final book in books) {
         if (!shouldIncludeBookByPath(
@@ -1974,11 +2057,13 @@ class DatabaseLibraryProvider implements LibraryProvider {
           continue;
         }
 
-        _cachedKeys.add(BookCompositeKey.create(
-          title: book.title,
-          categoryId: book.categoryId,
-          fileType: book.fileType,
-        ));
+        _cachedKeys.add(
+          BookCompositeKey.create(
+            title: book.title,
+            categoryId: book.categoryId,
+            fileType: book.fileType,
+          ),
+        );
 
         if (!_categoryIdToPath.containsKey(book.categoryId)) {
           final categoryPath = await _getPathForCategoryId(book.categoryId);
@@ -2093,7 +2178,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
     });
 
     debugPrint(
-        '⏱️ Transaction (books+categories): ${DateTime.now().difference(tQuery).inMilliseconds}ms (${allDbBooks.length} books, ${allCatRows.length} categories)');
+      '⏱️ Transaction (books+categories): ${DateTime.now().difference(tQuery).inMilliseconds}ms (${allDbBooks.length} books, ${allCatRows.length} categories)',
+    );
 
     final booksByCategory = <int, List<Map<String, dynamic>>>{};
     for (final bookData in allDbBooks) {
@@ -2153,7 +2239,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
       totalCategories += _countCategories(catalogCategory);
     }
     debugPrint(
-        '⏱️ Category tree build: ${DateTime.now().difference(tTree).inMilliseconds}ms');
+      '⏱️ Category tree build: ${DateTime.now().difference(tTree).inMilliseconds}ms',
+    );
 
     final talmudBavliCategory = library.subCategories.where((category) {
       return category.title == DatabaseConstants.talmudBavliFolderName;
@@ -2176,7 +2263,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
     _titlesCached = true;
 
     debugPrint(
-        '💾 Database catalog built with $totalCategories categories and ${allDbBooks.length} books from DB');
+      '💾 Database catalog built with $totalCategories categories and ${allDbBooks.length} books from DB',
+    );
 
     // NOTE: Library is now built ONLY from the database.
     // Files that are not in the DB will not appear in the library browser.
@@ -2197,8 +2285,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
   ) async {
     if (categoryPath.isEmpty) {
       // Return default category
-      final defaultCategory =
-          await repository.getCategoryByTitle('ללא קטגוריה');
+      final defaultCategory = await repository.getCategoryByTitle(
+        'ללא קטגוריה',
+      );
       if (defaultCategory != null) {
         return defaultCategory.id;
       }
@@ -2220,8 +2309,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
     // Walk through each level of the category hierarchy
     for (final categoryName in categoryPath) {
       // Try to find existing category with this name under the current parent
-      final existingCategory =
-          await repository.getCategoryByTitleAndParent(categoryName, parentId);
+      final existingCategory = await repository.getCategoryByTitleAndParent(
+        categoryName,
+        parentId,
+      );
 
       if (existingCategory != null) {
         // Category exists - use it as parent for next level
@@ -2438,8 +2529,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
       // (ספרי המשתמש שכבר נטענו) נשמר עד הניסיון הבא, במקום להיעלם.
       final db = await repo.database.database;
       withTransaction(db, () {
-        userBooks =
-            repo.database.bookDao.getAllBooksMinimal(db, withFileColumns: true);
+        userBooks = repo.database.bookDao.getAllBooksMinimal(
+          db,
+          withFileColumns: true,
+        );
         userCats = repo.database.categoryDao.getAllCategoryRows(db);
         userAuthors = repo.database.bookDao.getBookAuthorsMap(db);
       });
@@ -2463,8 +2556,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
       }
 
       // קיבוץ קטגוריות לפי parentId.
-      final allUserCategories =
-          userCats.map((row) => db_models.Category.fromJson(row)).toList();
+      final allUserCategories = userCats
+          .map((row) => db_models.Category.fromJson(row))
+          .toList();
       final categoriesByParent = <int?, List<db_models.Category>>{};
       for (final cat in allUserCategories) {
         categoriesByParent.putIfAbsent(cat.parentId, () => []).add(cat);
@@ -2472,8 +2566,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
       // חיפוש קטגוריית "ספרים אישיים" ברמת השורש של user_books.db.
       final rootCats = categoriesByParent[null] ?? [];
-      final personalRootInUserDb =
-          rootCats.where((c) => c.title == 'ספרים אישיים').firstOrNull;
+      final personalRootInUserDb = rootCats
+          .where((c) => c.title == 'ספרים אישיים')
+          .firstOrNull;
       if (personalRootInUserDb == null) {
         return;
       }
@@ -2484,7 +2579,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
       // הגדרה: האם למזג תיקיות מותאמות אישית ישירות לעץ הראשי לפי שם
       // (במקום להציג אותן תחת קטגוריית "ספרים אישיים" נפרדת).
-      final mergeIntoLibraryRoot = Settings.getValue<bool>(
+      final mergeIntoLibraryRoot =
+          Settings.getValue<bool>(
             SettingsRepository.keyMergeUserBooksIntoLibrary,
             defaultValue: false,
           ) ??
@@ -2500,12 +2596,11 @@ class DatabaseLibraryProvider implements LibraryProvider {
       // ספרים שיושבים ישירות תחת "ספרים אישיים" (בד"כ אין כאלה — תיקיות
       // הן רמה אחת מתחת — אבל מטפלים ליתר ביטחון).
       final directBooksUnderRoot =
-          (booksByCategory[personalRootInUserDb.id] ?? [])
-            ..sort((a, b) {
-              final orderA = (a['orderIndex'] as num?)?.toDouble() ?? 999.0;
-              final orderB = (b['orderIndex'] as num?)?.toDouble() ?? 999.0;
-              return orderA.compareTo(orderB);
-            });
+          (booksByCategory[personalRootInUserDb.id] ?? [])..sort((a, b) {
+            final orderA = (a['orderIndex'] as num?)?.toDouble() ?? 999.0;
+            final orderB = (b['orderIndex'] as num?)?.toDouble() ?? 999.0;
+            return orderA.compareTo(orderB);
+          });
 
       if (mergeIntoLibraryRoot) {
         // במצב מיזוג: גם "ספרים אישיים" וגם שם התיקייה שהמשתמש בחר
@@ -2525,12 +2620,14 @@ class DatabaseLibraryProvider implements LibraryProvider {
           );
           if (book == null) continue;
           library.books.add(book);
-          _userBooksCachedKeys.add(BookCompositeKey.create(
-            title: book.title,
-            categoryId: personalRootId,
-            fileType: book.fileType,
-            isUserBook: true,
-          ));
+          _userBooksCachedKeys.add(
+            BookCompositeKey.create(
+              title: book.title,
+              categoryId: personalRootId,
+              fileType: book.fileType,
+              isUserBook: true,
+            ),
+          );
         }
 
         for (final pickedFolder in pickedFolders) {
@@ -2555,12 +2652,14 @@ class DatabaseLibraryProvider implements LibraryProvider {
             );
             if (book == null) continue;
             library.books.add(book);
-            _userBooksCachedKeys.add(BookCompositeKey.create(
-              title: book.title,
-              categoryId: pickedFolder.id,
-              fileType: book.fileType,
-              isUserBook: true,
-            ));
+            _userBooksCachedKeys.add(
+              BookCompositeKey.create(
+                title: book.title,
+                categoryId: pickedFolder.id,
+                fileType: book.fileType,
+                isUserBook: true,
+              ),
+            );
           }
 
           // תת-תיקיות של התיקייה הנבחרת — מתמזגות בשורש הספרייה לפי שם.
@@ -2625,12 +2724,14 @@ class DatabaseLibraryProvider implements LibraryProvider {
           );
           if (book == null) continue;
           personalCategoryInLibrary.books.add(book);
-          _userBooksCachedKeys.add(BookCompositeKey.create(
-            title: book.title,
-            categoryId: personalRootId,
-            fileType: book.fileType,
-            isUserBook: true,
-          ));
+          _userBooksCachedKeys.add(
+            BookCompositeKey.create(
+              title: book.title,
+              categoryId: personalRootId,
+              fileType: book.fileType,
+              isUserBook: true,
+            ),
+          );
         }
 
         for (final child in pickedFolders) {
@@ -2733,13 +2834,14 @@ class DatabaseLibraryProvider implements LibraryProvider {
     final nativeCategoryId = dbCategory.id;
     _userBooksCategoryIds.add(nativeCategoryId);
 
-    final dbBooks = [
-      ...?booksByCategory[dbCategory.id],
-    ]..sort((a, b) {
-        final orderA = (a['orderIndex'] as num?)?.toDouble() ?? 999.0;
-        final orderB = (b['orderIndex'] as num?)?.toDouble() ?? 999.0;
-        return orderA.compareTo(orderB);
-      });
+    final dbBooks =
+        [
+          ...?booksByCategory[dbCategory.id],
+        ]..sort((a, b) {
+          final orderA = (a['orderIndex'] as num?)?.toDouble() ?? 999.0;
+          final orderB = (b['orderIndex'] as num?)?.toDouble() ?? 999.0;
+          return orderA.compareTo(orderB);
+        });
     for (final dbBook in dbBooks) {
       final book = _convertMinimalBookMapToBook(
         dbBook,
@@ -2752,12 +2854,14 @@ class DatabaseLibraryProvider implements LibraryProvider {
       );
       if (book == null) continue;
       category.books.add(book);
-      _userBooksCachedKeys.add(BookCompositeKey.create(
-        title: book.title,
-        categoryId: nativeCategoryId,
-        fileType: book.fileType,
-        isUserBook: true,
-      ));
+      _userBooksCachedKeys.add(
+        BookCompositeKey.create(
+          title: book.title,
+          categoryId: nativeCategoryId,
+          fileType: book.fileType,
+          isUserBook: true,
+        ),
+      );
     }
 
     final children = [
@@ -2898,6 +3002,27 @@ class DatabaseLibraryProvider implements LibraryProvider {
       );
     }
 
+    if (filePath != null && fileType == 'epub') {
+      final resolvedFilePath = resolveMovedFileBookPath(filePath);
+      return EpubBook(
+        id: id,
+        title: title,
+        category: category,
+        path: resolvedFilePath,
+        filePath: resolvedFilePath,
+        author: author,
+        heShortDesc: metaHeShortDesc,
+        heDesc: metaHeDesc,
+        pubDate: pubDate,
+        pubPlace: pubPlace,
+        order: order,
+        topics: topics,
+        categoryPath: categoryPath,
+        categoryId: categoryId,
+        isUserBook: isUserBook,
+      );
+    }
+
     return TextBook(
       id: id,
       title: title,
@@ -2922,13 +3047,18 @@ class DatabaseLibraryProvider implements LibraryProvider {
   /// Counts the total number of categories in the tree.
   int _countCategories(Category category) {
     return 1 +
-        category.subCategories
-            .fold(0, (sum, sub) => sum + _countCategories(sub));
+        category.subCategories.fold(
+          0,
+          (sum, sub) => sum + _countCategories(sub),
+        );
   }
 
   @override
   Future<List<Link>> getAllLinksForBook(
-      String title, int categoryId, String fileType) async {
+    String title,
+    int categoryId,
+    String fileType,
+  ) async {
     if (!_sqliteProvider.isInitialized || _sqliteProvider.repository == null) {
       return [];
     }
@@ -2969,8 +3099,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
           anchorSpans: _parseAnchorSpans(row['anchorSpans'] as String?),
           heRefEnd:
               (row['targetRangeEndHeRef'] as String?)?.trim().isNotEmpty == true
-                  ? (row['targetRangeEndHeRef'] as String).trim()
-                  : null,
+              ? (row['targetRangeEndHeRef'] as String).trim()
+              : null,
           index2End: row['targetRangeEndLineIndex'] != null
               ? (row['targetRangeEndLineIndex'] as int) + 1
               : null,
@@ -2993,12 +3123,13 @@ class DatabaseLibraryProvider implements LibraryProvider {
     required int endLineIndex,
     Iterable<String>? targetBookTitles,
   }) async {
-    final normalizedTargetBookTitles = targetBookTitles
-        ?.map((targetTitle) => targetTitle.trim())
-        .where((targetTitle) => targetTitle.isNotEmpty)
-        .toSet()
-        .toList()
-      ?..sort();
+    final normalizedTargetBookTitles =
+        targetBookTitles
+            ?.map((targetTitle) => targetTitle.trim())
+            .where((targetTitle) => targetTitle.isNotEmpty)
+            .toSet()
+            .toList()
+          ?..sort();
     if (!_sqliteProvider.isInitialized || _sqliteProvider.repository == null) {
       return [];
     }
@@ -3041,8 +3172,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
           anchorSpans: _parseAnchorSpans(row['anchorSpans'] as String?),
           heRefEnd:
               (row['targetRangeEndHeRef'] as String?)?.trim().isNotEmpty == true
-                  ? (row['targetRangeEndHeRef'] as String).trim()
-                  : null,
+              ? (row['targetRangeEndHeRef'] as String).trim()
+              : null,
           index2End: row['targetRangeEndLineIndex'] != null
               ? (row['targetRangeEndLineIndex'] as int) + 1
               : null,
@@ -3060,7 +3191,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
   /// מיועד לבניית רשימת המפרשים של ספר בלי לטעון את כל הקישורים לזיכרון.
   /// מחזיר null אם המסד לא זמין או שהשאילתה נכשלה.
   Future<({List<LinkTargetSummary> targets, int maxSourceLine})?>
-      getBookLinkTargetsSummary(String title, int categoryId) async {
+  getBookLinkTargetsSummary(String title, int categoryId) async {
     if (!_sqliteProvider.isInitialized || _sqliteProvider.repository == null) {
       return null;
     }
@@ -3096,7 +3227,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
   /// שהשאילתה וה-split לא יחסמו את ה-UI thread בזמן גלילה. כש-[versionTitle]
   /// לא null נטען נוסח המהדורה הזו (version_line) על שלד שורות הספר.
   Future<({int startLine, int endLine, int totalLines, List<String> lines})?>
-      getBookTextRange(
+  getBookTextRange(
     String title,
     int categoryId,
     String fileType, {
@@ -3157,15 +3288,16 @@ class DatabaseLibraryProvider implements LibraryProvider {
     if (!_sqliteProvider.isInitialized || _sqliteProvider.repository == null) {
       return false;
     }
-    final keys =
-        await (_selectableVersionKeysFuture ??= _loadSelectableVersionKeys());
+    final keys = await (_selectableVersionKeysFuture ??=
+        _loadSelectableVersionKeys());
     return keys.contains('$title $categoryId');
   }
 
   Future<Set<String>> _loadSelectableVersionKeys() async {
     try {
       final rows = await _runSelectableVersionKeysInIsolate(
-          dbPath: _sqliteProvider.dbPath);
+        dbPath: _sqliteProvider.dbPath,
+      );
       return rows.map((r) => '${r['title']} ${r['categoryId']}').toSet();
     } catch (e) {
       debugPrint('⚠️ Error loading selectable version keys: $e');
@@ -3194,16 +3326,21 @@ class DatabaseLibraryProvider implements LibraryProvider {
       if (resolvedBook == null) return 'שגיאה: הספר לא נמצא במסד הנתונים';
 
       // link.index2 is 1-based; lineIndex in DB is 0-based
-      final line = await resolvedBook.repository
-          .getLineByIndex(resolvedBook.book.id, link.index2 - 1);
+      final line = await resolvedBook.repository.getLineByIndex(
+        resolvedBook.book.id,
+        link.index2 - 1,
+      );
       if (line == null) return 'שגיאה: אינדקס מחוץ לטווח';
 
       // קישור-טווח: מצרפים את כל שורות הטווח עד index2End (1-based, כולל)
       // בשאילתת טווח אחת במקום שאילתה פר-שורה.
       final end0 = (link.index2End ?? link.index2) - 1;
       if (end0 <= link.index2 - 1) return line.content;
-      final rangeLines = await resolvedBook.repository
-          .getLines(resolvedBook.book.id, link.index2 - 1, end0);
+      final rangeLines = await resolvedBook.repository.getLines(
+        resolvedBook.book.id,
+        link.index2 - 1,
+        end0,
+      );
       if (rangeLines.isEmpty) return line.content;
       return rangeLines.map((l) => l.content).join('<br>');
     } catch (e) {
@@ -3214,7 +3351,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   /// Get all alternative TOC structures available in the database for a specific book
   Future<List<AltTocStructure>> getAlternativeStructuresForBook(
-      String bookTitle) async {
+    String bookTitle,
+  ) async {
     if (!_sqliteProvider.isInitialized || _sqliteProvider.repository == null) {
       return [];
     }
@@ -3235,7 +3373,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
       return results.map((json) => AltTocStructure.fromJson(json)).toList();
     } catch (e) {
       debugPrint(
-          '⚠️ Error in getAlternativeStructuresForBook "$bookTitle": $e');
+        '⚠️ Error in getAlternativeStructuresForBook "$bookTitle": $e',
+      );
       return [];
     }
   }
@@ -3244,8 +3383,9 @@ class DatabaseLibraryProvider implements LibraryProvider {
   Future<List<AltTocStructure>> getAlternativeStructures() async {
     return _dbOperation<List<AltTocStructure>>(
       (db) async {
-        final results =
-            db.select('SELECT * FROM alt_toc_structure').toMapList();
+        final results = db
+            .select('SELECT * FROM alt_toc_structure')
+            .toMapList();
         return results.map((json) => AltTocStructure.fromJson(json)).toList();
       },
       [],
@@ -3259,13 +3399,18 @@ class DatabaseLibraryProvider implements LibraryProvider {
       (db) async {
         // We join with tocText to get the actual text
         // Order by ID to ensure consistent order (or maybe level/parentId)
-        final results = db.select('''
+        final results = db
+            .select(
+              '''
           SELECT e.*, t.text
           FROM alt_toc_entry e
           JOIN tocText t ON e.textId = t.id
           WHERE e.structureId = ?
           ORDER BY e.id
-        ''', [structureId]).toMapList();
+        ''',
+              [structureId],
+            )
+            .toMapList();
 
         return results.map((json) => AltTocEntry.fromJson(json)).toList();
       },
@@ -3276,23 +3421,31 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   /// מחזיר רשימת (lineIndex, text) לכל ערכי כותרות משנה בעלי שורה מוגדרת
   Future<List<({int lineIndex, String text})>> getAltTocLineIndices(
-      int structureId) async {
+    int structureId,
+  ) async {
     return _dbOperation<List<({int lineIndex, String text})>>(
       (db) async {
-        final results = db.select('''
+        final results = db
+            .select(
+              '''
           SELECT l.lineIndex, t.text
           FROM alt_toc_entry e
           JOIN tocText t ON e.textId = t.id
           JOIN line l ON e.lineId = l.id
           WHERE e.structureId = ?
           ORDER BY l.lineIndex
-        ''', [structureId]).toMapList();
+        ''',
+              [structureId],
+            )
+            .toMapList();
 
         return results
-            .map((r) => (
-                  lineIndex: r['lineIndex'] as int,
-                  text: r['text'] as String,
-                ))
+            .map(
+              (r) => (
+                lineIndex: r['lineIndex'] as int,
+                text: r['text'] as String,
+              ),
+            )
             .toList();
       },
       [],
@@ -3302,11 +3455,15 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   /// Get links (books/lines) associated with a specific alternative TOC entry
   Future<List<Link>> getLinksForAltTocEntry(
-      int structureId, int altTocEntryId) async {
+    int structureId,
+    int altTocEntryId,
+  ) async {
     return _dbOperation<List<Link>>(
       (db) async {
         // Join line_alt_toc -> line -> book
-        final results = db.select('''
+        final results = db
+            .select(
+              '''
           SELECT 
             b.title as bookTitle,
             l.lineIndex,
@@ -3316,7 +3473,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
           JOIN book b ON l.bookId = b.id
           WHERE lat.structureId = ? AND lat.altTocEntryId = ?
           ORDER BY b.title, l.lineIndex
-        ''', [structureId, altTocEntryId]).toMapList();
+        ''',
+              [structureId, altTocEntryId],
+            )
+            .toMapList();
 
         return results.map((row) {
           final bookTitle = row['bookTitle'] as String;
@@ -3338,17 +3498,25 @@ class DatabaseLibraryProvider implements LibraryProvider {
 
   /// Get the alternative TOC entry associated with a specific book line
   Future<int?> getAltTocEntryForLine(
-      String bookTitle, int lineIndex, int structureId) async {
+    String bookTitle,
+    int lineIndex,
+    int structureId,
+  ) async {
     return _dbOperation<int?>(
       (db) async {
-        final results = db.select('''
+        final results = db
+            .select(
+              '''
           SELECT lat.altTocEntryId
           FROM line_alt_toc lat
           JOIN line l ON lat.lineId = l.id
           JOIN book b ON l.bookId = b.id
           WHERE b.title = ? AND l.lineIndex = ? AND lat.structureId = ?
           LIMIT 1
-  ''', [bookTitle, lineIndex, structureId]).toMapList();
+  ''',
+              [bookTitle, lineIndex, structureId],
+            )
+            .toMapList();
 
         if (results.isNotEmpty) {
           return results.first['altTocEntryId'] as int;
@@ -3414,7 +3582,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
         () => _scanExternalFolderInIsolate((folderPath, folderName, dbPath)),
       );
       debugPrint(
-          '📁 Isolate found ${discovered.length} books to process in $folderPath');
+        '📁 Isolate found ${discovered.length} books to process in $folderPath',
+      );
 
       // Phase 2 (main isolate): only metadata updates + new-book inserts.
       // This is deliberately light: unchanged books were already filtered in
@@ -3436,7 +3605,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
         }
         if (book.conversionError != null) {
           debugPrint(
-              '⚠️ DOCX conversion failed for ${book.title}: ${book.conversionError}');
+            '⚠️ DOCX conversion failed for ${book.title}: ${book.conversionError}',
+          );
           failedDetails.add((book.title, book.conversionError!));
           failed++;
           continue;
@@ -3457,7 +3627,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
               );
             }
             debugPrint(
-                '📁 Updated external book (metadata+TOC): ${book.title}');
+              '📁 Updated external book (metadata+TOC): ${book.title}',
+            );
             updated++;
             updatedBookIds.add(book.existingBookId!);
             continue;
@@ -3467,12 +3638,18 @@ class DatabaseLibraryProvider implements LibraryProvider {
           // Re-check authoritatively before inserting (guards against Phase-1
           // fallback duplicates and concurrent-scan races).
           if (await _recheckBeforeInsert(
-              repository, book.path, book.fileSize, book.lastModified)) {
+            repository,
+            book.path,
+            book.fileSize,
+            book.lastModified,
+          )) {
             continue;
           }
 
-          final categoryId =
-              await _getOrCreateCategoryInDb(book.categoryPath, repository);
+          final categoryId = await _getOrCreateCategoryInDb(
+            book.categoryPath,
+            repository,
+          );
 
           List<db_models.TocEntry>? tocEntries;
           if (book.tocEntries != null && book.tocEntries!.isNotEmpty) {
@@ -3504,7 +3681,8 @@ class DatabaseLibraryProvider implements LibraryProvider {
             sourceId: scanSourceId,
           );
           debugPrint(
-              '📁 Inserted external book to DB: ${book.title} (type: ${book.fileType})');
+            '📁 Inserted external book to DB: ${book.title} (type: ${book.fileType})',
+          );
           added++;
         } catch (e) {
           debugPrint('⚠️ Failed to process book: ${book.path} - $e');
@@ -3512,14 +3690,17 @@ class DatabaseLibraryProvider implements LibraryProvider {
         }
       }
 
-      debugPrint('📁 Finished scanning custom folder: $folderPath '
-          '(added=$added, updated=$updated, failed=$failed)');
+      debugPrint(
+        '📁 Finished scanning custom folder: $folderPath '
+        '(added=$added, updated=$updated, failed=$failed)',
+      );
       return ScanResult(
-          addedBooks: added,
-          updatedBooks: updated,
-          failedBooks: failed,
-          failedDetails: failedDetails,
-          updatedBookIds: updatedBookIds);
+        addedBooks: added,
+        updatedBooks: updated,
+        failedBooks: failed,
+        failedDetails: failedDetails,
+        updatedBookIds: updatedBookIds,
+      );
     } catch (e) {
       debugPrint('⚠️ Scan failed for $folderPath: $e');
       return ScanResult(fatalError: e);
@@ -3542,7 +3723,10 @@ class DatabaseLibraryProvider implements LibraryProvider {
     if (alreadyInDb.fileSize != fileSize ||
         alreadyInDb.lastModified != lastModified) {
       await repository.updateExternalBookMetadata(
-          alreadyInDb.id, fileSize, lastModified);
+        alreadyInDb.id,
+        fileSize,
+        lastModified,
+      );
       debugPrint('📁 Updated metadata (recheck): $filePath');
     }
     return true;

--- a/lib/data/data_providers/file_system_library_provider.dart
+++ b/lib/data/data_providers/file_system_library_provider.dart
@@ -75,7 +75,8 @@ class FileSystemLibraryProvider implements LibraryProvider {
 
   @override
   Future<Map<String, List<Book>>> loadBooks(
-      Map<String, Map<String, dynamic>> metadata) async {
+    Map<String, Map<String, dynamic>> metadata,
+  ) async {
     if (!_isInitialized) await initialize();
 
     final Map<String, List<Book>> booksByCategory = {};
@@ -91,8 +92,9 @@ class FileSystemLibraryProvider implements LibraryProvider {
     final personalBooksPath = getPersonalBooksPath();
     final personalBooksDir = Directory(personalBooksPath);
     if (await personalBooksDir.exists()) {
-      await _loadBooksRecursively(
-          personalBooksDir, metadata, booksByCategory, ['ספרים אישיים'], map);
+      await _loadBooksRecursively(personalBooksDir, metadata, booksByCategory, [
+        'ספרים אישיים',
+      ], map);
     }
 
     await _loadBundledTalmudBavliBooks(metadata, booksByCategory, map);
@@ -140,7 +142,7 @@ class FileSystemLibraryProvider implements LibraryProvider {
   Future<Directory?> _resolveBundledTalmudBavliDirectory() async {
     final folderName =
         Settings.getValue<String>(SettingsRepository.keyLibraryFolderName) ??
-            '';
+        '';
 
     for (final candidatePath in DatabaseConstants.getTalmudBavliDirectoryPaths(
       _libraryPath,
@@ -174,12 +176,18 @@ class FileSystemLibraryProvider implements LibraryProvider {
         if (entity is Directory) {
           final newPath = [...currentPath, getTitleFromPath(entity.path)];
           await _loadBooksRecursively(
-              entity, metadata, booksByCategory, newPath, keyToPath);
+            entity,
+            metadata,
+            booksByCategory,
+            newPath,
+            keyToPath,
+          );
         } else if (entity is File) {
           final book = _createBookFromFile(entity, metadata, currentPath);
           if (book != null) {
-            final categoryName =
-                currentPath.isNotEmpty ? currentPath.last : 'ללא קטגוריה';
+            final categoryName = currentPath.isNotEmpty
+                ? currentPath.last
+                : 'ללא קטגוריה';
             booksByCategory.putIfAbsent(categoryName, () => []);
             booksByCategory[categoryName]!.add(book);
 
@@ -235,7 +243,9 @@ class FileSystemLibraryProvider implements LibraryProvider {
       );
     }
 
-    if (path.endsWith('.txt') || path.endsWith('.docx')) {
+    if (path.endsWith('.txt') ||
+        path.endsWith('.docx') ||
+        path.endsWith('.epub')) {
       final categoryPathStr = categoryPath.join(', ');
       final categoryId = categoryPathStr.hashCode;
       _categoryIdToPath[categoryId] = categoryPathStr;
@@ -288,6 +298,8 @@ class FileSystemLibraryProvider implements LibraryProvider {
 
     if (path.endsWith('.docx')) {
       return convertDocxWithCache(file, title);
+    } else if (path.endsWith('.epub')) {
+      return convertEpubWithCache(file, title);
     } else {
       return readTextFileSmart(file);
     }
@@ -319,7 +331,10 @@ class FileSystemLibraryProvider implements LibraryProvider {
   }
 
   Future<String?> _getBookPath(
-      String title, int categoryId, String fileType) async {
+    String title,
+    int categoryId,
+    String fileType,
+  ) async {
     final map = await keyToPath;
     final key = _generateKey(title, categoryId, fileType);
     return map[key];
@@ -330,8 +345,11 @@ class FileSystemLibraryProvider implements LibraryProvider {
     _categoryIdToPath.clear();
 
     // Helper to add path
-    void addPath(String path, String rootPath,
-        [List<String> prefix = const []]) {
+    void addPath(
+      String path,
+      String rootPath, [
+      List<String> prefix = const [],
+    ]) {
       final title = getTitleFromPath(path);
       final fileType = path.split('.').last.toLowerCase();
 
@@ -397,6 +415,7 @@ class FileSystemLibraryProvider implements LibraryProvider {
         final lower = entity.path.toLowerCase();
         if (lower.endsWith('.txt') ||
             lower.endsWith('.docx') ||
+            lower.endsWith('.epub') ||
             lower.endsWith('.pdf')) {
           results.add(entity.path);
         }
@@ -441,8 +460,11 @@ class FileSystemLibraryProvider implements LibraryProvider {
   }
 
   /// Checks if a book is in the personal folder or a custom folder
-  Future<bool> isPersonalBook(String title,
-      {String? category, String? fileType}) async {
+  Future<bool> isPersonalBook(
+    String title, {
+    String? category,
+    String? fileType,
+  }) async {
     String? bookPath;
     if (category != null && fileType != null) {
       bookPath = await _getBookPath(title, category.hashCode, fileType);
@@ -460,14 +482,16 @@ class FileSystemLibraryProvider implements LibraryProvider {
     if (bookPath == null) return false;
 
     // Check if in the built-in personal folder
-    if (bookPath
-        .contains('${Platform.pathSeparator}אישי${Platform.pathSeparator}')) {
+    if (bookPath.contains(
+      '${Platform.pathSeparator}אישי${Platform.pathSeparator}',
+    )) {
       return true;
     }
 
     // Check if in any custom folder
-    final customFoldersJson =
-        Settings.getValue<String>(SettingsRepository.keyCustomFolders);
+    final customFoldersJson = Settings.getValue<String>(
+      SettingsRepository.keyCustomFolders,
+    );
     final customFolders = CustomFoldersManager.loadFolders(customFoldersJson);
 
     for (final folder in customFolders) {
@@ -496,9 +520,10 @@ class FileSystemLibraryProvider implements LibraryProvider {
     }
     if (path == null) throw Exception('Book not found: $title');
 
-    if (path.endsWith('.docx')) {
+    if (path.endsWith('.docx') || path.endsWith('.epub')) {
       throw Exception(
-          'Cannot save to DOCX files. Only text files are supported.');
+        'Cannot save to DOCX/EPUB files. Only text files are supported.',
+      );
     }
 
     final file = File(path);
@@ -591,8 +616,11 @@ class FileSystemLibraryProvider implements LibraryProvider {
         );
 
         // Create book with proper category reference
-        final bookWithCategory =
-            _createBookWithCategory(book, category, metadata);
+        final bookWithCategory = _createBookWithCategory(
+          book,
+          category,
+          metadata,
+        );
         category.books.add(bookWithCategory);
       }
     }
@@ -601,7 +629,8 @@ class FileSystemLibraryProvider implements LibraryProvider {
     _sortLibraryRecursive(library);
 
     debugPrint(
-        '📁 FileSystem catalog built with ${library.subCategories.length} top-level categories');
+      '📁 FileSystem catalog built with ${library.subCategories.length} top-level categories',
+    );
     return library;
   }
 
@@ -734,7 +763,10 @@ class FileSystemLibraryProvider implements LibraryProvider {
 
   @override
   Future<List<Link>> getAllLinksForBook(
-      String title, int categoryId, String fileType) async {
+    String title,
+    int categoryId,
+    String fileType,
+  ) async {
     if (!_isInitialized) await initialize();
 
     try {

--- a/lib/data/data_providers/file_system_library_provider.dart
+++ b/lib/data/data_providers/file_system_library_provider.dart
@@ -296,9 +296,10 @@ class FileSystemLibraryProvider implements LibraryProvider {
       return null;
     }
 
-    if (path.endsWith('.docx')) {
+    final lowerPath = path.toLowerCase();
+    if (lowerPath.endsWith('.docx')) {
       return convertDocxWithCache(file, title);
-    } else if (path.endsWith('.epub')) {
+    } else if (lowerPath.endsWith('.epub')) {
       return convertEpubWithCache(file, title);
     } else {
       return readTextFileSmart(file);
@@ -520,7 +521,8 @@ class FileSystemLibraryProvider implements LibraryProvider {
     }
     if (path == null) throw Exception('Book not found: $title');
 
-    if (path.endsWith('.docx') || path.endsWith('.epub')) {
+    final lowerPath = path.toLowerCase();
+    if (lowerPath.endsWith('.docx') || lowerPath.endsWith('.epub')) {
       throw Exception(
         'Cannot save to DOCX/EPUB files. Only text files are supported.',
       );

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -59,17 +59,19 @@ class IndexingRepository {
   /// גודל מספרי טקסט, וכך שאר הספרייה זמינה לחיפוש מוקדם ככל האפשר.
   @visibleForTesting
   static List<Book> orderBooksForIndexing(List<Book> books) => [
-        ...books.where((b) => b is! PdfBook),
-        ...books.whereType<PdfBook>(),
-      ];
+    ...books.where((b) => b is! PdfBook),
+    ...books.whereType<PdfBook>(),
+  ];
 
   @visibleForTesting
   static int chronologicalOrderForBook(Book book) {
     final foundationalTier = foundationalTierForBook(book);
     if (foundationalTier != null) return foundationalTier - 1;
 
-    final eraOrder =
-        GenerationCache.instance.getOrderForBook(book.id, book.isUserBook);
+    final eraOrder = GenerationCache.instance.getOrderForBook(
+      book.id,
+      book.isUserBook,
+    );
     final base = book.isUserBook ? 96 : 64;
     return base + eraOrder.clamp(0, 31);
   }
@@ -87,8 +89,9 @@ class IndexingRepository {
 
   static String? _categoryPathForBook(Book book) {
     if (!book.isUserBook && book.id != null) {
-      final cached =
-          ReferenceBooksCache.instance.getCategoryPathForBookSync(book.id!);
+      final cached = ReferenceBooksCache.instance.getCategoryPathForBookSync(
+        book.id!,
+      );
       if (cached != null && cached.isNotEmpty) return cached;
     }
 
@@ -159,9 +162,9 @@ class IndexingRepository {
 
       final catalogueOrderByBookKey =
           SearchCatalogueOrderHelper.buildKeyOrderMap(
-        library,
-        keyOf: (book) => catalogueOrderKey(book as Book),
-      );
+            library,
+            keyOf: (book) => catalogueOrderKey(book as Book),
+          );
       await Future.wait([
         GenerationCache.instance.warmUp(),
         ReferenceBooksCache.instance.warmUp(),
@@ -178,7 +181,8 @@ class IndexingRepository {
 
       debugPrint('📚 התחלת אינדוקס: $totalBooks ספרים');
       debugPrint(
-          '📊 ספרים שכבר מאונדקסים: ${_tantivyDataProvider.indexedFilePaths.length}');
+        '📊 ספרים שכבר מאונדקסים: ${_tantivyDataProvider.indexedFilePaths.length}',
+      );
 
       // ‏prefetch של PDF אחד קדימה: חילוץ ה-PDF (pdfrx) היה 41% מזמן
       // האינדוקס ורץ סדרתית בין ספרי הטקסט; כאן חילוץ ה-PDF הבא שטרם
@@ -212,14 +216,12 @@ class IndexingRepository {
 
         var bookWasIndexed = false;
         try {
-          // DocxBook עובר אינדוקס דרך זרימת TextBook (העטיפה משמרת
-          // id/categoryId כדי ש-`book.text` יחלץ docx → text).
-          // catalogueOrderKey של DocxBook ו-TextBook העטוף זהה: כשיש id
-          // המפתח הוא 'id:<id>', וכשאין — title+categoryKey+'docx'+path
-          // (העטיפה מעבירה filePath ?? path, ו-fileType נשאר 'docx').
-          final TextBook? textBookForIndex = book is TextBook
-              ? book
-              : (book is DocxBook ? book.toTextBook() : null);
+          // DocxBook/EpubBook עוברים אינדוקס דרך זרימת TextBook (העטיפה
+          // משמרת id/categoryId כדי ש-`book.text` יחלץ קובץ → text).
+          // catalogueOrderKey של העטוף זהה למקור: כשיש id המפתח הוא
+          // 'id:<id>', וכשאין — title+categoryKey+fileType+path
+          // (העטיפה מעבירה filePath ?? path, ו-fileType נשמר).
+          final TextBook? textBookForIndex = _asTextBookForIndex(book);
           if (textBookForIndex != null) {
             if (!isBookIndexed(book)) {
               // דיווח הספר הנוכחי כבר בתחילת עיבודו — אחרת המונה נראה
@@ -240,8 +242,9 @@ class IndexingRepository {
                 cancelled = true;
                 break;
               }
-              _tantivyDataProvider.indexedFilePaths
-                  .add(buildIndexedBookFilePath(book));
+              _tantivyDataProvider.indexedFilePaths.add(
+                buildIndexedBookFilePath(book),
+              );
               actuallyIndexed++;
               indexedSinceCommit++;
               bookWasIndexed = true;
@@ -278,8 +281,9 @@ class IndexingRepository {
                 cancelled = true;
                 break;
               }
-              _tantivyDataProvider.indexedFilePaths
-                  .add(buildIndexedBookFilePath(book));
+              _tantivyDataProvider.indexedFilePaths.add(
+                buildIndexedBookFilePath(book),
+              );
               actuallyIndexed++;
               indexedSinceCommit++;
               bookWasIndexed = true;
@@ -302,13 +306,15 @@ class IndexingRepository {
             final index = await _tantivyDataProvider.engine;
             await index.commit();
             debugPrint(
-                '💾 commit אחרי $indexedSinceCommit ספרים: ${commitStopwatch.elapsedMilliseconds}ms');
+              '💾 commit אחרי $indexedSinceCommit ספרים: ${commitStopwatch.elapsedMilliseconds}ms',
+            );
             indexedSinceCommit = 0;
           }
 
           if (processedBooks % 50 == 0) {
             debugPrint(
-                '📈 התקדמות: $processedBooks/$totalBooks (מאונדקסים: $actuallyIndexed, דולגו: $skipped, שגיאות: $errors, ${totalStopwatch.elapsed})');
+              '📈 התקדמות: $processedBooks/$totalBooks (מאונדקסים: $actuallyIndexed, דולגו: $skipped, שגיאות: $errors, ${totalStopwatch.elapsed})',
+            );
           }
 
           // אירוע התקדמות לכל ספר שאונדקס בפועל; בסריקת מדולגים — רק אחת
@@ -435,11 +441,14 @@ class IndexingRepository {
               extraFacets: extraFacets,
             );
       engineStopwatch.stop();
-      final size =
-          hasBytes ? '${bytes.length} בייטים' : '${text!.length} תווים';
-      debugPrint('📖 "${book.title}": $size → $added מסמכים | '
-          'טעינה ${loadStopwatch.elapsedMilliseconds}ms, '
-          'מנוע ${engineStopwatch.elapsedMilliseconds}ms');
+      final size = hasBytes
+          ? '${bytes.length} בייטים'
+          : '${text!.length} תווים';
+      debugPrint(
+        '📖 "${book.title}": $size → $added מסמכים | '
+        'טעינה ${loadStopwatch.elapsedMilliseconds}ms, '
+        'מנוע ${engineStopwatch.elapsedMilliseconds}ms',
+      );
       wroteDocuments = added > 0;
     } else {
       debugPrint('⚠️ ספר ריק: ${book.title} - מדלג');
@@ -473,8 +482,10 @@ class IndexingRepository {
     if (openError != null) {
       debugPrint('❌ שגיאה בפתיחת PDF לאינדוקס: ${book.title}: $openError');
     }
-    debugPrint('📄 "${book.title}": חולצו ${pages.length} עמודים '
-        'ב-${extracted.extractMs}ms${preExtracted != null ? ' (prefetch)' : ''}');
+    debugPrint(
+      '📄 "${book.title}": חולצו ${pages.length} עמודים '
+      'ב-${extracted.extractMs}ms${preExtracted != null ? ' (prefetch)' : ''}',
+    );
     if (!_tantivyDataProvider.isIndexing.value) {
       return;
     }
@@ -551,8 +562,10 @@ class IndexingRepository {
       ],
     );
     engineStopwatch.stop();
-    debugPrint('📄 "${book.title}": ${pages.length} עמודים → $added מסמכים | '
-        'מנוע ${engineStopwatch.elapsedMilliseconds}ms');
+    debugPrint(
+      '📄 "${book.title}": ${pages.length} עמודים → $added מסמכים | '
+      'מנוע ${engineStopwatch.elapsedMilliseconds}ms',
+    );
     return added;
   }
 
@@ -570,23 +583,25 @@ class IndexingRepository {
     final index = await _tantivyDataProvider.engine;
     // add (ולא upsert): כל מסלולי הכתיבה מדלגים על ספר שכבר מאונדקס
     // (isBookIndexed), כך שהספר כאן תמיד חדש ואין מה למחוק.
-    await index.addDocumentsBatch(docs: [
-      DocumentInput(
-        id: buildCatalogueDocumentId(
-          catalogueOrder:
-              catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF,
-          ordinal: 0,
+    await index.addDocumentsBatch(
+      docs: [
+        DocumentInput(
+          id: buildCatalogueDocumentId(
+            catalogueOrder:
+                catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF,
+            ordinal: 0,
+          ),
+          title: book.title,
+          reference: '',
+          topics: _bookTopics(book),
+          text: '',
+          segment: BigInt.zero,
+          isPdf: book is PdfBook,
+          filePath: buildIndexedBookFilePath(book),
+          generationOrder: chronologicalOrderForBook(book),
         ),
-        title: book.title,
-        reference: '',
-        topics: _bookTopics(book),
-        text: '',
-        segment: BigInt.zero,
-        isPdf: book is PdfBook,
-        filePath: buildIndexedBookFilePath(book),
-        generationOrder: chronologicalOrderForBook(book),
-      ),
-    ]);
+      ],
+    );
   }
 
   /// מוחק את המסמכים החלקיים של ספר שכתיבתו למנוע נכשלה באמצע: בלעדי זה
@@ -654,10 +669,12 @@ class IndexingRepository {
   /// ההכרעה הזו עברה למנוע (add_pdf_book מסנן זבל ומחזיר 0 כשאין תוכן);
   /// כשל בפתיחת הקובץ מופץ לקורא, שמחליט בין sidecar להפצת השגיאה.
   Future<
-      ({
-        List<({String reference, String text, int pageIndex})> pages,
-        List<PdfOutlineNode> outline,
-      })> _extractPdfPages(PdfBook book) async {
+    ({
+      List<({String reference, String text, int pageIndex})> pages,
+      List<PdfOutlineNode> outline,
+    })
+  >
+  _extractPdfPages(PdfBook book) async {
     const empty = (
       pages: <({String reference, String text, int pageIndex})>[],
       outline: <PdfOutlineNode>[],
@@ -665,12 +682,13 @@ class IndexingRepository {
     final file = File(book.path);
     if (!await file.exists()) return empty;
 
-    final document = await PdfDocument.openFile(book.path)
-        .timeout(const Duration(seconds: 60));
+    final document = await PdfDocument.openFile(
+      book.path,
+    ).timeout(const Duration(seconds: 60));
     final outline = await document.loadOutline().timeout(
-          const Duration(seconds: 15),
-          onTimeout: () => <PdfOutlineNode>[],
-        );
+      const Duration(seconds: 15),
+      onTimeout: () => <PdfOutlineNode>[],
+    );
 
     final pages = <({String reference, String text, int pageIndex})>[];
 
@@ -686,9 +704,9 @@ class IndexingRepository {
       final texts = await Future.wait([
         for (int i = start; i < end; i++)
           document.pages[i].loadText().timeout(
-                const Duration(seconds: 5),
-                onTimeout: () => null,
-              ),
+            const Duration(seconds: 5),
+            onTimeout: () => null,
+          ),
       ]);
 
       for (int i = start; i < end; i++) {
@@ -712,7 +730,7 @@ class IndexingRepository {
   }
 
   Future<List<({String reference, String text, int pageIndex})>>
-      _loadPdfSidecar(PdfBook book, List<PdfOutlineNode> outline) async {
+  _loadPdfSidecar(PdfBook book, List<PdfOutlineNode> outline) async {
     final candidates = <String>{
       '${book.path}.txt',
       p.setExtension(book.path, '.txt'),
@@ -730,18 +748,25 @@ class IndexingRepository {
     if (sidecar == null) return const [];
 
     final ocrText = await sidecar.readAsString();
-    final pagesText =
-        ocrText.contains('\f') ? ocrText.split('\f') : <String>[ocrText];
+    final pagesText = ocrText.contains('\f')
+        ? ocrText.split('\f')
+        : <String>[ocrText];
 
     final pages = <({String reference, String text, int pageIndex})>[];
     for (int pageIndex = 0; pageIndex < pagesText.length; pageIndex++) {
-      final bookmark =
-          await refFromPageNumber(pageIndex + 1, outline, book.title);
+      final bookmark = await refFromPageNumber(
+        pageIndex + 1,
+        outline,
+        book.title,
+      );
       final ref = bookmark.isNotEmpty
           ? '${book.title}, $bookmark, עמוד ${pageIndex + 1}'
           : '${book.title}, עמוד ${pageIndex + 1}';
-      pages.add(
-          (reference: ref, text: pagesText[pageIndex], pageIndex: pageIndex));
+      pages.add((
+        reference: ref,
+        text: pagesText[pageIndex],
+        pageIndex: pageIndex,
+      ));
     }
     return pages;
   }
@@ -764,7 +789,8 @@ class IndexingRepository {
 
     if (text.isEmpty) {
       debugPrint(
-          '⚠️ ספר ריק: ${book.title} (categoryId: ${book.categoryId}) - מדלג');
+        '⚠️ ספר ריק: ${book.title} (categoryId: ${book.categoryId}) - מדלג',
+      );
       return null;
     }
 
@@ -785,15 +811,15 @@ class IndexingRepository {
   /// נתיב ה-facet של הספר — משותף לכל מסלולי הכתיבה (טקסט, PDF, סמן-ריק),
   /// כדי שהמסלולים לא יסטו זה מזה.
   String _bookTopics(Book book) => BookFacet.buildFacetPath(
-        title: book.title,
-        topics: book.topics,
-        externalLibraryId: book.externalLibraryId,
-        bookId: book.id,
-        isUserBook: book.isUserBook,
-        categoryPath: book.category?.path ?? book.categoryPath,
-        fileType: book.fileType,
-        filePath: book is FileBook ? book.path : book.filePath,
-      );
+    title: book.title,
+    topics: book.topics,
+    externalLibraryId: book.externalLibraryId,
+    bookId: book.id,
+    isUserBook: book.isUserBook,
+    categoryPath: book.category?.path ?? book.categoryPath,
+    fileType: book.fileType,
+    filePath: book is FileBook ? book.path : book.filePath,
+  );
 
   @visibleForTesting
   static Future<bool> optimizeIndexBestEffort(
@@ -921,10 +947,8 @@ class IndexingRepository {
         }
 
         try {
-          // DocxBook ממופה ל-TextBook (ראה הסבר ב-indexAllBooks).
-          final TextBook? textBookForIndex = book is TextBook
-              ? book
-              : (book is DocxBook ? book.toTextBook() : null);
+          // DocxBook/EpubBook ממופים ל-TextBook (ראה הסבר ב-indexAllBooks).
+          final TextBook? textBookForIndex = _asTextBookForIndex(book);
           if (textBookForIndex != null) {
             if (!isBookIndexed(book)) {
               onProgress(processedBooks + 1, totalBooks);
@@ -942,8 +966,9 @@ class IndexingRepository {
                 cancelled = true;
                 break;
               }
-              _tantivyDataProvider.indexedFilePaths
-                  .add(buildIndexedBookFilePath(book));
+              _tantivyDataProvider.indexedFilePaths.add(
+                buildIndexedBookFilePath(book),
+              );
               actuallyIndexed++;
             }
           } else if (book is PdfBook) {
@@ -963,8 +988,9 @@ class IndexingRepository {
                 cancelled = true;
                 break;
               }
-              _tantivyDataProvider.indexedFilePaths
-                  .add(buildIndexedBookFilePath(book));
+              _tantivyDataProvider.indexedFilePaths.add(
+                buildIndexedBookFilePath(book),
+              );
               actuallyIndexed++;
             }
           }
@@ -990,7 +1016,8 @@ class IndexingRepository {
 
       if (!cancelled) {
         debugPrint(
-            '✅ אינדוקס ספרים ספציפיים הושלם! (מאונדקסים: $actuallyIndexed, שגיאות: $errors)');
+          '✅ אינדוקס ספרים ספציפיים הושלם! (מאונדקסים: $actuallyIndexed, שגיאות: $errors)',
+        );
         final index = await _tantivyDataProvider.engine;
         final commitStopwatch = Stopwatch()..start();
         await index.commit();
@@ -1116,8 +1143,8 @@ class IndexingRepository {
   /// ולכן אחרי העברה הן מצביעות לנתיב הישן. בלי הסרתן, האינדוקס האוטומטי
   /// שלאחר הרענון מוסיף את אותם ספרים בנתיב החדש ⇒ כפילויות ותוצאות שבורות.
   Future<bool> dropRelocatedFileBookEntries(
-          Iterable<Book> relocatedBooks) async =>
-      dropBookIndexEntries(relocatedBooks);
+    Iterable<Book> relocatedBooks,
+  ) async => dropBookIndexEntries(relocatedBooks);
 
   /// מאנדקס מחדש ספרים שתוכנם השתנה: מסיר את רשומותיהם הישנות מהאינדקס
   /// ומאנדקס אותם מחדש דרך [indexBooks].
@@ -1189,21 +1216,21 @@ class IndexingRepository {
     ]);
     // computeBookFingerprint היא קריאת FFI סינכרונית; העטיפה ה-async
     // נשמרת רק כדי לא לשבור את חתימת ההזרקה של הטסטים.
-    final fingerprint = fingerprintOf ??
+    final fingerprint =
+        fingerprintOf ??
         ((TextBook book, String text) async => computeBookFingerprint(
-              text: text,
-              title: book.title,
-              topics: _bookTopics(book),
-              catalogueOrder:
-                  catalogueOrderByBookKey[catalogueOrderKey(book)] ??
-                      0xFFFFFFFF,
-              generationOrder: chronologicalOrderForBook(book),
-              extraFacets: _bookExtraFacets(book),
-            ));
+          text: text,
+          title: book.title,
+          topics: _bookTopics(book),
+          catalogueOrder:
+              catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF,
+          generationOrder: chronologicalOrderForBook(book),
+          extraFacets: _bookExtraFacets(book),
+        ));
 
     final candidates = library
         .getAllBooks()
-        .where((b) => b is TextBook || b is DocxBook)
+        .where((b) => b is TextBook || b is DocxBook || b is EpubBook)
         .toList();
     final total = candidates.length;
     final changed = <Book>[];
@@ -1230,8 +1257,7 @@ class IndexingRepository {
           continue;
         }
 
-        final TextBook textBook =
-            book is TextBook ? book : (book as DocxBook).toTextBook();
+        final TextBook textBook = _asTextBookForIndex(book)!;
         final text = await textLoader(textBook);
         if (text == null) {
           // אין תוכן להשוואה (כשל טעינה) — לא נוגעים ברשומה הקיימת.
@@ -1250,7 +1276,8 @@ class IndexingRepository {
         await Future.delayed(Duration.zero);
       }
       debugPrint(
-          '🔎 reconcile: סריקת $processed/$total ספרים ב-${scanStopwatch.elapsed}');
+        '🔎 reconcile: סריקת $processed/$total ספרים ב-${scanStopwatch.elapsed}',
+      );
     } finally {
       await _setDbReadBoost(false);
       _tantivyDataProvider.isIndexing.value = false;
@@ -1274,11 +1301,22 @@ class IndexingRepository {
   /// Returns true for book types that the indexer actually processes.
   /// Non-indexable types (ExternalLibraryBook וכו') מדולגים בשקט
   /// ב-indexAllBooks, ולכן חייבים להיות מחוץ לבדיקות הסטטוס.
-  /// DocxBook נכלל — הוא ממופה ל-TextBook ב-indexAllBooks באמצעות
-  /// `DocxBook.toTextBook()`, ו-`book.text` כבר יודע לחלץ את התוכן
-  /// דרך `docxToText` (ראה DatabaseLibraryProvider.getBookText).
+  /// DocxBook/EpubBook נכללים — הם ממופים ל-TextBook ב-indexAllBooks דרך
+  /// `toTextBook()`, ו-`book.text` כבר יודע לחלץ את התוכן דרך הממיר
+  /// המתאים (ראה DatabaseLibraryProvider.getBookText).
   static bool isIndexableBook(Book book) =>
-      book is TextBook || book is PdfBook || book is DocxBook;
+      book is TextBook ||
+      book is PdfBook ||
+      book is DocxBook ||
+      book is EpubBook;
+
+  /// ממפה ספר לזרימת האינדוקס של TextBook; null לסוגים שאינם טקסטואליים.
+  static TextBook? _asTextBookForIndex(Book book) => switch (book) {
+    final TextBook b => b,
+    final DocxBook b => b.toTextBook(),
+    final EpubBook b => b.toTextBook(),
+    _ => null,
+  };
 
   /// Waits until the underlying data provider is fully initialized
   /// (indexedFilePaths loaded from the index itself).

--- a/lib/library/view/book_preview_panel.dart
+++ b/lib/library/view/book_preview_panel.dart
@@ -85,12 +85,17 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
   void _createNewTab() {
     if (widget.book == null) return;
 
-    // DocxBook יורש מ-FileBook ולא מ-TextBook — העטיפה דרך
-    // DocxBook.toTextBook משמרת id/categoryId/externalLibraryId שדרושים
+    // DocxBook/EpubBook יורשים מ-FileBook ולא מ-TextBook — העטיפה דרך
+    // toTextBook משמרת id/categoryId/externalLibraryId שדרושים
     // ל-LibraryProviderManager (בלעדיהם getBookContent יחזיר תוכן ריק).
     final book = widget.book;
-    final TextBook? textBook =
-        book is TextBook ? book : (book is DocxBook ? book.toTextBook() : null);
+    final TextBook? textBook = book is TextBook
+        ? book
+        : book is DocxBook
+        ? book.toTextBook()
+        : book is EpubBook
+        ? book.toTextBook()
+        : null;
 
     if (textBook != null) {
       setState(() {
@@ -195,10 +200,9 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
             Icon(
               FluentIcons.book_24_regular,
               size: 64,
-              color: Theme.of(context)
-                  .colorScheme
-                  .secondary
-                  .withValues(alpha: 0.3),
+              color: Theme.of(
+                context,
+              ).colorScheme.secondary.withValues(alpha: 0.3),
             ),
             const SizedBox(height: 16),
             Text(
@@ -222,10 +226,9 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
             Icon(
               FluentIcons.link_24_regular,
               size: 64,
-              color: Theme.of(context)
-                  .colorScheme
-                  .secondary
-                  .withValues(alpha: 0.3),
+              color: Theme.of(
+                context,
+              ).colorScheme.secondary.withValues(alpha: 0.3),
             ),
             const SizedBox(height: 16),
             Text(
@@ -385,8 +388,9 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
             backgroundColor: Theme.of(context).colorScheme.surface,
             zoomStepsDelegateProvider:
                 const PdfViewerZoomStepsDelegateProviderSmart(),
-            sizeDelegateProvider:
-                PdfViewerSizeDelegateProviderLegacy(maxScale: 10),
+            sizeDelegateProvider: PdfViewerSizeDelegateProviderLegacy(
+              maxScale: 10,
+            ),
             horizontalCacheExtent: 0,
             verticalCacheExtent: 1,
             pageAnchor: PdfPageAnchor.top,
@@ -481,13 +485,15 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
 
   List<Widget> _buildParagraph(List<double> widths, Color color) {
     return widths
-        .map((width) => Align(
-              alignment: Alignment.centerRight,
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 10.0),
-                child: _SkeletonLine(width: width, height: 18, color: color),
-              ),
-            ))
+        .map(
+          (width) => Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 10.0),
+              child: _SkeletonLine(width: width, height: 18, color: color),
+            ),
+          ),
+        )
         .toList();
   }
 }

--- a/lib/migration/generator/generator.dart
+++ b/lib/migration/generator/generator.dart
@@ -435,12 +435,13 @@ class DatabaseGenerator {
 
     if (ext == '.docx' || ext == '.epub') {
       final title = path.basenameWithoutExtension(bookPath);
-      final bytes = await File(bookPath).readAsBytes();
-      final content = await Isolate.run(
-        () => ext == '.docx'
+      // הקריאה בתוך ה-isolate — נמנעת העתקת buffer גדול בין isolates.
+      final content = await Isolate.run(() {
+        final bytes = File(bookPath).readAsBytesSync();
+        return ext == '.docx'
             ? docxToText(bytes, title)
-            : epubToText(bytes, title),
-      );
+            : epubToText(bytes, title);
+      });
       final lines = content.split('\n');
 
       await processLinesWithTocEntries(bookId, lines);

--- a/lib/migration/generator/generator.dart
+++ b/lib/migration/generator/generator.dart
@@ -16,6 +16,7 @@ import '../database/repository/seforim_repository.dart';
 import 'link_processor.dart';
 import 'hebrew_text_utils.dart' as hebrew_text_utils;
 import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+import 'package:otzaria/utils/file/epub_to_otzaria.dart';
 
 /// DatabaseGenerator is responsible for generating the Otzaria database from source files.
 /// It processes directories, books, and links to create a structured database.
@@ -53,7 +54,7 @@ class DatabaseGenerator {
   final Map<String, List<String>> _bookContentCache = {};
 
   DatabaseGenerator(this.sourceDirectory, this.repository, {this.onProgress})
-      : _libraryRoot = sourceDirectory;
+    : _libraryRoot = sourceDirectory;
 
   /// Sets the total books to process for progress reporting.
   void setTotalBooksToProcess(int total) {
@@ -82,7 +83,8 @@ class DatabaseGenerator {
       final libraryDir = Directory(libraryPath);
       if (!await libraryDir.exists()) {
         throw StateError(
-            'התיקייה "אוצריא" לא נמצאה בתיקייה שנבחרה. נא לבחור את תיקיית האב של אוצריא.');
+          'התיקייה "אוצריא" לא נמצאה בתיקייה שנבחרה. נא לבחור את תיקיית האב של אוצריא.',
+        );
       }
 
       _libraryRoot = libraryPath;
@@ -109,7 +111,9 @@ class DatabaseGenerator {
         await repository.restoreNormalMode();
       } catch (innerEx) {
         _log.warning(
-            'Error restoring database settings after failure', innerEx);
+          'Error restoring database settings after failure',
+          innerEx,
+        );
       }
 
       _log.severe('Error during generation', e, stackTrace);
@@ -124,7 +128,10 @@ class DatabaseGenerator {
   /// [level] The current level in the directory hierarchy
   /// [metadata] The metadata for books
   Future<void> processDirectory(
-      String directory, int? parentCategoryId, int level) async {
+    String directory,
+    int? parentCategoryId,
+    int level,
+  ) async {
     final dir = Directory(directory);
     final entities = await dir.list().toList();
     final sortedEntities = entities
@@ -132,12 +139,19 @@ class DatabaseGenerator {
 
     for (final entity in sortedEntities) {
       if (entity is Directory) {
-        final categoryId =
-            await createCategory(entity.path, parentCategoryId, level);
+        final categoryId = await createCategory(
+          entity.path,
+          parentCategoryId,
+          level,
+        );
         await processDirectory(entity.path, categoryId, level + 1);
       } else if (entity is File &&
-          ['.txt', '.pdf', '.docx']
-              .contains(path.extension(entity.path).toLowerCase())) {
+          [
+            '.txt',
+            '.pdf',
+            '.docx',
+            '.epub',
+          ].contains(path.extension(entity.path).toLowerCase())) {
         // Skip if already processed from priority list
         final key = _toLibraryRelativeKey(entity.path);
         if (_processedPriorityBookKeys.contains(key)) {
@@ -222,7 +236,9 @@ class DatabaseGenerator {
 
   /// Finds a category by name and parent ID
   Future<Category?> _findCategoryByNameAndParent(
-      String name, int? parentId) async {
+    String name,
+    int? parentId,
+  ) async {
     final categories = parentId == null
         ? await repository.getRootCategories()
         : await repository.getCategoryChildren(parentId);
@@ -251,8 +267,10 @@ class DatabaseGenerator {
     try {
       final filename = path.basename(bookPath);
       final title = path.basenameWithoutExtension(filename);
-      final sourceId =
-          await _resolveSourceIdFor(bookPath, sourceName: sourceName);
+      final sourceId = await _resolveSourceIdFor(
+        bookPath,
+        sourceName: sourceName,
+      );
 
       // Extract file type from the file path
       final fileExtension = path.extension(bookPath).toLowerCase();
@@ -268,7 +286,10 @@ class DatabaseGenerator {
           await repository.updateBookSourceId(existingBook.id, sourceId);
         }
 
-        if ((fileType == 'txt' || fileType == 'docx' || fileType == 'pdf') &&
+        if ((fileType == 'txt' ||
+                fileType == 'docx' ||
+                fileType == 'epub' ||
+                fileType == 'pdf') &&
             insertContent) {
           await repository.clearBookContent(existingBook.id);
           await processBookContent(bookPath, existingBook.id);
@@ -276,30 +297,44 @@ class DatabaseGenerator {
           try {
             final file = File(bookPath);
             final stat = await file.stat();
-            final targetFilePath =
-                (fileType != "txt" || !insertContent) ? bookPath : null;
-            await repository.updateBookStorage(existingBook.id, targetFilePath,
-                stat.size, stat.modified.millisecondsSinceEpoch);
+            final targetFilePath = (fileType != "txt" || !insertContent)
+                ? bookPath
+                : null;
+            await repository.updateBookStorage(
+              existingBook.id,
+              targetFilePath,
+              stat.size,
+              stat.modified.millisecondsSinceEpoch,
+            );
           } catch (e) {
             _log.warning(
-                'Failed to update storage stats for file: $bookPath', e);
+              'Failed to update storage stats for file: $bookPath',
+              e,
+            );
           }
         } else {
           try {
-            if (fileType == 'txt' || fileType == 'docx') {
+            if (fileType == 'txt' || fileType == 'docx' || fileType == 'epub') {
               // We're moving to file-backed storage, so clear lines from DB to save space, but preserve TOC
               await repository.deleteBookLines(existingBook.id);
               await repository.updateBookTotalLines(existingBook.id, 0);
             }
             final file = File(bookPath);
             final stat = await file.stat();
-            final targetFilePath =
-                (fileType != "txt" || !insertContent) ? bookPath : null;
-            await repository.updateBookStorage(existingBook.id, targetFilePath,
-                stat.size, stat.modified.millisecondsSinceEpoch);
+            final targetFilePath = (fileType != "txt" || !insertContent)
+                ? bookPath
+                : null;
+            await repository.updateBookStorage(
+              existingBook.id,
+              targetFilePath,
+              stat.size,
+              stat.modified.millisecondsSinceEpoch,
+            );
           } catch (e) {
             _log.warning(
-                'Failed to update storage stats for file: $bookPath', e);
+              'Failed to update storage stats for file: $bookPath',
+              e,
+            );
           }
         }
 
@@ -308,9 +343,10 @@ class DatabaseGenerator {
             ? (_processedBooksCount * 100 ~/ _totalBooksToProcess)
             : 0;
         onProgress?.call(
-            _processedBooksCount /
-                (_totalBooksToProcess > 0 ? _totalBooksToProcess : 1),
-            'עודכן ספר: $title ($pct%)');
+          _processedBooksCount /
+              (_totalBooksToProcess > 0 ? _totalBooksToProcess : 1),
+          'עודכן ספר: $title ($pct%)',
+        );
         // The book was updated; no need to fall through to the duplicate-skip
         // or delete-and-re-insert logic.
         return;
@@ -361,16 +397,20 @@ class DatabaseGenerator {
           ? (_processedBooksCount * 100 ~/ _totalBooksToProcess)
           : 0;
       onProgress?.call(
-          _processedBooksCount /
-              (_totalBooksToProcess > 0 ? _totalBooksToProcess : 1),
-          'מעבד ספר: $title ($pct%)');
+        _processedBooksCount /
+            (_totalBooksToProcess > 0 ? _totalBooksToProcess : 1),
+        'מעבד ספר: $title ($pct%)',
+      );
 
       // NOTE: Original files are never deleted. The DB is the single source of truth
       // but original files are always preserved on disk.
     } catch (e, stackTrace) {
       final title = path.basenameWithoutExtension(bookPath);
-      _log.severe('❌ Critical error processing book: $title at $bookPath', e,
-          stackTrace);
+      _log.severe(
+        '❌ Critical error processing book: $title at $bookPath',
+        e,
+        stackTrace,
+      );
       debugPrint('❌ Critical error processing book: $title');
       debugPrint('   Path: $bookPath');
       debugPrint('   Error: $e');
@@ -393,10 +433,14 @@ class DatabaseGenerator {
       return;
     }
 
-    if (ext == '.docx') {
+    if (ext == '.docx' || ext == '.epub') {
       final title = path.basenameWithoutExtension(bookPath);
       final bytes = await File(bookPath).readAsBytes();
-      final content = await Isolate.run(() => docxToText(bytes, title));
+      final content = await Isolate.run(
+        () => ext == '.docx'
+            ? docxToText(bytes, title)
+            : epubToText(bytes, title),
+      );
       final lines = content.split('\n');
 
       await processLinesWithTocEntries(bookId, lines);
@@ -491,7 +535,8 @@ class DatabaseGenerator {
         return content.split('\n');
       } catch (e2) {
         debugPrint(
-            '❌ Failed to read file with both UTF-8 and latin1: $bookPath');
+          '❌ Failed to read file with both UTF-8 and latin1: $bookPath',
+        );
         rethrow;
       }
     }
@@ -506,7 +551,9 @@ class DatabaseGenerator {
   /// [lines] The lines of the book content
 
   Future<void> processLinesWithTocEntries(
-      int bookId, List<String> lines) async {
+    int bookId,
+    List<String> lines,
+  ) async {
     // Collect all TOC entry metadata in a single pass.
     // We use the entry's position in allTocEntries as its local ID.
     final allTocEntries = <TocEntryData>[];
@@ -544,13 +591,15 @@ class DatabaseGenerator {
           }
 
           final localIdx = allTocEntries.length;
-          allTocEntries.add(TocEntryData(
-            id: localIdx,
-            parentId: parentLocalIdx,
-            level: level,
-            text: plainText,
-            lineIndex: lineIndex,
-          ));
+          allTocEntries.add(
+            TocEntryData(
+              id: localIdx,
+              parentId: parentLocalIdx,
+              level: level,
+              text: plainText,
+              lineIndex: lineIndex,
+            ),
+          );
 
           if (currentReference.length >= level) {
             currentReference.removeRange(level - 1, currentReference.length);
@@ -562,16 +611,19 @@ class DatabaseGenerator {
         }
       }
 
-      final lineHeRef =
-          currentReference.isEmpty ? null : currentReference.join(', ').trim();
+      final lineHeRef = currentReference.isEmpty
+          ? null
+          : currentReference.join(', ').trim();
 
-      linesBatch.add(Line(
-        id: 0, // auto-assigned by SQLite
-        bookId: bookId,
-        lineIndex: lineIndex,
-        content: line,
-        heRef: lineHeRef?.isEmpty == true ? null : lineHeRef,
-      ));
+      linesBatch.add(
+        Line(
+          id: 0, // auto-assigned by SQLite
+          bookId: bookId,
+          lineIndex: lineIndex,
+          content: line,
+          heRef: lineHeRef?.isEmpty == true ? null : lineHeRef,
+        ),
+      );
 
       if (linesBatch.length >= batchSize) {
         await repository.insertLinesBatch(linesBatch);
@@ -599,17 +651,19 @@ class DatabaseGenerator {
         }
       }
 
-      final actualId = await repository.insertTocEntry(TocEntry(
-        id: 0, // auto-assign
-        bookId: bookId,
-        parentId: parentDbId,
-        text: entryData.text,
-        level: entryData.level,
-        lineIndex: entryData.lineIndex,
-        lineId: null, // fixed by SQL below
-        isLastChild: false,
-        hasChildren: false,
-      ));
+      final actualId = await repository.insertTocEntry(
+        TocEntry(
+          id: 0, // auto-assign
+          bookId: bookId,
+          parentId: parentDbId,
+          text: entryData.text,
+          level: entryData.level,
+          lineIndex: entryData.lineIndex,
+          lineId: null, // fixed by SQL below
+          isLastChild: false,
+          hasChildren: false,
+        ),
+      );
 
       localIdxToDbId[entryData.id] = actualId;
       actualParentStack[entryData.level] = actualId;
@@ -701,8 +755,9 @@ class DatabaseGenerator {
   /// Compute a normalized key for a book file relative to the library root
   String _toLibraryRelativeKey(String filePath) {
     try {
-      final rel =
-          path.relative(filePath, from: _libraryRoot).replaceAll('\\', '/');
+      final rel = path
+          .relative(filePath, from: _libraryRoot)
+          .replaceAll('\\', '/');
       return rel;
     } catch (e) {
       return path.basename(filePath);
@@ -729,8 +784,12 @@ class DatabaseGenerator {
       var count = 0;
       await for (final entity in dir.list(recursive: true)) {
         if (entity is File &&
-            ['.txt', '.pdf', '.docx']
-                .contains(path.extension(entity.path).toLowerCase())) {
+            [
+              '.txt',
+              '.pdf',
+              '.docx',
+              '.epub',
+            ].contains(path.extension(entity.path).toLowerCase())) {
           count++;
         }
       }

--- a/lib/migration/sync/file_sync_service.dart
+++ b/lib/migration/sync/file_sync_service.dart
@@ -130,7 +130,8 @@ class FileSyncService {
       // Delete the book completely (including lines, TOC, links, etc.)
       await _repository.deleteBookCompletely(existingBook.id);
       _log.info(
-          'Successfully deleted book from DB: $title (id: ${existingBook.id})');
+        'Successfully deleted book from DB: $title (id: ${existingBook.id})',
+      );
       return true;
     } catch (e, stackTrace) {
       _log.warning('Error deleting book from DB: $filePath', e, stackTrace);
@@ -145,34 +146,40 @@ class FileSyncService {
     // First, delete all books in this category
     final books = await repo.getBooksByCategory(categoryId);
     debugPrint(
-        '[FileSyncService] _deleteCategoryRecursive: categoryId=$categoryId, found ${books.length} books');
+      '[FileSyncService] _deleteCategoryRecursive: categoryId=$categoryId, found ${books.length} books',
+    );
     for (final book in books) {
       debugPrint(
-          '[FileSyncService]   deleting book: id=${book.id}, title="${book.title}"');
+        '[FileSyncService]   deleting book: id=${book.id}, title="${book.title}"',
+      );
       try {
         await repo.deleteBookCompletely(book.id);
       } catch (e, st) {
         _log.warning(
-            'Failed to delete book ${book.id} ("${book.title}"), continuing',
-            e,
-            st);
+          'Failed to delete book ${book.id} ("${book.title}"), continuing',
+          e,
+          st,
+        );
       }
     }
 
     // Then, recursively delete subcategories
     final subCategories = await repo.getCategoryChildren(categoryId);
     debugPrint(
-        '[FileSyncService] _deleteCategoryRecursive: categoryId=$categoryId, found ${subCategories.length} subcategories');
+      '[FileSyncService] _deleteCategoryRecursive: categoryId=$categoryId, found ${subCategories.length} subcategories',
+    );
     for (final subCat in subCategories) {
       debugPrint(
-          '[FileSyncService]   recursing into subcategory: id=${subCat.id}, title="${subCat.title}"');
+        '[FileSyncService]   recursing into subcategory: id=${subCat.id}, title="${subCat.title}"',
+      );
       try {
         await _deleteCategoryRecursive(subCat.id);
       } catch (e, st) {
         _log.warning(
-            'Failed to delete subcategory ${subCat.id} ("${subCat.title}"), continuing',
-            e,
-            st);
+          'Failed to delete subcategory ${subCat.id} ("${subCat.title}"), continuing',
+          e,
+          st,
+        );
       }
     }
 
@@ -269,9 +276,11 @@ class FileSyncService {
     List<String> otherFolderPaths,
   ) {
     final folderDepth = _normalizeFolderPath(folderPath).length;
-    return otherFolderPaths.any((other) =>
-        _normalizeFolderPath(other).length > folderDepth &&
-        _isPathInsideFolder(bookPath, other));
+    return otherFolderPaths.any(
+      (other) =>
+          _normalizeFolderPath(other).length > folderDepth &&
+          _isPathInsideFolder(bookPath, other),
+    );
   }
 
   Future<bool> _categoryBelongsToAnyConfiguredFolder(
@@ -287,10 +296,12 @@ class FileSyncService {
       for (final book in books) {
         final sourceName = sourceNameCache.containsKey(book.sourceId)
             ? sourceNameCache[book.sourceId]
-            : (sourceNameCache[book.sourceId] =
-                (await repo.getSourceById(book.sourceId))?.name);
-        final sourceFolderPath =
-            _extractCustomFolderPathFromSourceName(sourceName);
+            : (sourceNameCache[book.sourceId] = (await repo.getSourceById(
+                book.sourceId,
+              ))?.name);
+        final sourceFolderPath = _extractCustomFolderPathFromSourceName(
+          sourceName,
+        );
         if (sourceFolderPath != null &&
             customFolders.any(
               (folder) => _normalizeFolderPath(folder.path) == sourceFolderPath,
@@ -302,8 +313,9 @@ class FileSyncService {
         if (bookPath == null || bookPath.isEmpty) {
           continue;
         }
-        if (customFolders
-            .any((folder) => _isPathInsideFolder(bookPath, folder.path))) {
+        if (customFolders.any(
+          (folder) => _isPathInsideFolder(bookPath, folder.path),
+        )) {
           return true;
         }
       }
@@ -326,14 +338,17 @@ class FileSyncService {
       return;
     }
 
-    final personalSubCategories =
-        await repo.getCategoryChildren(personalCategory.id);
+    final personalSubCategories = await repo.getCategoryChildren(
+      personalCategory.id,
+    );
 
     final staleFolderCategories = <Category>[];
     for (final category in personalSubCategories) {
       final belongsToConfiguredFolder =
           await _categoryBelongsToAnyConfiguredFolder(
-              category.id, customFolders);
+            category.id,
+            customFolders,
+          );
       if (!belongsToConfiguredFolder) {
         staleFolderCategories.add(category);
       }
@@ -365,12 +380,11 @@ class FileSyncService {
     CustomFolder folder,
     Set<String> validBookKeys, {
     List<String> otherConfiguredFolderPaths = const [],
-  }) =>
-      _removeFolderBooksBySource(
-        folder.path,
-        keepKeys: validBookKeys,
-        otherConfiguredFolderPaths: otherConfiguredFolderPaths,
-      );
+  }) => _removeFolderBooksBySource(
+    folder.path,
+    keepKeys: validBookKeys,
+    otherConfiguredFolderPaths: otherConfiguredFolderPaths,
+  );
 
   /// מסיר מ-`user_books.db` את ספרי התיקייה [folderPath], לפי שם ה-`source`
   /// הייחודי (הנתיב המלא) — לא לפי שם הקטגוריה. כך שתי תיקיות שונות בעלות
@@ -410,8 +424,9 @@ class FileSyncService {
       for (final book in books) {
         final sourceName = sourceNameCache.containsKey(book.sourceId)
             ? sourceNameCache[book.sourceId]
-            : (sourceNameCache[book.sourceId] =
-                (await repo.getSourceById(book.sourceId))?.name);
+            : (sourceNameCache[book.sourceId] = (await repo.getSourceById(
+                book.sourceId,
+              ))?.name);
         // שיוך לתיקייה לפי שם ה-source. נפילה-חזרה לפי נתיב הקובץ מוגבלת
         // *אך ורק* למקור ה-legacy המדויק שמסלול ההוספה הישן ייצר
         // ('external'), כדי לזהות נתונים ישנים בלי לגעת בספרים ממקור אחר
@@ -419,13 +434,17 @@ class FileSyncService {
         // ספר legacy משויך רק לתיקייה המוגדרת *העמוקה ביותר* שמכילה אותו —
         // אחרת מחיקת תיקיית-אב הייתה גוררת גם ספרי תיקיית-בן מקוננת.
         final bookPath = book.filePath;
-        final belongsToFolder = sourceName == folderSourceName ||
+        final belongsToFolder =
+            sourceName == folderSourceName ||
             (sourceName == CustomFolderSource.legacyExternalSourceName &&
                 bookPath != null &&
                 bookPath.isNotEmpty &&
                 _isPathInsideFolder(bookPath, folderPath) &&
                 !_belongsToDeeperFolder(
-                    bookPath, folderPath, otherConfiguredFolderPaths));
+                  bookPath,
+                  folderPath,
+                  otherConfiguredFolderPaths,
+                ));
         if (!belongsToFolder) continue;
         if (keepKeys != null) {
           // זרימת prune (רענון): ספר "עותק עצמאי" (התוכן נשמר בתוכנה,
@@ -433,7 +452,8 @@ class FileSyncService {
           // הרעיון של ההכנסה לתוכנה. לכן מוחקים רק ספרי "קריאה מהקבצים"
           // (file-backed) שקובצם נעלם; עותק עצמאי נמחק רק דרך הספרייה.
           if (!book.isFileBacked) continue;
-          final key = '${book.categoryId}|${book.title}|'
+          final key =
+              '${book.categoryId}|${book.title}|'
               '${(book.fileType ?? '').toLowerCase()}';
           if (keepKeys.contains(key)) continue;
         }
@@ -468,14 +488,15 @@ class FileSyncService {
   }
 
   /// Internal method to scan a single path and import files
-  Future<FileSyncResult> _scanAndImportPath(
-      {required String rootPath,
-      required List<String> categoryPrefix,
-      required bool insertContent,
-      String? customSourceName,
-      required DatabaseGenerator generator,
-      Set<String>? validBookKeys,
-      _FolderScanCaches? caches}) async {
+  Future<FileSyncResult> _scanAndImportPath({
+    required String rootPath,
+    required List<String> categoryPrefix,
+    required bool insertContent,
+    String? customSourceName,
+    required DatabaseGenerator generator,
+    Set<String>? validBookKeys,
+    _FolderScanCaches? caches,
+  }) async {
     int addedBooks = 0;
     int updatedBooks = 0;
     int addedCategories = 0;
@@ -559,9 +580,10 @@ class FileSyncService {
     final title = path.basenameWithoutExtension(filePath);
     final extension = path.extension(filePath).toLowerCase();
 
-    // PDF and DOCX files always act as external (content never in DB)
-    final isPdfOrDocx = extension == '.pdf' || extension == '.docx';
-    final effectiveInsertContent = isPdfOrDocx ? false : insertContent;
+    // PDF, DOCX and EPUB files always act as external (content never in DB)
+    final isBinaryFormat =
+        extension == '.pdf' || extension == '.docx' || extension == '.epub';
+    final effectiveInsertContent = isBinaryFormat ? false : insertContent;
 
     // Build category path
     final relativeCategories = _parsePathToCategories(filePath, basePath);
@@ -576,13 +598,14 @@ class FileSyncService {
     final chainKey = categoryPath.join('\u0000');
     var categoryResult = caches.categoryChains[chainKey];
     final isFirstChainResolution = categoryResult == null;
-    categoryResult ??= caches.categoryChains[chainKey] =
-        await generator.findOrCreateCategoryChain(categoryPath);
+    categoryResult ??= caches.categoryChains[chainKey] = await generator
+        .findOrCreateCategoryChain(categoryPath);
     final categoryId = categoryResult.categoryId;
     // הקטגוריות נוצרו רק בפתרון הראשון של השרשרת; קבצים נוספים באותה
     // תיקייה לא סופרים אותן שוב.
-    final categoriesCreated =
-        isFirstChainResolution ? categoryResult.categoriesCreated : 0;
+    final categoriesCreated = isFirstChainResolution
+        ? categoryResult.categoriesCreated
+        : 0;
 
     // Extract file type from extension (remove the dot)
     final fileType = extension.replaceFirst('.', '').toLowerCase();
@@ -601,10 +624,13 @@ class FileSyncService {
 
     if (existingBook != null) {
       debugPrint(
-          '[FileSyncService] Found existing book: title=$title, id=${existingBook.id}, filePath=${existingBook.filePath}, isFileBacked=${existingBook.isFileBacked}, totalLines=${existingBook.totalLines}');
+        '[FileSyncService] Found existing book: title=$title, id=${existingBook.id}, filePath=${existingBook.filePath}, isFileBacked=${existingBook.isFileBacked}, totalLines=${existingBook.totalLines}',
+      );
 
       final existingSourceName = await caches.sourceNameById(
-          existingBook.sourceId, _customFoldersRepo);
+        existingBook.sourceId,
+        _customFoldersRepo,
+      );
 
       // Book exists - check if file has changed
       final file = File(filePath);
@@ -613,7 +639,8 @@ class FileSyncService {
       final lastModified = fileStat.modified.millisecondsSinceEpoch;
 
       // Only update if file has actually changed
-      final fileChanged = existingBook.fileSize != fileSize ||
+      final fileChanged =
+          existingBook.fileSize != fileSize ||
           existingBook.lastModified != lastModified;
 
       // Also update if the storage preference changed (e.g. user toggled addToDatabase)
@@ -625,11 +652,13 @@ class FileSyncService {
       if (fileChanged || storageChanged || sourceChanged) {
         if (storageChanged) {
           debugPrint(
-              '[FileSyncService] Storage preference changed for ${existingBook.title}: isFileBacked=${existingBook.isFileBacked} -> $expectedIsContentExternal');
+            '[FileSyncService] Storage preference changed for ${existingBook.title}: isFileBacked=${existingBook.isFileBacked} -> $expectedIsContentExternal',
+          );
         }
         if (sourceChanged) {
           debugPrint(
-              '[FileSyncService] Source changed for ${existingBook.title}: $existingSourceName -> $customSourceName');
+            '[FileSyncService] Source changed for ${existingBook.title}: $existingSourceName -> $customSourceName',
+          );
         }
         wasUpdated = true;
         await generator.createAndProcessBook(
@@ -741,10 +770,12 @@ class FileSyncService {
             }
 
             _log.info(
-                'Scanning custom folder: ${folder.path} (addToDatabase: ${folder.addToDatabase})');
+              'Scanning custom folder: ${folder.path} (addToDatabase: ${folder.addToDatabase})',
+            );
 
-            sharedCaches ??=
-                _FolderScanCaches(await _customFoldersRepo.getAllBooks());
+            sharedCaches ??= _FolderScanCaches(
+              await _customFoldersRepo.getAllBooks(),
+            );
 
             final folderValidKeys = <String>{};
             final result = await _scanAndImportPath(
@@ -845,20 +876,22 @@ class FileSyncService {
       return const FileSyncResult(errors: ['Sync already in progress']);
     }
 
-    final libraryPath =
-        Settings.getValue<String>(SettingsRepository.keyLibraryPath);
+    final libraryPath = Settings.getValue<String>(
+      SettingsRepository.keyLibraryPath,
+    );
     if (libraryPath == null || libraryPath.isEmpty) {
       _log.warning('Library path not set, skipping sync');
       return const FileSyncResult(errors: ['Library path not set']);
     }
 
-    final customFoldersJson =
-        Settings.getValue<String>(SettingsRepository.keyCustomFolders);
+    final customFoldersJson = Settings.getValue<String>(
+      SettingsRepository.keyCustomFolders,
+    );
     final customFolders = CustomFoldersManager.loadFolders(customFoldersJson);
 
     final libraryFolderName =
         Settings.getValue<String>(SettingsRepository.keyLibraryFolderName) ??
-            '';
+        '';
     final result = await syncCustomFoldersWithInputs(
       libraryPath: libraryPath,
       customFolders: customFolders,
@@ -874,7 +907,7 @@ class FileSyncService {
   Future<List<String>> _findNewFiles(String basePath) async {
     final newFiles = <String>[];
     final dir = Directory(basePath);
-    final supportedExtensions = {'.txt', '.pdf', '.docx'};
+    final supportedExtensions = {'.txt', '.pdf', '.docx', '.epub'};
 
     if (!await dir.exists()) return newFiles;
 
@@ -946,11 +979,12 @@ class _FileProcessResult {
 /// שרשרת קטגוריות — במקום כמה שאילתות DB לכל קובץ.
 class _FolderScanCaches {
   _FolderScanCaches(List<Book> books)
-      : booksByKey = {
-          for (final book in books)
-            '${book.categoryId}|${book.title}|'
-                '${(book.fileType ?? '').toLowerCase()}': book,
-        };
+    : booksByKey = {
+        for (final book in books)
+          '${book.categoryId}|${book.title}|'
+                  '${(book.fileType ?? '').toLowerCase()}':
+              book,
+      };
 
   /// מפתח: `categoryId|title|fileType` — זהה לבדיקת הקיום המקורית.
   final Map<String, Book> booksByKey;
@@ -964,8 +998,9 @@ class _FolderScanCaches {
     if (_sourceNamesById.containsKey(sourceId)) {
       return _sourceNamesById[sourceId];
     }
-    return _sourceNamesById[sourceId] =
-        (await repo.getSourceById(sourceId))?.name;
+    return _sourceNamesById[sourceId] = (await repo.getSourceById(
+      sourceId,
+    ))?.name;
   }
 }
 

--- a/lib/models/books.dart
+++ b/lib/models/books.dart
@@ -585,11 +585,13 @@ class EpubBook extends FileBook {
 
   factory EpubBook.fromJson(Map<String, dynamic> json) {
     return EpubBook(
+      id: json['id'],
       title: json['title'],
       path: json['path'],
       author: json['author'],
       filePath: json['filePath'],
       categoryPath: json['categoryPath'],
+      categoryId: json['categoryId'],
       heCategories: json['heCategories'],
       heEra: json['heEra'],
       isUserBook: json['isUserBook'] ?? false,
@@ -600,6 +602,7 @@ class EpubBook extends FileBook {
   @override
   Map<String, dynamic> toJson() {
     return {
+      'id': id,
       'title': title,
       'path': path,
       'type': 'EpubBook',
@@ -607,6 +610,7 @@ class EpubBook extends FileBook {
       'filePath': filePath,
       'fileType': fileType,
       'categoryPath': categoryPath,
+      'categoryId': categoryId,
       'heCategories': heCategories,
       'heEra': heEra,
       'isUserBook': isUserBook,

--- a/lib/models/books.dart
+++ b/lib/models/books.dart
@@ -585,17 +585,17 @@ class EpubBook extends FileBook {
 
   factory EpubBook.fromJson(Map<String, dynamic> json) {
     return EpubBook(
-      id: json['id'],
-      title: json['title'],
-      path: json['path'],
-      author: json['author'],
-      filePath: json['filePath'],
-      categoryPath: json['categoryPath'],
-      categoryId: json['categoryId'],
-      heCategories: json['heCategories'],
-      heEra: json['heEra'],
-      isUserBook: json['isUserBook'] ?? false,
-      externalLibraryId: json['externalLibraryId'],
+      id: json['id'] as int?,
+      title: json['title'] as String,
+      path: json['path'] as String,
+      author: json['author'] as String?,
+      filePath: json['filePath'] as String?,
+      categoryPath: json['categoryPath'] as String?,
+      categoryId: json['categoryId'] as int?,
+      heCategories: json['heCategories'] as String?,
+      heEra: json['heEra'] as String?,
+      isUserBook: json['isUserBook'] as bool? ?? false,
+      externalLibraryId: json['externalLibraryId'] as String?,
     );
   }
 

--- a/lib/models/books.dart
+++ b/lib/models/books.dart
@@ -83,6 +83,8 @@ abstract class Book {
         return PdfBook.fromJson(json);
       case 'DocxBook':
         return DocxBook.fromJson(json);
+      case 'EpubBook':
+        return EpubBook.fromJson(json);
       case 'ExternalLibraryBook':
         return ExternalLibraryBook.fromJson(json);
       default:
@@ -93,30 +95,31 @@ abstract class Book {
   /// Creates a new `Book` instance.
   ///
   /// The [title] parameter is required and cannot be null.
-  Book(
-      {this.id,
-      required this.title,
-      this.category,
-      this.author,
-      this.heCategories,
-      this.heEra,
-      this.compDateStringHe,
-      this.compPlaceStringHe,
-      this.pubDateStringHe,
-      this.pubPlaceStringHe,
-      this.heShortDesc,
-      this.heDesc,
-      this.pubDate,
-      this.pubPlace,
-      this.order = 999,
-      this.topics = '',
-      this.filePath,
-      this.fileType,
-      this.categoryPath,
-      this.categoryId,
-      this.extraTitles,
-      this.isUserBook = false,
-      this.externalLibraryId});
+  Book({
+    this.id,
+    required this.title,
+    this.category,
+    this.author,
+    this.heCategories,
+    this.heEra,
+    this.compDateStringHe,
+    this.compPlaceStringHe,
+    this.pubDateStringHe,
+    this.pubPlaceStringHe,
+    this.heShortDesc,
+    this.heDesc,
+    this.pubDate,
+    this.pubPlace,
+    this.order = 999,
+    this.topics = '',
+    this.filePath,
+    this.fileType,
+    this.categoryPath,
+    this.categoryId,
+    this.extraTitles,
+    this.isUserBook = false,
+    this.externalLibraryId,
+  });
 }
 
 ///a representation of a text book (opposite PDF book).
@@ -127,31 +130,32 @@ class TextBook extends Book {
   /// נטען מ-version_line במקום הטקסט הממוזג.
   final String? versionTitle;
 
-  TextBook(
-      {super.id,
-      required super.title,
-      super.category,
-      super.author,
-      super.heCategories,
-      super.heEra,
-      super.compDateStringHe,
-      super.compPlaceStringHe,
-      super.pubDateStringHe,
-      super.pubPlaceStringHe,
-      super.heShortDesc,
-      super.heDesc,
-      super.pubDate,
-      super.pubPlace,
-      super.order = 999,
-      super.topics,
-      super.filePath,
-      super.fileType = 'txt',
-      super.categoryPath,
-      super.categoryId,
-      super.extraTitles,
-      super.isUserBook,
-      super.externalLibraryId,
-      this.versionTitle});
+  TextBook({
+    super.id,
+    required super.title,
+    super.category,
+    super.author,
+    super.heCategories,
+    super.heEra,
+    super.compDateStringHe,
+    super.compPlaceStringHe,
+    super.pubDateStringHe,
+    super.pubPlaceStringHe,
+    super.heShortDesc,
+    super.heDesc,
+    super.pubDate,
+    super.pubPlace,
+    super.order = 999,
+    super.topics,
+    super.filePath,
+    super.fileType = 'txt',
+    super.categoryPath,
+    super.categoryId,
+    super.extraTitles,
+    super.isUserBook,
+    super.externalLibraryId,
+    this.versionTitle,
+  });
 
   /// Retrieves the table of contents of the book.
   ///
@@ -178,7 +182,10 @@ class TextBook extends Book {
     );
     if (provider != null && categoryId != null) {
       return await provider.getAllLinksForBook(
-          title, categoryId!, fileType ?? 'txt');
+        title,
+        categoryId!,
+        fileType ?? 'txt',
+      );
     }
     return [];
   }
@@ -285,28 +292,28 @@ class ExternalLibraryBook extends Book {
   ///
   /// [title] and [id] are required. Other parameters are optional.
   /// [link] is required for online access to the book.
-  ExternalLibraryBook(
-      {required super.title,
-      required int id,
-      super.author,
-      super.heCategories,
-      super.heEra,
-      super.compDateStringHe,
-      super.compPlaceStringHe,
-      super.pubDateStringHe,
-      super.pubPlaceStringHe,
-      super.pubPlace,
-      super.pubDate,
-      super.topics,
-      super.heShortDesc,
-      super.heDesc,
-      required this.link,
-      super.categoryPath,
-      super.categoryId,
-      super.fileType = 'link',
-      super.isUserBook,
-      super.externalLibraryId})
-      : super(id: id);
+  ExternalLibraryBook({
+    required super.title,
+    required int id,
+    super.author,
+    super.heCategories,
+    super.heEra,
+    super.compDateStringHe,
+    super.compPlaceStringHe,
+    super.pubDateStringHe,
+    super.pubPlaceStringHe,
+    super.pubPlace,
+    super.pubDate,
+    super.topics,
+    super.heShortDesc,
+    super.heDesc,
+    required this.link,
+    super.categoryPath,
+    super.categoryId,
+    super.fileType = 'link',
+    super.isUserBook,
+    super.externalLibraryId,
+  }) : super(id: id);
 
   /// Returns the publication date of the book.
   ///
@@ -388,30 +395,31 @@ abstract class FileBook extends Book {
 ///represents a PDF format book, which is always a file on the device, and there for the [String] fiels 'path'
 ///is required
 class PdfBook extends FileBook {
-  PdfBook(
-      {super.id,
-      required super.title,
-      super.category,
-      required super.path,
-      super.topics,
-      super.author,
-      super.heCategories,
-      super.heEra,
-      super.compDateStringHe,
-      super.compPlaceStringHe,
-      super.pubDateStringHe,
-      super.pubPlaceStringHe,
-      super.heShortDesc,
-      super.heDesc,
-      super.pubDate,
-      super.pubPlace,
-      super.filePath,
-      super.categoryPath,
-      super.categoryId,
-      super.fileType = 'pdf',
-      super.order = 999,
-      super.isUserBook,
-      super.externalLibraryId});
+  PdfBook({
+    super.id,
+    required super.title,
+    super.category,
+    required super.path,
+    super.topics,
+    super.author,
+    super.heCategories,
+    super.heEra,
+    super.compDateStringHe,
+    super.compPlaceStringHe,
+    super.pubDateStringHe,
+    super.pubPlaceStringHe,
+    super.heShortDesc,
+    super.heDesc,
+    super.pubDate,
+    super.pubPlace,
+    super.filePath,
+    super.categoryPath,
+    super.categoryId,
+    super.fileType = 'pdf',
+    super.order = 999,
+    super.isUserBook,
+    super.externalLibraryId,
+  });
 
   factory PdfBook.fromJson(Map<String, dynamic> json) {
     return PdfBook(
@@ -452,30 +460,31 @@ class PdfBook extends FileBook {
 
 /// Represents a DOCX format book.
 class DocxBook extends FileBook {
-  DocxBook(
-      {super.id,
-      required super.title,
-      super.category,
-      required super.path,
-      super.topics,
-      super.author,
-      super.heCategories,
-      super.heEra,
-      super.compDateStringHe,
-      super.compPlaceStringHe,
-      super.pubDateStringHe,
-      super.pubPlaceStringHe,
-      super.heShortDesc,
-      super.heDesc,
-      super.pubDate,
-      super.pubPlace,
-      super.filePath,
-      super.categoryPath,
-      super.categoryId,
-      super.fileType = 'docx',
-      super.order = 999,
-      super.isUserBook,
-      super.externalLibraryId});
+  DocxBook({
+    super.id,
+    required super.title,
+    super.category,
+    required super.path,
+    super.topics,
+    super.author,
+    super.heCategories,
+    super.heEra,
+    super.compDateStringHe,
+    super.compPlaceStringHe,
+    super.pubDateStringHe,
+    super.pubPlaceStringHe,
+    super.heShortDesc,
+    super.heDesc,
+    super.pubDate,
+    super.pubPlace,
+    super.filePath,
+    super.categoryPath,
+    super.categoryId,
+    super.fileType = 'docx',
+    super.order = 999,
+    super.isUserBook,
+    super.externalLibraryId,
+  });
 
   factory DocxBook.fromJson(Map<String, dynamic> json) {
     return DocxBook(
@@ -546,6 +555,100 @@ class DocxBook extends FileBook {
   }
 }
 
+/// Represents an EPUB format book.
+class EpubBook extends FileBook {
+  EpubBook({
+    super.id,
+    required super.title,
+    super.category,
+    required super.path,
+    super.topics,
+    super.author,
+    super.heCategories,
+    super.heEra,
+    super.compDateStringHe,
+    super.compPlaceStringHe,
+    super.pubDateStringHe,
+    super.pubPlaceStringHe,
+    super.heShortDesc,
+    super.heDesc,
+    super.pubDate,
+    super.pubPlace,
+    super.filePath,
+    super.categoryPath,
+    super.categoryId,
+    super.fileType = 'epub',
+    super.order = 999,
+    super.isUserBook,
+    super.externalLibraryId,
+  });
+
+  factory EpubBook.fromJson(Map<String, dynamic> json) {
+    return EpubBook(
+      title: json['title'],
+      path: json['path'],
+      author: json['author'],
+      filePath: json['filePath'],
+      categoryPath: json['categoryPath'],
+      heCategories: json['heCategories'],
+      heEra: json['heEra'],
+      isUserBook: json['isUserBook'] ?? false,
+      externalLibraryId: json['externalLibraryId'],
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'path': path,
+      'type': 'EpubBook',
+      'author': author,
+      'filePath': filePath,
+      'fileType': fileType,
+      'categoryPath': categoryPath,
+      'heCategories': heCategories,
+      'heEra': heEra,
+      'isUserBook': isUserBook,
+      'externalLibraryId': externalLibraryId,
+    };
+  }
+
+  @override
+  String toString() => 'EpubBook(title: $title, path: $path)';
+
+  /// עוטף את ה-EpubBook ל-TextBook, באותו דפוס כמו [DocxBook.toTextBook] —
+  /// שימור `id`/`categoryId`/`externalLibraryId` חיוני לאיתור ב-cache,
+  /// ו-`filePath` נופל ל-`path` כדי שזרימת getBookText תפעיל epubToText.
+  TextBook toTextBook() {
+    return TextBook(
+      id: id,
+      title: title,
+      category: category,
+      author: author,
+      heCategories: heCategories,
+      heEra: heEra,
+      compDateStringHe: compDateStringHe,
+      compPlaceStringHe: compPlaceStringHe,
+      pubDateStringHe: pubDateStringHe,
+      pubPlaceStringHe: pubPlaceStringHe,
+      heShortDesc: heShortDesc,
+      heDesc: heDesc,
+      pubDate: pubDate,
+      pubPlace: pubPlace,
+      order: order,
+      topics: topics,
+      filePath: filePath ?? path,
+      fileType: fileType ?? 'epub',
+      categoryPath: categoryPath,
+      categoryId: categoryId,
+      extraTitles: extraTitles,
+      isUserBook: isUserBook,
+      externalLibraryId: externalLibraryId,
+    );
+  }
+}
+
 ///represents an entry in table of content , which is a node in a hirarchial tree of topics.
 ///every entry has its 'level' in the tree, and an index of the line in the book that it is refers to
 class TocEntry {
@@ -555,16 +658,16 @@ class TocEntry {
   final TocEntry? parent;
   List<TocEntry> children = [];
   String get fullText => () {
-        TocEntry? parent = this.parent;
-        String text = this.text;
-        while (parent != null && parent.level > 1) {
-          if (parent.text != '') {
-            text = '${parent.text}, $text';
-          }
-          parent = parent.parent;
-        }
-        return text;
-      }();
+    TocEntry? parent = this.parent;
+    String text = this.text;
+    while (parent != null && parent.level > 1) {
+      if (parent.text != '') {
+        text = '${parent.text}, $text';
+      }
+      parent = parent.parent;
+    }
+    return text;
+  }();
 
   ///creats [TocEntry]
   TocEntry({

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -636,6 +636,7 @@ class PluginBridgeAdapter {
       'type': switch (book) {
         PdfBook() => 'pdf',
         DocxBook() => 'docx',
+        EpubBook() => 'epub',
         _ => 'text',
       },
     };

--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -139,19 +139,19 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
 
     _isAutoLoadInFlight = true;
     context.read<SearchBloc>().add(
-          LoadMoreResults(
-            customSpacing: widget.tab.spacingValues,
-            alternativeWords: widget.tab.alternativeWords,
-            searchOptions: widget.tab.effectiveSearchOptions(
-              query: context.read<SearchBloc>().state.searchQuery,
-            ),
-            negativeCustomSpacing: widget.tab.negativeSpacingValues,
-            negativeAlternativeWords: widget.tab.negativeAlternativeWords,
-            negativeSearchOptions: widget.tab.effectiveNegativeSearchOptions(
-              query: context.read<SearchBloc>().state.negativeQuery,
-            ),
-          ),
-        );
+      LoadMoreResults(
+        customSpacing: widget.tab.spacingValues,
+        alternativeWords: widget.tab.alternativeWords,
+        searchOptions: widget.tab.effectiveSearchOptions(
+          query: context.read<SearchBloc>().state.searchQuery,
+        ),
+        negativeCustomSpacing: widget.tab.negativeSpacingValues,
+        negativeAlternativeWords: widget.tab.negativeAlternativeWords,
+        negativeSearchOptions: widget.tab.effectiveNegativeSearchOptions(
+          query: context.read<SearchBloc>().state.negativeQuery,
+        ),
+      ),
+    );
   }
 
   String _searchResultDedupeKey({
@@ -210,24 +210,29 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
   }) async {
     // שחזור הספר מהקטלוג לפי מפתח האינדקס היציב — פתיחה לפי כותרת בלבד
     // הייתה פותחת ספר רשמי במקום ספר אישי בעל אותה כותרת.
-    final resolvedBook =
-        await widget.tab.searchBloc.resolveBookForIndexedPath(filePath);
+    final resolvedBook = await widget.tab.searchBloc.resolveBookForIndexedPath(
+      filePath,
+    );
     if (!mounted) return;
 
     final rawQuery = widget.tab.queryController.text;
-    final hasEnabledOptions =
-        effectiveOptions.values.any((m) => m.values.any((v) => v == true));
-    final hasAlternativeWords = widget.tab.alternativeWords.values
-        .any((alts) => alts.any((w) => w.trim().isNotEmpty));
-    final hasSpacingValues =
-        widget.tab.spacingValues.values.any((v) => v.trim().isNotEmpty);
+    final hasEnabledOptions = effectiveOptions.values.any(
+      (m) => m.values.any((v) => v == true),
+    );
+    final hasAlternativeWords = widget.tab.alternativeWords.values.any(
+      (alts) => alts.any((w) => w.trim().isNotEmpty),
+    );
+    final hasSpacingValues = widget.tab.spacingValues.values.any(
+      (v) => v.trim().isNotEmpty,
+    );
     final currentMode = widget.tab.searchBloc.state.configuration.searchMode;
 
     // אין צורך בזיהוי "שאילתת רגקס": המנוע מנקה מטא-תווים
     // ב-sanitize_query לפני בניית השאילתה, כך שקלט המשתמש
     // לעולם אינו מפורש כתבנית — שאילתה בלי אפשרויות מיוחדות
     // היא תמיד ליטרלית וניתנת לחיפוש פשוט בתוך הספר.
-    final shouldUseSimpleInBook = !hasEnabledOptions &&
+    final shouldUseSimpleInBook =
+        !hasEnabledOptions &&
         !hasAlternativeWords &&
         !hasSpacingValues &&
         currentMode != SearchMode.fuzzy;
@@ -239,113 +244,118 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
 
     final openLeftPane =
         (Settings.getValue<bool>('key-pin-sidebar') ?? false) ||
-            (Settings.getValue<bool>('key-default-sidebar-open') ?? false);
+        (Settings.getValue<bool>('key-default-sidebar-open') ?? false);
 
     if (isPdf) {
       final pageNumber = segment + 1;
       context.read<TabsBloc>().add(
-            OpenOrFocusTab(
-              PdfBookTab(
-                book: resolvedBook is PdfBook
-                    ? resolvedBook
-                    : PdfBook(title: title, path: filePath),
-                pageNumber: pageNumber,
-                dedupeKey: _searchResultDedupeKey(
-                  title: title,
-                  reference: reference,
-                  segment: segment,
-                  isPdf: true,
-                  filePath: filePath,
-                ),
-                searchText: rawQuery,
-                searchOptions: effectiveOptions,
-                alternativeWords: widget.tab.alternativeWords,
-                spacingValues: widget.tab.spacingValues,
-                searchMode: inBookMode,
-                searchDistance: inBookDistance,
-                openLeftPane: openLeftPane,
-                requiresStableLayout: true,
-              ),
-              targetTitle: reference,
-              insertAdjacent: true,
+        OpenOrFocusTab(
+          PdfBookTab(
+            book: resolvedBook is PdfBook
+                ? resolvedBook
+                : PdfBook(title: title, path: filePath),
+            pageNumber: pageNumber,
+            dedupeKey: _searchResultDedupeKey(
+              title: title,
+              reference: reference,
+              segment: segment,
+              isPdf: true,
+              filePath: filePath,
             ),
-          );
+            searchText: rawQuery,
+            searchOptions: effectiveOptions,
+            alternativeWords: widget.tab.alternativeWords,
+            spacingValues: widget.tab.spacingValues,
+            searchMode: inBookMode,
+            searchDistance: inBookDistance,
+            openLeftPane: openLeftPane,
+            requiresStableLayout: true,
+          ),
+          targetTitle: reference,
+          insertAdjacent: true,
+        ),
+      );
     } else {
       context.read<TabsBloc>().add(
-            OpenOrFocusTab(
-              TextBookTab(
-                book: switch (resolvedBook) {
-                  final TextBook book => book,
-                  final DocxBook book => book.toTextBook(),
-                  _ => TextBook(title: title),
-                },
-                index: segment,
-                dedupeKey: _searchResultDedupeKey(
-                  title: title,
-                  reference: reference,
-                  segment: segment,
-                  isPdf: false,
-                  filePath: filePath,
-                ),
-                searchText: rawQuery,
-                searchOptions: effectiveOptions,
-                alternativeWords: widget.tab.alternativeWords,
-                spacingValues: widget.tab.spacingValues,
-                searchMode: inBookMode,
-                searchDistance: inBookDistance,
-                showPageShapeView:
-                    PageShapeSettingsManager.getViewModePreference(title),
-                openLeftPane: openLeftPane,
-              ),
-              targetTitle: reference,
-              insertAdjacent: true,
+        OpenOrFocusTab(
+          TextBookTab(
+            book: switch (resolvedBook) {
+              final TextBook book => book,
+              final DocxBook book => book.toTextBook(),
+              final EpubBook book => book.toTextBook(),
+              _ => TextBook(title: title),
+            },
+            index: segment,
+            dedupeKey: _searchResultDedupeKey(
+              title: title,
+              reference: reference,
+              segment: segment,
+              isPdf: false,
+              filePath: filePath,
             ),
-          );
+            searchText: rawQuery,
+            searchOptions: effectiveOptions,
+            alternativeWords: widget.tab.alternativeWords,
+            spacingValues: widget.tab.spacingValues,
+            searchMode: inBookMode,
+            searchDistance: inBookDistance,
+            showPageShapeView: PageShapeSettingsManager.getViewModePreference(
+              title,
+            ),
+            openLeftPane: openLeftPane,
+          ),
+          targetTitle: reference,
+          insertAdjacent: true,
+        ),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(builder: (context, constrains) {
-      return BlocListener<SearchBloc, SearchState>(
-        listenWhen: (previous, current) =>
-            previous.isLoading != current.isLoading ||
-            previous.results.length != current.results.length ||
-            previous.totalResults != current.totalResults ||
-            previous.searchQuery != current.searchQuery ||
-            previous.currentFacets.join('|') != current.currentFacets.join('|'),
-        listener: (context, state) {
-          if (!state.isLoading) {
-            _isAutoLoadInFlight = false;
-          }
+    return LayoutBuilder(
+      builder: (context, constrains) {
+        return BlocListener<SearchBloc, SearchState>(
+          listenWhen: (previous, current) =>
+              previous.isLoading != current.isLoading ||
+              previous.results.length != current.results.length ||
+              previous.totalResults != current.totalResults ||
+              previous.searchQuery != current.searchQuery ||
+              previous.currentFacets.join('|') !=
+                  current.currentFacets.join('|'),
+          listener: (context, state) {
+            if (!state.isLoading) {
+              _isAutoLoadInFlight = false;
+            }
 
-          // חיפוש חדש (שינוי שאילתה או קטגוריה) — מאפס את הגלילה לראש הרשימה.
-          // טעינת המשך (LoadMore) שומרת על אותה חתימה ולכן לא נוגעת בגלילה,
-          // וכך גם chunks עוקבים של אותו חיפוש (החתימה זהה).
-          final signature = _searchSignature(state);
-          if (signature != _lastSearchSignature) {
-            _lastSearchSignature = signature;
+            // חיפוש חדש (שינוי שאילתה או קטגוריה) — מאפס את הגלילה לראש הרשימה.
+            // טעינת המשך (LoadMore) שומרת על אותה חתימה ולכן לא נוגעת בגלילה,
+            // וכך גם chunks עוקבים של אותו חיפוש (החתימה זהה).
+            final signature = _searchSignature(state);
+            if (signature != _lastSearchSignature) {
+              _lastSearchSignature = signature;
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted && _scrollController.hasClients) {
+                  _scrollController.jumpTo(0);
+                }
+              });
+            }
+
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted && _scrollController.hasClients) {
-                _scrollController.jumpTo(0);
+              if (mounted) {
+                _handleScroll();
               }
             });
-          }
-
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted) {
-              _handleScroll();
-            }
-          });
-        },
-        child: BlocBuilder<SearchBloc, SearchState>(
-          builder: (context, state) {
-            // עכשיו רק מציגים את התוצאות - השורה התחתונה מוצגת במקום אחר
-            return _buildResultsContent(state, constrains);
           },
-        ),
-      );
-    });
+          child: BlocBuilder<SearchBloc, SearchState>(
+            builder: (context, state) {
+              // עכשיו רק מציגים את התוצאות - השורה התחתונה מוצגת במקום אחר
+              return _buildResultsContent(state, constrains);
+            },
+          ),
+        );
+      },
+    );
   }
 
   Widget _buildResultsContent(SearchState state, BoxConstraints constrains) {
@@ -402,7 +412,8 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
       key: PageStorageKey(widget.tab),
       controller: _scrollController,
       padding: const EdgeInsets.all(16),
-      itemCount: state.results.length +
+      itemCount:
+          state.results.length +
           ((showInlineLoadingIndicator || showLoadMoreButton) ? 1 : 0),
       itemBuilder: (context, index) {
         // האיטם האחרון מציג אינדיקטור טעינה בזמן הזרמה,
@@ -434,20 +445,19 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                   text: state.isLoading ? 'טוען...' : remainingText,
                   onPressed: () {
                     context.read<SearchBloc>().add(
-                          LoadMoreResults(
-                            customSpacing: widget.tab.spacingValues,
-                            alternativeWords: widget.tab.alternativeWords,
-                            searchOptions: effectiveOptions,
-                            negativeCustomSpacing:
-                                widget.tab.negativeSpacingValues,
-                            negativeAlternativeWords:
-                                widget.tab.negativeAlternativeWords,
-                            negativeSearchOptions:
-                                widget.tab.effectiveNegativeSearchOptions(
+                      LoadMoreResults(
+                        customSpacing: widget.tab.spacingValues,
+                        alternativeWords: widget.tab.alternativeWords,
+                        searchOptions: effectiveOptions,
+                        negativeCustomSpacing: widget.tab.negativeSpacingValues,
+                        negativeAlternativeWords:
+                            widget.tab.negativeAlternativeWords,
+                        negativeSearchOptions: widget.tab
+                            .effectiveNegativeSearchOptions(
                               query: state.negativeQuery,
                             ),
-                          ),
-                        );
+                      ),
+                    );
                   },
                   isLoading: state.isLoading,
                   icon: state.isLoading
@@ -546,9 +556,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                           child: Text(
                             '${index + 1}',
                             style: TextStyle(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onPrimaryContainer,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onPrimaryContainer,
                               fontWeight: FontWeight.bold,
                               fontSize: 16,
                             ),
@@ -569,8 +579,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                     child: Icon(
                                       FluentIcons.document_pdf_24_regular,
                                       size: 16,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
                                     ),
                                   ),
                                 Expanded(
@@ -579,8 +590,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                     style: TextStyle(
                                       fontSize: 15,
                                       fontWeight: FontWeight.bold,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
                                     ),
                                     textAlign: TextAlign.right,
                                     maxLines: 1,
@@ -591,9 +603,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                   icon: Icon(
                                     FluentIcons.copy_24_regular,
                                     size: 16,
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
                                   ),
                                   tooltip: 'העתק טקסט',
                                   visualDensity: VisualDensity.compact,
@@ -603,10 +615,12 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                     minHeight: 28,
                                   ),
                                   onPressed: () {
-                                    final plainText =
-                                        utils.stripHtmlIfNeeded(rawHtml);
+                                    final plainText = utils.stripHtmlIfNeeded(
+                                      rawHtml,
+                                    );
                                     Clipboard.setData(
-                                        ClipboardData(text: plainText));
+                                      ClipboardData(text: plainText),
+                                    );
                                     UiSnack.show(UiSnack.textCopied);
                                   },
                                 ),
@@ -619,9 +633,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                   wrappedTitleText,
                                   style: TextStyle(
                                     fontSize: 13,
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
                                   ),
                                   textAlign: TextAlign.right,
                                   softWrap: true,
@@ -636,8 +650,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                               text: TextSpan(
                                 style: TextStyle(
                                   fontSize: 16,
-                                  color:
-                                      Theme.of(context).colorScheme.onSurface,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurface,
                                   height: 1.5,
                                 ),
                                 children: snippetSpans,
@@ -743,12 +758,11 @@ class _MergedSiblingsSectionState extends State<_MergedSiblingsSection> {
   bool _expanded = false;
 
   String get _badgeText => switch (widget.groupingMode) {
-        ResultGroupingMode.sameSection =>
-          'נמצאו ${widget.mergedCount} תוצאות בטווח זה',
-        ResultGroupingMode.identicalText =>
-          'מופיע ב-${widget.mergedCount} מקומות',
-        ResultGroupingMode.none => 'נמצאו ${widget.mergedCount} תוצאות',
-      };
+    ResultGroupingMode.sameSection =>
+      'נמצאו ${widget.mergedCount} תוצאות בטווח זה',
+    ResultGroupingMode.identicalText => 'מופיע ב-${widget.mergedCount} מקומות',
+    ResultGroupingMode.none => 'נמצאו ${widget.mergedCount} תוצאות',
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -765,8 +779,10 @@ class _MergedSiblingsSectionState extends State<_MergedSiblingsSection> {
             onTap: () => setState(() => _expanded = !_expanded),
             borderRadius: AppTokens.borderRadiusAll,
             child: Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
+              padding: const EdgeInsets.symmetric(
+                horizontal: 4.0,
+                vertical: 2.0,
+              ),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/lib/settings/panels/custom_folders_panel.dart
+++ b/lib/settings/panels/custom_folders_panel.dart
@@ -27,10 +27,10 @@ enum _FolderContentKind {
   /// רק קבצי טקסט (TXT) — ניתן לשמור כעותק עצמאי בתוכנה.
   textOnly,
 
-  /// רק קבצי PDF/Word — נקראים תמיד ישירות מהקבצים.
+  /// רק קבצי PDF/Word/EPUB — נקראים תמיד ישירות מהקבצים.
   binaryOnly,
 
-  /// גם טקסט וגם PDF/Word — רק הטקסט יישמר כעותק עצמאי.
+  /// גם טקסט וגם PDF/Word/EPUB — רק הטקסט יישמר כעותק עצמאי.
   mixed,
 }
 
@@ -59,14 +59,16 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
   @override
   void initState() {
     super.initState();
-    DatabaseLibraryProvider.operationQueue.busyCount
-        .addListener(_onQueueBusyChanged);
+    DatabaseLibraryProvider.operationQueue.busyCount.addListener(
+      _onQueueBusyChanged,
+    );
   }
 
   @override
   void dispose() {
-    DatabaseLibraryProvider.operationQueue.busyCount
-        .removeListener(_onQueueBusyChanged);
+    DatabaseLibraryProvider.operationQueue.busyCount.removeListener(
+      _onQueueBusyChanged,
+    );
     super.dispose();
   }
 
@@ -79,13 +81,17 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
     try {
       final dir = Directory(path);
       if (!await dir.exists()) return _FolderContentKind.empty;
-      await for (final entity
-          in dir.list(recursive: true, followLinks: false)) {
+      await for (final entity in dir.list(
+        recursive: true,
+        followLinks: false,
+      )) {
         if (entity is! File) continue;
         final lower = entity.path.toLowerCase();
         if (lower.endsWith('.txt')) {
           hasText = true;
-        } else if (lower.endsWith('.pdf') || lower.endsWith('.docx')) {
+        } else if (lower.endsWith('.pdf') ||
+            lower.endsWith('.docx') ||
+            lower.endsWith('.epub')) {
           hasBinary = true;
         }
         if (hasText && hasBinary) break;
@@ -131,8 +137,10 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
 
     final zipFiles = dir
         .listSync()
-        .where((entity) =>
-            entity is File && entity.path.toLowerCase().endsWith('.zip'))
+        .where(
+          (entity) =>
+              entity is File && entity.path.toLowerCase().endsWith('.zip'),
+        )
         .cast<File>()
         .toList();
 
@@ -155,8 +163,9 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
     // אין צורך לאפס כאן את הסיווג — ה-listener מאפס את כל הקאש בסיום
     // הסריקה (כולל חילוץ ZIP ששינה את הרכב הקבצים).
 
-    String msg =
-        SettingsMessages.folderAdded(path.split(Platform.pathSeparator).last);
+    String msg = SettingsMessages.folderAdded(
+      path.split(Platform.pathSeparator).last,
+    );
     if (zipExtracted && extractedFileName != null) {
       msg += '\n${SettingsMessages.fileExtracted(extractedFileName)}';
     }
@@ -168,7 +177,8 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
     final confirmed = await showConfirmationDialog(
       context: context,
       title: 'הסרת תיקייה',
-      content: 'האם להסיר את התיקייה "${folder.name}" מהספרייה?\n'
+      content:
+          'האם להסיר את התיקייה "${folder.name}" מהספרייה?\n'
           'הספרים יוסרו מהתוכנה, אך הקבצים המקוריים בדיסק לא יימחקו.',
       isDangerous: false,
     );
@@ -188,7 +198,8 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
       final confirmed = await showConfirmationDialog(
         context: context,
         title: 'שמירת עותק עצמאי בתוכנה',
-        content: 'עותק של תוכן הספרים יישמר בתוך התוכנה, כך שהם יעבדו גם '
+        content:
+            'עותק של תוכן הספרים יישמר בתוך התוכנה, כך שהם יעבדו גם '
             'אם הקבצים המקוריים יוזזו או יימחקו.\n'
             'הקבצים המקוריים יישארו במקומם.\n\n'
             'שים לב: אם תערוך קובץ בעתיד, יהיה עליך ללחוץ "סרוק מחדש" '
@@ -215,7 +226,9 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
 
   /// תפריט אפשרויות לתיקייה — פתיחה במנהל הקבצים, העתקת נתיב והסרה.
   Future<void> _showFolderMenu(
-      BuildContext anchorContext, CustomFolder folder) async {
+    BuildContext anchorContext,
+    CustomFolder folder,
+  ) async {
     const entries = <AppMenuEntry<_FolderMenuAction>>[
       AppMenuEntry(
         value: _FolderMenuAction.openFolder,
@@ -239,8 +252,10 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
       context: context,
       anchorContext: anchorContext,
       itemsBuilder: (m) => entries
-          .map((e) =>
-              buildAppPopupMenuItem<_FolderMenuAction>(context, e, m, null))
+          .map(
+            (e) =>
+                buildAppPopupMenuItem<_FolderMenuAction>(context, e, m, null),
+          )
           .toList(),
     );
 
@@ -299,9 +314,9 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
                       : const Icon(FluentIcons.arrow_clockwise_24_regular),
                   onPressed: isSyncing
                       ? null
-                      : () => context
-                          .read<CustomFoldersBloc>()
-                          .add(const RescanCustomFolders()),
+                      : () => context.read<CustomFoldersBloc>().add(
+                          const RescanCustomFolders(),
+                        ),
                   tooltip: 'סרוק מחדש תיקיות אישיות',
                 ),
               ActionButton.recommended(
@@ -347,14 +362,18 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
   }
 
   Widget _buildFolderItem(
-      CustomFolder folder, bool isSyncing, String? activePath) {
+    CustomFolder folder,
+    bool isSyncing,
+    String? activePath,
+  ) {
     // הספינר על תיקייה בודדת מוצג כשהפעולה נוגעת בה:
     // • כשזו התיקייה הפעילה (הוספה / החלפת מצב) — תמיד, גם אם היא מוגדרת
     //   לקריאה מהקבצים (תיקייה חדשה נוצרת עם addToDatabase=false אך עדיין
     //   נסרקת).
     // • כשהפעולה גלובלית (activePath == null, כגון סריקה מחדש או כתיבה דרך
     //   התור המשותף) — רק על תיקיות שנשמרות כעותק עצמאי, שהן אלו שנכתבות.
-    final showFolderSpinner = isSyncing &&
+    final showFolderSpinner =
+        isSyncing &&
         (activePath == folder.path ||
             (activePath == null && folder.addToDatabase));
     // מתחיל סיווג עצלן של הרכב הקבצים (פעם אחת לכל תיקייה).
@@ -410,8 +429,10 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
                 ),
               Builder(
                 builder: (buttonContext) => IconButton(
-                  icon: const Icon(FluentIcons.more_vertical_24_regular,
-                      size: 18),
+                  icon: const Icon(
+                    FluentIcons.more_vertical_24_regular,
+                    size: 18,
+                  ),
                   onPressed: isSyncing
                       ? null
                       : () => _showFolderMenu(buttonContext, folder),

--- a/lib/settings/panels/personal_books_import_panel.dart
+++ b/lib/settings/panels/personal_books_import_panel.dart
@@ -54,15 +54,17 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
   void initState() {
     super.initState();
     _service = widget.service ?? PersonalBooksImportService();
-    DatabaseLibraryProvider.operationQueue.busyCount
-        .addListener(_onQueueBusyChanged);
+    DatabaseLibraryProvider.operationQueue.busyCount.addListener(
+      _onQueueBusyChanged,
+    );
     _refreshFileList();
   }
 
   @override
   void dispose() {
-    DatabaseLibraryProvider.operationQueue.busyCount
-        .removeListener(_onQueueBusyChanged);
+    DatabaseLibraryProvider.operationQueue.busyCount.removeListener(
+      _onQueueBusyChanged,
+    );
     super.dispose();
   }
 
@@ -79,7 +81,7 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
     final result = await FilePicker.pickFiles(
       allowMultiple: true,
       type: FileType.custom,
-      allowedExtensions: const ['txt', 'pdf', 'docx'],
+      allowedExtensions: const ['txt', 'pdf', 'docx', 'epub'],
       dialogTitle: 'בחר קבצי ספרים לייבוא',
     );
     if (result == null) return null;
@@ -98,11 +100,13 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
 
       if (result.errors.isNotEmpty) {
         UiSnack.showError(
-            SettingsMessages.importErrors(result.errors.join('\n')));
+          SettingsMessages.importErrors(result.errors.join('\n')),
+        );
       }
       if (result.skippedUnsupported > 0) {
-        UiSnack.show(SettingsMessages.unsupportedFilesSkipped(
-            result.skippedUnsupported));
+        UiSnack.show(
+          SettingsMessages.unsupportedFilesSkipped(result.skippedUnsupported),
+        );
       }
       if (result.copied == 0) return;
 
@@ -112,12 +116,17 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
 
       // ההודעות על תוצאת הסריקה מגיעות מה-BLoC דרך ה-listener למטה.
       final folderPath = await _service.getFolderPath();
-      final alreadyRegistered =
-          bloc.state.folders.any((f) => f.path == folderPath);
-      bloc.add(alreadyRegistered
-          ? RescanCustomFolders(
-              showNoChangesMessage: false, onlyFolderPath: folderPath)
-          : AddCustomFolder(folderPath));
+      final alreadyRegistered = bloc.state.folders.any(
+        (f) => f.path == folderPath,
+      );
+      bloc.add(
+        alreadyRegistered
+            ? RescanCustomFolders(
+                showNoChangesMessage: false,
+                onlyFolderPath: folderPath,
+              )
+            : AddCustomFolder(folderPath),
+      );
     } finally {
       if (mounted) setState(() => _isCopying = false);
     }
@@ -143,10 +152,12 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
     }
     await _refreshFileList();
     // הסריקה מסירה מה-DB ספרים שקובצם נמחק (prune) ומרעננת את הספרייה.
-    bloc.add(RescanCustomFolders(
-      showNoChangesMessage: false,
-      onlyFolderPath: await _service.getFolderPath(),
-    ));
+    bloc.add(
+      RescanCustomFolders(
+        showNoChangesMessage: false,
+        onlyFolderPath: await _service.getFolderPath(),
+      ),
+    );
     UiSnack.show(SettingsMessages.bookDeleted(title));
   }
 
@@ -156,6 +167,8 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
         return 'PDF';
       case '.docx':
         return 'Word';
+      case '.epub':
+        return 'EPUB';
       default:
         return 'טקסט';
     }
@@ -174,14 +187,15 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
         if (!state.isSyncing) _refreshFileList();
       },
       builder: (context, state) {
-        final isBusy = _isCopying ||
+        final isBusy =
+            _isCopying ||
             state.isSyncing ||
             DatabaseLibraryProvider.operationQueue.isBusy;
         return ExpandableSection(
           icon: FluentIcons.book_add_24_regular,
           title: 'הספרים שלי',
           subtitle: _importedFiles.isEmpty
-              ? 'ייבוא קבצי TXT, PDF ו-Word לספרייה'
+              ? 'ייבוא קבצי TXT, PDF, Word ו-EPUB לספרייה'
               : '${_importedFiles.length} ספרים מיובאים',
           trailing: ActionButton.recommended(
             text: 'ייבוא ספרים',
@@ -217,8 +231,11 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
     return ListTile(
       dense: true,
       hoverColor: Colors.transparent,
-      leading:
-          RtlIcon(FluentIcons.book_24_regular, color: cs.primary, size: 20),
+      leading: RtlIcon(
+        FluentIcons.book_24_regular,
+        color: cs.primary,
+        size: 20,
+      ),
       title: Text(
         p.basenameWithoutExtension(file.path),
         style: const TextStyle(fontSize: 14),

--- a/lib/settings/services/custom_folders/personal_books_import_service.dart
+++ b/lib/settings/services/custom_folders/personal_books_import_service.dart
@@ -32,7 +32,12 @@ class PersonalBooksImportService {
   final String? _folderPathOverride;
 
   /// הסיומות שמנוע הסנכרון יודע לקלוט (תואם ל-FileSyncService).
-  static const Set<String> supportedExtensions = {'.txt', '.pdf', '.docx'};
+  static const Set<String> supportedExtensions = {
+    '.txt',
+    '.pdf',
+    '.docx',
+    '.epub',
+  };
 
   /// נתיב תיקיית הספרים האישיים.
   Future<String> getFolderPath() async =>

--- a/lib/tabs/models/tab.dart
+++ b/lib/tabs/models/tab.dart
@@ -82,17 +82,20 @@ abstract class OpenedTab {
     return tab.clone();
   }
 
-  factory OpenedTab.fromBook(Book book, int index,
-      {String searchText = '',
-      String highlightText = '',
-      int? permanentHighlightLine,
-      List<String>? commentators,
-      bool openLeftPane = false,
-      bool isPinned = false,
-      bool? showPageShapeView,
-      bool requiresStableLayout = false,
-      String? pinpointHighlight,
-      int? pinpointHighlightSectionIndex}) {
+  factory OpenedTab.fromBook(
+    Book book,
+    int index, {
+    String searchText = '',
+    String highlightText = '',
+    int? permanentHighlightLine,
+    List<String>? commentators,
+    bool openLeftPane = false,
+    bool isPinned = false,
+    bool? showPageShapeView,
+    bool requiresStableLayout = false,
+    String? pinpointHighlight,
+    int? pinpointHighlightSectionIndex,
+  }) {
     if (book is PdfBook) {
       return PdfBookTab(
         book: book,
@@ -102,11 +105,13 @@ abstract class OpenedTab {
         isPinned: isPinned,
         requiresStableLayout: requiresStableLayout,
       );
-    } else if (book is DocxBook) {
-      // DOCX רץ דרך זרימת TextBook — העטיפה דרך DocxBook.toTextBook
+    } else if (book is DocxBook || book is EpubBook) {
+      // DOCX/EPUB רצים דרך זרימת TextBook — העטיפה דרך toTextBook
       // משמרת id/categoryId/externalLibraryId שדרושים ל-LibraryProviderManager.
       return TextBookTab(
-        book: book.toTextBook(),
+        book: book is DocxBook
+            ? book.toTextBook()
+            : (book as EpubBook).toTextBook(),
         index: index,
         searchText: searchText,
         highlightText: highlightText,

--- a/lib/text_book/text_book_repository.dart
+++ b/lib/text_book/text_book_repository.dart
@@ -86,6 +86,9 @@ class TextBookRepository {
           if (ext == 'docx') {
             return await convertDocxWithCache(file, title);
           }
+          if (ext == 'epub') {
+            return await convertEpubWithCache(file, title);
+          }
           if (ext == 'pdf') return '';
           return await readTextFileSmart(file);
         }
@@ -319,6 +322,8 @@ class TextBookRepository {
           final String content;
           if (ext == 'docx') {
             content = await convertDocxWithCache(file, title);
+          } else if (ext == 'epub') {
+            content = await convertEpubWithCache(file, title);
           } else if (ext == 'pdf') {
             content = '';
           } else {

--- a/lib/utils/file/docx_cache.dart
+++ b/lib/utils/file/docx_cache.dart
@@ -7,9 +7,10 @@ import 'package:flutter/foundation.dart';
 import 'package:otzaria/data/data_providers/cache_database_holder.dart';
 import 'package:otzaria/migration/models/docx_text_cache_entry.dart';
 import 'package:otzaria/utils/file/docx_to_otzaria.dart';
+import 'package:otzaria/utils/file/epub_to_otzaria.dart';
 
-/// משך חיים של רשומת מטמון docx ללא גישה. רשומות של ספרים שלא נפתחו
-/// מעבר לפרק זמן זה מנוקות — כדי ש-`cache.db` לא יגדל ללא הגבלה (כל
+/// משך חיים של רשומת מטמון המרה (docx/epub) ללא גישה. רשומות של ספרים שלא
+/// נפתחו מעבר לפרק זמן זה מנוקות — כדי ש-`cache.db` לא יגדל ללא הגבלה (כל
 /// רשומה מכילה את טקסט הספר המלא, כולל base64 של תמונות).
 const Duration _docxCacheTtl = Duration(days: 90);
 
@@ -23,7 +24,7 @@ final Random _pruneSampler = Random();
 /// בכל פתיחה.
 bool _shouldOpportunisticPrune() => _pruneSampler.nextInt(20) == 0;
 
-/// המרות docx פעילות (מפתח: `path|size|mtime`) — מבטל המרה כפולה מקבילה
+/// המרות פעילות (מפתח: `path|size|mtime`) — מבטל המרה כפולה מקבילה
 /// כשגם `getBookContent` וגם `getBookToc` פותחים את אותו ספר *לפני*
 /// שהמטמון נכתב (פתיחה ראשונה ממש).
 final Map<String, Future<String>> _inFlight = {};
@@ -39,7 +40,20 @@ final Map<String, Future<String>> _inFlight = {};
 /// הכותרת ([title]) אינה חלק ממפתח המטמון — היא מוזרקת מחדש בכל קריאה
 /// (ראו [_withFreshTitle]), כך ששינוי שם הספר אינו פוסל את המטמון אך
 /// הכותרת המוצגת תמיד עדכנית.
-Future<String> convertDocxWithCache(File file, String title) async {
+Future<String> convertDocxWithCache(File file, String title) =>
+    _convertWithCache(file, title, kDocxConverterVersion, docxToText);
+
+/// ממיר קובץ EPUB לטקסט של אוצריא — אותו מנגנון מטמון כמו
+/// [convertDocxWithCache] (הרשומות חולקות טבלה; המפתח הוא נתיב הקובץ).
+Future<String> convertEpubWithCache(File file, String title) =>
+    _convertWithCache(file, title, kEpubConverterVersion, epubToText);
+
+Future<String> _convertWithCache(
+  File file,
+  String title,
+  int converterVersion,
+  String Function(Uint8List, String) converter,
+) async {
   final stat = await file.stat();
   final size = stat.size;
   final mtime = stat.modified.millisecondsSinceEpoch;
@@ -49,17 +63,20 @@ Future<String> convertDocxWithCache(File file, String title) async {
   try {
     final repo = await CacheDatabaseHolder.instance.repository;
     final entry = await repo.getDocxTextCacheEntry(path);
-    if (entry != null && entry.isValidFor(size, mtime, kDocxConverterVersion)) {
+    if (entry != null && entry.isValidFor(size, mtime, converterVersion)) {
       final now = DateTime.now().millisecondsSinceEpoch;
       // throttle: touch לכל היותר פעם ביום (מונע כתיבת WAL בכל פתיחה).
       if (now - entry.accessedAt > _touchThrottleMs) {
         unawaited(repo.touchDocxTextCacheEntry(path, now).catchError((_) {}));
       }
       if (_shouldOpportunisticPrune()) {
-        unawaited(repo
-            .pruneDocxTextCacheAccessedBefore(
-                now - _docxCacheTtl.inMilliseconds)
-            .catchError((_) {}));
+        unawaited(
+          repo
+              .pruneDocxTextCacheAccessedBefore(
+                now - _docxCacheTtl.inMilliseconds,
+              )
+              .catchError((_) {}),
+        );
       }
       return _withFreshTitle(entry.text, title);
     }
@@ -73,7 +90,7 @@ Future<String> convertDocxWithCache(File file, String title) async {
   final pending = _inFlight[key];
   if (pending != null) return _withFreshTitle(await pending, title);
 
-  final future = _convert(path, title);
+  final future = _convert(path, title, converter);
   _inFlight[key] = future;
   final String text;
   try {
@@ -83,37 +100,50 @@ Future<String> convertDocxWithCache(File file, String title) async {
   }
 
   // שמירה ברקע (fire-and-forget): הטקסט כבר מוכן, אין צורך להמתין ל-DB.
-  unawaited(_persist(path, size, mtime, text));
+  unawaited(_persist(path, size, mtime, converterVersion, text));
   return text;
 }
 
 /// ההמרה עצמה. ה-bytes נקראים *בתוך* ה-[Isolate.run] (לא לפניו) כדי לא
 /// להעתיק buffer גדול (עשרות MB) בין ה-main isolate ל-worker — רק הנתיב
 /// והכותרת (מחרוזות קטנות) עוברים.
-Future<String> _convert(String path, String title) {
+Future<String> _convert(
+  String path,
+  String title,
+  String Function(Uint8List, String) converter,
+) {
   return Isolate.run(() {
     final bytes = File(path).readAsBytesSync();
-    return docxToText(bytes, title);
+    return converter(bytes, title);
   });
 }
 
 /// שמירת התוצאה במטמון + ניקוי TTL. best-effort — כשל אינו פוגע בטקסט שכבר
 /// הוחזר למשתמש.
-Future<void> _persist(String path, int size, int mtime, String text) async {
+Future<void> _persist(
+  String path,
+  int size,
+  int mtime,
+  int converterVersion,
+  String text,
+) async {
   try {
     final repo = await CacheDatabaseHolder.instance.repository;
     final now = DateTime.now().millisecondsSinceEpoch;
-    await repo.upsertDocxTextCacheEntry(DocxTextCacheEntry(
-      filePath: path,
-      fileSize: size,
-      lastModified: mtime,
-      converterVersion: kDocxConverterVersion,
-      text: text,
-      createdAt: now,
-      accessedAt: now,
-    ));
-    await repo
-        .pruneDocxTextCacheAccessedBefore(now - _docxCacheTtl.inMilliseconds);
+    await repo.upsertDocxTextCacheEntry(
+      DocxTextCacheEntry(
+        filePath: path,
+        fileSize: size,
+        lastModified: mtime,
+        converterVersion: converterVersion,
+        text: text,
+        createdAt: now,
+        accessedAt: now,
+      ),
+    );
+    await repo.pruneDocxTextCacheAccessedBefore(
+      now - _docxCacheTtl.inMilliseconds,
+    );
   } catch (e) {
     debugPrint('⚠️ docx cache write failed (text still returned): $e');
   }

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -13,9 +13,9 @@ import 'package:otzaria/utils/file/docx_to_otzaria.dart' show escapeHtmlText;
 /// העלאה כאן פוסלת אוטומטית רשומות ישנות וגורמת להמרה מחדש.
 /// v2: הערות שוליים מבוססות-קישור (בלי epub:type) — זיהוי היריסטי לפי
 /// טקסט-סַמָּן, הזרקה חוצת-פרקים (קובץ הערות נפרד), ודיכוי כפילות היעד.
-const int kEpubConverterVersion = 2;
-
-ZipDecoder? _zipDecoder;
+/// v3: סינון קישורים חיצוניים (scheme), תקרת גודל לתמונות מוטמעות,
+/// וטבלאות מקוננות — שורות ישירות בלבד + רינדור רקורסיבי בתאים.
+const int kEpubConverterVersion = 3;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -26,13 +26,13 @@ ZipDecoder? _zipDecoder;
 /// מבוססות-קישור ([_resolveNoteref]) — מוצגות בפורמט ההערות של אוצריא,
 /// כמו בממיר ה-DOCX.
 String epubToText(Uint8List bytes, String title) {
-  _zipDecoder ??= ZipDecoder();
-
   final List<String> output = ['<h1>${escapeHtmlText(title)}</h1>'];
 
+  // ZipDecoder הוא stateful — מופע מקומי לכל המרה מונע דריסת מצב בין
+  // קריאות מקבילות באותו isolate.
   final Archive archive;
   try {
-    archive = _zipDecoder!.decodeBytes(bytes);
+    archive = ZipDecoder().decodeBytes(bytes);
   } catch (_) {
     // ZIP פגום — מחזירים לפחות את כותרת הספר במקום לקרוס.
     return output.join('\n');
@@ -173,11 +173,16 @@ String _dirOf(String path) {
   return i < 0 ? '' : path.substring(0, i);
 }
 
+/// href עם scheme (http:, mailto:, data:…) — יעד חיצוני לארכיון.
+final _schemeRegExp = RegExp('^[a-zA-Z][a-zA-Z0-9+.-]*:');
+
 /// פותר href יחסי (כולל percent-encoding) לנתיב מנורמל בארכיון, בלי fragment.
+/// קישור חיצוני (עם scheme) מחזיר '' — אינו קובץ בארכיון.
 String _resolveHref(String baseDir, String href) {
   var h = href;
   final hash = h.indexOf('#');
   if (hash >= 0) h = h.substring(0, hash);
+  if (_schemeRegExp.hasMatch(h)) return '';
   try {
     h = Uri.decodeFull(h);
   } catch (_) {}
@@ -272,6 +277,10 @@ String? _mediaTypeFromExtension(String path) {
   return null;
 }
 
+/// תקרת גודל לתמונה מוטמעת. הטקסט המלא (כולל ה-base64) נשמר במטמון
+/// cache.db ובזיכרון — תמונה ענקית הייתה מנפחת את שניהם; מעליה מדולגת.
+const _maxEmbeddedImageBytes = 4 * 1024 * 1024;
+
 /// נתיב מנורמל → data URI, לכל תמונות ה-manifest (עובד גם offline).
 Map<String, String> _buildImageMap(
   _ArchiveFiles files,
@@ -283,7 +292,7 @@ Map<String, String> _buildImageMap(
         _imageMediaTypes[item.mediaType] ?? _mediaTypeFromExtension(item.path);
     if (mediaType == null) continue;
     final bytes = files.read(item.path);
-    if (bytes == null) continue;
+    if (bytes == null || bytes.length > _maxEmbeddedImageBytes) continue;
     images[item.path.toLowerCase()] =
         'data:$mediaType;base64,${base64Encode(bytes)}';
   }
@@ -555,9 +564,24 @@ void _processList(
   }
 }
 
-/// טבלה → `<table>` בשורת פלט אחת (שורה=widget בקורא), כולל colspan/rowspan.
+/// שורות הטבלה הישירות בלבד (כולל דרך thead/tbody/tfoot) — לא שורות של
+/// טבלאות מקוננות בתאים, שמרונדרות רקורסיבית בתוך התא שלהן.
+List<dom.Element> _directTableRows(dom.Element table) {
+  final rows = <dom.Element>[];
+  for (final child in table.children) {
+    if (child.localName == 'tr') {
+      rows.add(child);
+    } else if (const {'thead', 'tbody', 'tfoot'}.contains(child.localName)) {
+      rows.addAll(child.children.where((e) => e.localName == 'tr'));
+    }
+  }
+  return rows;
+}
+
+/// טבלה → `<table>` בשורת פלט אחת (שורה=widget בקורא), כולל colspan/rowspan
+/// וטבלאות מקוננות בתאים.
 String? _buildTableHtml(dom.Element table, _EpubContext ctx) {
-  final rows = table.querySelectorAll('tr');
+  final rows = _directTableRows(table);
   if (rows.isEmpty) return null;
 
   final buf = StringBuffer(
@@ -573,10 +597,18 @@ String? _buildTableHtml(dom.Element table, _EpubContext ctx) {
       final rowspan = cell.attributes['rowspan'];
       if (colspan != null) attrs.write(' colspan="$colspan"');
       if (rowspan != null) attrs.write(' rowspan="$rowspan"');
-      final content = _renderInlineChildren(cell, ctx).trim();
+      final content = StringBuffer();
+      for (final node in cell.nodes) {
+        if (node is dom.Element && node.localName == 'table') {
+          final nested = _buildTableHtml(node, ctx);
+          if (nested != null) content.write(nested);
+        } else {
+          _renderInlineNode(node, ctx, content);
+        }
+      }
       buf.write(
         '<$tag$attrs style="border: 1px solid #999; padding: 4px;">'
-        '$content</$tag>',
+        '${content.toString().trim()}</$tag>',
       );
     }
     buf.write('</tr>');

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -12,7 +12,7 @@ import 'package:otzaria/utils/file/text_encoding.dart'
 
 /// גרסת הממיר [epubToText] — **חובה להעלות בכל שינוי שמשפיע על הפלט**:
 /// מטמון התוכן כולל את הגרסה במפתח-התוקף, והעלאה פוסלת רשומות ישנות.
-const int kEpubConverterVersion = 8;
+const int kEpubConverterVersion = 9;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -53,10 +53,11 @@ String epubToText(Uint8List bytes, String title) {
   final opfDir = _dirOf(opfPath);
   final manifest = _parseManifest(opf, opfDir);
   final spine = _parseSpine(opf, manifest);
+  final coverPath = _findCoverPath(opf, manifest);
 
   final ctx = _EpubContext(
     files: files,
-    images: _buildImageMap(files, manifest),
+    images: _buildImageMap(files, manifest, coverPath: coverPath),
   );
 
   // שלב 1: פירוק כל הפרקים ובניית אינדקס עוגנים (id) גלובלי — נדרש להערות
@@ -101,7 +102,34 @@ String epubToText(Uint8List bytes, String title) {
     _processBlockChildren(ch.body.nodes, ctx, output);
   }
 
+  // כריכה מוצהרת (manifest) שלא הופיעה באף פרק — למשל עמוד כריכה
+  // linear="no" שדולג — מוזרקת אחרי הכותרת, כך שהכריכה תמיד מוצגת.
+  final coverUri = coverPath == null
+      ? null
+      : ctx.images[coverPath.toLowerCase()];
+  if (coverUri != null && !output.any((l) => l.contains(coverUri))) {
+    output.insert(1, '<img src="$coverUri" style="max-width: 100%;"/>');
+  }
+
   return output.join('\n');
+}
+
+/// מאתר את תמונת הכריכה המוצהרת: EPUB3 — פריט manifest עם
+/// `properties="cover-image"`; EPUB2 — `<meta name="cover" content="id">`.
+String? _findCoverPath(
+  xml.XmlDocument opf,
+  Map<String, _ManifestItem> manifest,
+) {
+  for (final item in manifest.values) {
+    if (item.properties.split(' ').contains('cover-image')) return item.path;
+  }
+  for (final meta in _elementsByLocal(opf, 'meta')) {
+    if (meta.getAttribute('name') == 'cover') {
+      final item = manifest[meta.getAttribute('content')];
+      if (item != null) return item.path;
+    }
+  }
+  return null;
 }
 
 /// גישה לקבצי הארכיון לפי נתיב, עם fallback חסר-רגישות-לרישיות — קבצי EPUB
@@ -291,18 +319,25 @@ String? _mediaTypeFromExtension(String path) {
 /// cache.db ובזיכרון — תמונה ענקית הייתה מנפחת את שניהם; מעליה מדולגת.
 const _maxEmbeddedImageBytes = 4 * 1024 * 1024;
 
+/// תקרה מוגדלת לתמונת הכריכה — כריכות סרוקות כבדות במיוחד, ויש רק אחת.
+const _maxEmbeddedCoverBytes = 10 * 1024 * 1024;
+
 /// נתיב מנורמל → data URI, לכל תמונות ה-manifest (עובד גם offline).
 Map<String, String> _buildImageMap(
   _ArchiveFiles files,
-  Map<String, _ManifestItem> manifest,
-) {
+  Map<String, _ManifestItem> manifest, {
+  String? coverPath,
+}) {
   final images = <String, String>{};
   for (final item in manifest.values) {
     final mediaType =
         _imageMediaTypes[item.mediaType] ?? _mediaTypeFromExtension(item.path);
     if (mediaType == null) continue;
+    final maxBytes = item.path == coverPath
+        ? _maxEmbeddedCoverBytes
+        : _maxEmbeddedImageBytes;
     final bytes = files.read(item.path);
-    if (bytes == null || bytes.length > _maxEmbeddedImageBytes) continue;
+    if (bytes == null || bytes.length > maxBytes) continue;
     // ??= — המופע הראשון גובר (עקבי עם קדימות ההתאמה המדויקת בארכיון).
     images[item.path.toLowerCase()] ??=
         'data:$mediaType;base64,${base64Encode(bytes)}';
@@ -646,7 +681,9 @@ String? _buildTableHtml(dom.Element table, _EpubContext ctx) {
 }
 
 String? _imgHtml(dom.Element e, _EpubContext ctx) {
-  final src = e.attributes['src'] ?? _attr(e, 'xlink:href');
+  // גם `<image>` של SVG (עטיפת הכריכה הנפוצה) — href/xlink:href.
+  final src =
+      e.attributes['src'] ?? e.attributes['href'] ?? _attr(e, 'xlink:href');
   if (src == null || src.isEmpty) return null;
   final resolved = _resolveHref(ctx.baseDir, src).toLowerCase();
   final uri = ctx.images[resolved];
@@ -689,7 +726,7 @@ void _renderInlineNode(dom.Node node, _EpubContext ctx, StringBuffer buf) {
     buf.write('<br>');
     return;
   }
-  if (tag == 'img') {
+  if (tag == 'img' || tag == 'image') {
     final img = _imgHtml(node, ctx);
     if (img != null) buf.write(img);
     return;

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -12,7 +12,7 @@ import 'package:otzaria/utils/file/text_encoding.dart'
 
 /// גרסת הממיר [epubToText] — **חובה להעלות בכל שינוי שמשפיע על הפלט**:
 /// מטמון התוכן כולל את הגרסה במפתח-התוקף, והעלאה פוסלת רשומות ישנות.
-const int kEpubConverterVersion = 9;
+const int kEpubConverterVersion = 10;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -84,6 +84,24 @@ String epubToText(Uint8List bytes, String title) {
     }
   }
 
+  // כותרות מה-TOC של הספר (NCX/nav) — לספרים שפרקיהם בלי תגיות כותרת:
+  // רשומה בלי עוגן ממופה לתחילת הפרק, רשומה עם עוגן — לבלוק היעד.
+  final chapterTocHeading = <String, (String, int)>{};
+  for (final t in _parseTocEntries(files, manifest)) {
+    final level = (t.depth + 1).clamp(2, 6).toInt();
+    if (t.fragment == null || t.fragment!.isEmpty) {
+      chapterTocHeading.putIfAbsent(t.pathLower, () => (t.title, level));
+    } else {
+      dom.Element? el = ctx.anchors['${t.pathLower}#${t.fragment}'];
+      // עוגן inline (למשל <a id>) — מטפסים לבלוק העוטף, שם מקום הכותרת.
+      while (el != null && !_isBlockElement(el)) {
+        el = el.parent;
+      }
+      if (el == null || _headingTags.contains(el.localName)) continue;
+      ctx.tocHeadings.putIfAbsent(el, () => (t.title, level));
+    }
+  }
+
   // שלב 2: סריקה מקדימה — סימון יעדי הערות לדיכוי, לפני הרינדור, כדי
   // שגוף הערה לא יופיע פעמיים גם כשהיעד קודם להפניה בסדר הפרקים.
   for (final ch in chapters) {
@@ -99,8 +117,10 @@ String epubToText(Uint8List bytes, String title) {
   for (final ch in chapters) {
     ctx.baseDir = _dirOf(ch.path);
     ctx.chapterPath = ch.path;
+    ctx.pendingChapterHeading = chapterTocHeading[ch.path.toLowerCase()];
     _processBlockChildren(ch.body.nodes, ctx, output);
   }
+  ctx.pendingChapterHeading = null;
 
   // כריכה מוצהרת (manifest) שלא הופיעה באף פרק — למשל עמוד כריכה
   // linear="no" שדולג — מוזרקת אחרי הכותרת, כך שהכריכה תמיד מוצגת.
@@ -112,6 +132,133 @@ String epubToText(Uint8List bytes, String title) {
   }
 
   return output.join('\n');
+}
+
+/// רשומת תוכן-עניינים מ-NCX/nav: יעד (נתיב+עוגן), כותרת ועומק קינון.
+class _TocRef {
+  final String pathLower;
+  final String? fragment;
+  final String title;
+  final int depth;
+  const _TocRef(this.pathLower, this.fragment, this.title, this.depth);
+}
+
+xml.XmlElement? _childByLocal(xml.XmlElement parent, String local) {
+  for (final c in parent.childElements) {
+    if (c.name.local == local) return c;
+  }
+  return null;
+}
+
+/// קורא את רשומות ה-TOC של הספר: קודם מסמך הניווט של EPUB3 (`nav`), ואם
+/// אין — `toc.ncx` של EPUB2. משמש לסינתוז כותרות בספרים שפרקיהם בלי
+/// תגיות `<h1>`–`<h6>` (שמהן נבנה תוכן העניינים של אוצריא).
+List<_TocRef> _parseTocEntries(
+  _ArchiveFiles files,
+  Map<String, _ManifestItem> manifest,
+) {
+  final entries = <_TocRef>[];
+
+  void addEntry(String baseDir, String href, String title, int depth) {
+    if (title.isEmpty || href.isEmpty) return;
+    final hash = href.indexOf('#');
+    final fragment = hash >= 0 ? href.substring(hash + 1) : null;
+    final path = _resolveHref(baseDir, href);
+    if (path.isEmpty) return;
+    entries.add(_TocRef(path.toLowerCase(), fragment, title, depth));
+  }
+
+  // EPUB3: מסמך ניווט (properties="nav") — עץ <ol>/<li>/<a>.
+  for (final item in manifest.values) {
+    if (!item.properties.split(' ').contains('nav')) continue;
+    final bytes = files.read(item.path);
+    if (bytes == null) break;
+    final dom.Document doc;
+    try {
+      doc = html_parser.parse(_decodeBytes(bytes));
+    } catch (_) {
+      break;
+    }
+    final navBase = _dirOf(item.path);
+    dom.Element? toc;
+    for (final nav in doc.querySelectorAll('nav')) {
+      if (_hasEpubType(nav, const {'toc'})) {
+        toc = nav;
+        break;
+      }
+      toc ??= nav;
+    }
+    if (toc == null) break;
+
+    void walkOl(dom.Element ol, int depth) {
+      for (final li in ol.children.where((e) => e.localName == 'li')) {
+        dom.Element? link;
+        dom.Element? childOl;
+        for (final c in li.children) {
+          if (c.localName == 'a' && link == null) link = c;
+          if (c.localName == 'ol' && childOl == null) childOl = c;
+        }
+        if (link != null) {
+          addEntry(
+            navBase,
+            link.attributes['href'] ?? '',
+            _collapseWhitespace(link.text).trim(),
+            depth,
+          );
+        }
+        if (childOl != null) walkOl(childOl, depth + 1);
+      }
+    }
+
+    for (final ol in toc.children.where((e) => e.localName == 'ol')) {
+      walkOl(ol, 1);
+    }
+    break;
+  }
+  if (entries.isNotEmpty) return entries;
+
+  // EPUB2: קובץ NCX — עץ <navMap>/<navPoint>.
+  for (final item in manifest.values) {
+    final isNcx =
+        item.mediaType == 'application/x-dtbncx+xml' ||
+        item.path.toLowerCase().endsWith('.ncx');
+    if (!isNcx) continue;
+    final bytes = files.read(item.path);
+    if (bytes == null) break;
+    final xml.XmlDocument doc;
+    try {
+      doc = xml.XmlDocument.parse(_decodeBytes(bytes));
+    } catch (_) {
+      break;
+    }
+    final ncxBase = _dirOf(item.path);
+
+    void walkNavPoints(Iterable<xml.XmlElement> elements, int depth) {
+      for (final np in elements.where((e) => e.name.local == 'navPoint')) {
+        final label = _childByLocal(np, 'navLabel');
+        final text = label == null ? null : _childByLocal(label, 'text');
+        final src = _childByLocal(np, 'content')?.getAttribute('src');
+        if (text != null && src != null) {
+          addEntry(
+            ncxBase,
+            src,
+            _collapseWhitespace(text.innerText).trim(),
+            depth,
+          );
+        }
+        walkNavPoints(np.childElements, depth + 1);
+      }
+    }
+
+    for (final el in doc.descendantElements) {
+      if (el.name.local == 'navMap') {
+        walkNavPoints(el.childElements, 1);
+        break;
+      }
+    }
+    break;
+  }
+  return entries;
 }
 
 /// מאתר את תמונת הכריכה המוצהרת: EPUB3 — פריט manifest עם
@@ -171,6 +318,13 @@ class _EpubContext {
 
   /// מטמון סיווג ההפניות — הסריקה המקדימה והרינדור עוברים על אותם קישורים.
   final Map<dom.Element, _NoterefResolution?> noterefCache = {};
+
+  /// בלוק-יעד של רשומת TOC (עוגן) → (כותרת, רמה) לסינתוז לפני הבלוק —
+  /// לספרים שמבנה הפרקים שלהם מוגדר ב-NCX/nav ולא בתגיות כותרת.
+  final Map<dom.Element, (String, int)> tocHeadings = {};
+
+  /// כותרת-פרק מה-TOC הממתינה לבלוק הראשון של הפרק הנוכחי.
+  (String, int)? pendingChapterHeading;
 
   String baseDir = '';
   String chapterPath = '';
@@ -498,7 +652,15 @@ void _processBlockChildren(
     }
     inlineRun.clear();
     final text = buf.toString().trim();
-    if (text.isNotEmpty) output.add(text);
+    if (text.isEmpty) return;
+    // תוכן inline ראשון בפרק — פולט לפניו כותרת-פרק ממתינה מה-TOC.
+    final pending = ctx.pendingChapterHeading;
+    if (pending != null) {
+      ctx.pendingChapterHeading = null;
+      output.add(_tocHeadingLine(pending));
+      if (_isDupOfSynthesized(text, pending.$1)) return;
+    }
+    output.add(text);
   }
 
   for (final node in nodes) {
@@ -524,6 +686,32 @@ void _processBlockElement(
   }
 
   final tag = e.localName ?? '';
+  final isHeading = _headingTags.contains(tag);
+  const leafTags = {
+    'p', 'figcaption', 'summary', 'dt', 'dd', 'pre', //
+    'ol', 'ul', 'table', 'img', 'hr',
+  };
+  final isTransparentWrapper =
+      !isHeading && !leafTags.contains(tag) && _containsBlockChildren(e);
+
+  // כותרות מסונתזות מה-TOC (ספרים בלי תגיות כותרת): כותרת-עוגן נפלטת לפני
+  // בלוק היעד, וכותרת-פרק ממתינה — לפני הבלוק הראשון שאינו עטיפה. פרק
+  // שנפתח בכותרת אמיתית מייתר את הסינתוז.
+  String? synthesizedTitle;
+  final anchorHeading = ctx.tocHeadings.remove(e);
+  if (isHeading) {
+    ctx.pendingChapterHeading = null;
+  } else if (anchorHeading != null) {
+    ctx.pendingChapterHeading = null;
+    output.add(_tocHeadingLine(anchorHeading));
+    synthesizedTitle = anchorHeading.$1;
+  } else if (!isTransparentWrapper && ctx.pendingChapterHeading != null) {
+    final pending = ctx.pendingChapterHeading!;
+    ctx.pendingChapterHeading = null;
+    output.add(_tocHeadingLine(pending));
+    synthesizedTitle = pending.$1;
+  }
+
   switch (tag) {
     case 'h1':
     case 'h2':
@@ -543,7 +731,8 @@ void _processBlockElement(
     case 'dd':
     case 'pre':
       final text = _renderInlineChildren(e, ctx).trim();
-      if (text.isNotEmpty) output.add(text);
+      if (text.isEmpty || _isDupOfSynthesized(text, synthesizedTitle)) return;
+      output.add(text);
     case 'ol':
       _processList(e, ctx, output, ordered: true, depth: 0);
     case 'ul':
@@ -561,7 +750,8 @@ void _processBlockElement(
         _processBlockChildren(e.nodes, ctx, output);
       } else {
         final text = _renderInlineChildren(e, ctx).trim();
-        if (text.isNotEmpty) output.add(text);
+        if (text.isEmpty || _isDupOfSynthesized(text, synthesizedTitle)) return;
+        output.add(text);
       }
     default:
       // div/section/article/aside/figure וכו' — עטיפות שקופות: יורדים
@@ -570,9 +760,21 @@ void _processBlockElement(
         _processBlockChildren(e.nodes, ctx, output);
       } else {
         final text = _renderInlineChildren(e, ctx).trim();
-        if (text.isNotEmpty) output.add(text);
+        if (text.isEmpty || _isDupOfSynthesized(text, synthesizedTitle)) return;
+        output.add(text);
       }
   }
+}
+
+String _tocHeadingLine((String, int) heading) =>
+    '<h${heading.$2}>${escapeHtmlText(heading.$1)}</h${heading.$2}>';
+
+/// האם הבלוק הוא רק כפילות של הכותרת שסונתזה זה-עתה מה-TOC (פסקת-כותרת
+/// מעוצבת שממנה נלקחה הכותרת) — ואז מדלגים עליו למניעת טקסט כפול.
+bool _isDupOfSynthesized(String blockHtml, String? synthesizedTitle) {
+  if (synthesizedTitle == null) return false;
+  final plain = blockHtml.replaceAll(RegExp(r'<[^>]*>'), '').trim();
+  return plain == synthesizedTitle.trim();
 }
 
 /// רשימות מרונדרות כשורות עם קידומת והזחה לפי עומק — לא `<ol>`/`<ul>`

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -12,7 +12,7 @@ import 'package:otzaria/utils/file/text_encoding.dart'
 
 /// גרסת הממיר [epubToText] — **חובה להעלות בכל שינוי שמשפיע על הפלט**:
 /// מטמון התוכן כולל את הגרסה במפתח-התוקף, והעלאה פוסלת רשומות ישנות.
-const int kEpubConverterVersion = 7;
+const int kEpubConverterVersion = 8;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -192,6 +192,8 @@ String _resolveHref(String baseDir, String href) {
     h = Uri.decodeFull(h);
   } catch (_) {}
   if (h.isEmpty) return '';
+  // נתיב שורש-מוחלט ('/x') נפתר משורש הארכיון, לא מתיקיית הפרק.
+  if (h.startsWith('/')) return _normalizePath(h);
   return _normalizePath(baseDir.isEmpty ? h : '$baseDir/$h');
 }
 
@@ -251,12 +253,15 @@ List<String> _parseSpine(
   Map<String, _ManifestItem> manifest,
 ) {
   final result = <String>[];
+  final seen = <String>{};
   for (final itemref in _elementsByLocal(opf, 'itemref')) {
     if (itemref.getAttribute('linear') == 'no') continue;
     final idref = itemref.getAttribute('idref');
     final item = idref != null ? manifest[idref] : null;
     if (item == null) continue;
     if (item.properties.split(' ').contains('nav')) continue;
+    // spine פגום שמפנה לאותו קובץ פעמיים — בלי הסינון התוכן היה מוכפל.
+    if (!seen.add(item.path)) continue;
     result.add(item.path);
   }
   return result;
@@ -298,7 +303,8 @@ Map<String, String> _buildImageMap(
     if (mediaType == null) continue;
     final bytes = files.read(item.path);
     if (bytes == null || bytes.length > _maxEmbeddedImageBytes) continue;
-    images[item.path.toLowerCase()] =
+    // ??= — המופע הראשון גובר (עקבי עם קדימות ההתאמה המדויקת בארכיון).
+    images[item.path.toLowerCase()] ??=
         'data:$mediaType;base64,${base64Encode(bytes)}';
   }
   return images;
@@ -378,10 +384,15 @@ _NoterefResolution? _resolveNoterefUncached(dom.Element a, _EpubContext ctx) {
   if (isExplicit) return _NoterefResolution(target);
   if (target == null) return null;
   if (_hasEpubType(target, _footnoteTypes)) return _NoterefResolution(target);
+  // כותרות הן יעדי ניווט, לא גופי הערות — בלי הבדיקה קישור-סַמָּן קצר
+  // לכותרת קצרה היה מעלים אותה מהספר ומתוכן העניינים.
+  if (_headingTags.contains(target.localName)) return null;
   if (!_isNoteMarkerText(a.text)) return null;
   if (target.text.length > _maxHeuristicNoteLength) return null;
   return _NoterefResolution(target);
 }
+
+const _headingTags = {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'};
 
 /// שולף את טקסט ההערה מהיעד: מדלג על קישורי-חזרה (סַמָּן/חץ), ומסיר סַמָּן
 /// פותח שמשכפל את סמן ההפניה (ההערה "1. גוף" כשהקישור הוא "1").

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -326,9 +326,9 @@ const _maxHeuristicNoteLength = 1000;
 /// טקסט-סַמָּן של הפניית הערה: מספר, כוכבית/פגיון, אות בודדת, או אות/יות
 /// עבריות עם גרש/גרשיים (א׳, י"א) — אופציונלית בסוגריים ([1], (א)).
 final _noteMarkerRegExp = RegExp(
-  '^[\\[\\(]?([0-9]{1,4}|[*†‡§]|[a-zA-Z]|'
-  "[א-ת]{1,2}[\"״]?[א-ת]?[׳']?)"
-  '[\\]\\)]?\$',
+  r'^[\[\(]?([0-9]{1,4}|[*†‡§]|[a-zA-Z]|'
+  "[א-ת]{1,2}[\"״]?[א-ת]?[׳']?"
+  r')[\]\)]?$',
 );
 
 bool _isNoteMarkerText(String raw) {
@@ -394,10 +394,10 @@ String _extractNoteBody(dom.Element target, String marker) {
   walk(target);
   var text = _collapseWhitespace(buf.toString()).trim();
 
-  final core = marker.replaceAll(RegExp('^[\\[\\(]+|[\\]\\)]+\$'), '');
+  final core = marker.replaceAll(RegExp(r'^[\[\(]+|[\]\)]+$'), '');
   if (core.isNotEmpty) {
     text = text.replaceFirst(
-      RegExp('^[\\[\\(]?${RegExp.escape(core)}[\\]\\)]?[\\s.,:;\\)\\-]+'),
+      RegExp(r'^[\[\(]?' + RegExp.escape(core) + r'[\]\)]?[\s.,:;)\-]+'),
       '',
     );
   }

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -12,7 +12,7 @@ import 'package:otzaria/utils/file/text_encoding.dart'
 
 /// גרסת הממיר [epubToText] — **חובה להעלות בכל שינוי שמשפיע על הפלט**:
 /// מטמון התוכן כולל את הגרסה במפתח-התוקף, והעלאה פוסלת רשומות ישנות.
-const int kEpubConverterVersion = 6;
+const int kEpubConverterVersion = 7;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -185,6 +185,8 @@ String _resolveHref(String baseDir, String href) {
   var h = href;
   final hash = h.indexOf('#');
   if (hash >= 0) h = h.substring(0, hash);
+  final query = h.indexOf('?');
+  if (query >= 0) h = h.substring(0, query);
   if (_schemeRegExp.hasMatch(h)) return '';
   try {
     h = Uri.decodeFull(h);
@@ -343,6 +345,9 @@ bool _isNoteMarkerText(String raw) {
 /// קישור-חזרה בתוך גוף הערה (חץ/סימן שמוביל בחזרה לטקסט) — מדולג בשליפה.
 final _backlinkSymbolRegExp = RegExp('^[↩↵⤴⤶←→↑⬆^«»]+\$');
 
+/// סוגריים עוטפים של סַמָּן הערה — להסרה לפני השוואה לגוף ההערה.
+final _markerTrimRegExp = RegExp(r'^[\[\(]+|[\]\)]+$');
+
 /// יעד הפניית הערה שנפתר. [target] יכול להיות null עבור `epub:type="noteref"`
 /// מפורש שהעוגן שלו חסר — עדיין מרונדר כסמן, רק בלי גוף.
 class _NoterefResolution {
@@ -400,7 +405,7 @@ String _extractNoteBody(dom.Element target, String marker) {
   walk(target);
   var text = _collapseWhitespace(buf.toString()).trim();
 
-  final core = marker.replaceAll(RegExp(r'^[\[\(]+|[\]\)]+$'), '');
+  final core = marker.replaceAll(_markerTrimRegExp, '');
   if (core.isNotEmpty) {
     text = text.replaceFirst(
       RegExp(r'^[\[\(]?' + RegExp.escape(core) + r'[\]\)]?[\s.,:;)\-]+'),

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -1,0 +1,677 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart' as html_parser;
+import 'package:xml/xml.dart' as xml;
+
+import 'package:otzaria/utils/file/docx_to_otzaria.dart' show escapeHtmlText;
+
+/// גרסת הממיר [epubToText]. **חובה להעלות ערך זה בכל שינוי שמשפיע על הפלט**
+/// (עיצוב, כותרות, תמונות, טבלאות…). מטמון התוכן כולל את הגרסה במפתח-התוקף:
+/// העלאה כאן פוסלת אוטומטית רשומות ישנות וגורמת להמרה מחדש.
+/// v2: הערות שוליים מבוססות-קישור (בלי epub:type) — זיהוי היריסטי לפי
+/// טקסט-סַמָּן, הזרקה חוצת-פרקים (קובץ הערות נפרד), ודיכוי כפילות היעד.
+const int kEpubConverterVersion = 2;
+
+ZipDecoder? _zipDecoder;
+
+/// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
+/// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
+///
+/// כותרות הפרקים (h1–h6 שבמקור) מוסטות רמה אחת מטה (h1→h2…) כך ששם הספר
+/// נשאר הכותרת הראשית היחידה — ומהן נבנה תוכן העניינים (TocParser).
+/// תמונות מוטמעות כ-data URI, והערות שוליים — סמנטיות (epub:type) או
+/// מבוססות-קישור ([_resolveNoteref]) — מוצגות בפורמט ההערות של אוצריא,
+/// כמו בממיר ה-DOCX.
+String epubToText(Uint8List bytes, String title) {
+  _zipDecoder ??= ZipDecoder();
+
+  final List<String> output = ['<h1>${escapeHtmlText(title)}</h1>'];
+
+  final Archive archive;
+  try {
+    archive = _zipDecoder!.decodeBytes(bytes);
+  } catch (_) {
+    // ZIP פגום — מחזירים לפחות את כותרת הספר במקום לקרוס.
+    return output.join('\n');
+  }
+
+  final files = _ArchiveFiles(archive);
+
+  final opfPath = _findOpfPath(files);
+  if (opfPath == null) return output.join('\n');
+
+  final opfBytes = files.read(opfPath);
+  if (opfBytes == null) return output.join('\n');
+
+  final xml.XmlDocument opf;
+  try {
+    opf = xml.XmlDocument.parse(_decodeUtf8(opfBytes));
+  } catch (_) {
+    return output.join('\n');
+  }
+
+  final opfDir = _dirOf(opfPath);
+  final manifest = _parseManifest(opf, opfDir);
+  final spine = _parseSpine(opf, manifest);
+
+  final ctx = _EpubContext(
+    files: files,
+    images: _buildImageMap(files, manifest),
+  );
+
+  // שלב 1: פירוק כל הפרקים ובניית אינדקס עוגנים (id) גלובלי — נדרש להערות
+  // שוליים שגופן יושב בפרק אחר (קובץ הערות נפרד).
+  final chapters = <({String path, dom.Element body})>[];
+  for (final itemPath in spine) {
+    final chapterBytes = files.read(itemPath);
+    if (chapterBytes == null) continue;
+
+    final dom.Document doc;
+    try {
+      doc = html_parser.parse(_decodeUtf8(chapterBytes));
+    } catch (_) {
+      continue; // פרק פגום — ממשיכים לפרק הבא במקום לקרוס.
+    }
+
+    final body = doc.body;
+    if (body == null) continue;
+
+    chapters.add((path: itemPath, body: body));
+    for (final e in body.querySelectorAll('[id]')) {
+      if (e.id.isEmpty) continue;
+      ctx.anchors.putIfAbsent('${itemPath.toLowerCase()}#${e.id}', () => e);
+    }
+  }
+
+  // שלב 2: סריקה מקדימה — סימון יעדי הערות לדיכוי, לפני הרינדור, כדי
+  // שגוף הערה לא יופיע פעמיים גם כשהיעד קודם להפניה בסדר הפרקים.
+  for (final ch in chapters) {
+    ctx.baseDir = _dirOf(ch.path);
+    ctx.chapterPath = ch.path;
+    for (final a in ch.body.querySelectorAll('a')) {
+      final target = _resolveNoteref(a, ctx)?.target;
+      if (target != null) ctx.consumedNotes.add(target);
+    }
+  }
+
+  // שלב 3: רינדור.
+  for (final ch in chapters) {
+    ctx.baseDir = _dirOf(ch.path);
+    ctx.chapterPath = ch.path;
+    _processBlockChildren(ch.body.nodes, ctx, output);
+  }
+
+  return output.join('\n');
+}
+
+/// גישה לקבצי הארכיון לפי נתיב, עם fallback חסר-רגישות-לרישיות — קבצי EPUB
+/// מהשטח לא תמיד עקביים ברישיות בין ה-OPF לשמות הקבצים בפועל.
+class _ArchiveFiles {
+  final Map<String, ArchiveFile> _byPath = {};
+  final Map<String, ArchiveFile> _byLowerPath = {};
+
+  _ArchiveFiles(Archive archive) {
+    for (final file in archive) {
+      if (!file.isFile) continue;
+      final normalized = _normalizePath(file.name);
+      _byPath[normalized] = file;
+      _byLowerPath[normalized.toLowerCase()] = file;
+    }
+  }
+
+  List<int>? read(String path) {
+    final file = _byPath[path] ?? _byLowerPath[path.toLowerCase()];
+    return file?.content;
+  }
+
+  Iterable<String> get paths => _byPath.keys;
+}
+
+/// משאבי הספר המשותפים לעיבוד הפרקים: מפת תמונות, אינדקס עוגנים גלובלי,
+/// יעדי הערות שסומנו לדיכוי, והפרק הנוכחי (לפתרון נתיבים יחסיים).
+class _EpubContext {
+  final _ArchiveFiles files;
+
+  /// נתיב מנורמל בארכיון → `data:image/...;base64,...` מוכן להטמעה.
+  final Map<String, String> images;
+
+  /// `path#id` (path באותיות קטנות) → האלמנט, מכל פרקי ה-spine.
+  final Map<String, dom.Element> anchors = {};
+
+  /// יעדי הערות שגופן מוזרק בנקודת ההפניה — מדולגים ברינדור (מניעת כפילות).
+  final Set<dom.Element> consumedNotes = {};
+
+  String baseDir = '';
+  String chapterPath = '';
+  int footnoteCounter = 1;
+
+  _EpubContext({required this.files, required this.images});
+}
+
+String _decodeUtf8(List<int> bytes) => utf8.decode(bytes, allowMalformed: true);
+
+/// מנרמל נתיב בתוך הארכיון: מפריד `/`, פתרון `.`/`..`, והסרת `/` מוביל.
+String _normalizePath(String path) {
+  final parts = path.replaceAll('\\', '/').split('/');
+  final resolved = <String>[];
+  for (final part in parts) {
+    if (part.isEmpty || part == '.') continue;
+    if (part == '..') {
+      if (resolved.isNotEmpty) resolved.removeLast();
+      continue;
+    }
+    resolved.add(part);
+  }
+  return resolved.join('/');
+}
+
+String _dirOf(String path) {
+  final i = path.lastIndexOf('/');
+  return i < 0 ? '' : path.substring(0, i);
+}
+
+/// פותר href יחסי (כולל percent-encoding) לנתיב מנורמל בארכיון, בלי fragment.
+String _resolveHref(String baseDir, String href) {
+  var h = href;
+  final hash = h.indexOf('#');
+  if (hash >= 0) h = h.substring(0, hash);
+  try {
+    h = Uri.decodeFull(h);
+  } catch (_) {}
+  if (h.isEmpty) return '';
+  return _normalizePath(baseDir.isEmpty ? h : '$baseDir/$h');
+}
+
+/// איטרציה על אלמנטים לפי שם מקומי, בלי תלות ב-namespace prefix —
+/// container.xml וה-OPF מגיעים עם default namespaces משתנים בין קבצים.
+Iterable<xml.XmlElement> _elementsByLocal(xml.XmlNode root, String local) =>
+    root.descendantElements.where((e) => e.name.local == local);
+
+/// מאתר את נתיב קובץ ה-OPF דרך `META-INF/container.xml`, עם fallback לחיפוש
+/// ישיר של קובץ `.opf` בארכיון (קבצים שאינם תקניים לגמרי).
+String? _findOpfPath(_ArchiveFiles files) {
+  final containerBytes = files.read('META-INF/container.xml');
+  if (containerBytes != null) {
+    try {
+      final doc = xml.XmlDocument.parse(_decodeUtf8(containerBytes));
+      for (final rootfile in _elementsByLocal(doc, 'rootfile')) {
+        final fullPath = rootfile.getAttribute('full-path');
+        if (fullPath != null && fullPath.isNotEmpty) {
+          return _normalizePath(fullPath);
+        }
+      }
+    } catch (_) {}
+  }
+  for (final path in files.paths) {
+    if (path.toLowerCase().endsWith('.opf')) return path;
+  }
+  return null;
+}
+
+class _ManifestItem {
+  final String path;
+  final String mediaType;
+  final String properties;
+  const _ManifestItem(this.path, this.mediaType, this.properties);
+}
+
+/// `id` → פריט manifest עם נתיב פתור (יחסית לתיקיית ה-OPF).
+Map<String, _ManifestItem> _parseManifest(xml.XmlDocument opf, String opfDir) {
+  final items = <String, _ManifestItem>{};
+  for (final item in _elementsByLocal(opf, 'item')) {
+    final id = item.getAttribute('id');
+    final href = item.getAttribute('href');
+    if (id == null || href == null) continue;
+    items[id] = _ManifestItem(
+      _resolveHref(opfDir, href),
+      item.getAttribute('media-type') ?? '',
+      item.getAttribute('properties') ?? '',
+    );
+  }
+  return items;
+}
+
+/// נתיבי פרקי התוכן לפי סדר ה-spine. פריטי `linear="no"` ומסמך הניווט
+/// (`properties="nav"`) מדולגים — הם עמודי עזר, לא תוכן הספר.
+List<String> _parseSpine(
+  xml.XmlDocument opf,
+  Map<String, _ManifestItem> manifest,
+) {
+  final result = <String>[];
+  for (final itemref in _elementsByLocal(opf, 'itemref')) {
+    if (itemref.getAttribute('linear') == 'no') continue;
+    final idref = itemref.getAttribute('idref');
+    final item = idref != null ? manifest[idref] : null;
+    if (item == null) continue;
+    if (item.properties.split(' ').contains('nav')) continue;
+    result.add(item.path);
+  }
+  return result;
+}
+
+const _imageMediaTypes = {
+  'image/jpeg': 'image/jpeg',
+  'image/png': 'image/png',
+  'image/gif': 'image/gif',
+  'image/svg+xml': 'image/svg+xml',
+  'image/webp': 'image/webp',
+  'image/bmp': 'image/bmp',
+};
+
+String? _mediaTypeFromExtension(String path) {
+  final lower = path.toLowerCase();
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.svg')) return 'image/svg+xml';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.bmp')) return 'image/bmp';
+  return null;
+}
+
+/// נתיב מנורמל → data URI, לכל תמונות ה-manifest (עובד גם offline).
+Map<String, String> _buildImageMap(
+  _ArchiveFiles files,
+  Map<String, _ManifestItem> manifest,
+) {
+  final images = <String, String>{};
+  for (final item in manifest.values) {
+    final mediaType =
+        _imageMediaTypes[item.mediaType] ?? _mediaTypeFromExtension(item.path);
+    if (mediaType == null) continue;
+    final bytes = files.read(item.path);
+    if (bytes == null) continue;
+    images[item.path.toLowerCase()] =
+        'data:$mediaType;base64,${base64Encode(bytes)}';
+  }
+  return images;
+}
+
+/// ערך מאפיין גם כשהמפתח אינו String רגיל (package:html שומר מאפייני
+/// namespace כמו `epub:type` תחת מפתח מסוג AttributeName).
+String? _attr(dom.Element e, String name) {
+  final direct = e.attributes[name];
+  if (direct != null) return direct;
+  for (final entry in e.attributes.entries) {
+    if (entry.key.toString() == name) return entry.value;
+  }
+  return null;
+}
+
+const _footnoteTypes = {'footnote', 'rearnote', 'endnote'};
+
+bool _hasEpubType(dom.Element e, Set<String> types) {
+  final t = _attr(e, 'epub:type');
+  if (t == null) return false;
+  return t.split(' ').any(types.contains);
+}
+
+/// תקרת אורך (בתווים) ליעד של הערה *היריסטית*. קישור-סַמָּן מספרי עלול
+/// להצביע גם על פרק שלם (עמוד תוכן עניינים ממוספר) — יעד ארוך מכך אינו
+/// הערה, והקישור נשאר טקסט רגיל בלי לדכא את היעד.
+const _maxHeuristicNoteLength = 1000;
+
+/// טקסט-סַמָּן של הפניית הערה: מספר, כוכבית/פגיון, אות בודדת, או אות/יות
+/// עבריות עם גרש/גרשיים (א׳, י"א) — אופציונלית בסוגריים ([1], (א)).
+final _noteMarkerRegExp = RegExp(
+  '^[\\[\\(]?([0-9]{1,4}|[*†‡§]|[a-zA-Z]|'
+  "[א-ת]{1,2}[\"״]?[א-ת]?[׳']?)"
+  '[\\]\\)]?\$',
+);
+
+bool _isNoteMarkerText(String raw) {
+  final t = _collapseWhitespace(raw).trim();
+  if (t.isEmpty || t.length > 6) return false;
+  return _noteMarkerRegExp.hasMatch(t);
+}
+
+/// קישור-חזרה בתוך גוף הערה (חץ/סימן שמוביל בחזרה לטקסט) — מדולג בשליפה.
+final _backlinkSymbolRegExp = RegExp('^[↩↵⤴⤶←→↑⬆^«»]+\$');
+
+/// יעד הפניית הערה שנפתר. [target] יכול להיות null עבור `epub:type="noteref"`
+/// מפורש שהעוגן שלו חסר — עדיין מרונדר כסמן, רק בלי גוף.
+class _NoterefResolution {
+  final dom.Element? target;
+  const _NoterefResolution(this.target);
+}
+
+/// מסווג קישור כהפניית הערת שוליים ומאתר את גוף ההערה. שלושה מסלולים:
+/// `epub:type="noteref"` מפורש; יעד שהוא הערה סמנטית (`epub:type="footnote"`);
+/// או היריסטיקה — טקסט-סַמָּן קצר ([_isNoteMarkerText]) שמצביע לעוגן קיים
+/// ולא-ארוך. מחזיר null כשהקישור אינו הערה.
+_NoterefResolution? _resolveNoteref(dom.Element a, _EpubContext ctx) {
+  final href = a.attributes['href'] ?? '';
+  final hash = href.indexOf('#');
+  final id = hash >= 0 ? href.substring(hash + 1) : '';
+  final isExplicit = _hasEpubType(a, const {'noteref'});
+  if (id.isEmpty) return isExplicit ? const _NoterefResolution(null) : null;
+
+  final pathPart = hash > 0 ? href.substring(0, hash) : '';
+  final targetPath = pathPart.isEmpty
+      ? ctx.chapterPath
+      : _resolveHref(ctx.baseDir, href);
+  final target = ctx.anchors['${targetPath.toLowerCase()}#$id'];
+
+  if (isExplicit) return _NoterefResolution(target);
+  if (target == null) return null;
+  if (_hasEpubType(target, _footnoteTypes)) return _NoterefResolution(target);
+  if (!_isNoteMarkerText(a.text)) return null;
+  if (target.text.length > _maxHeuristicNoteLength) return null;
+  return _NoterefResolution(target);
+}
+
+/// שולף את טקסט ההערה מהיעד: מדלג על קישורי-חזרה (סַמָּן/חץ), ומסיר סַמָּן
+/// פותח שמשכפל את סמן ההפניה (ההערה "1. גוף" כשהקישור הוא "1").
+String _extractNoteBody(dom.Element target, String marker) {
+  final buf = StringBuffer();
+  void walk(dom.Node node) {
+    if (node is dom.Text) {
+      buf.write(node.data);
+      return;
+    }
+    if (node is! dom.Element) return;
+    final tag = node.localName ?? '';
+    if (tag == 'script' || tag == 'style') return;
+    if (tag == 'a') {
+      final t = _collapseWhitespace(node.text).trim();
+      if (_isNoteMarkerText(t) || _backlinkSymbolRegExp.hasMatch(t)) return;
+    }
+    node.nodes.forEach(walk);
+  }
+
+  walk(target);
+  var text = _collapseWhitespace(buf.toString()).trim();
+
+  final core = marker.replaceAll(RegExp('^[\\[\\(]+|[\\]\\)]+\$'), '');
+  if (core.isNotEmpty) {
+    text = text.replaceFirst(
+      RegExp('^[\\[\\(]?${RegExp.escape(core)}[\\]\\)]?[\\s.,:;\\)\\-]+'),
+      '',
+    );
+  }
+  return text;
+}
+
+final _whitespaceRun = RegExp(r'[ \t\r\n\f]+');
+
+String _collapseWhitespace(String s) => s.replaceAll(_whitespaceRun, ' ');
+
+const _blockTags = {
+  'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'section', 'article',
+  'aside', 'blockquote', 'ol', 'ul', 'li', 'table', 'figure', 'figcaption',
+  'header', 'footer', 'main', 'nav', 'pre', 'hr', 'img', 'details',
+  'summary', 'dl', 'dt', 'dd', //
+};
+
+bool _isBlockElement(dom.Node node) =>
+    node is dom.Element && _blockTags.contains(node.localName);
+
+bool _containsBlockChildren(dom.Element e) => e.nodes.any(_isBlockElement);
+
+/// מעבד רצף צאצאי-בלוק לפי הסדר ומוסיף שורות ל-[output].
+/// רצף inline בין בלוקים (טקסט חשוף בתוך div) נאסף לשורת פסקה משלו.
+void _processBlockChildren(
+  List<dom.Node> nodes,
+  _EpubContext ctx,
+  List<String> output,
+) {
+  final inlineRun = <dom.Node>[];
+
+  void flushInlineRun() {
+    if (inlineRun.isEmpty) return;
+    final buf = StringBuffer();
+    for (final node in inlineRun) {
+      _renderInlineNode(node, ctx, buf);
+    }
+    inlineRun.clear();
+    final text = buf.toString().trim();
+    if (text.isNotEmpty) output.add(text);
+  }
+
+  for (final node in nodes) {
+    if (_isBlockElement(node)) {
+      flushInlineRun();
+      _processBlockElement(node as dom.Element, ctx, output);
+    } else {
+      inlineRun.add(node);
+    }
+  }
+  flushInlineRun();
+}
+
+void _processBlockElement(
+  dom.Element e,
+  _EpubContext ctx,
+  List<String> output,
+) {
+  // גוף הערת שוליים (סמנטי או שסומן בסריקה המקדימה) — תוכנו כבר מוזרק
+  // בנקודת ההפניה.
+  if (_hasEpubType(e, _footnoteTypes) || ctx.consumedNotes.contains(e)) {
+    return;
+  }
+
+  final tag = e.localName ?? '';
+  switch (tag) {
+    case 'h1':
+    case 'h2':
+    case 'h3':
+    case 'h4':
+    case 'h5':
+    case 'h6':
+      final text = _renderInlineChildren(e, ctx).trim();
+      if (text.isEmpty) return;
+      // הסטה רמה אחת מטה — h1 שמור לשם הספר (שורת הפתיחה).
+      final level = (int.parse(tag.substring(1)) + 1).clamp(2, 6);
+      output.add('<h$level>$text</h$level>');
+    case 'p':
+    case 'figcaption':
+    case 'summary':
+    case 'dt':
+    case 'dd':
+    case 'pre':
+      final text = _renderInlineChildren(e, ctx).trim();
+      if (text.isNotEmpty) output.add(text);
+    case 'ol':
+      _processList(e, ctx, output, ordered: true, depth: 0);
+    case 'ul':
+      _processList(e, ctx, output, ordered: false, depth: 0);
+    case 'table':
+      final tableHtml = _buildTableHtml(e, ctx);
+      if (tableHtml != null) output.add(tableHtml);
+    case 'img':
+      final img = _imgHtml(e, ctx);
+      if (img != null) output.add(img);
+    case 'hr':
+      return;
+    case 'blockquote':
+      if (_containsBlockChildren(e)) {
+        _processBlockChildren(e.nodes, ctx, output);
+      } else {
+        final text = _renderInlineChildren(e, ctx).trim();
+        if (text.isNotEmpty) output.add(text);
+      }
+    default:
+      // div/section/article/aside/figure וכו' — עטיפות שקופות: יורדים
+      // לילדים; עטיפה שכל תוכנה inline הופכת לשורת פסקה אחת.
+      if (_containsBlockChildren(e)) {
+        _processBlockChildren(e.nodes, ctx, output);
+      } else {
+        final text = _renderInlineChildren(e, ctx).trim();
+        if (text.isNotEmpty) output.add(text);
+      }
+  }
+}
+
+/// רשימות מרונדרות כשורות עם קידומת והזחה לפי עומק — לא `<ol>`/`<ul>`
+/// (שנשברים בפורמט שורה-לכל-בלוק), באותה גישה כמו ממיר ה-DOCX.
+void _processList(
+  dom.Element list,
+  _EpubContext ctx,
+  List<String> output, {
+  required bool ordered,
+  required int depth,
+}) {
+  var number = int.tryParse(list.attributes['start'] ?? '') ?? 1;
+  final indent = '    ' * depth;
+
+  for (final child in list.children) {
+    if (child.localName != 'li') continue;
+    // פריט שהוא גוף הערה (רשימת הערות בסוף פרק) — הוזרק בנקודת ההפניה.
+    if (ctx.consumedNotes.contains(child)) continue;
+
+    final nestedLists = <dom.Element>[];
+    final buf = StringBuffer();
+    for (final node in child.nodes) {
+      if (node is dom.Element &&
+          (node.localName == 'ol' || node.localName == 'ul')) {
+        nestedLists.add(node);
+        continue;
+      }
+      if (_isBlockElement(node)) {
+        buf.write(_renderInlineChildren(node as dom.Element, ctx));
+        buf.write(' ');
+        continue;
+      }
+      _renderInlineNode(node, ctx, buf);
+    }
+
+    final text = buf.toString().trim();
+    if (text.isNotEmpty) {
+      final label = ordered ? '${number++}.' : '•';
+      output.add('$indent$label $text');
+    }
+    for (final nested in nestedLists) {
+      _processList(
+        nested,
+        ctx,
+        output,
+        ordered: nested.localName == 'ol',
+        depth: depth + 1,
+      );
+    }
+  }
+}
+
+/// טבלה → `<table>` בשורת פלט אחת (שורה=widget בקורא), כולל colspan/rowspan.
+String? _buildTableHtml(dom.Element table, _EpubContext ctx) {
+  final rows = table.querySelectorAll('tr');
+  if (rows.isEmpty) return null;
+
+  final buf = StringBuffer(
+    '<table style="border-collapse: collapse; width: 100%;">',
+  );
+  for (final row in rows) {
+    buf.write('<tr>');
+    for (final cell in row.children) {
+      final tag = cell.localName;
+      if (tag != 'td' && tag != 'th') continue;
+      final attrs = StringBuffer();
+      final colspan = cell.attributes['colspan'];
+      final rowspan = cell.attributes['rowspan'];
+      if (colspan != null) attrs.write(' colspan="$colspan"');
+      if (rowspan != null) attrs.write(' rowspan="$rowspan"');
+      final content = _renderInlineChildren(cell, ctx).trim();
+      buf.write(
+        '<$tag$attrs style="border: 1px solid #999; padding: 4px;">'
+        '$content</$tag>',
+      );
+    }
+    buf.write('</tr>');
+  }
+  buf.write('</table>');
+  return buf.toString();
+}
+
+String? _imgHtml(dom.Element e, _EpubContext ctx) {
+  final src = e.attributes['src'] ?? _attr(e, 'xlink:href');
+  if (src == null || src.isEmpty) return null;
+  final resolved = _resolveHref(ctx.baseDir, src).toLowerCase();
+  final uri = ctx.images[resolved];
+  if (uri == null) return null; // תמונה חיצונית/חסרה — אין מה להטמיע.
+  return '<img src="$uri" style="max-width: 100%;"/>';
+}
+
+String _renderInlineChildren(dom.Element parent, _EpubContext ctx) {
+  final buf = StringBuffer();
+  for (final node in parent.nodes) {
+    _renderInlineNode(node, ctx, buf);
+  }
+  return buf.toString();
+}
+
+/// תגיות inline שנשמרות כמו-שהן בפורמט אוצריא. השאר (span/a/code…) שקופות —
+/// עיצוב ה-CSS של ה-EPUB ממילא אינו זמין בקורא.
+const _inlineKeepTags = {
+  'b': 'b', 'strong': 'b',
+  'i': 'i', 'em': 'i', 'cite': 'i', 'dfn': 'i', 'var': 'i',
+  'u': 'u', 'ins': 'u',
+  's': 's', 'del': 's', 'strike': 's',
+  'sub': 'sub', 'sup': 'sup',
+  'small': 'small', 'big': 'big', //
+};
+
+void _renderInlineNode(dom.Node node, _EpubContext ctx, StringBuffer buf) {
+  if (node is dom.Text) {
+    buf.write(escapeHtmlText(_collapseWhitespace(node.data)));
+    return;
+  }
+  if (node is! dom.Element) return;
+  if (ctx.consumedNotes.contains(node)) {
+    return; // גוף הערה inline — הוזרק בנקודת ההפניה.
+  }
+
+  final tag = node.localName ?? '';
+
+  if (tag == 'br') {
+    buf.write('<br>');
+    return;
+  }
+  if (tag == 'img') {
+    final img = _imgHtml(node, ctx);
+    if (img != null) buf.write(img);
+    return;
+  }
+  if (tag == 'a' && _renderNoteref(node, ctx, buf)) return;
+
+  // סקריפטים/סגנונות אינם תוכן.
+  if (tag == 'script' || tag == 'style' || tag == 'template') return;
+
+  final mapped = _inlineKeepTags[tag];
+  if (mapped != null) {
+    buf.write('<$mapped>');
+    for (final child in node.nodes) {
+      _renderInlineNode(child, ctx, buf);
+    }
+    buf.write('</$mapped>');
+    return;
+  }
+
+  for (final child in node.nodes) {
+    _renderInlineNode(child, ctx, buf);
+  }
+}
+
+/// הפניית הערת שוליים ([_resolveNoteref]) — מרונדרת בפורמט ההערות של
+/// אוצריא, כמו בממיר ה-DOCX. מחזיר האם טופל.
+bool _renderNoteref(dom.Element a, _EpubContext ctx, StringBuffer buf) {
+  final res = _resolveNoteref(a, ctx);
+  if (res == null) return false;
+
+  final markerText = _collapseWhitespace(a.text).trim();
+  final marker = markerText.isNotEmpty
+      ? escapeHtmlText(markerText)
+      : '${ctx.footnoteCounter++}';
+
+  buf.write('<sup class="footnote-marker">$marker</sup>');
+  final target = res.target;
+  if (target != null) {
+    final body = _extractNoteBody(target, markerText);
+    if (body.isNotEmpty) {
+      buf.write('<i class="footnote">${escapeHtmlText(body)}</i>');
+    }
+  }
+  return true;
+}

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -15,7 +15,8 @@ import 'package:otzaria/utils/file/docx_to_otzaria.dart' show escapeHtmlText;
 /// טקסט-סַמָּן, הזרקה חוצת-פרקים (קובץ הערות נפרד), ודיכוי כפילות היעד.
 /// v3: סינון קישורים חיצוניים (scheme), תקרת גודל לתמונות מוטמעות,
 /// וטבלאות מקוננות — שורות ישירות בלבד + רינדור רקורסיבי בתאים.
-const int kEpubConverterVersion = 3;
+/// v4: אבטחה — colspan/rowspan עוברים אימות מספרי (מניעת הזרקת HTML).
+const int kEpubConverterVersion = 4;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -593,8 +594,9 @@ String? _buildTableHtml(dom.Element table, _EpubContext ctx) {
       final tag = cell.localName;
       if (tag != 'td' && tag != 'th') continue;
       final attrs = StringBuffer();
-      final colspan = cell.attributes['colspan'];
-      final rowspan = cell.attributes['rowspan'];
+      // אימות מספרי — העתקה מילולית הייתה מאפשרת הזרקת HTML מ-EPUB זדוני.
+      final colspan = int.tryParse(cell.attributes['colspan'] ?? '');
+      final rowspan = int.tryParse(cell.attributes['rowspan'] ?? '');
       if (colspan != null) attrs.write(' colspan="$colspan"');
       if (rowspan != null) attrs.write(' rowspan="$rowspan"');
       final content = StringBuffer();

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -12,7 +12,7 @@ import 'package:otzaria/utils/file/text_encoding.dart'
 
 /// גרסת הממיר [epubToText] — **חובה להעלות בכל שינוי שמשפיע על הפלט**:
 /// מטמון התוכן כולל את הגרסה במפתח-התוקף, והעלאה פוסלת רשומות ישנות.
-const int kEpubConverterVersion = 5;
+const int kEpubConverterVersion = 6;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -79,7 +79,7 @@ String epubToText(Uint8List bytes, String title) {
     chapters.add((path: itemPath, body: body));
     for (final e in body.querySelectorAll('[id]')) {
       if (e.id.isEmpty) continue;
-      ctx.anchors.putIfAbsent('${itemPath.toLowerCase()}#${e.id}', () => e);
+      ctx.anchors['${itemPath.toLowerCase()}#${e.id}'] ??= e;
     }
   }
 
@@ -603,11 +603,12 @@ String? _buildTableHtml(dom.Element table, _EpubContext ctx) {
       final tag = cell.localName;
       if (tag != 'td' && tag != 'th') continue;
       final attrs = StringBuffer();
-      // אימות מספרי — העתקה מילולית הייתה מאפשרת הזרקת HTML מ-EPUB זדוני.
+      // אימות מספרי-חיובי — העתקה מילולית הייתה מאפשרת הזרקת HTML מ-EPUB
+      // זדוני, וערכי אפס/שלילי שוברים רינדור במנועי תצוגה מסוימים.
       final colspan = int.tryParse(cell.attributes['colspan'] ?? '');
       final rowspan = int.tryParse(cell.attributes['rowspan'] ?? '');
-      if (colspan != null) attrs.write(' colspan="$colspan"');
-      if (rowspan != null) attrs.write(' rowspan="$rowspan"');
+      if (colspan != null && colspan > 0) attrs.write(' colspan="$colspan"');
+      if (rowspan != null && rowspan > 0) attrs.write(' rowspan="$rowspan"');
       final content = StringBuffer();
       for (final node in cell.nodes) {
         if (node is dom.Element && node.localName == 'table') {

--- a/lib/utils/file/epub_to_otzaria.dart
+++ b/lib/utils/file/epub_to_otzaria.dart
@@ -7,16 +7,12 @@ import 'package:html/parser.dart' as html_parser;
 import 'package:xml/xml.dart' as xml;
 
 import 'package:otzaria/utils/file/docx_to_otzaria.dart' show escapeHtmlText;
+import 'package:otzaria/utils/file/text_encoding.dart'
+    show decodeTextBytesSmart;
 
-/// גרסת הממיר [epubToText]. **חובה להעלות ערך זה בכל שינוי שמשפיע על הפלט**
-/// (עיצוב, כותרות, תמונות, טבלאות…). מטמון התוכן כולל את הגרסה במפתח-התוקף:
-/// העלאה כאן פוסלת אוטומטית רשומות ישנות וגורמת להמרה מחדש.
-/// v2: הערות שוליים מבוססות-קישור (בלי epub:type) — זיהוי היריסטי לפי
-/// טקסט-סַמָּן, הזרקה חוצת-פרקים (קובץ הערות נפרד), ודיכוי כפילות היעד.
-/// v3: סינון קישורים חיצוניים (scheme), תקרת גודל לתמונות מוטמעות,
-/// וטבלאות מקוננות — שורות ישירות בלבד + רינדור רקורסיבי בתאים.
-/// v4: אבטחה — colspan/rowspan עוברים אימות מספרי (מניעת הזרקת HTML).
-const int kEpubConverterVersion = 4;
+/// גרסת הממיר [epubToText] — **חובה להעלות בכל שינוי שמשפיע על הפלט**:
+/// מטמון התוכן כולל את הגרסה במפתח-התוקף, והעלאה פוסלת רשומות ישנות.
+const int kEpubConverterVersion = 5;
 
 /// ממיר קובץ EPUB לפורמט הטקסט של אוצריא: שורת `<h1>` עם שם הספר, ואחריה
 /// שורה לכל בלוק (פסקה/כותרת/טבלה/תמונה) לפי סדר פרקי ה-spine.
@@ -49,7 +45,7 @@ String epubToText(Uint8List bytes, String title) {
 
   final xml.XmlDocument opf;
   try {
-    opf = xml.XmlDocument.parse(_decodeUtf8(opfBytes));
+    opf = xml.XmlDocument.parse(_decodeBytes(opfBytes));
   } catch (_) {
     return output.join('\n');
   }
@@ -72,7 +68,7 @@ String epubToText(Uint8List bytes, String title) {
 
     final dom.Document doc;
     try {
-      doc = html_parser.parse(_decodeUtf8(chapterBytes));
+      doc = html_parser.parse(_decodeBytes(chapterBytes));
     } catch (_) {
       continue; // פרק פגום — ממשיכים לפרק הבא במקום לקרוס.
     }
@@ -145,6 +141,9 @@ class _EpubContext {
   /// יעדי הערות שגופן מוזרק בנקודת ההפניה — מדולגים ברינדור (מניעת כפילות).
   final Set<dom.Element> consumedNotes = {};
 
+  /// מטמון סיווג ההפניות — הסריקה המקדימה והרינדור עוברים על אותם קישורים.
+  final Map<dom.Element, _NoterefResolution?> noterefCache = {};
+
   String baseDir = '';
   String chapterPath = '';
   int footnoteCounter = 1;
@@ -152,7 +151,10 @@ class _EpubContext {
   _EpubContext({required this.files, required this.images});
 }
 
-String _decodeUtf8(List<int> bytes) => utf8.decode(bytes, allowMalformed: true);
+/// פענוח בייטים לטקסט עם זיהוי BOM/UTF-16 — EPUB רשאי להישמר גם ב-UTF-16.
+String _decodeBytes(List<int> bytes) => decodeTextBytesSmart(
+  bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
+);
 
 /// מנרמל נתיב בתוך הארכיון: מפריד `/`, פתרון `.`/`..`, והסרת `/` מוביל.
 String _normalizePath(String path) {
@@ -202,7 +204,7 @@ String? _findOpfPath(_ArchiveFiles files) {
   final containerBytes = files.read('META-INF/container.xml');
   if (containerBytes != null) {
     try {
-      final doc = xml.XmlDocument.parse(_decodeUtf8(containerBytes));
+      final doc = xml.XmlDocument.parse(_decodeBytes(containerBytes));
       for (final rootfile in _elementsByLocal(doc, 'rootfile')) {
         final fullPath = rootfile.getAttribute('full-path');
         if (fullPath != null && fullPath.isNotEmpty) {
@@ -352,7 +354,10 @@ class _NoterefResolution {
 /// `epub:type="noteref"` מפורש; יעד שהוא הערה סמנטית (`epub:type="footnote"`);
 /// או היריסטיקה — טקסט-סַמָּן קצר ([_isNoteMarkerText]) שמצביע לעוגן קיים
 /// ולא-ארוך. מחזיר null כשהקישור אינו הערה.
-_NoterefResolution? _resolveNoteref(dom.Element a, _EpubContext ctx) {
+_NoterefResolution? _resolveNoteref(dom.Element a, _EpubContext ctx) =>
+    ctx.noterefCache.putIfAbsent(a, () => _resolveNoterefUncached(a, ctx));
+
+_NoterefResolution? _resolveNoterefUncached(dom.Element a, _EpubContext ctx) {
   final href = a.attributes['href'] ?? '';
   final hash = href.indexOf('#');
   final id = hash >= 0 ? href.substring(hash + 1) : '';
@@ -407,7 +412,11 @@ String _extractNoteBody(dom.Element target, String marker) {
 
 final _whitespaceRun = RegExp(r'[ \t\r\n\f]+');
 
-String _collapseWhitespace(String s) => s.replaceAll(_whitespaceRun, ' ');
+/// רק כשיש באמת מה לכווץ — רווח בודד רגיל אינו מצדיק אלוקציה.
+final _collapsibleWhitespace = RegExp(r'[\t\r\n\f]| {2,}');
+
+String _collapseWhitespace(String s) =>
+    s.contains(_collapsibleWhitespace) ? s.replaceAll(_whitespaceRun, ' ') : s;
 
 const _blockTags = {
   'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'section', 'article',

--- a/test/settings/services/custom_folders/personal_books_import_service_test.dart
+++ b/test/settings/services/custom_folders/personal_books_import_service_test.dart
@@ -44,14 +44,24 @@ void main() {
     });
 
     test('מדלג על סיומות לא נתמכות', () async {
-      final epub = await createSourceFile('ספר.epub', 'x');
+      final mobi = await createSourceFile('ספר.mobi', 'x');
       final txt = await createSourceFile('ספר.txt', 'תוכן');
 
-      final result = await service.copyFiles([epub, txt]);
+      final result = await service.copyFiles([mobi, txt]);
 
       expect(result.copied, 1);
       expect(result.skippedUnsupported, 1);
-      expect(File(p.join(importPath, 'ספר.epub')).existsSync(), isFalse);
+      expect(File(p.join(importPath, 'ספר.mobi')).existsSync(), isFalse);
+    });
+
+    test('קובץ EPUB נתמך ומועתק', () async {
+      final epub = await createSourceFile('ספר.epub', 'epub-bytes');
+
+      final result = await service.copyFiles([epub]);
+
+      expect(result.copied, 1);
+      expect(result.skippedUnsupported, 0);
+      expect(File(p.join(importPath, 'ספר.epub')).existsSync(), isTrue);
     });
 
     test('קובץ בשם קיים דורס את הגרסה הקודמת', () async {

--- a/test/tabs/models/epub_book_wrap_test.dart
+++ b/test/tabs/models/epub_book_wrap_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/tabs/models/tab.dart';
+import 'package:otzaria/tabs/models/text_tab.dart';
+import '../../helpers/memory_settings_cache.dart';
+
+/// טסטי רגרסיה לעטיפת `EpubBook → TextBook` ב-[OpenedTab.fromBook] —
+/// מקבילים לטסטי DocxBook: בלי שימור `id`/`categoryId`/`externalLibraryId`
+/// ה-cache לא מאתר את הספר והתוכן יוצא ריק במסך הקריאה.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+  });
+
+  group('OpenedTab.fromBook(EpubBook) — שימור זיהויים', () {
+    test('שומר id, categoryId ו-externalLibraryId על ה-TextBook העטוף', () {
+      final epub = EpubBook(
+        id: 1234,
+        title: 'בדיקה',
+        path: r'C:\library\test\בדיקה.epub',
+        categoryId: 42,
+        categoryPath: 'ספרים אישיים',
+        author: 'מחבר',
+        heShortDesc: 'תיאור',
+        filePath: r'C:\library\test\בדיקה.epub',
+        externalLibraryId: 'sefaria:123',
+      );
+
+      final tab = OpenedTab.fromBook(epub, 0);
+      addTearDown(tab.dispose);
+
+      expect(tab, isA<TextBookTab>());
+      final textTab = tab as TextBookTab;
+
+      expect(textTab.book.id, 1234);
+      expect(
+        textTab.book.categoryId,
+        42,
+        reason:
+            'categoryId דרוש ל-BookCompositeKey ב-LibraryProviderManager. '
+            'בלעדיו getBookContent לא מאתר את הקובץ והגוף יוצא ריק.',
+      );
+      expect(textTab.book.externalLibraryId, 'sefaria:123');
+      expect(textTab.book.title, 'בדיקה');
+      expect(textTab.book.fileType, 'epub');
+      expect(textTab.book.filePath, r'C:\library\test\בדיקה.epub');
+    });
+
+    test('משתמש ב-path כשfilePath null (fallback קיים)', () {
+      final epub = EpubBook(
+        title: 'בדיקה',
+        path: r'C:\library\test\בדיקה.epub',
+        categoryId: 7,
+        // filePath מושמט בכוונה כדי שייפול ל-fallback של book.path
+      );
+
+      final tab = OpenedTab.fromBook(epub, 0) as TextBookTab;
+      addTearDown(tab.dispose);
+
+      expect(tab.book.filePath, r'C:\library\test\בדיקה.epub');
+      expect(tab.book.categoryId, 7);
+      expect(tab.book.fileType, 'epub');
+    });
+  });
+
+  group('EpubBook — סריאליזציה', () {
+    test('toJson/fromJson משמרים את השדות דרך Book.fromJson', () {
+      final epub = EpubBook(
+        title: 'ספר',
+        path: r'C:\books\ספר.epub',
+        author: 'מחבר',
+        categoryPath: 'קטגוריה',
+        isUserBook: true,
+      );
+
+      final restored = Book.fromJson(epub.toJson());
+
+      expect(restored, isA<EpubBook>());
+      final restoredEpub = restored as EpubBook;
+      expect(restoredEpub.title, 'ספר');
+      expect(restoredEpub.path, r'C:\books\ספר.epub');
+      expect(restoredEpub.author, 'מחבר');
+      expect(restoredEpub.isUserBook, isTrue);
+      expect(restoredEpub.fileType, 'epub');
+    });
+  });
+}

--- a/test/tabs/models/epub_book_wrap_test.dart
+++ b/test/tabs/models/epub_book_wrap_test.dart
@@ -69,10 +69,12 @@ void main() {
   group('EpubBook — סריאליזציה', () {
     test('toJson/fromJson משמרים את השדות דרך Book.fromJson', () {
       final epub = EpubBook(
+        id: 77,
         title: 'ספר',
         path: r'C:\books\ספר.epub',
         author: 'מחבר',
         categoryPath: 'קטגוריה',
+        categoryId: 42,
         isUserBook: true,
       );
 
@@ -85,6 +87,9 @@ void main() {
       expect(restoredEpub.author, 'מחבר');
       expect(restoredEpub.isUserBook, isTrue);
       expect(restoredEpub.fileType, 'epub');
+      // בלי id/categoryId שחזור טאב שמור נכשל באיתור התוכן (BookCompositeKey).
+      expect(restoredEpub.id, 77);
+      expect(restoredEpub.categoryId, 42);
     });
   });
 }

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -24,6 +24,7 @@ Uint8List _buildEpub({
   Map<String, List<int>>? binaryFiles,
   String? extraManifest,
   String? extraSpine,
+  String? extraMetadata,
 }) {
   final order = spineOrder ?? chapters.keys.toList();
 
@@ -52,6 +53,7 @@ Uint8List _buildEpub({
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:identifier id="uid">test-book</dc:identifier>
     <dc:title>ספר בדיקה</dc:title>
+${extraMetadata ?? ''}
   </metadata>
   <manifest>
 $manifestItems
@@ -415,6 +417,82 @@ void main() {
 
       expect(result, isNot(contains('<img')));
       expect(result, contains('טקסט'));
+    });
+
+    test('תמונת כריכה בעטיפת SVG‏ (<svg><image>) מוטמעת', () {
+      const png = [0x89, 0x50, 0x4E, 0x47];
+      final epub = _buildEpub(
+        chapters: {
+          'cover.xhtml': _xhtml(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">'
+            '<image xlink:href="img/cover.png" width="600" height="800"/>'
+            '</svg>',
+          ),
+          'ch1.xhtml': _xhtml('<p>תוכן</p>'),
+        },
+        binaryFiles: {'img/cover.png': png},
+        extraManifest:
+            '<item id="cimg" href="img/cover.png" media-type="image/png"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('data:image/png;base64,${base64Encode(png)}'));
+    });
+
+    test('כריכה מוצהרת (cover-image) שדולגה מוזרקת אחרי הכותרת', () {
+      const png = [0x89, 0x50, 0x4E, 0x47, 0x01];
+      // עמוד הכריכה linear="no" ולכן מדולג — הכריכה מגיעה מה-manifest.
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>תוכן הספר</p>'),
+        },
+        binaryFiles: {'img/cover.png': png},
+        extraManifest:
+            '<item id="cimg" href="img/cover.png" '
+            'media-type="image/png" properties="cover-image"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines[1], startsWith('<img src="data:image/png'));
+      expect(
+        RegExp(base64Encode(png)).allMatches(result).length,
+        1,
+      );
+    });
+
+    test('כריכה שכבר מופיעה בפרק אינה מוזרקת שוב (אין כפילות)', () {
+      const png = [0x89, 0x50, 0x4E, 0x47, 0x02];
+      final epub = _buildEpub(
+        chapters: {
+          'cover.xhtml': _xhtml('<p><img src="img/cover.png"/></p>'),
+          'ch1.xhtml': _xhtml('<p>תוכן</p>'),
+        },
+        binaryFiles: {'img/cover.png': png},
+        extraManifest:
+            '<item id="cimg" href="img/cover.png" '
+            'media-type="image/png" properties="cover-image"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(RegExp(base64Encode(png)).allMatches(result).length, 1);
+    });
+
+    test('כריכת EPUB2‏ (meta name="cover") מזוהה ומוזרקת', () {
+      const png = [0x89, 0x50, 0x4E, 0x47, 0x03];
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>תוכן</p>'),
+        },
+        binaryFiles: {'img/old_cover.png': png},
+        extraManifest:
+            '<item id="oldcover" href="img/old_cover.png" '
+            'media-type="image/png"/>',
+        extraMetadata: '<meta name="cover" content="oldcover"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains(base64Encode(png)));
     });
 
     test('תמונה חסרה בארכיון לא מפילה את ההמרה', () {

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -155,6 +155,28 @@ void main() {
     });
   });
 
+  group('epubToText - קידוד', () {
+    test('פרק בקידוד UTF-16LE (עם BOM) מפוענח לעברית תקינה', () {
+      final xhtml = _xhtml('<p>בדיקת קידוד</p>');
+      final utf16Bytes = <int>[0xFF, 0xFE];
+      for (final unit in xhtml.codeUnits) {
+        utf16Bytes.add(unit & 0xFF);
+        utf16Bytes.add((unit >> 8) & 0xFF);
+      }
+      final epub = _buildEpub(
+        chapters: {},
+        binaryFiles: {'ch1.xhtml': utf16Bytes},
+        extraManifest:
+            '<item id="u16" href="ch1.xhtml" '
+            'media-type="application/xhtml+xml"/>',
+        extraSpine: '<itemref idref="u16"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('בדיקת קידוד'));
+    });
+  });
+
   group('epubToText - כותרות', () {
     test('כותרות מוסטות רמה אחת מטה (h1 בפרק → h2) לטובת תוכן העניינים', () {
       final epub = _buildEpub(

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -268,6 +268,29 @@ void main() {
       expect(lines, contains('    1. בן'));
     });
 
+    test('טבלה מקוננת מרונדרת בתוך התא ולא משוטחת לשורות הטבלה החיצונית', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<table>'
+            '<tr><td>חיצוני<table><tr><td>פנימי</td></tr></table></td></tr>'
+            '<tr><td>שורה שנייה</td></tr>'
+            '</table>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      final tableLine = result
+          .split('\n')
+          .firstWhere((l) => l.startsWith('<table'), orElse: () => '');
+
+      // הטבלה הפנימית שלמה בתוך התא, והתוכן שלה לא מוכפל.
+      expect(tableLine, contains('פנימי'));
+      expect(RegExp('פנימי').allMatches(tableLine).length, 1);
+      // לטבלה החיצונית בדיוק 2 שורות ישירות + שורת הטבלה הפנימית = 3 <tr>.
+      expect(RegExp('<tr>').allMatches(tableLine).length, 3);
+    });
+
     test('טבלה נשמרת כשורת פלט אחת עם colspan', () {
       final epub = _buildEpub(
         chapters: {
@@ -305,6 +328,36 @@ void main() {
         result,
         contains('data:image/png;base64,${base64Encode(pngBytes)}'),
       );
+    });
+
+    test('תמונה מעל תקרת הגודל אינה מוטמעת (מניעת ניפוח זיכרון/מטמון)', () {
+      final hugeImage = List<int>.filled(4 * 1024 * 1024 + 1, 0x42);
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>לפני</p><img src="big.png"/><p>אחרי</p>'),
+        },
+        binaryFiles: {'big.png': hugeImage},
+        extraManifest: '<item id="big" href="big.png" media-type="image/png"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, isNot(contains('<img')));
+      expect(result, contains('לפני'));
+      expect(result, contains('אחרי'));
+    });
+
+    test('תמונה עם כתובת חיצונית (http) אינה מוטמעת ואינה מפילה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>טקסט</p><img src="https://example.com/pic.png"/>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, isNot(contains('<img')));
+      expect(result, contains('טקסט'));
     });
 
     test('תמונה חסרה בארכיון לא מפילה את ההמרה', () {
@@ -423,6 +476,22 @@ void main() {
 
       expect(result, isNot(contains('footnote-marker')));
       expect(result, contains('תוכן ארוך מאוד.'));
+    });
+
+    test('קישור חיצוני (http) עם fragment אינו מסווג כהערה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>ראה<a href="https://example.com/page#fn1">1</a> במקור</p>'
+            '<p id="fn1">פסקה מקומית שאינה קשורה</p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, isNot(contains('footnote-marker')));
+      // הפסקה המקומית לא דוכאה בטעות.
+      expect(result, contains('פסקה מקומית שאינה קשורה'));
     });
 
     test('קישור לעוגן של הערה מזוהה גם בלי epub:type על הקישור', () {

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -1,0 +1,472 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/utils/file/epub_to_otzaria.dart';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const _containerXml = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0"
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf"
+        media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>''';
+
+/// בונה EPUB מינימלי תקין: container.xml, OPF עם manifest/spine, ופרקים.
+Uint8List _buildEpub({
+  required Map<String, String> chapters,
+  List<String>? spineOrder,
+  Map<String, List<int>>? binaryFiles,
+  String? extraManifest,
+  String? extraSpine,
+}) {
+  final order = spineOrder ?? chapters.keys.toList();
+
+  final manifestItems = StringBuffer();
+  var i = 0;
+  for (final name in chapters.keys) {
+    manifestItems.writeln(
+      '<item id="c$i" href="$name" media-type="application/xhtml+xml"/>',
+    );
+    i++;
+  }
+  if (extraManifest != null) manifestItems.writeln(extraManifest);
+
+  final spineItems = StringBuffer();
+  for (final name in order) {
+    final idx = chapters.keys.toList().indexOf(name);
+    spineItems.writeln('<itemref idref="c$idx"/>');
+  }
+  if (extraSpine != null) spineItems.writeln(extraSpine);
+
+  final opf =
+      '''
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0"
+    unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">test-book</dc:identifier>
+    <dc:title>ספר בדיקה</dc:title>
+  </metadata>
+  <manifest>
+$manifestItems
+  </manifest>
+  <spine>
+$spineItems
+  </spine>
+</package>''';
+
+  final encoder = ZipEncoder();
+  final archive = Archive();
+  void addText(String path, String content) {
+    final bytes = utf8.encode(content);
+    archive.addFile(ArchiveFile(path, bytes.length, bytes));
+  }
+
+  addText('META-INF/container.xml', _containerXml);
+  addText('OEBPS/content.opf', opf);
+  for (final entry in chapters.entries) {
+    addText('OEBPS/${entry.key}', entry.value);
+  }
+  for (final entry in (binaryFiles ?? const <String, List<int>>{}).entries) {
+    archive.addFile(
+      ArchiveFile('OEBPS/${entry.key}', entry.value.length, entry.value),
+    );
+  }
+  return Uint8List.fromList(encoder.encode(archive));
+}
+
+String _xhtml(String body) =>
+    '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>פרק</title></head>
+<body>$body</body>
+</html>''';
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('epubToText - מבנה בסיסי', () {
+    test('שורת הפתיחה היא h1 עם שם הספר', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>שלום עולם</p>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר בדיקה');
+      final lines = result.split('\n');
+
+      expect(lines.first, '<h1>ספר בדיקה</h1>');
+      expect(lines, contains('שלום עולם'));
+    });
+
+    test('פרקים מומרים לפי סדר ה-spine, לא לפי סדר הקבצים', () {
+      final epub = _buildEpub(
+        chapters: {
+          'b.xhtml': _xhtml('<p>שני</p>'),
+          'a.xhtml': _xhtml('<p>ראשון</p>'),
+        },
+        spineOrder: ['a.xhtml', 'b.xhtml'],
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result.indexOf('ראשון'), lessThan(result.indexOf('שני')));
+    });
+
+    test('EPUB פגום (לא ZIP) מחזיר לפחות את הכותרת בלי לזרוק', () {
+      final result = epubToText(Uint8List.fromList([1, 2, 3, 4]), 'ספר פגום');
+      expect(result, '<h1>ספר פגום</h1>');
+    });
+
+    test('פריט spine עם linear="no" מדולג', () {
+      final epub = _buildEpub(
+        chapters: {
+          'main.xhtml': _xhtml('<p>תוכן ראשי</p>'),
+          'cover.xhtml': _xhtml('<p>עמוד שער</p>'),
+        },
+        spineOrder: ['main.xhtml'],
+        extraSpine: '<itemref idref="c1" linear="no"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('תוכן ראשי'));
+      expect(result, isNot(contains('עמוד שער')));
+    });
+
+    test('מסמך הניווט (properties="nav") מדולג', () {
+      final epub = _buildEpub(
+        chapters: {
+          'main.xhtml': _xhtml('<p>תוכן</p>'),
+        },
+        extraManifest:
+            '<item id="nav" href="nav.xhtml" properties="nav" '
+            'media-type="application/xhtml+xml"/>',
+        extraSpine: '<itemref idref="nav"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+      expect(result, contains('תוכן'));
+    });
+  });
+
+  group('epubToText - כותרות', () {
+    test('כותרות מוסטות רמה אחת מטה (h1 בפרק → h2) לטובת תוכן העניינים', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<h1>פרק א</h1><h2>סימן א</h2><p>גוף</p>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines, contains('<h2>פרק א</h2>'));
+      expect(lines, contains('<h3>סימן א</h3>'));
+    });
+
+    test('h6 בפרק נשאר h6 (clamp)', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<h6>עמוק</h6>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      expect(result, contains('<h6>עמוק</h6>'));
+    });
+  });
+
+  group('epubToText - עיצוב inline', () {
+    test('strong/em ממופים ל-b/i, ותגיות שאינן נתמכות נשמטות אך תוכנן נשמר', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p><strong>מודגש</strong> <em>נטוי</em> <span class="x">רגיל</span></p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<b>מודגש</b>'));
+      expect(result, contains('<i>נטוי</i>'));
+      expect(result, contains('רגיל'));
+      expect(result, isNot(contains('<span')));
+    });
+
+    test('תווי < > & בתוכן עוברים escape', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>א &lt;ב&gt; &amp; ג</p>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      expect(result, contains('א &lt;ב&gt; &amp; ג'));
+    });
+
+    test('קישור רגיל הופך לטקסט (בלי תגית a)', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>ראה <a href="http://x.com">כאן</a> בהמשך</p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('ראה כאן בהמשך'));
+      expect(result, isNot(contains('<a ')));
+    });
+
+    test('script/style אינם תוכן', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>תוכן</p><style>p { color: red; }</style>'
+            '<script>alert(1)</script>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('תוכן'));
+      expect(result, isNot(contains('color')));
+      expect(result, isNot(contains('alert')));
+    });
+  });
+
+  group('epubToText - רשימות וטבלאות', () {
+    test('רשימה ממוספרת מרונדרת עם מספרים ותבליטים עם נקודה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<ol><li>ראשון</li><li>שני</li></ol><ul><li>תבליט</li></ul>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines, contains('1. ראשון'));
+      expect(lines, contains('2. שני'));
+      expect(lines, contains('• תבליט'));
+    });
+
+    test('רשימה מקוננת מקבלת הזחה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<ol><li>אב<ol><li>בן</li></ol></li></ol>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines, contains('1. אב'));
+      expect(lines, contains('    1. בן'));
+    });
+
+    test('טבלה נשמרת כשורת פלט אחת עם colspan', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<table><tr><td colspan="2">רחב</td></tr>'
+            '<tr><td>א</td><td>ב</td></tr></table>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      final tableLine = result
+          .split('\n')
+          .firstWhere((l) => l.startsWith('<table'), orElse: () => '');
+
+      expect(tableLine, contains('colspan="2"'));
+      expect(tableLine, contains('רחב'));
+      expect(tableLine, contains('</table>'));
+    });
+  });
+
+  group('epubToText - תמונות', () {
+    test('תמונה מה-manifest מוטמעת כ-data URI', () {
+      const pngBytes = [0x89, 0x50, 0x4E, 0x47]; // PNG header prefix
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p><img src="img/pic.png" alt=""/></p>'),
+        },
+        binaryFiles: {'img/pic.png': pngBytes},
+        extraManifest:
+            '<item id="pic" href="img/pic.png" media-type="image/png"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(
+        result,
+        contains('data:image/png;base64,${base64Encode(pngBytes)}'),
+      );
+    });
+
+    test('תמונה חסרה בארכיון לא מפילה את ההמרה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>לפני</p><img src="missing.png"/><p>אחרי</p>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('לפני'));
+      expect(result, contains('אחרי'));
+      expect(result, isNot(contains('<img')));
+    });
+  });
+
+  group('epubToText - הערות שוליים', () {
+    test('הערה סמנטית (epub:type) מוזרקת בפורמט ההערות של אוצריא', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>גוף<a epub:type="noteref" href="#fn1">1</a> המשך</p>'
+            '<aside epub:type="footnote" id="fn1"><p>תוכן ההערה</p></aside>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<sup class="footnote-marker">1</sup>'));
+      expect(result, contains('<i class="footnote">תוכן ההערה</i>'));
+      // גוף ההערה אינו מופיע גם כפסקה נפרדת.
+      expect(RegExp('תוכן ההערה').allMatches(result).length, 1);
+    });
+
+    test('הערה מבוססת-קישור (בלי epub:type בכלל): סמן מספרי + דיכוי היעד', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>גוף הטקסט<a href="#fn1">1</a> ממשיך כאן.</p>'
+            '<p id="fn1">1. זה גוף ההערה <a href="#ref1">↩</a></p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<sup class="footnote-marker">1</sup>'));
+      // הסמן הכפול ("1.") וקישור-החזרה (↩) הוסרו מגוף ההערה.
+      expect(result, contains('<i class="footnote">זה גוף ההערה</i>'));
+      // היעד לא מופיע גם כפסקה נפרדת.
+      expect(RegExp('זה גוף ההערה').allMatches(result).length, 1);
+      expect(result, isNot(contains('↩')));
+    });
+
+    test('הערה בקובץ נפרד (חוצת-פרקים) מוזרקת ומדוכאת בקובץ ההערות', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>טקסט עם הפניה<a href="notes.xhtml#n1">2</a>.</p>',
+          ),
+          'notes.xhtml': _xhtml(
+            '<p>כותרת ההערות</p>'
+            '<p id="n1">[2] תוכן ההערה המרוחקת</p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<sup class="footnote-marker">2</sup>'));
+      expect(result, contains('<i class="footnote">תוכן ההערה המרוחקת</i>'));
+      expect(RegExp('תוכן ההערה המרוחקת').allMatches(result).length, 1);
+      // תוכן שאינו הערה בקובץ ההערות נשאר.
+      expect(result, contains('כותרת ההערות'));
+    });
+
+    test('סמן אות עברית (א) מזוהה כהפניית הערה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>דין ראשון<a href="#he1">א</a>.</p>'
+            '<p id="he1">א. מקור הדין</p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<sup class="footnote-marker">א</sup>'));
+      expect(result, contains('<i class="footnote">מקור הדין</i>'));
+    });
+
+    test('קישור עם טקסט ארוך (ניווט פנימי) אינו מזוהה כהערה והיעד נשמר', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>ראה <a href="#sec2">בפרק הבא על הלכות שבת</a>.</p>'
+            '<h2 id="sec2">הלכות שבת</h2>'
+            '<p>תוכן הפרק.</p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, isNot(contains('footnote-marker')));
+      expect(result, contains('ראה בפרק הבא על הלכות שבת'));
+      expect(result, contains('<h3>הלכות שבת</h3>'));
+    });
+
+    test('סמן מספרי שמצביע על יעד ארוך (קישור לפרק) אינו הופך להערה', () {
+      final longText = 'תוכן ארוך מאוד. ' * 100; // מעל תקרת ההיריסטיקה
+      final epub = _buildEpub(
+        chapters: {
+          'toc.xhtml': _xhtml('<p>פרק <a href="ch1.xhtml#c1">1</a></p>'),
+          'ch1.xhtml': _xhtml('<div id="c1"><p>$longText</p></div>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, isNot(contains('footnote-marker')));
+      expect(result, contains('תוכן ארוך מאוד.'));
+    });
+
+    test('קישור לעוגן של הערה מזוהה גם בלי epub:type על הקישור', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>גוף<a href="#fn1">א</a></p>'
+            '<div epub:type="rearnote" id="fn1">הערה</div>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<sup class="footnote-marker">א</sup>'));
+      expect(result, contains('<i class="footnote">הערה</i>'));
+    });
+  });
+
+  group('epubToText - עטיפות בלוק', () {
+    test('div עוטף עם בלוקים פנימיים שקוף; div עם inline בלבד הופך לשורה', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<div class="wrapper"><p>פסקה</p></div>'
+            '<div>טקסט חשוף</div>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines, contains('פסקה'));
+      expect(lines, contains('טקסט חשוף'));
+      expect(result, isNot(contains('<div')));
+    });
+
+    test('רווחים לבנים (הזחות ושורות של ה-XHTML) מכווצים לרווח יחיד', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>מילה\n      ראשונה</p>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+      expect(result, contains('מילה ראשונה'));
+    });
+  });
+}

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -477,6 +477,21 @@ void main() {
       expect(result, contains('כותרת ההערות'));
     });
 
+    test('href עם פרמטרי שאילתה (?v=1) נפתר לעוגן הנכון', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>טקסט<a href="notes.xhtml?v=1#q1">3</a>.</p>',
+          ),
+          'notes.xhtml': _xhtml('<p id="q1">3. הערה עם שאילתה</p>'),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<sup class="footnote-marker">3</sup>'));
+      expect(result, contains('<i class="footnote">הערה עם שאילתה</i>'));
+    });
+
     test('סמן אות עברית (א) מזוהה כהפניית הערה', () {
       final epub = _buildEpub(
         chapters: {

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -140,6 +140,18 @@ void main() {
       expect(result, isNot(contains('עמוד שער')));
     });
 
+    test('spine שמפנה לאותו פרק פעמיים אינו מכפיל את התוכן', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<p>תוכן יחיד</p>'),
+        },
+        spineOrder: ['ch1.xhtml', 'ch1.xhtml'],
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(RegExp('תוכן יחיד').allMatches(result).length, 1);
+    });
+
     test('מסמך הניווט (properties="nav") מדולג', () {
       final epub = _buildEpub(
         chapters: {
@@ -505,6 +517,23 @@ void main() {
 
       expect(result, contains('<sup class="footnote-marker">א</sup>'));
       expect(result, contains('<i class="footnote">מקור הדין</i>'));
+    });
+
+    test('קישור-סַמָּן לכותרת אינו הופך אותה להערה — הכותרת נשמרת', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>ראה סימן<a href="#sec">א</a>.</p>'
+            '<h2 id="sec">קצר</h2>'
+            '<p>תוכן הסימן.</p>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, contains('<h3>קצר</h3>'));
+      expect(result, isNot(contains('footnote-marker')));
+      expect(RegExp('קצר').allMatches(result).length, 1);
     });
 
     test('קישור עם טקסט ארוך (ניווט פנימי) אינו מזוהה כהערה והיעד נשמר', () {

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -291,6 +291,26 @@ void main() {
       expect(RegExp('<tr>').allMatches(tableLine).length, 3);
     });
 
+    test('ערכי colspan/rowspan לא-מספריים נדחים (מניעת הזרקת HTML)', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<table><tr>'
+            "<td colspan='2&quot; onclick=&quot;evil()'>תא</td>"
+            '<td rowspan="abc">שני</td>'
+            '</tr></table>',
+          ),
+        },
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(result, isNot(contains('onclick')));
+      expect(result, isNot(contains('evil')));
+      expect(result, isNot(contains('rowspan')));
+      expect(result, contains('תא'));
+      expect(result, contains('שני'));
+    });
+
     test('טבלה נשמרת כשורת פלט אחת עם colspan', () {
       final epub = _buildEpub(
         chapters: {

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -677,6 +677,99 @@ void main() {
     });
   });
 
+  group('epubToText - תוכן עניינים מ-NCX/nav', () {
+    const ncx = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    <navPoint id="n1" playOrder="1">
+      <navLabel><text>שער ראשון</text></navLabel>
+      <content src="ch1.xhtml"/>
+      <navPoint id="n2" playOrder="2">
+        <navLabel><text>סימן א</text></navLabel>
+        <content src="ch1.xhtml#s1"/>
+      </navPoint>
+    </navPoint>
+  </navMap>
+</ncx>''';
+
+    test('ספר בלי תגיות כותרת מקבל כותרות מסונתזות מה-NCX', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>שער ראשון</p>'
+            '<p>פתיחה לשער.</p>'
+            '<p id="s1">דין ראשון בסימן.</p>',
+          ),
+        },
+        binaryFiles: {'toc.ncx': utf8.encode(ncx)},
+        extraManifest:
+            '<item id="ncx" href="toc.ncx" '
+            'media-type="application/x-dtbncx+xml"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines, contains('<h2>שער ראשון</h2>'));
+      expect(lines, contains('<h3>סימן א</h3>'));
+      // פסקת-הכותרת הכפולה דולגה, ושאר התוכן נשמר בסדר.
+      expect(RegExp('שער ראשון').allMatches(result).length, 1);
+      expect(
+        result.indexOf('<h3>סימן א</h3>'),
+        lessThan(result.indexOf('דין ראשון')),
+      );
+    });
+
+    test('ספר שיש לו כותרות אמיתיות אינו מקבל כפילות מה-NCX', () {
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml('<h1>שער ראשון</h1><p>תוכן.</p>'),
+        },
+        binaryFiles: {'toc.ncx': utf8.encode(ncx)},
+        extraManifest:
+            '<item id="ncx" href="toc.ncx" '
+            'media-type="application/x-dtbncx+xml"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+
+      expect(RegExp('שער ראשון').allMatches(result).length, 1);
+      expect(result, contains('<h2>שער ראשון</h2>'));
+    });
+
+    test('מסמך ניווט EPUB3 (nav) משמש לסינתוז כשאין NCX', () {
+      const nav = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:epub="http://www.idpf.org/2007/ops">
+<body><nav epub:type="toc"><ol>
+  <li><a href="ch1.xhtml">פרק הפתיחה</a>
+    <ol><li><a href="ch1.xhtml#p2">חלק שני</a></li></ol>
+  </li>
+</ol></nav></body>
+</html>''';
+      final epub = _buildEpub(
+        chapters: {
+          'ch1.xhtml': _xhtml(
+            '<p>תוכן ראשון.</p><p id="p2">תוכן שני.</p>',
+          ),
+        },
+        binaryFiles: {'nav.xhtml': utf8.encode(nav)},
+        extraManifest:
+            '<item id="nav" href="nav.xhtml" properties="nav" '
+            'media-type="application/xhtml+xml"/>',
+      );
+      final result = epubToText(epub, 'ספר');
+      final lines = result.split('\n');
+
+      expect(lines, contains('<h2>פרק הפתיחה</h2>'));
+      expect(lines, contains('<h3>חלק שני</h3>'));
+      expect(
+        result.indexOf('<h3>חלק שני</h3>'),
+        lessThan(result.indexOf('תוכן שני')),
+      );
+    });
+  });
+
   group('epubToText - עטיפות בלוק', () {
     test('div עוטף עם בלוקים פנימיים שקוף; div עם inline בלבד הופך לשורה', () {
       final epub = _buildEpub(

--- a/test/utils/file/epub_to_otzaria_test.dart
+++ b/test/utils/file/epub_to_otzaria_test.dart
@@ -313,13 +313,14 @@ void main() {
       expect(RegExp('<tr>').allMatches(tableLine).length, 3);
     });
 
-    test('ערכי colspan/rowspan לא-מספריים נדחים (מניעת הזרקת HTML)', () {
+    test('ערכי colspan/rowspan לא-מספריים או לא-חיוביים נדחים', () {
       final epub = _buildEpub(
         chapters: {
           'ch1.xhtml': _xhtml(
             '<table><tr>'
             "<td colspan='2&quot; onclick=&quot;evil()'>תא</td>"
             '<td rowspan="abc">שני</td>'
+            '<td colspan="0" rowspan="-1">שלישי</td>'
             '</tr></table>',
           ),
         },
@@ -329,8 +330,10 @@ void main() {
       expect(result, isNot(contains('onclick')));
       expect(result, isNot(contains('evil')));
       expect(result, isNot(contains('rowspan')));
+      expect(result, isNot(contains('colspan')));
       expect(result, contains('תא'));
       expect(result, contains('שני'));
+      expect(result, contains('שלישי'));
     });
 
     test('טבלה נשמרת כשורת פלט אחת עם colspan', () {


### PR DESCRIPTION
הוספת EPUB כפורמט ספר נתמך, באותו דפוס בדיוק כמו התמיכה הקיימת ב-DOCX: ממיר ייעודי (epub_to_otzaria) הופך את הקובץ לפורמט הטקסט של אוצריא, EpubBook נעטף כ-TextBook דרך toTextBook(), ומשם כל הזרימות הקיימות (תצוגה, TOC, אינדוקס Tantivy, איתור) עובדות ללא שינוי.

הממיר: פרקים לפי סדר ה-spine, כותרות מוסטות רמה (h1 שמור לשם הספר, מהכותרות נבנה תוכן העניינים), תמונות כ-data URI, טבלאות ורשימות, והערות שוליים — סמנטיות (epub:type) וגם מבוססות-קישור (זיהוי היריסטי לפי טקסט-סמן, כולל הערות בקובץ נפרד, עם דיכוי כפילות היעד).

מטמון ההמרות של DOCX הוכלל לשני הפורמטים (גרסת-ממיר נפרדת לכל אחד), וסיומת epub נרשמה בכל נקודות הסריקה/ייבוא/סנכרון/אינדוקס.