### PR TITLE
לעזי רש"י: הצגת פירוש הלעז בלחיצה ימנית

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -678,6 +678,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Plugins | `test/plugins/utils/reader_location_resolver_test.dart`, `…plugin_store_link_parser_test.dart`, `…plugin_bridge_adapter_test.dart` |
 | Shamor Zachor | `test/shamor_zachor/shamor_zachor_test.dart` (+ 4 more in that dir) |
 | Dictionary lookup | `test/tools/dictionary/dictionary_lookup_repository_test.dart` |
+| Laaz Rashi dictionary | `test/tools/dictionary/laaz_dictionary_test.dart` |
 | Commentary reverse links | `test/commentary_reverse_links_test.dart` |
 | Inline links | `test/inline_links_test.dart` |
 | Dialog navigation | `test/dialog_navigation_test.dart` |

--- a/lib/data/data_providers/book_database_resolver.dart
+++ b/lib/data/data_providers/book_database_resolver.dart
@@ -57,16 +57,33 @@ class BookDatabaseResolver {
     return firstSegment == _personalRootTitle;
   }
 
+  /// מאתר ספר לפי מאפייניו במסדי הספרייה.
+  ///
+  /// [officialOnly] מונע fallback ל-`user_books.db`.
   static Future<ResolvedDbBookRecord?> resolveBook({
     required String title,
     int? categoryId,
     String? fileType,
     String? filePath,
     bool preferUserBooks = false,
+    bool officialOnly = false,
   }) async {
-    final candidates = await _loadRepositoryCandidates(
-      preferUserBooks: preferUserBooks,
-    );
+    final List<ResolvedBookRepositoryCandidate> candidates;
+    if (officialOnly) {
+      final repository = await _loadOfficialRepository();
+      candidates = repository == null
+          ? const <ResolvedBookRepositoryCandidate>[]
+          : <ResolvedBookRepositoryCandidate>[
+              ResolvedBookRepositoryCandidate(
+                repository: repository,
+                isUserBooks: false,
+              ),
+            ];
+    } else {
+      candidates = await _loadRepositoryCandidates(
+        preferUserBooks: preferUserBooks,
+      );
+    }
 
     return resolveBookInCandidates(
       title: title,

--- a/lib/pdf_book/view/pdf_commentary_panel.dart
+++ b/lib/pdf_book/view/pdf_commentary_panel.dart
@@ -109,7 +109,9 @@ LinkTargetsAggregation aggregateLinkTargetsFromLinks(Iterable<Link> links) {
 /// כמו [aggregateLinkTargetsFromLinks], בלי לטעון את הקישורים עצמם.
 @visibleForTesting
 LinkTargetsAggregation aggregateLinkTargetsFromSummary(
-    List<LinkTargetSummary> targets, int maxSourceLine) {
+  List<LinkTargetSummary> targets,
+  int maxSourceLine,
+) {
   final commentators = <String>{};
   final linkCountByTitle = <String, int>{};
   final nonCommentaryTitles = <String>{};
@@ -398,7 +400,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       if (repo == null) return null;
       final dbBook = companion.categoryId != null
           ? await repo.getBookByTitleAndCategory(
-              companion.title, companion.categoryId!)
+              companion.title,
+              companion.categoryId!,
+            )
           : await repo.getBookByTitle(companion.title);
       final lines = dbBook?.totalLines ?? 0;
       return lines > 0 ? lines : null;
@@ -410,7 +414,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
   /// סיכום קישורי הספר (יעדים + ספירות) מהמסד — תחליף קל לסריקת כל הקישורים
   /// כש-tab.links מחזיק רק חלון סביב המיקום הנוכחי.
   Future<({List<LinkTargetSummary> targets, int maxSourceLine})?>
-      _loadLinkTargetsSummary() async {
+  _loadLinkTargetsSummary() async {
     try {
       final library = await DataRepository.instance.library;
       final companion =
@@ -423,7 +427,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       );
       if (provider is! DatabaseLibraryProvider) return null;
       return provider.getBookLinkTargetsSummary(
-          companion.title, companion.categoryId!);
+        companion.title,
+        companion.categoryId!,
+      );
     } catch (_) {
       return null;
     }
@@ -437,7 +443,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       final summary = await _loadLinkTargetsSummary();
       aggregation = summary != null
           ? aggregateLinkTargetsFromSummary(
-              summary.targets, summary.maxSourceLine)
+              summary.targets,
+              summary.maxSourceLine,
+            )
           // הסיכום נכשל — נבנה לפחות מחלון הקישורים הטעון (חלקי, עדיף מריק).
           : aggregateLinkTargetsFromLinks(widget.tab.links);
     }
@@ -573,8 +581,10 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
     _searchComputeDebounce?.cancel();
     // כשאין קישורים אין מה לחשב — טעינתם תפעיל תזמון מחדש (לפי חתימה).
     if (_orderedLinks.isEmpty) return;
-    _searchComputeDebounce =
-        Timer(const Duration(milliseconds: 250), _computeSearchCounts);
+    _searchComputeDebounce = Timer(
+      const Duration(milliseconds: 250),
+      _computeSearchCounts,
+    );
   }
 
   /// עובר על כל הקישורים ומזין את משפך העדכון של ספירות החיפוש, במקביל
@@ -635,8 +645,10 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       setState(() {
         _searchResultsPerLink.addAll(_pendingCounts);
         _pendingCounts.clear();
-        _totalSearchResults =
-            _searchResultsPerLink.values.fold(0, (sum, count) => sum + count);
+        _totalSearchResults = _searchResultsPerLink.values.fold(
+          0,
+          (sum, count) => sum + count,
+        );
 
         // Reset current index if out of bounds
         if (_currentSearchIndex >= _totalSearchResults &&
@@ -660,7 +672,10 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
 
   /// בניית תפריט הקשר למפרש ספציפי
   List<AppContextMenuEntry> _buildCommentaryContextMenuEntries(
-      BuildContext menuCtx, Link link) {
+    BuildContext menuCtx,
+    Link link,
+    Offset tapPosition,
+  ) {
     return ContextMenuUtils.buildCommentaryContextMenu(
       context: menuCtx,
       link: link,
@@ -668,6 +683,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       fontSize: widget.fontSize,
       savedSelectedText: _savedSelectedText,
       onCopySelected: _copyFormattedText,
+      tapPosition: tapPosition,
     );
   }
 
@@ -788,7 +804,11 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
     for (final link in widget.tab.links) {
       if (!LinkTypes.isDependentTextLink(link.connectionType)) continue;
       if (!pdfLinkInVisibleScope(
-          link.index1, range.startLine, range.endLine, extra)) {
+        link.index1,
+        range.startLine,
+        range.endLine,
+        extra,
+      )) {
         continue;
       }
       final title = utils.getTitleFromPath(link.path2);
@@ -883,11 +903,11 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
           icon: const Icon(FluentIcons.open_24_regular),
           tooltip: 'פתח כרטסיית מפרשים',
           onPressed: () => context.read<TabsBloc>().add(
-                AddTab(
-                  PdfCommentatorsTab(sourceTab: widget.tab),
-                  insertAdjacent: true,
-                ),
-              ),
+            AddTab(
+              PdfCommentatorsTab(sourceTab: widget.tab),
+              insertAdjacent: true,
+            ),
+          ),
         ),
         const SizedBox(width: gap),
         // 4. הפעלת שדה החיפוש
@@ -1134,8 +1154,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
         }
 
         // Initialize keys
-        final currentLinkKeys =
-            _orderedLinks.map((l) => _getLinkKey(l)).toSet();
+        final currentLinkKeys = _orderedLinks
+            .map((l) => _getLinkKey(l))
+            .toSet();
 
         // קישורים חדשים (טעינה/מעבר קטע) — חישוב ספירות חיפוש מחדש אם יש
         // שאילתה פעילה.
@@ -1159,12 +1180,15 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
           for (final key in staleSearchKeys) {
             _searchResultsPerLink.remove(key);
           }
-          _pendingCounts
-              .removeWhere((key, _) => !currentLinkKeys.contains(key));
+          _pendingCounts.removeWhere(
+            (key, _) => !currentLinkKeys.contains(key),
+          );
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted) return;
-            final newTotal =
-                _searchResultsPerLink.values.fold(0, (sum, c) => sum + c);
+            final newTotal = _searchResultsPerLink.values.fold(
+              0,
+              (sum, c) => sum + c,
+            );
             if (_totalSearchResults != newTotal ||
                 _currentSearchIndex >= newTotal) {
               setState(() {
@@ -1179,7 +1203,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
 
         return ScrollablePositionedList.builder(
           key: PageStorageKey(
-              'commentary_${widget.tab.currentTextLineNumber}_${widget.tab.activeCommentators.hashCode}_$_allExpanded'),
+            'commentary_${widget.tab.currentTextLineNumber}_${widget.tab.activeCommentators.hashCode}_$_allExpanded',
+          ),
           itemCount: sortedGroups.length,
           itemScrollController: _itemScrollController,
           itemPositionsListener: _itemPositionsListener,
@@ -1258,7 +1283,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       final BuildContext? itemContext = itemKey?.currentContext;
 
       // בודק אם הפריט כבר בעץ הרינדור (לא נדרשת גלילה גסה)
-      final bool itemInRenderTree = itemContext != null &&
+      final bool itemInRenderTree =
+          itemContext != null &&
           itemContext.mounted &&
           itemContext.findRenderObject() is RenderBox;
 
@@ -1303,7 +1329,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       builder: (context, settingsState) {
         return _CollapsibleCommentaryGroup(
           key: PageStorageKey(
-              '${group.bookTitle}_${widget.tab.currentTextLineNumber}'),
+            '${group.bookTitle}_${widget.tab.currentTextLineNumber}',
+          ),
           group: group,
           settingsState: settingsState,
           tab: widget.tab,
@@ -1381,10 +1408,12 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
 
     return BlocBuilder<SettingsBloc, SettingsState>(
       builder: (context, settingsState) {
-        final restoredExpanded = PageStorage.maybeOf(context)?.readState(
-          context,
-          identifier: keyStr,
-        ) as bool?;
+        final restoredExpanded =
+            PageStorage.maybeOf(context)?.readState(
+                  context,
+                  identifier: keyStr,
+                )
+                as bool?;
         final isExpanded =
             _expandedLinkStates[keyStr] ?? restoredExpanded ?? false;
 
@@ -1399,10 +1428,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
             child: RtlIcon(
               FluentIcons.chevron_left_24_regular,
               size: 20,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.6),
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.6),
             ),
           ),
           backgroundColor: Theme.of(context).colorScheme.surface,
@@ -1413,7 +1441,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
               fontSize: settingsState.commentatorsFontSize - 2,
               fontWeight: FontWeight.bold,
               fontVariations: AppFonts.boldFontVariations(
-                  settingsState.commentatorsFontFamily),
+                settingsState.commentatorsFontFamily,
+              ),
               fontFamily: settingsState.commentatorsFontFamily,
             ),
           ),
