### PR TITLE
Classify EXPLICATION as commentary

### DIFF
--- a/lib/models/link_types.dart
+++ b/lib/models/link_types.dart
@@ -1,4 +1,4 @@
-/// קבועים ועזרים לסיווג סוגי קישורים, בהתאם ל-14 הסוגים ב-seforim.db v3.
+/// קבועים ועזרים לסיווג סוגי קישורים ב־seforim.db.
 class LinkTypes {
   LinkTypes._();
 
@@ -17,8 +17,9 @@ class LinkTypes {
   static const String related = 'RELATED';
   static const String other = 'OTHER';
 
-  /// סוג תלוי חדש (למשל "עין איה") — נחשב כמפרש, לא כהפניה.
+  /// ביאורים תלויי־טקסט, ולכן מוצגים כמפרשים ולא כהפניות.
   static const String elucidation = 'ELUCIDATION';
+  static const String explication = 'EXPLICATION';
 
   /// סוגי קישור תלויי-טקסט — טקסטים שתלויים בטקסט הבסיס (פירוש/תרגום/מדרש
   /// וכד׳) ומוצגים בפאנל המפרשים. "עין משפט" הוא כלי הפניה ולכן מוצג בקישורים.
@@ -30,6 +31,7 @@ class LinkTypes {
     parshanut,
     diburHamatchil,
     elucidation,
+    explication,
   };
 
   /// האם הקישור הוא תלוי-טקסט (מפרש) — מוצג בפאנל המפרשים ולא כהפניה צדדית.

--- a/test/models/link_types_test.dart
+++ b/test/models/link_types_test.dart
@@ -12,6 +12,7 @@ void main() {
         'PARSHANUT',
         'DIBUR_HAMATCHIL',
         'ELUCIDATION',
+        'EXPLICATION',
       ]) {
         expect(LinkTypes.isDependentTextLink(type), isTrue, reason: type);
       }
@@ -46,6 +47,7 @@ void main() {
       expect(LinkTypes.isReferenceLikeLink('EIN_MISHPAT'), isTrue);
       expect(LinkTypes.isReferenceLikeLink('OTHER'), isTrue);
       expect(LinkTypes.isReferenceLikeLink('COMMENTARY'), isFalse);
+      expect(LinkTypes.isReferenceLikeLink('EXPLICATION'), isFalse);
       expect(LinkTypes.isReferenceLikeLink('SOURCE'), isFalse);
       expect(LinkTypes.isReferenceLikeLink(null), isFalse);
     });


### PR DESCRIPTION
## מה השתנה

`EXPLICATION` נוסף לסוגי הקישורים התלויים, ונוספו בדיקות שמוודאות שהוא אינו מוצג כהפניה.

## למה

הסוג קיים ב־SeforimLibrary, אך האפליקציה סיווגה אותו כהפניה למרות שהוא ביאור/פרשנות.

## בדיקה

- `flutter analyze`
- `flutter test test/models/link_types_test.dart`