### PR TITLE
add otzaria_icons v0.2.0 dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,9 @@ dependencies:
   fuzzywuzzy: ^1.2.0
   flutter_svg: ^2.3.0  
   fluentui_system_icons: ^1.1.273
+  otzaria_icons:
+    git:
+      url: https://github.com/Otzaria/otzaria_icons
   file_picker: ^11.0.2
   provider: ^6.1.5+1
   multi_split_view: ^3.6.2


### PR DESCRIPTION
@Y-PLONI
הוספת התלויות של [ספריית האייקונים](https://github.com/Otzaria/otzaria_icons) החדשה
(נכון לרגע זה 110 אייקונים זמינים לשימוש, רובם מאותם משפחות)
[הגלרייה](https://otzaria.github.io/otzaria_icons/)