@@ -1426,10 +1455,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                   fontSize: settingsState.commentatorsFontSize - 4,
                   fontWeight: FontWeight.normal,
                   fontFamily: settingsState.commentatorsFontFamily,
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.5),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.5),
                 ),
               );
             },
@@ -1466,8 +1494,12 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                       ) ??
                       true; // לא הוכרע — סלחני
                 },
-                menuBuilder: (menuCtx, _) =>
-                    _buildCommentaryContextMenuEntries(menuCtx, link),
+                menuBuilder: (menuCtx, tapPosition) =>
+                    _buildCommentaryContextMenuEntries(
+                      menuCtx,
+                      link,
+                      tapPosition,
+                    ),
                 child: GestureDetector(
                   onTap: () {
                     widget.openBookCallback(
@@ -1478,10 +1510,11 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                         index: link.index2 - 1,
                         openLeftPane:
                             (Settings.getValue<bool>('key-pin-sidebar') ??
-                                    false) ||
-                                (Settings.getValue<bool>(
-                                        'key-default-sidebar-open') ??
-                                    false),
+                                false) ||
+                            (Settings.getValue<bool>(
+                                  'key-default-sidebar-open',
+                                ) ??
+                                false),
                       ),
                     );
                   },
@@ -1493,11 +1526,13 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                         if (snapshot.connectionState ==
                             ConnectionState.waiting) {
                           return const Center(
-                              child: CircularProgressIndicator());
+                            child: CircularProgressIndicator(),
+                          );
                         }
                         if (snapshot.hasError) {
                           debugPrint(
-                              'Error loading link content: ${snapshot.error}');
+                            'Error loading link content: ${snapshot.error}',
+                          );
                           debugPrint('Stack trace: ${snapshot.stackTrace}');
                           return Text('שגיאה: ${snapshot.error}');
                         }
@@ -1505,7 +1540,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                           builder: (context, settingsState) {
                             return Text(
                               utils.stripHtmlPreservingBreaks(
-                                  snapshot.data ?? ''),
+                                snapshot.data ?? '',
+                              ),
                               textAlign: TextAlign.justify,
                               style: TextStyle(
                                 fontSize: settingsState.commentatorsFontSize,
@@ -1514,10 +1550,11 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                                 fontWeight: settingsState.commentatorsFontBold
                                     ? FontWeight.bold
                                     : null,
-                                fontVariations: settingsState
-                                        .commentatorsFontBold
+                                fontVariations:
+                                    settingsState.commentatorsFontBold
                                     ? AppFonts.boldFontVariations(
-                                        settingsState.commentatorsFontFamily)
+                                        settingsState.commentatorsFontFamily,
+                                      )
                                     : null,
                               ),
                             );
@@ -1557,8 +1594,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
 
               if (targetPage != null) {
                 if (widget.tab.pdfViewerController.isReady) {
-                  widget.tab.pdfViewerController
-                      .goToPage(pageNumber: targetPage);
+                  widget.tab.pdfViewerController.goToPage(
+                    pageNumber: targetPage,
+                  );
                 }
                 return;
               }
@@ -1583,8 +1621,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
     }
 
     final range = _getCurrentRange(currentLine);
-    final commentatorsKey =
-        (widget.tab.activeCommentators.toList()..sort()).join('|');
+    final commentatorsKey = (widget.tab.activeCommentators.toList()..sort())
+        .join('|');
     final extraKey = widget.extraLineIndices == null
         ? ''
         : (widget.extraLineIndices!.toList()..sort()).join(',');
@@ -1609,7 +1647,11 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
     final extraLines = widget.extraLineIndices;
     for (final link in widget.tab.links) {
       if (!pdfLinkInVisibleScope(
-          link.index1, range.startLine, range.endLine, extraLines)) {
+        link.index1,
+        range.startLine,
+        range.endLine,
+        extraLines,
+      )) {
         continue;
       }
 
@@ -1618,8 +1660,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       if (isCommentary) {
         hasAnyCommentaryLinks = true;
         if (showAllWhenEmpty ||
-            widget.tab.activeCommentators
-                .contains(utils.getTitleFromPath(link.path2))) {
+            widget.tab.activeCommentators.contains(
+              utils.getTitleFromPath(link.path2),
+            )) {
           commentaryLinks.add(link);
         }
         continue;
@@ -1639,8 +1682,9 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       }
       return a.index1.compareTo(b.index1);
     });
-    final sortedNonCommentaryLinks =
-        CommentaryService.sortLinksByEraSync(nonCommentaryLinks);
+    final sortedNonCommentaryLinks = CommentaryService.sortLinksByEraSync(
+      nonCommentaryLinks,
+    );
 
     final groups = _groupConsecutiveLinks(commentaryLinks);
     final cache = _PdfVisibleContentCache(
@@ -1655,7 +1699,8 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
   }
 
   ({int startLine, int endLine}) _getCurrentRange(int currentLine) {
-    final endLine = widget.lineEndOverride ??
+    final endLine =
+        widget.lineEndOverride ??
         (widget.tab.currentTextLineNumberEnd ?? currentLine + 50);
     return (startLine: currentLine, endLine: endLine);
   }
@@ -1737,7 +1782,8 @@ class _CollapsibleCommentaryGroup extends StatefulWidget {
   final PdfBookTab tab;
   final double fontSize;
   final Function(OpenedTab) openBookCallback;
-  final List<AppContextMenuEntry> Function(BuildContext, Link) buildContextMenu;
+  final List<AppContextMenuEntry> Function(BuildContext, Link, Offset)
+  buildContextMenu;
   // מחזיר את הטקסט הנבחר הנוכחי (מנוהל ע"י ה-SelectionArea היחיד של הפאנל),
   // לבדיקה אם לחיצה ימנית נופלת על הבחירה ולכן יש לשמרה.
   final String? Function() getSavedSelectedText;
@@ -1787,8 +1833,10 @@ class _CollapsibleCommentaryGroupState
             widget.onExpansionChanged(!widget.isExpanded);
           },
           child: Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 12.0,
+            ),
             child: Row(
               children: [
                 AnimatedRotation(
@@ -1797,10 +1845,9 @@ class _CollapsibleCommentaryGroupState
                   child: RtlIcon(
                     FluentIcons.chevron_left_24_regular,
                     size: 20,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.6),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.6),
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -1811,7 +1858,8 @@ class _CollapsibleCommentaryGroupState
                       fontSize: widget.settingsState.commentatorsFontSize - 2,
                       fontWeight: FontWeight.bold,
                       fontVariations: AppFonts.boldFontVariations(
-                          widget.settingsState.commentatorsFontFamily),
+                        widget.settingsState.commentatorsFontFamily,
+                      ),
                       fontFamily: widget.settingsState.commentatorsFontFamily,
                     ),
                   ),
@@ -1824,10 +1872,15 @@ class _CollapsibleCommentaryGroupState
         if (widget.isExpanded)
           ...widget.group.links.map((link) {
             return Padding(
-              key: widget.getKeyForLink
-                  ?.call(link), // Attach the key here for scrolling
+              key: widget.getKeyForLink?.call(
+                link,
+              ), // Attach the key here for scrolling
               padding: const EdgeInsets.only(
-                  right: 32.0, left: 16.0, top: 8.0, bottom: 8.0),
+                right: 32.0,
+                left: 16.0,
+                top: 8.0,
+                bottom: 8.0,
+              ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -1842,10 +1895,9 @@ class _CollapsibleCommentaryGroupState
                           fontWeight: FontWeight.normal,
                           fontFamily:
                               widget.settingsState.commentatorsFontFamily,
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onSurface
-                              .withValues(alpha: 0.5),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.onSurface.withValues(alpha: 0.5),
                         ),
                       );
                     },
@@ -1868,11 +1920,12 @@ class _CollapsibleCommentaryGroupState
                           ) ??
                           true; // לא הוכרע — סלחני
                     },
-                    menuBuilder: (menuCtx, _) =>
-                        widget.buildContextMenu(menuCtx, link),
+                    menuBuilder: (menuCtx, tapPosition) =>
+                        widget.buildContextMenu(menuCtx, link, tapPosition),
                     child: PdfCommentaryContent(
                       key: ValueKey(
-                          '${link.path2}_${link.index1}_${link.index2}_${widget.tab.currentTextLineNumber}'),
+                        '${link.path2}_${link.index1}_${link.index2}_${widget.tab.currentTextLineNumber}',
+                      ),
                       link: link,
                       fontSize: widget.fontSize,
                       openBookCallback: widget.openBookCallback,

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -26,7 +26,10 @@ import 'package:otzaria/widgets/layout/commentators_filter_screen.dart';
 import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
 import 'package:otzaria/widgets/misc/progressive_scrolling.dart';
 import 'package:otzaria/settings/settings_exports.dart';
+import 'package:otzaria/tools/dictionary/dictionary_context_menu_entries.dart';
+import 'package:otzaria/tools/dictionary/repository/dictionary_lookup_repository.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
+import 'package:otzaria/utils/text/word_at_position.dart';
 import 'package:otzaria/utils/ui/context_menu_utils.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
@@ -2202,7 +2205,7 @@ class _CollapsibleCommentaryGroupState
                                     ) ??
                                     true; // לא הוכרע — סלחני
                               },
-                          menuBuilder: (menuCtx, _) {
+                          menuBuilder: (menuCtx, tapPosition) {
                             final savedTextAtBuild = captureSelectedTextForMenu(
                               widget.savedSelectedTextListenable,
                             );
@@ -2212,6 +2215,7 @@ class _CollapsibleCommentaryGroupState
                               openBookCallback: widget.openBookCallback,
                               fontSize: widget.fontSize,
                               savedSelectedText: savedTextAtBuild,
+                              tapPosition: tapPosition,
                               onCopySelected: () => ContextMenuUtils.copyFormattedText(
                                 context: menuCtx,
                                 savedSelectedText:
@@ -2345,37 +2349,53 @@ class _NotesCommentaryWidgetState extends State<_NotesCommentaryWidget> {
                     ) ??
                     true;
               },
-              menuBuilder: (menuCtx, _) => [
-                AppContextMenuEntry(
-                  label: 'העתק',
-                  icon: FluentIcons.copy_24_regular,
-                  enabled:
-                      _selectedText != null && _selectedText!.trim().isNotEmpty,
-                  onTap: () => ContextMenuUtils.copyFormattedText(
-                    context: menuCtx,
-                    savedSelectedText: _selectedText,
-                    fontSize: widget.fontSize,
-                  ),
-                ),
-                if (!widget.state.book.isUserBook) ...[
-                  const AppContextMenuEntry.divider(),
+              menuBuilder: (menuCtx, tapPosition) {
+                final dictionaryText =
+                    (_selectedText?.trim().isNotEmpty == true)
+                    ? _selectedText
+                    : wordAtGlobalPosition(tapPosition);
+                final dictionaryEntries = buildDictionaryContextMenuEntries(
+                  context: menuCtx,
+                  selectedText: dictionaryText,
+                  repository: DictionaryLookupRepository.instance,
+                );
+                return [
                   AppContextMenuEntry(
-                    label: 'דווח על טעות בספר',
-                    icon: FluentIcons.error_circle_24_regular,
+                    label: 'העתק',
+                    icon: FluentIcons.copy_24_regular,
                     enabled:
                         _selectedText != null &&
                         _selectedText!.trim().isNotEmpty,
-                    onTap: () => ErrorReportHelper.showErrorReportDialog(
+                    onTap: () => ContextMenuUtils.copyFormattedText(
                       context: menuCtx,
-                      selectedText: _selectedText ?? '',
-                      state: widget.state,
+                      savedSelectedText: _selectedText,
                       fontSize: widget.fontSize,
-                      bookTitle: widget.state.book.title,
-                      savedSelectedIndex: widget.reportLineIndex,
                     ),
                   ),
-                ],
-              ],
+                  if (dictionaryEntries.isNotEmpty) ...[
+                    const AppContextMenuEntry.divider(),
+                    ...dictionaryEntries,
+                  ],
+                  if (!widget.state.book.isUserBook) ...[
+                    const AppContextMenuEntry.divider(),
+                    AppContextMenuEntry(
+                      label: 'דווח על טעות בספר',
+                      icon: FluentIcons.error_circle_24_regular,
+                      enabled:
+                          _selectedText != null &&
+                          _selectedText!.trim().isNotEmpty,
+                      onTap: () => ErrorReportHelper.showErrorReportDialog(
+                        context: menuCtx,
+                        selectedText: _selectedText ?? '',
+                        state: widget.state,
+                        fontSize: widget.fontSize,
+                        bookTitle: widget.state.book.title,
+                        savedSelectedIndex: widget.reportLineIndex,
+                      ),
+                    ),
+                  ],
+                ];
+              },
               child: SingleChildScrollView(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/text_book/view/selected_line_links_view.dart
+++ b/lib/text_book/view/selected_line_links_view.dart
@@ -552,13 +552,14 @@ class _SelectedLineLinksViewState extends State<SelectedLineLinksView> {
                   ) ??
                   true; // לא הוכרע — סלחני
             },
-            menuBuilder: (menuCtx, _) =>
+            menuBuilder: (menuCtx, tapPosition) =>
                 ContextMenuUtils.buildCommentaryContextMenu(
                   context: menuCtx,
                   link: link,
                   openBookCallback: widget.openBookCallback,
                   fontSize: widget.fontSize,
                   savedSelectedText: _savedSelectedText,
+                  tapPosition: tapPosition,
                   onCopySelected: () => ContextMenuUtils.copyFormattedText(
                     context: menuCtx,
                     savedSelectedText: _savedSelectedText,

--- a/lib/tools/dictionary/dictionary_context_menu_entries.dart
+++ b/lib/tools/dictionary/dictionary_context_menu_entries.dart
@@ -23,6 +23,7 @@ List<AppContextMenuEntry> buildDictionaryContextMenuEntries({
 
   final entries = <AppContextMenuEntry>[];
   final shouldCheckAcronyms = repository.isLikelyAcronym(trimmed);
+  final shouldCheckLaaz = repository.isLikelyLaazTranslit(trimmed);
 
   if (shouldCheckAcronyms && !repository.areAcronymsLoaded) {
     unawaited(repository.ensureAcronymsLoaded().catchError((_) {}));
@@ -32,7 +33,7 @@ List<AppContextMenuEntry> buildDictionaryContextMenuEntries({
     unawaited(repository.ensureAramaicLoaded().catchError((_) {}));
   }
 
-  if (!repository.areLaazLoaded) {
+  if (shouldCheckLaaz && !repository.areLaazLoaded) {
     unawaited(repository.ensureLaazLoaded().catchError((_) {}));
   }
 
@@ -68,7 +69,7 @@ List<AppContextMenuEntry> buildDictionaryContextMenuEntries({
     }
   }
 
-  if (repository.areLaazLoaded && repository.isLikelyLaazTranslit(trimmed)) {
+  if (shouldCheckLaaz && repository.areLaazLoaded) {
     final laazGroups = repository.findLaazMatchGroups(trimmed);
     if (laazGroups.isNotEmpty) {
       entries.add(

--- a/lib/tools/dictionary/dictionary_context_menu_entries.dart
+++ b/lib/tools/dictionary/dictionary_context_menu_entries.dart
@@ -32,6 +32,10 @@ List<AppContextMenuEntry> buildDictionaryContextMenuEntries({
     unawaited(repository.ensureAramaicLoaded().catchError((_) {}));
   }
 
+  if (!repository.areLaazLoaded) {
+    unawaited(repository.ensureLaazLoaded().catchError((_) {}));
+  }
+
   if (shouldCheckAcronyms && repository.areAcronymsLoaded) {
     final acronymEntries = repository.findAcronymMatches(trimmed);
     if (acronymEntries.isNotEmpty) {
@@ -64,6 +68,32 @@ List<AppContextMenuEntry> buildDictionaryContextMenuEntries({
     }
   }
 
+  if (repository.areLaazLoaded && repository.isLikelyLaazTranslit(trimmed)) {
+    final laazGroups = repository.findLaazMatchGroups(trimmed);
+    if (laazGroups.isNotEmpty) {
+      entries.add(
+        AppContextMenuEntry(
+          label: 'לעזי רש"י',
+          icon: FluentIcons.book_letter_24_regular,
+          children: laazGroups
+              .map<AppContextMenuEntry>(
+                (group) => AppContextMenuEntry(
+                  label: _summarizeLaazEntry(group.first),
+                  onTap: () => _showMeaningDialog(
+                    context: context,
+                    title: group.first.laazHebrew.isNotEmpty
+                        ? group.first.laazHebrew
+                        : group.first.lemma,
+                    content: _buildLaazDialogContent(context, group),
+                  ),
+                ),
+              )
+              .toList(),
+        ),
+      );
+    }
+  }
+
   return entries;
 }
 
@@ -73,47 +103,48 @@ AppContextMenuEntry _buildAcronymSubmenu(
 ) {
   final items = acronymEntries.length == 1
       ? acronymEntries.single.meanings
-          .map<AppContextMenuEntry>(
-            (meaning) => AppContextMenuEntry(
-              label: _summarizePlainText(meaning),
-              onTap: () => _showMeaningDialog(
-                context: context,
-                title: acronymEntries.single.acronym,
-                content: _buildAcronymDialogContent(meaning),
+            .map<AppContextMenuEntry>(
+              (meaning) => AppContextMenuEntry(
+                label: _summarizePlainText(meaning),
+                onTap: () => _showMeaningDialog(
+                  context: context,
+                  title: acronymEntries.single.acronym,
+                  content: _buildAcronymDialogContent(meaning),
+                ),
               ),
-            ),
-          )
-          .toList()
+            )
+            .toList()
       : acronymEntries
-          .map<AppContextMenuEntry>(
-            (entry) => entry.meanings.length == 1
-                ? AppContextMenuEntry(
-                    label:
-                        '${entry.acronym} - ${_summarizePlainText(entry.meanings.single)}',
-                    onTap: () => _showMeaningDialog(
-                      context: context,
-                      title: entry.acronym,
-                      content:
-                          _buildAcronymDialogContent(entry.meanings.single),
-                    ),
-                  )
-                : AppContextMenuEntry(
-                    label: entry.acronym,
-                    children: entry.meanings
-                        .map<AppContextMenuEntry>(
-                          (meaning) => AppContextMenuEntry(
-                            label: _summarizePlainText(meaning),
-                            onTap: () => _showMeaningDialog(
-                              context: context,
-                              title: entry.acronym,
-                              content: _buildAcronymDialogContent(meaning),
+            .map<AppContextMenuEntry>(
+              (entry) => entry.meanings.length == 1
+                  ? AppContextMenuEntry(
+                      label:
+                          '${entry.acronym} - ${_summarizePlainText(entry.meanings.single)}',
+                      onTap: () => _showMeaningDialog(
+                        context: context,
+                        title: entry.acronym,
+                        content: _buildAcronymDialogContent(
+                          entry.meanings.single,
+                        ),
+                      ),
+                    )
+                  : AppContextMenuEntry(
+                      label: entry.acronym,
+                      children: entry.meanings
+                          .map<AppContextMenuEntry>(
+                            (meaning) => AppContextMenuEntry(
+                              label: _summarizePlainText(meaning),
+                              onTap: () => _showMeaningDialog(
+                                context: context,
+                                title: entry.acronym,
+                                content: _buildAcronymDialogContent(meaning),
+                              ),
                             ),
-                          ),
-                        )
-                        .toList(),
-                  ),
-          )
-          .toList();
+                          )
+                          .toList(),
+                    ),
+            )
+            .toList();
 
   return AppContextMenuEntry(
     label: 'פתיחת ראשי תיבות',
@@ -162,6 +193,83 @@ Widget _buildAcronymDialogContent(String meaning) {
   );
 }
 
+String _summarizeLaazEntry(LaazDictionaryEntry entry) {
+  final title = entry.laazHebrew.isNotEmpty ? entry.laazHebrew : entry.lemma;
+  final description = entry.meaning.isNotEmpty ? entry.meaning : entry.note;
+  if (description == null || description.isEmpty) {
+    return _summarizePlainText(title);
+  }
+  return _summarizePlainText('$title - $description');
+}
+
+Widget _buildLaazDialogContent(
+  BuildContext context,
+  List<LaazDictionaryEntry> group,
+) {
+  final entry = group.first;
+  final lemmas = <String>{for (final e in group) e.lemma}.join(', ');
+  final references = <String>{
+    for (final e in group)
+      if (e.sourceReference.isNotEmpty) e.sourceReference,
+  }.join(', ');
+  final textTheme = Theme.of(context).textTheme;
+  final colorScheme = Theme.of(context).colorScheme;
+  final secondaryStyle = textTheme.bodySmall?.copyWith(
+    color: colorScheme.onSurfaceVariant,
+  );
+
+  return SizedBox(
+    width: 520,
+    child: SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$lemmas — ${entry.laazHebrew}',
+            style: textTheme.bodyLarge,
+          ),
+          if (entry.laazLatin.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              entry.laazLatin,
+              textDirection: TextDirection.ltr,
+              style: textTheme.bodyMedium?.copyWith(
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+          if (entry.meaning.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              entry.meaning,
+              style: textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+          if (references.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text('רש"י $references', style: secondaryStyle),
+          ],
+          if (entry.note != null) ...[
+            const SizedBox(height: 8),
+            Text(entry.note!, style: secondaryStyle),
+          ],
+          if (entry.english != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              entry.english!,
+              textDirection: TextDirection.ltr,
+              style: secondaryStyle,
+            ),
+          ],
+        ],
+      ),
+    ),
+  );
+}
+
 Widget _buildAramaicDialogContent(AramaicDictionaryEntry entry) {
   return SizedBox(
     width: 520,
@@ -185,10 +293,10 @@ void _showMeaningDialog({
   required Widget content,
 }) {
   context.read<TourCubit>().recordInteraction(
-        TourInteraction(
-          type: TourInteractionType.dictionaryUsed,
-        ),
-      );
+    TourInteraction(
+      type: TourInteractionType.dictionaryUsed,
+    ),
+  );
   showSingleActionDialog(
     context: context,
     title: title,

--- a/lib/tools/dictionary/repository/db_dictionary_book_source.dart
+++ b/lib/tools/dictionary/repository/db_dictionary_book_source.dart
@@ -2,14 +2,12 @@ import 'package:otzaria/data/data_providers/book_database_resolver.dart';
 
 /// שולף את שורות התוכן של ספר-מילון מבסיס הנתונים לפי כותרת.
 ///
-/// מחזיר רשימה ריקה אם הספר לא קיים או שה-DB אינו זמין — כך פיצ'רים
-/// מילוניים פשוט לא מופיעים, בלי שגיאות למשתמש.
+/// מחזיר רשימה ריקה אם הספר אינו קיים במסד הרשמי.
 Future<List<String>> loadDictionaryBookLines(String title) async {
-  try {
-    final resolved = await BookDatabaseResolver.resolveBook(title: title);
-    if (resolved == null) return const <String>[];
-    return await resolved.repository.getLineContents(resolved.book.id);
-  } catch (_) {
-    return const <String>[];
-  }
+  final resolved = await BookDatabaseResolver.resolveBook(
+    title: title,
+    officialOnly: true,
+  );
+  if (resolved == null) return const <String>[];
+  return resolved.repository.getLineContents(resolved.book.id);
 }

--- a/lib/tools/dictionary/repository/db_dictionary_book_source.dart
+++ b/lib/tools/dictionary/repository/db_dictionary_book_source.dart
@@ -1,0 +1,15 @@
+import 'package:otzaria/data/data_providers/book_database_resolver.dart';
+
+/// שולף את שורות התוכן של ספר-מילון מבסיס הנתונים לפי כותרת.
+///
+/// מחזיר רשימה ריקה אם הספר לא קיים או שה-DB אינו זמין — כך פיצ'רים
+/// מילוניים פשוט לא מופיעים, בלי שגיאות למשתמש.
+Future<List<String>> loadDictionaryBookLines(String title) async {
+  try {
+    final resolved = await BookDatabaseResolver.resolveBook(title: title);
+    if (resolved == null) return const <String>[];
+    return await resolved.repository.getLineContents(resolved.book.id);
+  } catch (_) {
+    return const <String>[];
+  }
+}

--- a/lib/tools/dictionary/repository/dictionary_lookup_repository.dart
+++ b/lib/tools/dictionary/repository/dictionary_lookup_repository.dart
@@ -72,6 +72,10 @@ class LaazDictionaryEntry {
     dotAll: true,
   );
   static final RegExp _latinLetter = RegExp(r'[a-zA-Z]');
+  static final RegExp _hebrewLetter = RegExp('[א-ת]');
+  static final RegExp _joinedLatinAndHebrew = RegExp(
+    r'^([^א-ת]*[a-zA-Z])([א-ת].*)$',
+  );
 
   /// מפרק את כל שורות הספר לערכי מילון; שורות כותרת ושורות לא-תקינות מדולגות.
   static List<LaazDictionaryEntry> parseLines(List<String> lines) {
@@ -119,13 +123,38 @@ class LaazDictionaryEntry {
     var meaning = '';
 
     if (parts.length >= 5) {
-      laazLatin = _stripTags(parts[3]);
+      final middleField = _stripTags(parts[3]);
       final meaningField = _removeTrailingBlocks(parts.sublist(4).join(' / '));
-      meaning = _matchGroup(_bold, meaningField) ?? _stripTags(meaningField);
+      final trailingField =
+          _matchGroup(_bold, meaningField) ?? _stripTags(meaningField);
+      final headIsLatin =
+          _latinLetter.hasMatch(afterLemma) &&
+          !_hebrewLetter.hasMatch(afterLemma);
+      final middleHasHebrew = _hebrewLetter.hasMatch(middleField);
+      final trailingIsLatin =
+          _latinLetter.hasMatch(trailingField) &&
+          !_hebrewLetter.hasMatch(trailingField);
+
+      if (headIsLatin && middleHasHebrew) {
+        laazHebrew = middleField;
+        laazLatin = afterLemma;
+        meaning = trailingField;
+      } else if (middleHasHebrew &&
+          (trailingField.isEmpty || trailingIsLatin)) {
+        laazLatin = trailingField;
+        meaning = middleField;
+      } else {
+        laazLatin = middleField;
+        meaning = trailingField;
+      }
     } else if (parts.length == 4) {
       final lastField = _removeTrailingBlocks(parts[3]);
       final boldLast = _matchGroup(_bold, lastField) ?? _stripTags(lastField);
-      if (_latinLetter.hasMatch(boldLast)) {
+      final joinedFields = _joinedLatinAndHebrew.firstMatch(boldLast);
+      if (joinedFields != null) {
+        laazLatin = joinedFields.group(1)?.trim() ?? '';
+        meaning = joinedFields.group(2)?.trim() ?? '';
+      } else if (_latinLetter.hasMatch(boldLast)) {
         // וריאנט שבו הלטינית מודגשת בשדה האחרון והפירוש נגרר אחרי התעתיק.
         laazLatin = boldLast;
         final split = _splitTranslitAndMeaning(afterLemma);
@@ -154,7 +183,9 @@ class LaazDictionaryEntry {
   ) {
     final tokens = text.split(RegExp(r'\s+'));
     var translitEnd = 0;
-    while (translitEnd < tokens.length && tokens[translitEnd].contains('"')) {
+    while (translitEnd < tokens.length &&
+        (tokens[translitEnd].contains('"') ||
+            tokens[translitEnd].contains('״'))) {
       translitEnd++;
     }
     if (translitEnd == 0) translitEnd = 1;
@@ -514,7 +545,7 @@ class DictionaryLookupRepository {
 
   /// מחזיר התאמות מדויקות ללעז לפי התעתיק העברי, עמיד לחילופי כתיב בין דפוסים.
   List<LaazDictionaryEntry> findLaazMatches(String raw) {
-    final key = _foldLaazTranslit(_normalizeAramaic(raw));
+    final key = _canonicalizeLaazTranslit(_normalizeAramaic(raw));
     if (key.isEmpty) return const <LaazDictionaryEntry>[];
 
     return _laazByTranslit[key] ?? const <LaazDictionaryEntry>[];
@@ -591,7 +622,9 @@ class DictionaryLookupRepository {
     final byTranslit = <String, List<LaazDictionaryEntry>>{};
 
     for (final entry in laazEntries) {
-      final translit = _foldLaazTranslit(_normalizeAramaic(entry.laazHebrew));
+      final translit = _canonicalizeLaazTranslit(
+        _normalizeAramaic(entry.laazHebrew),
+      );
       if (translit.isNotEmpty) {
         byTranslit
             .putIfAbsent(translit, () => <LaazDictionaryEntry>[])
@@ -671,12 +704,15 @@ class DictionaryLookupRepository {
     return _normalizeCommon(_trimDecorations(raw), keepQuotes: false);
   }
 
-  static final RegExp _consonantBeforeVav = RegExp('[בי](?=ו)');
+  static const Map<String, String> _laazTranslitAliases = <String, String>{
+    'שוון': 'שבון',
+    'שיון': 'שבון',
+    'רווישטיר': 'ריוישטיר',
+  };
 
-  /// מקפל חילופי כתיב בין דפוסים בתעתיקי לעז: העיצור שלפני ו' נכתב ב/ו/י
-  /// (שבו"ן=שוו"ן=שיו"ן). ההחלפה משמרת אורך כדי לא למזג מילים שונות (שו"ן).
-  static String _foldLaazTranslit(String normalized) {
-    return normalized.replaceAll(_consonantBeforeVav, 'ו');
+  /// מאחד רק חילופי כתיב שנמצאו בפועל, בלי למזג ראשי תיבות ומילים אחרות.
+  static String _canonicalizeLaazTranslit(String normalized) {
+    return _laazTranslitAliases[normalized] ?? normalized;
   }
 
   static String _normalizeCommon(String raw, {required bool keepQuotes}) {

--- a/lib/tools/dictionary/repository/dictionary_lookup_repository.dart
+++ b/lib/tools/dictionary/repository/dictionary_lookup_repository.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:otzaria/tools/dictionary/repository/db_dictionary_book_source.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 
 /// מייצג התאמה במילון ראשי התיבות.
@@ -24,6 +25,167 @@ class AramaicDictionaryEntry {
 
   final String aramaic;
   final String hebrew;
+}
+
+/// מייצג ערך במילון לעזי רש"י (ספר "אוצר לעזי רש"י").
+class LaazDictionaryEntry {
+  const LaazDictionaryEntry({
+    required this.entryNumber,
+    required this.sourceReference,
+    required this.lemma,
+    required this.laazHebrew,
+    required this.laazLatin,
+    required this.meaning,
+    this.note,
+    this.english,
+  });
+
+  /// המספר הרץ של הערך בספר.
+  final String entryNumber;
+
+  /// המקור ברש"י (למשל "ברכות ט:" או "בראשית א,ב").
+  final String sourceReference;
+
+  /// מילת הערך מדברי רש"י.
+  final String lemma;
+
+  /// הלעז בתעתיק עברי, כולל גרשיים כפי שמודפס.
+  final String laazHebrew;
+
+  /// הלעז באותיות לטיניות (עשוי להיות ריק).
+  final String laazLatin;
+
+  /// הפירוש העברי (עשוי להיות ריק בערכים חריגים).
+  final String meaning;
+
+  /// הערת העורך, אם קיימת.
+  final String? note;
+
+  /// תרגום אנגלי, אם קיים.
+  final String? english;
+
+  static final RegExp _htmlTag = RegExp(r'<[^>]*>');
+  static final RegExp _bold = RegExp(r'<b>(.*?)</b>', dotAll: true);
+  static final RegExp _small = RegExp(r'<small>(.*?)</small>', dotAll: true);
+  static final RegExp _ltrSpan = RegExp(
+    r'<span[^>]*>(.*?)</span>',
+    dotAll: true,
+  );
+  static final RegExp _latinLetter = RegExp(r'[a-zA-Z]');
+
+  /// מפרק את כל שורות הספר לערכי מילון; שורות כותרת ושורות לא-תקינות מדולגות.
+  static List<LaazDictionaryEntry> parseLines(List<String> lines) {
+    return lines
+        .map(parseLine)
+        .whereType<LaazDictionaryEntry>()
+        .toList(growable: false);
+  }
+
+  /// מפרק שורת ערך בודדת; מחזיר null לשורת כותרת או שורה שאינה ערך.
+  static LaazDictionaryEntry? parseLine(String line) {
+    // פענוח ישויות HTML לפני הפירוק, כדי שלא ידלפו לשדות או ישבשו את המפריד.
+    final trimmed = line
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .trim();
+    if (trimmed.isEmpty || trimmed.startsWith('<h')) return null;
+    if (!trimmed.contains(' / ')) return null;
+
+    final parts = trimmed.split(' / ');
+    if (parts.length < 3) return null;
+
+    final entryNumber = _stripTags(parts[0]);
+    var sourceReference = parts[1].trim();
+    if (sourceReference.startsWith('(') && sourceReference.endsWith(')')) {
+      sourceReference = sourceReference
+          .substring(1, sourceReference.length - 1)
+          .trim();
+    }
+
+    final note = _matchGroup(_small, trimmed);
+    final english = _cleanEnglish(_matchGroup(_ltrSpan, trimmed));
+
+    final headField = _removeTrailingBlocks(parts[2]);
+    final lemmaMatch = _bold.firstMatch(headField);
+    if (lemmaMatch == null) return null;
+    final lemma = _stripTags(lemmaMatch.group(1) ?? '');
+    if (lemma.isEmpty) return null;
+    final afterLemma = _stripTags(
+      headField.replaceRange(lemmaMatch.start, lemmaMatch.end, ' '),
+    );
+
+    var laazHebrew = afterLemma;
+    var laazLatin = '';
+    var meaning = '';
+
+    if (parts.length >= 5) {
+      laazLatin = _stripTags(parts[3]);
+      final meaningField = _removeTrailingBlocks(parts.sublist(4).join(' / '));
+      meaning = _matchGroup(_bold, meaningField) ?? _stripTags(meaningField);
+    } else if (parts.length == 4) {
+      final lastField = _removeTrailingBlocks(parts[3]);
+      final boldLast = _matchGroup(_bold, lastField) ?? _stripTags(lastField);
+      if (_latinLetter.hasMatch(boldLast)) {
+        // וריאנט שבו הלטינית מודגשת בשדה האחרון והפירוש נגרר אחרי התעתיק.
+        laazLatin = boldLast;
+        final split = _splitTranslitAndMeaning(afterLemma);
+        laazHebrew = split.translit;
+        meaning = split.meaning;
+      } else {
+        meaning = boldLast;
+      }
+    }
+
+    return LaazDictionaryEntry(
+      entryNumber: entryNumber,
+      sourceReference: sourceReference,
+      lemma: lemma,
+      laazHebrew: laazHebrew,
+      laazLatin: laazLatin,
+      meaning: meaning,
+      note: note,
+      english: english,
+    );
+  }
+
+  /// מפריד תעתיק מפירוש נגרר: מילות התעתיק מזוהות לפי גרשיים.
+  static ({String translit, String meaning}) _splitTranslitAndMeaning(
+    String text,
+  ) {
+    final tokens = text.split(RegExp(r'\s+'));
+    var translitEnd = 0;
+    while (translitEnd < tokens.length && tokens[translitEnd].contains('"')) {
+      translitEnd++;
+    }
+    if (translitEnd == 0) translitEnd = 1;
+
+    return (
+      translit: tokens.take(translitEnd).join(' '),
+      meaning: tokens.skip(translitEnd).join(' '),
+    );
+  }
+
+  static String _removeTrailingBlocks(String text) {
+    return text.replaceAll(_small, ' ').replaceAll(_ltrSpan, ' ');
+  }
+
+  static String? _matchGroup(RegExp pattern, String text) {
+    final value = _stripTags(pattern.firstMatch(text)?.group(1) ?? '');
+    return value.isEmpty ? null : value;
+  }
+
+  static String? _cleanEnglish(String? raw) {
+    if (raw == null) return null;
+    final cleaned = raw.replaceFirst('✭', '').trim();
+    return cleaned.isEmpty ? null : cleaned;
+  }
+
+  static String _stripTags(String text) {
+    return text
+        .replaceAll(_htmlTag, ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
 }
 
 /// מייצג פירוש בודד לאחר פענוח סימוני העיצוב של המילון.
@@ -75,14 +237,16 @@ class AramaicDictionaryEntryPresentation {
         : raw.substring(expressionMatch.end).trim();
 
     String? expansion;
-    final expansionAtStart =
-        RegExp(r'^\(=\s*([^)]+?)\)\s*').firstMatch(remaining);
+    final expansionAtStart = RegExp(
+      r'^\(=\s*([^)]+?)\)\s*',
+    ).firstMatch(remaining);
     if (expansionAtStart != null) {
       expansion = expansionAtStart.group(1)?.trim();
       remaining = remaining.substring(expansionAtStart.end).trim();
     } else {
-      final inlineExpansion =
-          RegExp(r'\s+\(=\s*([^)]+?)\)\s*').firstMatch(remaining);
+      final inlineExpansion = RegExp(
+        r'\s+\(=\s*([^)]+?)\)\s*',
+      ).firstMatch(remaining);
       if (inlineExpansion != null) {
         expansion = inlineExpansion.group(1)?.trim();
         final before = remaining.substring(0, inlineExpansion.start).trim();
@@ -104,34 +268,48 @@ class DictionaryLookupRepository {
   DictionaryLookupRepository({
     Future<Map<String, List<String>>> Function()? loadAcronyms,
     Future<List<AramaicDictionaryEntry>> Function()? loadAramaicEntries,
-  })  : _loadAcronyms = loadAcronyms ?? _defaultLoadAcronyms,
-        _loadAramaicEntries = loadAramaicEntries ?? _defaultLoadAramaicEntries;
+    Future<List<LaazDictionaryEntry>> Function()? loadLaazEntries,
+  }) : _loadAcronyms = loadAcronyms ?? _defaultLoadAcronyms,
+       _loadAramaicEntries = loadAramaicEntries ?? _defaultLoadAramaicEntries,
+       _loadLaazEntries = loadLaazEntries ?? _defaultLoadLaazEntries;
 
   static final DictionaryLookupRepository instance =
       DictionaryLookupRepository();
 
+  /// כותרת ספר לעזי רש"י ב-DB; הזיהוי תמיד לפי כותרת, לא לפי id.
+  static const String laazBookTitle = 'אוצר לעזי רש"י';
+
   final Future<Map<String, List<String>>> Function() _loadAcronyms;
   final Future<List<AramaicDictionaryEntry>> Function() _loadAramaicEntries;
+  final Future<List<LaazDictionaryEntry>> Function() _loadLaazEntries;
 
   Future<void>? _acronymsLoadFuture;
   Future<void>? _aramaicLoadFuture;
+  Future<void>? _laazLoadFuture;
   bool _areAcronymsLoaded = false;
   bool _areAramaicLoaded = false;
+  bool _areLaazLoaded = false;
 
   Map<String, List<String>> _acronymsByKey = <String, List<String>>{};
   Map<String, String> _originalAcronymByKey = <String, String>{};
   List<AramaicDictionaryEntry> _aramaicEntries = <AramaicDictionaryEntry>[];
   Set<String> _aramaicTerms = <String>{};
+  List<LaazDictionaryEntry> _laazEntries = <LaazDictionaryEntry>[];
+  Map<String, List<LaazDictionaryEntry>> _laazByTranslit =
+      <String, List<LaazDictionaryEntry>>{};
 
-  bool get isLoaded => _areAcronymsLoaded && _areAramaicLoaded;
+  bool get isLoaded =>
+      _areAcronymsLoaded && _areAramaicLoaded && _areLaazLoaded;
   bool get areAcronymsLoaded => _areAcronymsLoaded;
   bool get areAramaicLoaded => _areAramaicLoaded;
+  bool get areLaazLoaded => _areLaazLoaded;
 
-  /// טוען את שני המילונים פעם אחת ומשאיר אותם בזיכרון.
+  /// טוען את כל המילונים פעם אחת ומשאיר אותם בזיכרון.
   Future<void> ensureLoaded() async {
     await Future.wait<void>([
       ensureAcronymsLoaded(),
       ensureAramaicLoaded(),
+      ensureLaazLoaded(),
     ]);
   }
 
@@ -187,11 +365,40 @@ class DictionaryLookupRepository {
     }
   }
 
+  /// טוען את מילון לעזי רש"י בלבד.
+  Future<void> ensureLaazLoaded() async {
+    if (_areLaazLoaded) return;
+
+    final pendingFuture = _laazLoadFuture;
+    if (pendingFuture != null) {
+      await pendingFuture;
+      return;
+    }
+
+    final loadFuture = _loadLaazInternal();
+    _laazLoadFuture = loadFuture;
+
+    try {
+      await loadFuture;
+      _areLaazLoaded = true;
+    } catch (_) {
+      _resetLaazCache();
+      rethrow;
+    } finally {
+      if (identical(_laazLoadFuture, loadFuture)) {
+        _laazLoadFuture = null;
+      }
+    }
+  }
+
   /// מחזיר את כלל רשומות ראשי התיבות.
   Map<String, List<String>> getAllAcronyms() {
-    return Map<String, List<String>>.unmodifiable(_acronymsByKey.map(
-      (key, meanings) => MapEntry(_originalAcronymByKey[key] ?? key, meanings),
-    ));
+    return Map<String, List<String>>.unmodifiable(
+      _acronymsByKey.map(
+        (key, meanings) =>
+            MapEntry(_originalAcronymByKey[key] ?? key, meanings),
+      ),
+    );
   }
 
   /// מחזיר את כל רשומות המילון הארמי-עברי.
@@ -206,6 +413,15 @@ class DictionaryLookupRepository {
         trimmed.contains('״') ||
         trimmed.contains("'") ||
         trimmed.contains('׳');
+  }
+
+  static final RegExp _innerGershayim = RegExp(
+    '[א-ת][֑-ׇ]*["״][א-ת]',
+  );
+
+  /// בודק אם הטקסט נראה כתעתיק לעז: גרשיים בין אותיות בתוך המילה.
+  bool isLikelyLaazTranslit(String raw) {
+    return _innerGershayim.hasMatch(raw.trim());
   }
 
   /// מחזיר את כל הפירושים לראשי תיבות אם קיימים.
@@ -291,6 +507,37 @@ class DictionaryLookupRepository {
     ];
   }
 
+  /// מחזיר את כל רשומות מילון לעזי רש"י.
+  List<LaazDictionaryEntry> getAllLaazEntries() {
+    return List<LaazDictionaryEntry>.unmodifiable(_laazEntries);
+  }
+
+  /// מחזיר התאמות מדויקות ללעז לפי התעתיק העברי, עמיד לחילופי כתיב בין דפוסים.
+  List<LaazDictionaryEntry> findLaazMatches(String raw) {
+    final key = _foldLaazTranslit(_normalizeAramaic(raw));
+    if (key.isEmpty) return const <LaazDictionaryEntry>[];
+
+    return _laazByTranslit[key] ?? const <LaazDictionaryEntry>[];
+  }
+
+  /// מחזיר את התאמות הלעז מקובצות: ערכים עם אותו תעתיק ואותו פירוש
+  /// (ממקורות רש"י שונים) מאוחדים לקבוצה אחת, לפי סדר ההופעה בספר.
+  List<List<LaazDictionaryEntry>> findLaazMatchGroups(String raw) {
+    final groups = <String, List<LaazDictionaryEntry>>{};
+    for (final entry in findLaazMatches(raw)) {
+      final title = entry.laazHebrew.isNotEmpty
+          ? entry.laazHebrew
+          : entry.lemma;
+      final description = entry.meaning.isNotEmpty
+          ? entry.meaning
+          : (entry.note ?? '');
+      final key =
+          '${_normalizeAramaic(title)}|${_normalizeAramaic(description)}';
+      groups.putIfAbsent(key, () => <LaazDictionaryEntry>[]).add(entry);
+    }
+    return groups.values.toList(growable: false);
+  }
+
   Future<void> _loadAcronymsInternal() async {
     final acronyms = await _loadAcronyms();
 
@@ -339,9 +586,27 @@ class DictionaryLookupRepository {
     _aramaicTerms = Set<String>.unmodifiable(aramaicTerms);
   }
 
+  Future<void> _loadLaazInternal() async {
+    final laazEntries = await _loadLaazEntries();
+    final byTranslit = <String, List<LaazDictionaryEntry>>{};
+
+    for (final entry in laazEntries) {
+      final translit = _foldLaazTranslit(_normalizeAramaic(entry.laazHebrew));
+      if (translit.isNotEmpty) {
+        byTranslit
+            .putIfAbsent(translit, () => <LaazDictionaryEntry>[])
+            .add(entry);
+      }
+    }
+
+    _laazEntries = List<LaazDictionaryEntry>.unmodifiable(laazEntries);
+    _laazByTranslit = byTranslit;
+  }
+
   static Future<Map<String, List<String>>> _defaultLoadAcronyms() async {
-    final String jsonString =
-        await rootBundle.loadString('assets/Acronyms.json');
+    final String jsonString = await rootBundle.loadString(
+      'assets/Acronyms.json',
+    );
     final jsonData = await compute(_decodeJsonObject, jsonString);
 
     return jsonData.map((key, value) {
@@ -354,9 +619,10 @@ class DictionaryLookupRepository {
   }
 
   static Future<List<AramaicDictionaryEntry>>
-      _defaultLoadAramaicEntries() async {
-    final String jsonString =
-        await rootBundle.loadString('assets/dictionary.json');
+  _defaultLoadAramaicEntries() async {
+    final String jsonString = await rootBundle.loadString(
+      'assets/dictionary.json',
+    );
     final jsonData = await compute(_decodeJsonObject, jsonString);
     final List<dynamic> entries = jsonData['מילון פשיטא'] ?? <dynamic>[];
 
@@ -378,6 +644,13 @@ class DictionaryLookupRepository {
         .toList();
   }
 
+  static Future<List<LaazDictionaryEntry>> _defaultLoadLaazEntries() async {
+    // קריאת ה-DB נשארת ב-main isolate (FFI); רק הפירוק עובר ל-compute.
+    final lines = await loadDictionaryBookLines(laazBookTitle);
+    if (lines.isEmpty) return const <LaazDictionaryEntry>[];
+    return compute(LaazDictionaryEntry.parseLines, lines);
+  }
+
   static Map<String, dynamic> _decodeJsonObject(String jsonString) {
     return jsonDecode(jsonString) as Map<String, dynamic>;
   }
@@ -396,6 +669,14 @@ class DictionaryLookupRepository {
 
   static String _normalizeAramaic(String raw) {
     return _normalizeCommon(_trimDecorations(raw), keepQuotes: false);
+  }
+
+  static final RegExp _consonantBeforeVav = RegExp('[בי](?=ו)');
+
+  /// מקפל חילופי כתיב בין דפוסים בתעתיקי לעז: העיצור שלפני ו' נכתב ב/ו/י
+  /// (שבו"ן=שוו"ן=שיו"ן). ההחלפה משמרת אורך כדי לא למזג מילים שונות (שו"ן).
+  static String _foldLaazTranslit(String normalized) {
+    return normalized.replaceAll(_consonantBeforeVav, 'ו');
   }
 
   static String _normalizeCommon(String raw, {required bool keepQuotes}) {
@@ -450,5 +731,11 @@ class DictionaryLookupRepository {
     _aramaicEntries = <AramaicDictionaryEntry>[];
     _aramaicTerms = <String>{};
     _areAramaicLoaded = false;
+  }
+
+  void _resetLaazCache() {
+    _laazEntries = <LaazDictionaryEntry>[];
+    _laazByTranslit = <String, List<LaazDictionaryEntry>>{};
+    _areLaazLoaded = false;
   }
 }

--- a/lib/utils/ui/context_menu_utils.dart
+++ b/lib/utils/ui/context_menu_utils.dart
@@ -11,8 +11,11 @@ import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/view/error_report_dialog.dart';
+import 'package:otzaria/tools/dictionary/dictionary_context_menu_entries.dart';
+import 'package:otzaria/tools/dictionary/repository/dictionary_lookup_repository.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/utils/text/copy_utils.dart';
+import 'package:otzaria/utils/text/word_at_position.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/text_book/view/selection/selected_text_copy.dart';
@@ -53,8 +56,10 @@ class ContextMenuUtils {
     required double fontSize,
     String? savedSelectedText,
     required VoidCallback onCopySelected,
+    Offset? tapPosition,
+    DictionaryLookupRepository? dictionaryRepository,
   }) {
-    return [
+    final entries = <AppContextMenuEntry>[
       AppContextMenuEntry(
         label: 'העתק',
         icon: FluentIcons.copy_24_regular,
@@ -76,17 +81,36 @@ class ContextMenuUtils {
         label: 'פתח ספר זה בחלון נפרד',
         icon: FluentIcons.open_24_regular,
         onTap: () {
-          openBookCallback(TextBookTab(
-            book: _targetBookFromLink(link),
-            index: link.index2 - 1,
-            openLeftPane: (Settings.getValue<bool>('key-pin-sidebar') ??
-                    false) ||
-                (Settings.getValue<bool>('key-default-sidebar-open') ?? false),
-          ));
+          openBookCallback(
+            TextBookTab(
+              book: _targetBookFromLink(link),
+              index: link.index2 - 1,
+              openLeftPane:
+                  (Settings.getValue<bool>('key-pin-sidebar') ?? false) ||
+                  (Settings.getValue<bool>('key-default-sidebar-open') ??
+                      false),
+            ),
+          );
         },
       ),
-      if (!link.targetIsUserBook) ...[
-        const AppContextMenuEntry.divider(),
+    ];
+
+    final dictionaryText = (savedSelectedText?.trim().isNotEmpty == true)
+        ? savedSelectedText
+        : (tapPosition != null ? wordAtGlobalPosition(tapPosition) : null);
+    final dictionaryEntries = buildDictionaryContextMenuEntries(
+      context: context,
+      selectedText: dictionaryText,
+      repository: dictionaryRepository ?? DictionaryLookupRepository.instance,
+    );
+    if (dictionaryEntries.isNotEmpty) {
+      entries.add(const AppContextMenuEntry.divider());
+      entries.addAll(dictionaryEntries);
+    }
+
+    if (!link.targetIsUserBook) {
+      entries.add(const AppContextMenuEntry.divider());
+      entries.add(
         AppContextMenuEntry(
           label: 'דווח על טעות בספר',
           icon: FluentIcons.error_circle_24_regular,
@@ -97,8 +121,10 @@ class ContextMenuUtils {
             savedSelectedText: savedSelectedText,
           ),
         ),
-      ],
-    ];
+      );
+    }
+
+    return entries;
   }
 
   /// ממפה מפרש ([link] + תוכנו [rawContent]) לפרמטרי דיווח הטעות: הדיווח מופנה
@@ -109,7 +135,8 @@ class ContextMenuUtils {
     int lineIndex,
     String bookTitle,
     String selectedText,
-  }) commentaryReportArgs({
+  })
+  commentaryReportArgs({
     required Link link,
     required String rawContent,
     String? savedSelectedText,

--- a/test/data_providers/book_database_resolver_test.dart
+++ b/test/data_providers/book_database_resolver_test.dart
@@ -423,6 +423,29 @@ void main() {
           reason: 'preferUserBooks=true מחפש קודם ב-user_books');
     });
 
+    test('resolveBook עם officialOnly לא נופל לספר אישי בעל אותה כותרת', () async {
+      final userBooksRepo = await UserBooksDatabaseHolder.instance.repository;
+      final catId = await userBooksRepo.insertCategory(
+        const migration_models.Category(title: 'ספרים אישיים'),
+      );
+      final sourceId = await userBooksRepo.insertSource('Personal::test', -1);
+      await userBooksRepo.insertBook(
+        migration_models.Book(
+          categoryId: catId,
+          sourceId: sourceId,
+          title: 'מילון אישי',
+          fileType: 'txt',
+        ),
+      );
+
+      final resolved = await BookDatabaseResolver.resolveBook(
+        title: 'מילון אישי',
+        officialOnly: true,
+      );
+
+      expect(resolved, isNull);
+    });
+
     test('resolveBookById עם isUserBook=true מחפש רק ב-user_books', () async {
       // ב-seforim וב-user_books נוצרים ספרים נפרדים. ה-AUTOINCREMENT יקצה
       // לכל אחד id משלו — שומרים את שני המזהים כדי לבדוק שכל DB מחזיר את שלו.

--- a/test/tools/dictionary/dictionary_lookup_repository_test.dart
+++ b/test/tools/dictionary/dictionary_lookup_repository_test.dart
@@ -135,6 +135,7 @@ void main() {
             hebrew: '{אַבָּא} אב *** {אֲבָא} רוצה',
           ),
         ],
+        loadLaazEntries: () async => const <LaazDictionaryEntry>[],
       );
     });
 
@@ -198,8 +199,9 @@ void main() {
       expect(entries, hasLength(1));
     });
 
-    testWidgets('מציג חיפוש ארמי גם כשמילון ראשי התיבות לא נטען',
-        (tester) async {
+    testWidgets('מציג חיפוש ארמי גם כשמילון ראשי התיבות לא נטען', (
+      tester,
+    ) async {
       await repository.ensureAramaicLoaded();
       await tester.pumpWidget(
         const MaterialApp(
@@ -227,6 +229,7 @@ void main() {
         loadAramaicEntries: () async => const <AramaicDictionaryEntry>[
           AramaicDictionaryEntry(aramaic: 'אבא', hebrew: 'יער'),
         ],
+        loadLaazEntries: () async => const <LaazDictionaryEntry>[],
       );
       await repository.ensureAcronymsLoaded();
       await tester.pumpWidget(

--- a/test/tools/dictionary/dictionary_lookup_repository_test.dart
+++ b/test/tools/dictionary/dictionary_lookup_repository_test.dart
@@ -18,6 +18,7 @@ void main() {
           AramaicDictionaryEntry(aramaic: 'בר אבא', hebrew: 'בן היער'),
           AramaicDictionaryEntry(aramaic: 'אבוה', hebrew: 'אביו'),
         ],
+        loadLaazEntries: () async => const <LaazDictionaryEntry>[],
       );
     });
 

--- a/test/tools/dictionary/laaz_dictionary_test.dart
+++ b/test/tools/dictionary/laaz_dictionary_test.dart
@@ -80,6 +80,43 @@ void main() {
       expect(entry.english, 'jasmine');
     });
 
+    test('מפרק ערך שבו התעתיק הלטיני מופיע לפני התעתיק העברי', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '3094 / (שמות טו,כד) / <b>וילנו</b> decompleinst sei / '
+        'דיקומפליינש"ט שי"י / '
+        '<b>התלונן (מלה במלה: קונן על עצמו)</b>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.laazHebrew, 'דיקומפליינש"ט שי"י');
+      expect(entry.laazLatin, 'decompleinst sei');
+      expect(entry.meaning, 'התלונן (מלה במלה: קונן על עצמו)');
+    });
+
+    test('מפרק ערך שבו הפירוש מקדים תעתיק לטיני מודגש', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '3027 / (בראשית ל,כ) / <b>יזבלני</b> הירבירייריא"ה / '
+        'אירוח, לינה / <b>herberjerie</b> <small></small>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.laazHebrew, 'הירבירייריא"ה');
+      expect(entry.laazLatin, 'herberjerie');
+      expect(entry.meaning, 'אירוח, לינה');
+    });
+
+    test('מפריד פירוש עברי שנדבק לתעתיק הלטיני', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '776 / (סוכה יז.) / <b>דה"מ וכן חצר</b> קלוישטר"א / '
+        '<b>cloistreחצר סגורה באכסדרה מרובעת</b>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.laazHebrew, 'קלוישטר"א');
+      expect(entry.laazLatin, 'cloistre');
+      expect(entry.meaning, 'חצר סגורה באכסדרה מרובעת');
+    });
+
     test('מפענח &amp; בשדות הערך (קיים בנתוני הספר בפועל)', () {
       final entry = LaazDictionaryEntry.parseLine(
         '1456 / (בבא קמא קיט.) / <b>מוכין</b> גרטויש"א / geatuise / '
@@ -179,6 +216,30 @@ void main() {
       expect(repository.findLaazMatches('שוו"ן').single.laazLatin, 'savon');
       expect(repository.findLaazMatches('שיו"ן').single.laazLatin, 'savon');
       expect(repository.findLaazMatches('שו"ן').single.laazLatin, 'son');
+    });
+
+    test('כינויי הכתיב אינם ממזגים את ראשי התיבות יו"ט עם בו"ט', () async {
+      repository = buildRepository(
+        () async => LaazDictionaryEntry.parseLines(const <String>[
+          '2439 / (נידה נו.) / <b>זבוגי</b> בו"ט / bot / <b>קרפדה</b>',
+        ]),
+      );
+      await repository.ensureLaazLoaded();
+
+      expect(repository.findLaazMatches('בו"ט'), hasLength(1));
+      expect(repository.findLaazMatches('יו"ט'), isEmpty);
+    });
+
+    test('שומר את כינוי הכתיב ריוישטי"ר/רווישט"יר', () async {
+      repository = buildRepository(
+        () async => LaazDictionaryEntry.parseLines(const <String>[
+          '3139 / (שמות כח,מא) / <b>דה"מ ומלאת</b> ריוישטי"ר / '
+              'rewestir / <b>להלביש, להסמיך</b>',
+        ]),
+      );
+      await repository.ensureLaazLoaded();
+
+      expect(repository.findLaazMatches('רווישט"יר'), hasLength(1));
     });
 
     test('ספר חסר ב-DB — טעינה ריקה בלי שגיאות והתאמות ריקות', () async {
@@ -408,6 +469,28 @@ void main() {
       );
 
       expect(entries, isEmpty);
+    });
+
+    testWidgets('מילה רגילה אינה מפעילה טעינת מילון לעזים', (tester) async {
+      var laazLoadCount = 0;
+      repository = DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: () async {
+          laazLoadCount++;
+          return const <LaazDictionaryEntry>[];
+        },
+      );
+      final context = await pumpHost(tester);
+
+      buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'שלום',
+        repository: repository,
+      );
+      await tester.pump();
+
+      expect(laazLoadCount, 0);
     });
   });
 }

--- a/test/tools/dictionary/laaz_dictionary_test.dart
+++ b/test/tools/dictionary/laaz_dictionary_test.dart
@@ -1,0 +1,413 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/tools/dictionary/dictionary_context_menu_entries.dart';
+import 'package:otzaria/tools/dictionary/repository/dictionary_lookup_repository.dart';
+
+void main() {
+  group('LaazDictionaryEntry.parseLine', () {
+    test('מפרק ערך תלמוד מלא עם תרגום אנגלי', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '7 / (ברכות ט:) / <b>כרתי</b> פוריל"ש / porels / '
+        '<b>כרשים (ירק מאכל)</b> '
+        '<span dir="ltr">✭ leek (vegetable used as food)</span>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.entryNumber, '7');
+      expect(entry.sourceReference, 'ברכות ט:');
+      expect(entry.lemma, 'כרתי');
+      expect(entry.laazHebrew, 'פוריל"ש');
+      expect(entry.laazLatin, 'porels');
+      expect(entry.meaning, 'כרשים (ירק מאכל)');
+      expect(entry.note, isNull);
+      expect(entry.english, 'leek (vegetable used as food)');
+    });
+
+    test('מפרק ערך תנ"ך עם הערה ובלי אנגלית', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '3001 / (בראשית א,ב) / <b>תהו</b> אישטורדישו"ן / estordison / '
+        '<b>עילפון, הלם, מבוכה</b> <small>ר\' אה"ל 549 ועוד.</small>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.sourceReference, 'בראשית א,ב');
+      expect(entry.lemma, 'תהו');
+      expect(entry.laazHebrew, 'אישטורדישו"ן');
+      expect(entry.laazLatin, 'estordison');
+      expect(entry.meaning, 'עילפון, הלם, מבוכה');
+      expect(entry.note, 'ר\' אה"ל 549 ועוד.');
+      expect(entry.english, isNull);
+    });
+
+    test('שומר צורה מנורמלת בסוגריים מרובעים בשדה הלטיני', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '14 / (ברכות כד.) / <b>פיהק</b> בדייליי"ר / '
+        'badeilier [badaillier] / <b>לפהק</b> '
+        '<span dir="ltr">✭ to yawn</span>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.laazLatin, 'badeilier [badaillier]');
+      expect(entry.meaning, 'לפהק');
+      expect(entry.english, 'to yawn');
+    });
+
+    test('מפרק וריאנט שבו הלטינית מודגשת בשדה האחרון', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '210 / (שבת נג:) / <b>דה"מ שאכלה כרשינין</b> מיניישונ"ש שלשול / '
+        '<b>meneisons [menaisons]</b> '
+        '<small>ר\' מילונו של לוי (מס\' 736).</small> '
+        '<span dir="ltr">✭ diarrhea</span>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.laazHebrew, 'מיניישונ"ש');
+      expect(entry.laazLatin, 'meneisons [menaisons]');
+      expect(entry.meaning, 'שלשול');
+    });
+
+    test('מפרק ערך ללא שדה לטיני כשהפירוש מודגש בשדה האחרון', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '49א / (ברכות מג:) / <b>סמלק</b> יסמי"ן / '
+        '<b>"בלשון ישמעאל".</b> <span dir="ltr">✭ jasmine</span>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.entryNumber, '49א');
+      expect(entry.laazHebrew, 'יסמי"ן');
+      expect(entry.laazLatin, isEmpty);
+      expect(entry.meaning, '"בלשון ישמעאל".');
+      expect(entry.english, 'jasmine');
+    });
+
+    test('מפענח &amp; בשדות הערך (קיים בנתוני הספר בפועל)', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '1456 / (בבא קמא קיט.) / <b>מוכין</b> גרטויש"א / geatuise / '
+        '<b>פסול הצמר</b> <small>יש לתקן ולקרוא a&amp;b bis 562.</small>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.note, 'יש לתקן ולקרוא a&b bis 562.');
+    });
+
+    test('עמיד ל-&nbsp; סביב המפריד ובתוך שדות', () {
+      final entry = LaazDictionaryEntry.parseLine(
+        '7 / (ברכות ט:) /&nbsp;<b>כרתי</b> פוריל"ש / porels / '
+        '<b>כרשים&nbsp;(ירק מאכל)</b>',
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.lemma, 'כרתי');
+      expect(entry.meaning, 'כרשים (ירק מאכל)');
+    });
+
+    test('מדלג על שורות כותרת ושורות ללא מפריד', () {
+      final entries = LaazDictionaryEntry.parseLines(const <String>[
+        '<h1>אוצר לעזי רש"י</h1>',
+        '<h2>תלמוד</h2>',
+        '<h3>ברכות</h3>',
+        'משה קטן',
+        '7 / (ברכות ט:) / <b>כרתי</b> פוריל"ש / porels / <b>כרשים</b>',
+      ]);
+
+      expect(entries, hasLength(1));
+      expect(entries.single.lemma, 'כרתי');
+    });
+  });
+
+  group('findLaazMatches', () {
+    late DictionaryLookupRepository repository;
+
+    DictionaryLookupRepository buildRepository(
+      Future<List<LaazDictionaryEntry>> Function() loadLaazEntries,
+    ) {
+      return DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: loadLaazEntries,
+      );
+    }
+
+    setUp(() {
+      repository = buildRepository(
+        () async => LaazDictionaryEntry.parseLines(const <String>[
+          '7 / (ברכות ט:) / <b>כרתי</b> פוריל"ש / porels / <b>כרשים (ירק מאכל)</b>',
+          '3001 / (בראשית א,ב) / <b>תהו</b> אישטורדישו"ן / estordison / <b>עילפון</b>',
+        ]),
+      );
+    });
+
+    test('מוצא לעז לפי התעתיק העברי גם עם גרשיים עבריים וניקוד', () async {
+      await repository.ensureLaazLoaded();
+
+      expect(repository.findLaazMatches('פוריל"ש'), hasLength(1));
+      expect(repository.findLaazMatches('פוריל״ש'), hasLength(1));
+      expect(repository.findLaazMatches('פּוֹרִילְש'), hasLength(1));
+      expect(
+        repository.findLaazMatches('פוריל"ש').single.laazLatin,
+        'porels',
+      );
+    });
+
+    test('מילת הערך מרש"י אינה מפעילה התאמה - רק תעתיק', () async {
+      await repository.ensureLaazLoaded();
+
+      expect(repository.findLaazMatches('תָּהוּ'), isEmpty);
+      expect(repository.findLaazMatches('כרתי'), isEmpty);
+    });
+
+    test('מחזיר ריק כשאין התאמה מדויקת', () async {
+      await repository.ensureLaazLoaded();
+
+      expect(repository.findLaazMatches('שלום'), isEmpty);
+    });
+
+    test('מוצא תעתיק בחילופי כתיב בין דפוסים (שבו"ן/שוו"ן/שיו"ן)', () async {
+      // הערכים האמיתיים מהספר: שבו"ן (savon, מס' 1434) ושו"ן (son, מס' 1725).
+      repository = buildRepository(
+        () async => LaazDictionaryEntry.parseLines(const <String>[
+          '1434 / (בבא קמא צג:) / <b>צפון</b> שבו"ן / savon / <b>סבון</b> '
+              '<span dir="ltr">✭ soap</span>',
+          '1725 / (סנהדרין צד:) / <b>משק</b> שו"ן / son / <b>צליל, רעש</b> '
+              '<span dir="ltr">✭ sound, noise</span>',
+        ]),
+      );
+      await repository.ensureLaazLoaded();
+
+      // ברש"י על ב"ק צג: מודפס "שיו"ן" ועל ב"ק קא. "שוו"ן" - אותו לעז.
+      expect(repository.findLaazMatches('שבו"ן').single.laazLatin, 'savon');
+      expect(repository.findLaazMatches('שוו"ן').single.laazLatin, 'savon');
+      expect(repository.findLaazMatches('שיו"ן').single.laazLatin, 'savon');
+      expect(repository.findLaazMatches('שו"ן').single.laazLatin, 'son');
+    });
+
+    test('ספר חסר ב-DB — טעינה ריקה בלי שגיאות והתאמות ריקות', () async {
+      repository = buildRepository(() async => const <LaazDictionaryEntry>[]);
+
+      await repository.ensureLaazLoaded();
+
+      expect(repository.areLaazLoaded, isTrue);
+      expect(repository.findLaazMatches('כרתי'), isEmpty);
+    });
+  });
+
+  group('isLikelyLaazTranslit', () {
+    final repository = DictionaryLookupRepository(
+      loadAcronyms: () async => <String, List<String>>{},
+      loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+      loadLaazEntries: () async => const <LaazDictionaryEntry>[],
+    );
+
+    test('מזהה גרשיים בתוך המילה, כולל גרשיים עבריים וניקוד', () {
+      expect(repository.isLikelyLaazTranslit('פוריל"ש'), isTrue);
+      expect(repository.isLikelyLaazTranslit('פוריל״ש'), isTrue);
+      expect(repository.isLikelyLaazTranslit('פּוֹרִיל"ש'), isTrue);
+      expect(repository.isLikelyLaazTranslit('שיו"ן'), isTrue);
+    });
+
+    test('דוחה מילים רגילות וגרשיים שאינם בתוך המילה', () {
+      expect(repository.isLikelyLaazTranslit('צפון'), isFalse);
+      expect(repository.isLikelyLaazTranslit('"צפון"'), isFalse);
+      expect(repository.isLikelyLaazTranslit('כרתי'), isFalse);
+      expect(repository.isLikelyLaazTranslit(''), isFalse);
+    });
+  });
+
+  group('findLaazMatchGroups', () {
+    DictionaryLookupRepository buildRepository(List<String> lines) {
+      return DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: () async => LaazDictionaryEntry.parseLines(lines),
+      );
+    }
+
+    test('מאחד ערכים זהים בתעתיק ובפירוש ממקורות רש"י שונים', () async {
+      final repository = buildRepository(const <String>[
+        '1432 / (בבא קמא צג:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+        '1466 / (בבא קמא קיט:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+        '1550 / (בבא מציעא פד:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+        '2311 / (בכורות כט:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+      ]);
+      await repository.ensureLaazLoaded();
+
+      final groups = repository.findLaazMatchGroups('פילטרי"ש');
+
+      expect(groups, hasLength(1));
+      expect(groups.single, hasLength(4));
+      expect(
+        groups.single.map((e) => e.sourceReference),
+        containsAll(<String>['בבא קמא צג:', 'בכורות כט:']),
+      );
+    });
+
+    test('תעתיק זהה עם פירושים שונים נשאר בקבוצות נפרדות', () async {
+      final repository = buildRepository(const <String>[
+        '1 / (ברכות ט:) / <b>כרתי</b> פוריל"ש / porels / <b>כרשים</b>',
+        '2 / (שבת י.) / <b>כרתי</b> פוריל"ש / porels / <b>ירק אחר</b>',
+      ]);
+      await repository.ensureLaazLoaded();
+
+      final groups = repository.findLaazMatchGroups('פוריל"ש');
+
+      expect(groups, hasLength(2));
+      expect(groups.first.single.meaning, 'כרשים');
+      expect(groups.last.single.meaning, 'ירק אחר');
+    });
+  });
+
+  group('ענף לעזי רש"י בתפריט ההקשר', () {
+    late DictionaryLookupRepository repository;
+
+    setUp(() {
+      repository = DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: () async => LaazDictionaryEntry.parseLines(
+          const <String>[
+            '7 / (ברכות ט:) / <b>כרתי</b> פוריל"ש / porels / <b>כרשים (ירק מאכל)</b>',
+          ],
+        ),
+      );
+    });
+
+    Future<BuildContext> pumpHost(WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox.shrink(),
+          ),
+        ),
+      );
+      return tester.element(find.byType(SizedBox));
+    }
+
+    testWidgets('מציג ענף לעזי רש"י כשיש התאמה ללעז', (tester) async {
+      await repository.ensureLoaded();
+      await repository.ensureLaazLoaded();
+      final context = await pumpHost(tester);
+
+      final entries = buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'פוריל"ש',
+        repository: repository,
+      );
+
+      expect(entries, hasLength(1));
+      expect(entries.single.label, contains('לעזי'));
+      expect(entries.single.children, hasLength(1));
+    });
+
+    testWidgets('מילה ללא גרשיים לא מציגה ענף, גם כשהיא מילת ערך', (
+      tester,
+    ) async {
+      await repository.ensureLoaded();
+      final context = await pumpHost(tester);
+
+      final entries = buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'כרתי',
+        repository: repository,
+      );
+
+      expect(entries, isEmpty);
+    });
+
+    testWidgets('תעתיק בכתיב דפוס שונה (שיו"ן) מוצא את ערך שבו"ן', (
+      tester,
+    ) async {
+      repository = DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: () async => LaazDictionaryEntry.parseLines(
+          const <String>[
+            '1434 / (בבא קמא צג:) / <b>צפון</b> שבו"ן / savon / <b>סבון</b> '
+                '<span dir="ltr">✭ soap</span>',
+          ],
+        ),
+      );
+      await repository.ensureLaazLoaded();
+      final context = await pumpHost(tester);
+
+      // כך הלעז מודפס ברש"י על בבא קמא צג: "צפון - שיו"ן".
+      final entries = buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'שיו"ן',
+        repository: repository,
+      );
+
+      expect(entries, hasLength(1));
+      expect(entries.single.label, contains('לעזי'));
+      expect(entries.single.children!.single.label, contains('סבון'));
+    });
+
+    testWidgets('ערכים כפולים ממקורות שונים מוצגים כפריט תפריט אחד', (
+      tester,
+    ) async {
+      repository = DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: () async => LaazDictionaryEntry.parseLines(
+          const <String>[
+            '1432 / (בבא קמא צג:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+            '1466 / (בבא קמא קיט:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+            '1550 / (בבא מציעא פד:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+            '2311 / (בכורות כט:) / <b>נמטי</b> פילטרי"ש / feltres / <b>לבדים (מצעים של לֶבֶד)</b>',
+          ],
+        ),
+      );
+      await repository.ensureLaazLoaded();
+      final context = await pumpHost(tester);
+
+      final entries = buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'פילטרי"ש',
+        repository: repository,
+      );
+
+      expect(entries, hasLength(1));
+      expect(entries.single.children, hasLength(1));
+      expect(entries.single.children!.single.label, contains('פילטרי"ש'));
+    });
+
+    testWidgets('פירושים שונים לאותו תעתיק נשארים פריטים נפרדים', (
+      tester,
+    ) async {
+      repository = DictionaryLookupRepository(
+        loadAcronyms: () async => <String, List<String>>{},
+        loadAramaicEntries: () async => const <AramaicDictionaryEntry>[],
+        loadLaazEntries: () async => LaazDictionaryEntry.parseLines(
+          const <String>[
+            '1 / (ברכות ט:) / <b>כרתי</b> פוריל"ש / porels / <b>כרשים</b>',
+            '2 / (שבת י.) / <b>כרתי</b> פוריל"ש / porels / <b>ירק אחר</b>',
+          ],
+        ),
+      );
+      await repository.ensureLaazLoaded();
+      final context = await pumpHost(tester);
+
+      final entries = buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'פוריל"ש',
+        repository: repository,
+      );
+
+      expect(entries, hasLength(1));
+      expect(entries.single.children, hasLength(2));
+    });
+
+    testWidgets('לא מציג ענף כשאין התאמה', (tester) async {
+      await repository.ensureLoaded();
+      await repository.ensureLaazLoaded();
+      final context = await pumpHost(tester);
+
+      final entries = buildDictionaryContextMenuEntries(
+        context: context,
+        selectedText: 'שלום',
+        repository: repository,
+      );
+
+      expect(entries, isEmpty);
+    });
+  });
+}

--- a/test/utils/word_at_position_test.dart
+++ b/test/utils/word_at_position_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/utils/text/word_at_position.dart';
+
+void main() {
+  Future<String?> wordAt(
+    WidgetTester tester,
+    String text,
+    String target,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: Center(child: Text(text))),
+      ),
+    );
+    final paragraph = tester.renderObject<RenderParagraph>(find.text(text));
+    final charIndex = text.indexOf(target) + target.length ~/ 2;
+    final caret = paragraph.getOffsetForCaret(
+      TextPosition(offset: charIndex),
+      Rect.zero,
+    );
+    final global = paragraph.localToGlobal(caret + const Offset(1, 5));
+    return wordAtGlobalPosition(global);
+  }
+
+  group('wordAtGlobalPosition', () {
+    testWidgets('מחזיר מילה רגילה תחת הסמן', (tester) async {
+      expect(await wordAt(tester, 'אמר שלום היום', 'שלום'), 'שלום');
+    });
+
+    testWidgets('שומר גרשיים ASCII בתוך המילה (לעז/ראשי תיבות)', (
+      tester,
+    ) async {
+      expect(await wordAt(tester, 'אמר פוריל"ש היום', 'פוריל"ש'), 'פוריל"ש');
+    });
+
+    testWidgets('שומר גרשיים עבריים (U+05F4) בתוך המילה', (tester) async {
+      expect(await wordAt(tester, 'אמר פוריל״ש היום', 'פוריל״ש'), 'פוריל״ש');
+    });
+
+    testWidgets('שומר גרשיים גם במילה מנוקדת', (tester) async {
+      expect(
+        await wordAt(tester, 'אמר פּוֹרִיל"ש היום', 'פּוֹרִיל"ש'),
+        'פּוֹרִיל"ש',
+      );
+    });
+
+    testWidgets('שומר גרש בסוף קיצור', (tester) async {
+      expect(await wordAt(tester, 'אמר וכו\' היום', 'וכו\''), 'וכו\'');
+    });
+  });
+}


### PR DESCRIPTION
טעינת ספר "אוצר לעזי רש"י" מ-seforim.db (ללא המרה ל-JSON), אינדוקס לפי תעתיק עם קיפול חילופי כתיב בין דפוסים (שיו"ן/שוו"ן/שבו"ן), וענף חדש בתפריט המילון המוצג רק על מילים עם גרשיים. פריטי המילון נוספו לכל תצוגות המפרשים (רשימה, טאבים, מפוצל, צורת הדף, PDF).

כהיום בלחצן ימיני ועין בפורם  התייעצויות עם יש שינוי אני יעלה את החדש