### PR TITLE
ספרייה: מסכתות הבבלי מוצגות פעם אחת ונפתחות לפי הגדרת הפורמט

### DIFF
--- a/lib/empty_library/bloc/empty_library_bloc.dart
+++ b/lib/empty_library/bloc/empty_library_bloc.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
 import 'package:otzaria/empty_library/bloc/empty_library_event.dart';
 import 'package:otzaria/empty_library/bloc/empty_library_state.dart';
 import 'package:otzaria/empty_library/services/android_storage_service.dart';
+import 'package:otzaria/library_update/services/companion_assets_service.dart';
 import 'package:otzaria/search/magic_dictionary_downloader.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/utils/download_eta_estimator.dart';
@@ -933,6 +934,23 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
     {
       final latestAsset = await _fetchLatestDatabaseAsset();
 
+      // ה-release האחרון של otzaria-library לא תמיד מכיל את התלמוד (יש בו גם
+      // releases של fordb) — מאתרים דרך ה-API, עם fallback לכתובת ה-latest.
+      TalmudRelease? talmudRelease;
+      var talmudAssetMissing = false;
+      try {
+        talmudRelease = await CompanionAssetsService.findLatestTalmudRelease(
+          _httpClient,
+        );
+      } on TalmudAssetNotFoundException catch (e) {
+        // הנכס אינו קיים באף release — גם כתובת ה-latest לא תכיל אותו; מדלגים,
+        // ובדיקת העדכון תתקין את התלמוד כשיפורסם מחדש.
+        debugPrint('$e');
+        talmudAssetMissing = true;
+      } catch (e) {
+        debugPrint('איתור release של התלמוד נכשל: $e');
+      }
+
       // שלושת הקבצים מורדים יחד ואז מחולצים יחד. פס ההתקדמות בשני השלבים
       // מתייחס לסכום שלושתם; רק כותרת המשנה משתנה לפי הקובץ הנוכחי.
       final assets = <_DownloadAsset>[
@@ -947,12 +965,14 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
         ),
         _DownloadAsset(
           url:
+              talmudRelease?.assetUrl ??
               'https://github.com/Otzaria/otzaria-library/releases/latest/download/talmud_bavli_latest.tar.zst',
           tempFileName: 'otzaria_talmud_bavli.tar.zst',
           downloadTitle: 'מוריד את התלמוד הבבלי',
           extractTitle: 'מחלץ את התלמוד הבבלי',
           isTar: true,
-        ),
+          sha256: talmudRelease?.sha256,
+        )..skipped = talmudAssetMissing,
         _DownloadAsset(
           url:
               'https://github.com/Otzaria/otzar-HB_catalog/releases/latest/download/otzar-HB_catalog.db.zst',
@@ -984,6 +1004,7 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
       // פתרון redirect-ים מראש (package:http מאבד את ה-Range בעת redirect) +
       // קריאת גודל כל קובץ דחוס, לחישוב פס התקדמות וזמן משוער מאוחדים.
       for (final asset in assets) {
+        if (asset.skipped) continue;
         try {
           final resolved = await _resolveRedirectWithSize(asset.url);
           asset.resolvedUrl = resolved.url;
@@ -1154,6 +1175,7 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
       url: asset.resolvedUrl!,
       destPath: tempPath,
       expectedSize: asset.compressedSize > 0 ? asset.compressedSize : null,
+      expectedSha256: asset.sha256,
       resumeToken: identity,
       onProgress: (downloaded, _) => emitProgress(downloaded),
     );
@@ -1220,7 +1242,11 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
     try {
       if (asset.isTar) {
         await _extractTarArchive(tempPath, outputDir, report);
-        await _writeTalmudVersionMarker(outputDir, asset.releaseTag);
+        // עדיף digest: תגי otzaria-library מתחלפים כמעט יומית גם כשהתוכן זהה.
+        await _writeTalmudVersionMarker(
+          outputDir,
+          asset.sha256 ?? asset.releaseTag,
+        );
       } else if (!asset.isCompressed) {
         // קובץ לא דחוס (lexical.db) — מועתק מ-temp ליעד ללא חילוץ.
         final outputPath = path.join(outputDir, asset.outputFileName!);
@@ -1272,14 +1298,14 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
     await _deleteDownloadState(tempPath);
   }
 
-  /// כותב את תג ה-release לתיקיית התלמוד שחולצה. בלי הסימון, בדיקת העדכון
-  /// הבאה מחתימה את התג העדכני גם כשהותקנה גרסה ישנה ממנו — והעדכון ידולג.
+  /// כותב את זיהוי הגרסה (digest או תג) לתיקיית התלמוד שחולצה. בלי הסימון,
+  /// בדיקת העדכון הבאה מחתימה את הזיהוי העדכני גם על התקנה ישנה — והעדכון ידולג.
   /// כשל כתיבה מכשיל את החילוץ בכוונה — הצלחה שקטה בלי סימון מחזירה את הבאג.
   static Future<void> _writeTalmudVersionMarker(
     String outputDir,
-    String? releaseTag,
+    String? versionStamp,
   ) async {
-    if (releaseTag == null) return;
+    if (versionStamp == null) return;
     final talmudDir = path.join(
       outputDir,
       DatabaseConstants.talmudBavliFolderName,
@@ -1288,7 +1314,7 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
     if (!await Directory(talmudDir).exists()) return;
     await File(
       DatabaseConstants.talmudBavliVersionFilePath(talmudDir),
-    ).writeAsString(releaseTag);
+    ).writeAsString(versionStamp);
   }
 
   /// חילוץ `.zst` יחיד (ל-DB) דרך השירות המשותף. עוטף כדי להתאים לחתימת
@@ -1452,6 +1478,7 @@ class _DownloadAsset {
     this.isMainDb = false,
     this.isCompressed = true,
     this.optional = false,
+    this.sha256,
   });
 
   /// כתובת ההורדה (לפני פתרון redirect).
@@ -1481,6 +1508,9 @@ class _DownloadAsset {
 
   /// `true` → best-effort: כשל בהורדה/חילוץ אינו מפיל את כל התהליך.
   final bool optional;
+
+  /// sha256 של הנכס מה-API — לאימות ההורדה ולסימון גרסת התלמוד.
+  final String? sha256;
 
   /// ה-URL הסופי לאחר פתרון redirect (נקבע בזמן ריצה).
   String? resolvedUrl;

--- a/lib/empty_library/bloc/empty_library_bloc.dart
+++ b/lib/empty_library/bloc/empty_library_bloc.dart
@@ -1220,6 +1220,7 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
     try {
       if (asset.isTar) {
         await _extractTarArchive(tempPath, outputDir, report);
+        await _writeTalmudVersionMarker(outputDir, asset.releaseTag);
       } else if (!asset.isCompressed) {
         // קובץ לא דחוס (lexical.db) — מועתק מ-temp ליעד ללא חילוץ.
         final outputPath = path.join(outputDir, asset.outputFileName!);
@@ -1269,6 +1270,25 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
     // מחיקת קובץ ה-temp לאחר חילוץ מוצלח.
     await File(tempPath).delete().catchError((_) => File(tempPath));
     await _deleteDownloadState(tempPath);
+  }
+
+  /// כותב את תג ה-release לתיקיית התלמוד שחולצה. בלי הסימון, בדיקת העדכון
+  /// הבאה מחתימה את התג העדכני גם כשהותקנה גרסה ישנה ממנו — והעדכון ידולג.
+  /// כשל כתיבה מכשיל את החילוץ בכוונה — הצלחה שקטה בלי סימון מחזירה את הבאג.
+  static Future<void> _writeTalmudVersionMarker(
+    String outputDir,
+    String? releaseTag,
+  ) async {
+    if (releaseTag == null) return;
+    final talmudDir = path.join(
+      outputDir,
+      DatabaseConstants.talmudBavliFolderName,
+    );
+    // אין ליצור את התיקייה: תיקייה עם סימון בלבד תיראה כהתקנה קיימת ומעודכנת.
+    if (!await Directory(talmudDir).exists()) return;
+    await File(
+      DatabaseConstants.talmudBavliVersionFilePath(talmudDir),
+    ).writeAsString(releaseTag);
   }
 
   /// חילוץ `.zst` יחיד (ל-DB) דרך השירות המשותף. עוטף כדי להתאים לחתימת

--- a/lib/library/models/library.dart
+++ b/lib/library/models/library.dart
@@ -113,14 +113,15 @@ class Library extends Category {
   /// The [categories] parameter is a list of categories that are contained in
   /// this library.
   Library({required List<Category> categories})
-      : super(
-            title: 'ספריית אוצריא',
-            description: '',
-            shortDescription: '',
-            order: 0,
-            subCategories: categories,
-            books: [],
-            parent: null) {
+    : super(
+        title: 'ספריית אוצריא',
+        description: '',
+        shortDescription: '',
+        order: 0,
+        subCategories: categories,
+        books: [],
+        parent: null,
+      ) {
     parent = this;
   }
 
@@ -158,7 +159,8 @@ class Library extends Category {
         return allBooks.firstWhere((book) => book.title == title);
       }
       return allBooks.firstWhere(
-          (book) => book.title == title && book.runtimeType == type);
+        (book) => book.title == title && book.runtimeType == type,
+      );
     } catch (e) {
       return null;
     }
@@ -173,9 +175,11 @@ class Library extends Category {
     // 1. חיפוש באותה קטגוריה בדיוק:
     if (book.category != null) {
       final companions = book.category!.books
-          .where((b) =>
-              _normalizeTitle(b.title) == normalizedTitle &&
-              b.runtimeType == companionType)
+          .where(
+            (b) =>
+                _normalizeTitle(b.title) == normalizedTitle &&
+                b.runtimeType == companionType,
+          )
           .take(2)
           .toList();
 
@@ -186,17 +190,21 @@ class Library extends Category {
 
     // 2. חיפוש גלובלי (מאפשר התאמה לפי נרמול הכותרת כפי שמקובל):
     final candidates = getAllBooks()
-        .where((b) =>
-            b.runtimeType == companionType &&
-            _normalizeTitle(b.title) == normalizedTitle)
+        .where(
+          (b) =>
+              b.runtimeType == companionType &&
+              _normalizeTitle(b.title) == normalizedTitle,
+        )
         .toList();
 
     // סינון התנגשויות ידועות (ירושלמי <-> בבלי)
     final filtered = candidates.where((candidate) {
-      final bookCat = book.categoryPath ??
+      final bookCat =
+          book.categoryPath ??
           book.heCategories ??
           (book is FileBook ? book.path : '');
-      final candCat = candidate.categoryPath ??
+      final candCat =
+          candidate.categoryPath ??
           candidate.heCategories ??
           (candidate is FileBook ? candidate.path : '');
 
@@ -227,7 +235,8 @@ class Library extends Category {
         return allBooks.firstWhere((book) => book.title == title);
       }
       return allBooks.firstWhere(
-          (book) => book.title == title && book.runtimeType == type);
+        (book) => book.title == title && book.runtimeType == type,
+      );
     } catch (e) {
       // לא נמצא - ממשיכים לחיפוש גמיש
     }
@@ -262,16 +271,18 @@ class Library extends Category {
     return ' $haystack '.contains(' $needle ');
   }
 
-  /// מנרמל כותרת לצורך השוואה
-  String _normalizeTitle(String title) {
-    return title
-        .trim()
-        .replaceAll(RegExp(r'\s+'), ' ') // רווחים מרובים לרווח אחד
-        .replaceAll('"', '')
-        .replaceAll("'", '')
-        .replaceAll('״', '')
-        .replaceAll('׳', '')
-        .replaceAll('<', '')
-        .replaceAll('>', '');
-  }
+  String _normalizeTitle(String title) => normalizeBookTitle(title);
+}
+
+/// מנרמל כותרת ספר להשוואה: רווחים עודפים, גרשיים וסוגריים משולשים.
+String normalizeBookTitle(String title) {
+  return title
+      .trim()
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .replaceAll('"', '')
+      .replaceAll("'", '')
+      .replaceAll('״', '')
+      .replaceAll('׳', '')
+      .replaceAll('<', '')
+      .replaceAll('>', '');
 }

--- a/lib/library/view/book_versions_dialog.dart
+++ b/lib/library/view/book_versions_dialog.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:otzaria/data/data_providers/database_library_provider.dart';
 import 'package:otzaria/models/book_version.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/utils/navigation/open_book.dart';
 import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// דיאלוג "גרסאות": רשימת המהדורות (book_version) של ספר מהספרייה הרשמית.
 /// בחירת מהדורה עם טקסט שמור פותחת את הספר בנוסח אותה מהדורה.
@@ -65,7 +67,7 @@ class _BookVersionsDialogState extends State<BookVersionsDialog> {
           return ListView.separated(
             itemCount: versions.length,
             separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (context, index) => _VersionTile(
+            itemBuilder: (context, index) => BookVersionTile(
               book: widget.book,
               version: versions[index],
               isOnlyVersion: versions.length == 1,
@@ -77,12 +79,27 @@ class _BookVersionsDialogState extends State<BookVersionsDialog> {
   }
 }
 
-class _VersionTile extends StatelessWidget {
+/// פותח קישור מהערות גרסה; קישורים יחסיים (כמו '/adin-even-israel') נפתרים
+/// מול אתר ספריא — מקור המטא-דאטה.
+Future<bool> _openNoteUrl(String url) async {
+  final uri = Uri.parse(url);
+  final resolved = uri.hasScheme
+      ? uri
+      : Uri.parse('https://www.sefaria.org').resolveUri(uri);
+  if (await canLaunchUrl(resolved)) {
+    await launchUrl(resolved);
+  }
+  return true;
+}
+
+/// שורת מהדורה בדיאלוג הגרסאות. ציבורי לצורך בדיקות widget.
+class BookVersionTile extends StatelessWidget {
   final TextBook book;
   final BookVersionInfo version;
   final bool isOnlyVersion;
 
-  const _VersionTile({
+  const BookVersionTile({
+    super.key,
     required this.book,
     required this.version,
     required this.isOnlyVersion,
@@ -100,10 +117,9 @@ class _VersionTile extends StatelessWidget {
       if (isDisplayedText) 'הנוסח המוצג בספרייה',
       if (!version.hasContent && !isOnlyVersion)
         'טקסט הגרסה אינו כלול במאגר הנוכחי',
-      if ((version.heVersionNotes ?? version.versionNotes)?.trim().isNotEmpty ==
-          true)
-        (version.heVersionNotes ?? version.versionNotes)!.trim(),
     ];
+    final notes = (version.heVersionNotes ?? version.versionNotes)?.trim();
+    final hasNotes = notes?.isNotEmpty == true;
 
     // בפריט מנוטרל ListTile צובע את האייקון בצבע ה-disabled של ה-theme.
     return ListTile(
@@ -115,11 +131,25 @@ class _VersionTile extends StatelessWidget {
         color: openable ? theme.colorScheme.primary : null,
       ),
       title: Text(version.displayTitle),
-      subtitle: subtitleParts.isEmpty
+      subtitle: subtitleParts.isEmpty && !hasNotes
           ? null
-          : Text(
-              subtitleParts.join('\n'),
-              style: theme.textTheme.bodySmall,
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (subtitleParts.isNotEmpty)
+                  Text(
+                    subtitleParts.join('\n'),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                // ההערות מגיעות מספריא כ-HTML עם קישורי <a> — רינדור כטקסט
+                // גולמי מציג את התגיות מעורבבות בפסקת RTL.
+                if (hasNotes)
+                  HtmlWidget(
+                    notes!,
+                    textStyle: theme.textTheme.bodySmall,
+                    onTapUrl: _openNoteUrl,
+                  ),
+              ],
             ),
       onTap: openable
           ? () {

--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -29,6 +29,7 @@ import 'package:otzaria/widgets/widgets_exports.dart';
 import 'package:otzaria/widgets/navigation/app_top_bar.dart';
 import 'package:otzaria/widgets/navigation/responsive_action_bar.dart';
 import 'package:otzaria/utils/navigation/open_book.dart';
+import 'package:otzaria/utils/navigation/talmud_bavli_open_format.dart';
 import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
 import 'package:otzaria/widgets/layout/context_overlay_panel.dart';
 import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
@@ -93,12 +94,18 @@ List<FlatLibraryRow> buildFlatLibraryRows({
   required Set<String> expandedPaths,
   required int Function(Category) topCategoryOrder,
   required int Function(int) normalizeOrder,
+  Set<String> talmudTextTitles = const {},
 }) {
   final rows = <FlatLibraryRow>[];
 
   void collect(Category current, int level) {
-    final books = current.books.toList()
-      ..sort((a, b) => a.order.compareTo(b.order));
+    final books =
+        current.books
+            .where(
+              (b) => !isTalmudBavliPdfLibraryDuplicate(b, talmudTextTitles),
+            )
+            .toList()
+          ..sort((a, b) => a.order.compareTo(b.order));
     final subs = current.subCategories.where((c) => c.hasBooks).toList();
     if (current is Library) {
       subs.sort((a, b) => topCategoryOrder(a).compareTo(topCategoryOrder(b)));
@@ -1131,7 +1138,7 @@ class _LibraryBrowserState extends State<LibraryBrowser>
         final settingsState = context.read<SettingsBloc>().state;
         if (settingsState.libraryViewMode == 'grid') {
           if (state.searchResults != null) {
-            final books = state.searchResults!;
+            final books = _visibleBooks(state.searchResults!);
             if (books.isEmpty) {
               final repo = context.read<FocusRepository>();
               return _buildEmptyState(context, state, settingsState, repo);
@@ -1163,12 +1170,13 @@ class _LibraryBrowserState extends State<LibraryBrowser>
           );
         }
         if (state.searchResults != null) {
-          if (state.searchResults!.isEmpty) {
+          final visibleResults = _visibleBooks(state.searchResults!);
+          if (visibleResults.isEmpty) {
             final repo = context.read<FocusRepository>();
             return _buildEmptyState(context, state, settingsState, repo);
           }
           return _buildSearchListView(
-            _filterBooksByTopics(state.searchResults!, state.selectedTopics),
+            _filterBooksByTopics(visibleResults, state.selectedTopics),
             _buildTopicsSelection(context, state),
           );
         }
@@ -1179,7 +1187,7 @@ class _LibraryBrowserState extends State<LibraryBrowser>
 
   List<Widget> _buildCategoryContent(Category category) {
     final List<Widget> items = [];
-    final filteredBooks = category.books.toList();
+    final filteredBooks = _visibleBooks(category.books);
     final filteredSubCategories = category.subCategories
         .where((c) => c.hasBooks)
         .toList();
@@ -1322,6 +1330,7 @@ class _LibraryBrowserState extends State<LibraryBrowser>
         expandedPaths: _expandedCategories,
         topCategoryOrder: _getTopCategoryOrder,
         normalizeOrder: _normalizeOrder,
+        talmudTextTitles: _talmudTextTitles(),
       );
 
   /// Key יציב לשורה — בלעדיו אנימציית השברון ומצב hover "זולגים" בין
@@ -1411,7 +1420,7 @@ class _LibraryBrowserState extends State<LibraryBrowser>
 
   List<Widget> _buildCategoryTree(Category category, int level) {
     final List<Widget> widgets = [];
-    final filteredBooks = category.books.toList()
+    final filteredBooks = _visibleBooks(category.books)
       ..sort((a, b) => a.order.compareTo(b.order));
     final filteredSubs = category.subCategories
         .where((c) => c.hasBooks)
@@ -1882,12 +1891,42 @@ class _LibraryBrowserState extends State<LibraryBrowser>
     );
   }
 
-  void _openBookInReader(Book book, int index) =>
-      openBook(context, book, index, '');
+  Set<String>? _talmudTextTitlesCache;
+  Category? _talmudTextTitlesLibrary;
+
+  /// כותרות מהדורות הטקסט של מסכתות הבבלי, ממוטמנות פר-מופע ספרייה.
+  Set<String> _talmudTextTitles() {
+    final library = context.read<LibraryBloc>().state.library;
+    if (library == null) return const {};
+    if (!identical(library, _talmudTextTitlesLibrary)) {
+      _talmudTextTitlesLibrary = library;
+      _talmudTextTitlesCache = talmudBavliTextTitles(library);
+    }
+    return _talmudTextTitlesCache!;
+  }
+
+  /// מסנן מהתצוגה מהדורות PDF כפולות של מסכתות הבבלי — מוצגת רשומה אחת
+  /// למסכת, והפתיחה נקבעת לפי הגדרת פורמט הבבלי.
+  List<Book> _visibleBooks(List<Book> books) {
+    final titles = _talmudTextTitles();
+    return books
+        .where((b) => !isTalmudBavliPdfLibraryDuplicate(b, titles))
+        .toList();
+  }
+
+  Future<void> _openBookInReader(Book book, int index) async {
+    final handled = await openLibraryBookPerTalmudBavliFormat(
+      context,
+      book,
+      index,
+    );
+    if (handled || !mounted) return;
+    openBook(context, book, index, '');
+  }
 
   /// מחזיר את הספר הראשון שיוצג בפועל בקטגוריה, לפי אותו סדר תצוגה כמו _buildCategoryContent
   Book? _getFirstDisplayedBook(Category category) {
-    final books = category.books.toList()
+    final books = _visibleBooks(category.books)
       ..sort((a, b) => a.order.compareTo(b.order));
     if (books.isNotEmpty) return books.first;
 

--- a/lib/library_update/services/companion_assets_service.dart
+++ b/lib/library_update/services/companion_assets_service.dart
@@ -178,13 +178,8 @@ class CompanionAssetsService {
         final installed = marker.existsSync()
             ? marker.readAsStringSync().trim()
             : '';
-        if (installed.isEmpty) {
-          // התקנה קיימת ללא סימון גרסה — מחתימים את הזיהוי הנוכחי בלי להוריד
-          // מחדש; עדכונים יזוהו מה-release הבא ואילך.
-          marker.writeAsStringSync(release.sha256 ?? release.tag);
-          return false;
-        }
-        if (await _isInstalledUpToDate(client, installed, release)) {
+        if (installed.isNotEmpty &&
+            await _isInstalledUpToDate(client, installed, release)) {
           // תגי הספרייה מתחלפים כמעט יומית גם כשקובץ התלמוד זהה — מרעננים את
           // הסימון ל-digest כדי שהבדיקות הבאות ישוו תוכן ולא תג.
           if (release.sha256 != null && installed != release.sha256) {

--- a/lib/library_update/services/companion_assets_service.dart
+++ b/lib/library_update/services/companion_assets_service.dart
@@ -214,11 +214,13 @@ class CompanionAssetsService {
             onDownloadProgress?.call((progress * 10000).round(), 10000);
           }
         });
-      } catch (_) {
-        // חילוץ שנכשל על קובץ שלם משאיר temp שיחזיר 416 בניסיון הבא (דילוג על
-        // ההורדה) ולולאה אינסופית — מוחקים כדי לכפות הורדה מחדש.
-        await File(tempPath).delete().catchError((_) => File(tempPath));
-        await _deleteTalmudDownloadState(tempPath);
+      } catch (e) {
+        // ארכיון פגום שנשאר שלם יחזיר 416 (דילוג הורדה) ולולאה — מוחקים; כשל
+        // מערכת-קבצים (קובץ יעד נעול) אינו ארכיון פגום — ה-temp נשמר ל-resume.
+        if (e is! FileSystemException) {
+          await File(tempPath).delete().catchError((_) => File(tempPath));
+          await _deleteTalmudDownloadState(tempPath);
+        }
         rethrow;
       }
       // מחיקת הקובץ הזמני לאחר חילוץ מוצלח.

--- a/lib/library_update/services/companion_assets_service.dart
+++ b/lib/library_update/services/companion_assets_service.dart
@@ -17,9 +17,28 @@ import 'package:seforim_library_updater/seforim_library_updater.dart';
 /// מוודא שהקבצים הנלווים לספרייה — התלמוד הבבלי, קטלוג otzar-HB ומילון
 /// החיפוש — קיימים ומעודכנים, כחלק מזרימת עדכון הספרייה.
 ///
+/// פרטי נכס התלמוד ב-release (ראה [CompanionAssetsService.findLatestTalmudRelease]).
+typedef TalmudRelease = ({
+  String tag,
+  String assetUrl,
+  int size,
+  String id,
+  String updatedAt,
+  String? sha256,
+});
+
+/// נזרק כשסריקת ה-releases הושלמה בלי למצוא את נכס התלמוד באף אחד מהם —
+/// להבדיל מכשל רשת/API, שבו ייתכן שהנכס קיים אך לא ניתן היה לאתרו.
+class TalmudAssetNotFoundException implements Exception {
+  @override
+  String toString() =>
+      'לא נמצא ${DatabaseConstants.talmudBavliArchiveFileName} באף release';
+}
+
 /// כל פריט הוא best-effort: כשל (אין רשת, קובץ נעול) נרשם ללוג ולא מפיל את
 /// העדכון. הקטלוג והמילון משתמשים במנגנוני הגרסה הקיימים שלהם; לתלמוד נוסף
-/// כאן סימון גרסה (תג ה-release) בקובץ בתוך התיקייה.
+/// כאן סימון גרסה בקובץ בתוך התיקייה — digest של הנכס (או תג ה-release
+/// כ-fallback כשאין digest).
 class CompanionAssetsService {
   static const String talmudReleaseApi =
       'https://api.github.com/repos/Otzaria/otzaria-library/releases/latest';
@@ -150,19 +169,29 @@ class CompanionAssetsService {
 
     final client = _clientFactory();
     try {
-      final release = await _fetchTalmudRelease(client);
+      final release = await findLatestTalmudRelease(
+        client,
+        apiUrl: _talmudReleaseApiUrl,
+      );
       if (existingDir != null) {
         final marker = File(p.join(existingDir, talmudVersionFileName));
         final installed = marker.existsSync()
             ? marker.readAsStringSync().trim()
             : '';
         if (installed.isEmpty) {
-          // התקנה קיימת ללא סימון גרסה — מחתימים את התג הנוכחי בלי להוריד
+          // התקנה קיימת ללא סימון גרסה — מחתימים את הזיהוי הנוכחי בלי להוריד
           // מחדש; עדכונים יזוהו מה-release הבא ואילך.
-          marker.writeAsStringSync(release.tag);
+          marker.writeAsStringSync(release.sha256 ?? release.tag);
           return false;
         }
-        if (installed == release.tag) return false;
+        if (await _isInstalledUpToDate(client, installed, release)) {
+          // תגי הספרייה מתחלפים כמעט יומית גם כשקובץ התלמוד זהה — מרעננים את
+          // הסימון ל-digest כדי שהבדיקות הבאות ישוו תוכן ולא תג.
+          if (release.sha256 != null && installed != release.sha256) {
+            marker.writeAsStringSync(release.sha256!);
+          }
+          return false;
+        }
       }
       if (cancelled()) return false;
 
@@ -228,7 +257,7 @@ class CompanionAssetsService {
       await _deleteTalmudDownloadState(tempPath);
       File(
         p.join(targetDir, talmudVersionFileName),
-      ).writeAsStringSync(release.tag);
+      ).writeAsStringSync(release.sha256 ?? release.tag);
       // קיום תיקיית התלמוד ממוטמן ב-DatabaseLibraryProvider — בלי ניקוי,
       // הריענון שאחרי העדכון לא יגלה את התיקייה החדשה עד הפעלה מחדש.
       _invalidateLibraryCaches();
@@ -238,20 +267,86 @@ class CompanionAssetsService {
     }
   }
 
-  Future<
-    ({
-      String tag,
-      String assetUrl,
-      int size,
-      String id,
-      String updatedAt,
-      String? sha256,
-    })
-  >
-  _fetchTalmudRelease(http.Client client) async {
+  /// האם ההתקנה המסומנת ב-[installed] עדכנית מול [release]: תג או digest
+  /// זהים, או שהתג המותקן ישן אך נכס התלמוד בו זהה בתוכנו ל-release האחרון.
+  Future<bool> _isInstalledUpToDate(
+    http.Client client,
+    String installed,
+    TalmudRelease release,
+  ) async {
+    if (installed == release.tag) return true;
+    final sha = release.sha256;
+    if (sha == null) return false;
+    if (installed == sha) return true;
+    if (installed == talmudInstallingMarker) return false;
+    // תגי הספרייה מתחלפים כמעט יומית עם אותו קובץ תלמוד בדיוק — משווים את
+    // ה-digest של התג המותקן כדי לא להוריד ~440MB על שינוי תג בלבד.
+    try {
+      final json = await _getGithubJson(
+        client,
+        _talmudReleaseApiUrl.replaceFirst(
+          '/releases/latest',
+          '/releases/tags/${Uri.encodeComponent(installed)}',
+        ),
+      );
+      return json is Map<String, dynamic> && _talmudAssetSha256(json) == sha;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// ה-sha256 של נכס התלמוד מתוך JSON של release, או `null` אם אין digest.
+  static String? _talmudAssetSha256(Map<String, dynamic> json) {
+    final assets = (json['assets'] as List?) ?? const [];
+    for (final a in assets) {
+      final asset = a as Map<String, dynamic>;
+      if (asset['name'] == DatabaseConstants.talmudBavliArchiveFileName) {
+        return switch (asset['digest']) {
+          final String digest when digest.startsWith('sha256:') =>
+            digest.substring('sha256:'.length),
+          _ => null,
+        };
+      }
+    }
+    return null;
+  }
+
+  /// ה-release העדכני ביותר שמכיל את נכס התלמוד: קודם `releases/latest`, ואם
+  /// הנכס חסר בו (למשל release של fordb) — נסרקים ה-releases עמוד אחר עמוד.
+  /// זורק [TalmudAssetNotFoundException] כשהסריקה הסתיימה בלי למצוא את הנכס.
+  static Future<TalmudRelease> findLatestTalmudRelease(
+    http.Client client, {
+    String apiUrl = talmudReleaseApi,
+  }) async {
+    final latest = await _getGithubJson(client, apiUrl);
+    if (latest is Map<String, dynamic>) {
+      final release = _talmudReleaseFrom(latest);
+      if (release != null) return release;
+    }
+    // תקרת העמודים שומרת על מגבלת ה-rate של GitHub; 300 releases רצופים בלי
+    // הנכס פירושם שהוא כבר לא מתפרסם.
+    for (var page = 1; page <= 3; page++) {
+      final list = await _getGithubJson(
+        client,
+        apiUrl.replaceFirst(
+          '/releases/latest',
+          '/releases?per_page=100&page=$page',
+        ),
+      );
+      if (list is! List || list.isEmpty) break;
+      for (final r in list) {
+        if (r is! Map<String, dynamic> || r['prerelease'] == true) continue;
+        final release = _talmudReleaseFrom(r);
+        if (release != null) return release;
+      }
+    }
+    throw TalmudAssetNotFoundException();
+  }
+
+  static Future<dynamic> _getGithubJson(http.Client client, String url) async {
     final response = await client
         .get(
-          Uri.parse(_talmudReleaseApiUrl),
+          Uri.parse(url),
           headers: const {
             'Accept': 'application/vnd.github+json',
             'User-Agent': 'otzaria',
@@ -261,11 +356,13 @@ class CompanionAssetsService {
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw Exception('GitHub API החזיר ${response.statusCode}');
     }
-    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return jsonDecode(response.body);
+  }
+
+  /// פרטי נכס התלמוד מתוך JSON של release, או `null` כשהתג/הנכס חסרים.
+  static TalmudRelease? _talmudReleaseFrom(Map<String, dynamic> json) {
     final tag = (json['tag_name'] as String?)?.trim();
-    if (tag == null || tag.isEmpty) {
-      throw Exception('release ללא tag_name');
-    }
+    if (tag == null || tag.isEmpty) return null;
     final assets = (json['assets'] as List?) ?? const [];
     for (final a in assets) {
       final asset = a as Map<String, dynamic>;
@@ -276,17 +373,11 @@ class CompanionAssetsService {
           size: (asset['size'] as num?)?.toInt() ?? 0,
           id: asset['id']?.toString() ?? '',
           updatedAt: asset['updated_at']?.toString() ?? '',
-          sha256: switch (asset['digest']) {
-            final String digest when digest.startsWith('sha256:') =>
-              digest.substring('sha256:'.length),
-            _ => null,
-          },
+          sha256: _talmudAssetSha256(json),
         );
       }
     }
-    throw Exception(
-      'לא נמצא ${DatabaseConstants.talmudBavliArchiveFileName} ב-release $tag',
-    );
+    return null;
   }
 
   /// מוריד את [url] דרך מנגנון ה-resume המאומת של חבילת העדכון. [identity]

--- a/lib/settings/tabs/design_settings_tab.dart
+++ b/lib/settings/tabs/design_settings_tab.dart
@@ -81,10 +81,21 @@ class DesignSettingsTab extends StatelessWidget {
     SettingsSearchEntry(
       id: 'design.pdf.talmud_bavli_format',
       title: 'פורמט פתיחת תלמוד בבלי',
-      subtitle: 'פתיחת מסכתות הבבלי בטקסט או ב-PDF (צורת הדף)',
+      subtitle:
+          'פתיחת מסכתות הבבלי בטקסט או ב-PDF, '
+          'מהספרייה ומכל מקום אחר',
       tab: SettingsTab.design,
       cardId: 'design.pdf',
-      keywords: ['תלמוד', 'בבלי', 'גמרא', 'צורת הדף', 'pdf', 'טקסט', 'מסכת'],
+      keywords: [
+        'תלמוד',
+        'בבלי',
+        'גמרא',
+        'צורת הדף',
+        'pdf',
+        'טקסט',
+        'מסכת',
+        'ספרייה',
+      ],
     ),
     SettingsSearchEntry(
       id: 'design.layout.sidebar_mode',
@@ -174,43 +185,44 @@ class DesignSettingsTab extends StatelessWidget {
                       currentValue: state.followSystemTheme
                           ? _ThemeMode.system
                           : state.isDarkMode
-                              ? _ThemeMode.dark
-                              : _ThemeMode.light,
+                          ? _ThemeMode.dark
+                          : _ThemeMode.light,
                       onChanged: (mode) {
                         if (mode == _ThemeMode.system) {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdateFollowSystemTheme(true));
+                          context.read<SettingsBloc>().add(
+                            UpdateFollowSystemTheme(true),
+                          );
                         } else {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdateFollowSystemTheme(false));
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdateDarkMode(mode == _ThemeMode.dark));
+                          context.read<SettingsBloc>().add(
+                            UpdateFollowSystemTheme(false),
+                          );
+                          context.read<SettingsBloc>().add(
+                            UpdateDarkMode(mode == _ThemeMode.dark),
+                          );
                         }
                       },
                     ),
                     ColorPickerTile(
                       key: ValueKey(
-                          'color-picker-${Theme.of(context).brightness == Brightness.dark ? 'dark' : 'light'}'),
+                        'color-picker-${Theme.of(context).brightness == Brightness.dark ? 'dark' : 'light'}',
+                      ),
                       currentColor:
                           Theme.of(context).brightness == Brightness.dark
-                              ? state.darkSeedColor
-                              : state.seedColor,
+                          ? state.darkSeedColor
+                          : state.seedColor,
                       defaultColor:
                           Theme.of(context).brightness == Brightness.dark
-                              ? AppSeedColors.defaultDark
-                              : AppSeedColors.defaultLight,
+                          ? AppSeedColors.defaultDark
+                          : AppSeedColors.defaultLight,
                       onChanged: (color) {
                         if (Theme.of(context).brightness == Brightness.dark) {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdateDarkSeedColor(color));
+                          context.read<SettingsBloc>().add(
+                            UpdateDarkSeedColor(color),
+                          );
                         } else {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdateSeedColor(color));
+                          context.read<SettingsBloc>().add(
+                            UpdateSeedColor(color),
+                          );
                         }
                       },
                     ),
@@ -242,9 +254,9 @@ class DesignSettingsTab extends StatelessWidget {
                         ],
                         currentValue: state.compactMenuMode,
                         onChanged: (value) {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdateCompactMenuMode(value));
+                          context.read<SettingsBloc>().add(
+                            UpdateCompactMenuMode(value),
+                          );
                         },
                       ),
                     ],
@@ -261,16 +273,16 @@ class DesignSettingsTab extends StatelessWidget {
                       title: 'תצוגת ספר בPDF',
                       subtitle: state.enablePerBookSettings
                           ? state.pdfBookViewByDefault
-                              ? 'ספרי PDF ייפתחו בתצוגת ספר'
-                              : 'ספרי PDF ייפתחו בתצוגה רגילה'
+                                ? 'ספרי PDF ייפתחו בתצוגת ספר'
+                                : 'ספרי PDF ייפתחו בתצוגה רגילה'
                           : state.pdfBookViewByDefault
-                              ? 'כל ספרי ה-PDF ייפתחו בתצוגת ספר'
-                              : 'כל ספרי ה-PDF ייפתחו בתצוגה רגילה',
+                          ? 'כל ספרי ה-PDF ייפתחו בתצוגת ספר'
+                          : 'כל ספרי ה-PDF ייפתחו בתצוגה רגילה',
                       value: state.pdfBookViewByDefault,
                       onChanged: (value) {
-                        context
-                            .read<SettingsBloc>()
-                            .add(UpdatePdfBookViewByDefault(value));
+                        context.read<SettingsBloc>().add(
+                          UpdatePdfBookViewByDefault(value),
+                        );
                       },
                     ),
                     SettingsActionTile.segmentedTile<String>(
@@ -280,21 +292,24 @@ class DesignSettingsTab extends StatelessWidget {
                         SegmentOption(
                           value: 'text',
                           label: 'טקסט',
-                          subtitle: 'מסכתות הבבלי ייפתחו במהדורת הטקסט '
-                              '(מתוצאות חיפוש, מאיתור מקורות, ומקישורים)',
+                          subtitle:
+                              'מסכתות הבבלי ייפתחו במהדורת הטקסט '
+                              '(מהספרייה, מתוצאות חיפוש, מאיתור מקורות '
+                              'ומקישורים)',
                         ),
                         SegmentOption(
                           value: 'pdf',
                           label: 'PDF',
-                          subtitle: 'מסכתות הבבלי ייפתחו במהדורת ה-PDF '
-                              '(צורת הדף) בדף המתאים',
+                          subtitle:
+                              'מסכתות הבבלי ייפתחו במהדורת ה-PDF '
+                              'בדף המתאים, גם בפתיחה מהספרייה',
                         ),
                       ],
                       currentValue: state.talmudBavliOpenFormat,
                       onChanged: (value) {
-                        context
-                            .read<SettingsBloc>()
-                            .add(UpdateTalmudBavliOpenFormat(value));
+                        context.read<SettingsBloc>().add(
+                          UpdateTalmudBavliOpenFormat(value),
+                        );
                       },
                     ),
                   ],
@@ -330,30 +345,30 @@ class DesignSettingsTab extends StatelessWidget {
                       currentValue: state.pinSidebar
                           ? _SidebarMode.pinned
                           : state.defaultSidebarOpen
-                              ? _SidebarMode.openOnBook
-                              : _SidebarMode.closed,
+                          ? _SidebarMode.openOnBook
+                          : _SidebarMode.closed,
                       onChanged: (mode) {
                         if (mode == _SidebarMode.pinned) {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdatePinSidebar(true));
-                          context
-                              .read<SettingsBloc>()
-                              .add(const UpdateDefaultSidebarOpen(true));
+                          context.read<SettingsBloc>().add(
+                            UpdatePinSidebar(true),
+                          );
+                          context.read<SettingsBloc>().add(
+                            const UpdateDefaultSidebarOpen(true),
+                          );
                         } else if (mode == _SidebarMode.openOnBook) {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdatePinSidebar(false));
-                          context
-                              .read<SettingsBloc>()
-                              .add(const UpdateDefaultSidebarOpen(true));
+                          context.read<SettingsBloc>().add(
+                            UpdatePinSidebar(false),
+                          );
+                          context.read<SettingsBloc>().add(
+                            const UpdateDefaultSidebarOpen(true),
+                          );
                         } else {
-                          context
-                              .read<SettingsBloc>()
-                              .add(UpdatePinSidebar(false));
-                          context
-                              .read<SettingsBloc>()
-                              .add(const UpdateDefaultSidebarOpen(false));
+                          context.read<SettingsBloc>().add(
+                            UpdatePinSidebar(false),
+                          );
+                          context.read<SettingsBloc>().add(
+                            const UpdateDefaultSidebarOpen(false),
+                          );
                         }
                       },
                     ),
@@ -362,13 +377,13 @@ class DesignSettingsTab extends StatelessWidget {
                       title: 'פתיחת פאנל המפרשים בפתיחת ספר',
                       subtitle: state.defaultCommentaryOpen
                           ? 'פאנל המפרשים ייפתח אוטומטית כשיש מפרשים נבחרים '
-                              '(מפרשים בצד ו-PDF בלבד)'
+                                '(מפרשים בצד ו-PDF בלבד)'
                           : 'פאנל המפרשים לא ייפתח אוטומטית בפתיחת ספר',
                       value: state.defaultCommentaryOpen,
                       onChanged: (value) {
-                        context
-                            .read<SettingsBloc>()
-                            .add(UpdateDefaultCommentaryOpen(value));
+                        context.read<SettingsBloc>().add(
+                          UpdateDefaultCommentaryOpen(value),
+                        );
                       },
                     ),
                     SettingsActionTile.switchTile(
@@ -378,9 +393,9 @@ class DesignSettingsTab extends StatelessWidget {
                           : 'רשימות ההערות יוצגו כשהן פתוחות',
                       value: state.personalNotesCollapsedByDefault,
                       onChanged: (value) {
-                        context
-                            .read<SettingsBloc>()
-                            .add(UpdatePersonalNotesCollapsedByDefault(value));
+                        context.read<SettingsBloc>().add(
+                          UpdatePersonalNotesCollapsedByDefault(value),
+                        );
                       },
                     ),
                     StatefulBuilder(
@@ -396,7 +411,9 @@ class DesignSettingsTab extends StatelessWidget {
                           onChanged: (value) {
                             setState(() {
                               Settings.setValue<bool>(
-                                  'key-splited-view', value);
+                                'key-splited-view',
+                                value,
+                              );
                               final settingsBloc = context.read<SettingsBloc>();
                               PerBookSettings.cleanupRedundantSettings(
                                 defaultFontSize: settingsBloc.state.fontSize,
@@ -406,7 +423,8 @@ class DesignSettingsTab extends StatelessWidget {
                                     settingsBloc.state.defaultRemovePunctuation,
                                 defaultShowSplitView: value,
                                 defaultContinuousReadingMode: settingsBloc
-                                    .state.defaultContinuousReadingMode,
+                                    .state
+                                    .defaultContinuousReadingMode,
                               );
                             });
                           },

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -34,6 +34,7 @@ import 'package:otzaria/utils/ui/context_menu_utils.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
 import 'package:otzaria/widgets/feedback/app_future_builder.dart';
+import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
 import 'package:flutter/foundation.dart';
 import 'dart:async';
 import 'package:otzaria/services/commentary_service.dart';
@@ -1729,7 +1730,13 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                                       _onListSelectionChanged(
                                         selection?.plainText,
                                       ),
-                                  child: listView,
+                                  child: ScrollablePositionedListScrollbar(
+                                    scrollController: _itemScrollController,
+                                    itemPositionsListener:
+                                        _itemPositionsListener,
+                                    itemCount: groups.length,
+                                    child: listView,
+                                  ),
                                 ),
                               ),
                             );

--- a/lib/utils/navigation/book_open_coordinator.dart
+++ b/lib/utils/navigation/book_open_coordinator.dart
@@ -36,11 +36,6 @@ class BookOpenCoordinator {
     List<String>? initialCommentators,
     bool navigateToPositionIfReused = false,
   }) {
-    final tabsState = tabsBloc.state;
-    if (tabsState.hasOpenTabs) {
-      historyBloc.add(CaptureStateForHistory(tabsState.currentTab!));
-    }
-
     final tab = buildTab(
       book,
       index,
@@ -52,6 +47,24 @@ class BookOpenCoordinator {
       markText: markText,
       initialCommentators: initialCommentators,
     );
+    openTab(
+      tab,
+      insertAdjacent: insertAdjacent,
+      navigateToPositionIfReused: navigateToPositionIfReused,
+    );
+  }
+
+  /// פותח טאב מוכן עם סמנטיקת [openBook]: לכידת מצב להיסטוריה, פתיחה/מיקוד
+  /// של הטאב וניווט למסך הקריאה — למסלולים שבונים את הטאב בעצמם.
+  void openTab(
+    OpenedTab tab, {
+    bool insertAdjacent = false,
+    bool navigateToPositionIfReused = false,
+  }) {
+    final tabsState = tabsBloc.state;
+    if (tabsState.hasOpenTabs) {
+      historyBloc.add(CaptureStateForHistory(tabsState.currentTab!));
+    }
     tabsBloc.add(
       OpenOrFocusTab(
         tab,

--- a/lib/utils/navigation/talmud_bavli_open_format.dart
+++ b/lib/utils/navigation/talmud_bavli_open_format.dart
@@ -1,14 +1,20 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/data/constants/database_constants.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/history/bloc/history_bloc.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
+import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
+import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
 import 'package:otzaria/tabs/models/resolving_tab.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/utils/navigation/book_open_coordinator.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/utils/file/page_converter.dart';
 
@@ -182,4 +188,58 @@ Future<OpenedTab> buildLinkTargetTab(Link link) async {
       requiresStableLayout: true,
     ),
   );
+}
+
+/// כותרות מנורמלות של מהדורות הטקסט הרשמיות של מסכתות הבבלי — הקלט של
+/// [isTalmudBavliPdfLibraryDuplicate]; ספר אישי אינו מייצג את ה-PDF המובנה.
+Set<String> talmudBavliTextTitles(Category library) => {
+  for (final book in library.getAllBooks())
+    if (book is TextBook && !book.isUserBook && isTalmudBavliBook(book))
+      normalizeBookTitle(book.title),
+};
+
+/// האם [book] הוא כפילות-תצוגה בספרייה: PDF נלווה של מסכת בבלי שקיימת לה
+/// מהדורת טקסט ב-[textTitles] — המסכת מוצגת פעם אחת, והפתיחה לפי ההגדרה.
+bool isTalmudBavliPdfLibraryDuplicate(Book book, Set<String> textTitles) =>
+    book is PdfBook &&
+    !book.isUserBook &&
+    book.externalLibraryId == null &&
+    textTitles.contains(normalizeBookTitle(book.title)) &&
+    isTalmudBavliBook(book);
+
+/// פתיחת ספר ממסך הספרייה בהתאם להגדרת פורמט הבבלי: מסכת טקסט נפתחת
+/// במהדורת ה-PDF כשההגדרה היא PDF. מחזיר true אם הפתיחה טופלה כאן.
+Future<bool> openLibraryBookPerTalmudBavliFormat(
+  BuildContext context,
+  Book book,
+  int index,
+) async {
+  if (book is! TextBook) return false;
+  final coordinator = BookOpenCoordinator(
+    tabsBloc: context.read<TabsBloc>(),
+    historyBloc: context.read<HistoryBloc>(),
+    navigationBloc: context.read<NavigationBloc>(),
+  );
+  final target = await resolveTalmudBavliPdfBook(book);
+  if (target == null) return false;
+  if (index <= 0) {
+    // אין מיקום מפורש — פתיחה רגילה של ה-PDF, כולל שחזור מיקום מההיסטוריה.
+    coordinator.openBook(target.pdfBook, 1, '');
+    return true;
+  }
+  coordinator.openTab(
+    buildTalmudBavliResolvingTab(
+      target: target,
+      textIndex: index,
+      buildTextTab: (key) =>
+          coordinator.buildTab(target.textBook, index, '', dedupeKey: key),
+      buildPdfTab: (page, key) => PdfBookTab(
+        book: target.pdfBook,
+        pageNumber: page,
+        dedupeKey: key,
+        requiresStableLayout: true,
+      ),
+    ),
+  );
+  return true;
 }

--- a/test/empty_library/empty_library_bloc_test.dart
+++ b/test/empty_library/empty_library_bloc_test.dart
@@ -135,6 +135,20 @@ void main() {
           return http.Response.bytes(downloadedBytes, 200);
         }
 
+        // כמו GitHub: releases/latest/download מפנה לנתיב עם תג ה-release.
+        if (request.url.host == 'github.com' &&
+            request.url.path.contains('/releases/latest/download/') &&
+            request.url.path.endsWith('talmud_bavli_latest.tar.zst')) {
+          return http.Response(
+            '',
+            302,
+            headers: const {
+              'location':
+                  'https://github.com/Otzaria/otzaria-library/releases/download/v5.0.0/talmud_bavli_latest.tar.zst',
+            },
+          );
+        }
+
         if (request.url.host == 'github.com' &&
             request.url.path.endsWith('talmud_bavli_latest.tar.zst')) {
           return http.Response.bytes(talmudBytes, 200);
@@ -193,7 +207,10 @@ void main() {
           expect(archivePath, startsWith(Directory.systemTemp.path));
           expect(path.basename(archivePath), 'otzaria_talmud_bavli.tar.zst');
           expect(await File(archivePath).readAsBytes(), talmudBytes);
-          // לא יוצרים קבצי tar אמיתיים בטסט — מדמים חילוץ
+          // מדמים חילוץ: הארכיון האמיתי יוצר את תיקיית התלמוד ביעד.
+          Directory(
+            path.join(outputDir, DatabaseConstants.talmudBavliFolderName),
+          ).createSync(recursive: true);
         },
       );
       addTearDown(bloc.close);
@@ -232,6 +249,18 @@ void main() {
       expect(
         File(path.join(tempDir.path, 'lexical.db.version')).readAsStringSync(),
         'v0.3.0',
+      );
+      // גם לתלמוד נכתב סימון גרסה מהתג שבשרשרת ה-redirect — בלעדיו החתמה
+      // מאוחרת עלולה לסמן התקנה ישנה כתג העדכני ולדלג על עדכון.
+      expect(
+        File(
+          path.join(
+            tempDir.path,
+            DatabaseConstants.talmudBavliFolderName,
+            DatabaseConstants.talmudBavliVersionFileName,
+          ),
+        ).readAsStringSync(),
+        'v5.0.0',
       );
     });
 

--- a/test/empty_library/empty_library_bloc_test.dart
+++ b/test/empty_library/empty_library_bloc_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:http/http.dart' as http;
@@ -106,9 +107,31 @@ void main() {
 
       final downloadedBytes = utf8.encode('compressed-db');
       final talmudBytes = utf8.encode('compressed-talmud');
+      final talmudDigest = sha256.convert(talmudBytes).toString();
       final catalogBytes = utf8.encode('compressed-catalog');
       final lexicalBytes = utf8.encode('lexical-dictionary');
       final client = MockClient((request) async {
+        // ה-API של otzaria-library — איתור release התלמוד (כולל digest).
+        if (request.url.path.contains(
+          '/repos/Otzaria/otzaria-library/releases/latest',
+        )) {
+          return http.Response(
+            jsonEncode({
+              'tag_name': 'v5.0.0',
+              'assets': [
+                {
+                  'name': DatabaseConstants.talmudBavliArchiveFileName,
+                  'browser_download_url':
+                      'https://github.com/Otzaria/otzaria-library/releases/download/v5.0.0/talmud_bavli_latest.tar.zst',
+                  'digest': 'sha256:$talmudDigest',
+                  'size': talmudBytes.length,
+                },
+              ],
+            }),
+            200,
+          );
+        }
+
         if (request.url.path.endsWith('/releases/latest')) {
           return http.Response(
             jsonEncode({
@@ -133,20 +156,6 @@ void main() {
         if (request.url.toString() ==
             'https://example.com/releases/seforim.db.zst') {
           return http.Response.bytes(downloadedBytes, 200);
-        }
-
-        // כמו GitHub: releases/latest/download מפנה לנתיב עם תג ה-release.
-        if (request.url.host == 'github.com' &&
-            request.url.path.contains('/releases/latest/download/') &&
-            request.url.path.endsWith('talmud_bavli_latest.tar.zst')) {
-          return http.Response(
-            '',
-            302,
-            headers: const {
-              'location':
-                  'https://github.com/Otzaria/otzaria-library/releases/download/v5.0.0/talmud_bavli_latest.tar.zst',
-            },
-          );
         }
 
         if (request.url.host == 'github.com' &&
@@ -250,8 +259,8 @@ void main() {
         File(path.join(tempDir.path, 'lexical.db.version')).readAsStringSync(),
         'v0.3.0',
       );
-      // גם לתלמוד נכתב סימון גרסה מהתג שבשרשרת ה-redirect — בלעדיו החתמה
-      // מאוחרת עלולה לסמן התקנה ישנה כתג העדכני ולדלג על עדכון.
+      // גם לתלמוד נכתב סימון גרסה — digest של הנכס מה-API, כדי שבדיקות עדכון
+      // ישוו תוכן ולא תג (תגי otzaria-library מתחלפים כמעט יומית).
       expect(
         File(
           path.join(
@@ -260,9 +269,104 @@ void main() {
             DatabaseConstants.talmudBavliVersionFileName,
           ),
         ).readAsStringSync(),
-        'v5.0.0',
+        talmudDigest,
       );
     });
+
+    test(
+      'נכס התלמוד לא קיים באף release → מדלגים בלי לפנות לכתובת ה-latest',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'otzaria-talmud-missing-',
+        );
+        addTearDown(() async {
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+        await Settings.init(cacheProvider: _MemoryCacheProvider());
+        await Settings.setValue<String>(SettingsRepository.keyLibraryPath, '');
+        await Settings.setValue<String>(
+          SettingsRepository.keyLibraryFolderName,
+          '',
+        );
+
+        final downloadedBytes = utf8.encode('compressed-db');
+        final catalogBytes = utf8.encode('compressed-catalog');
+        final requested = <Uri>[];
+        final client = MockClient((request) async {
+          requested.add(request.url);
+          // otzaria-library: אין נכס תלמוד ב-latest וגם לא ברשימת ה-releases.
+          if (request.url.path.contains(
+            '/repos/Otzaria/otzaria-library/releases/latest',
+          )) {
+            return http.Response(
+              jsonEncode({'tag_name': 'fordb-latest', 'assets': []}),
+              200,
+            );
+          }
+          if (request.url.path.endsWith(
+            '/repos/Otzaria/otzaria-library/releases',
+          )) {
+            return http.Response(jsonEncode([]), 200);
+          }
+          if (request.url.path.endsWith('/releases/latest')) {
+            return http.Response(
+              jsonEncode({
+                'assets': [
+                  {
+                    'name': 'seforim.db.zst',
+                    'browser_download_url':
+                        'https://example.com/releases/seforim.db.zst',
+                  },
+                ],
+              }),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          if (request.url.toString() ==
+              'https://example.com/releases/seforim.db.zst') {
+            return http.Response.bytes(downloadedBytes, 200);
+          }
+          if (request.url.host == 'github.com' &&
+              request.url.path.endsWith('otzar-HB_catalog.db.zst')) {
+            return http.Response.bytes(catalogBytes, 200);
+          }
+          // המילון (אופציונלי) — 404 מדלג עליו.
+          return http.Response('not found', 404);
+        });
+
+        final bloc = EmptyLibraryBloc(
+          httpClient: client,
+          defaultLibraryPathOverride: tempDir.path,
+          extractCompressedDatabase:
+              (archivePath, outputPath, onProgress) async {
+                await File(
+                  outputPath,
+                ).writeAsBytes(const [1, 2, 3], flush: true);
+              },
+          extractTarArchive: (a, o, p) async =>
+              fail('אסור לחלץ תלמוד כשהנכס לא קיים באף release'),
+        );
+        addTearDown(bloc.close);
+
+        final selected = bloc.stream
+            .where((state) => state is EmptyLibraryDirectorySelected)
+            .cast<EmptyLibraryDirectorySelected>()
+            .first;
+        bloc.add(DownloadLibraryRequested());
+        await selected.timeout(const Duration(seconds: 5));
+
+        expect(
+          requested.where(
+            (u) => u.path.endsWith('talmud_bavli_latest.tar.zst'),
+          ),
+          isEmpty,
+          reason: 'הנכס לא קיים — אין לפנות לכתובת latest/download שתחזיר 404',
+        );
+      },
+    );
 
     test('פס ההתקדמות מאוחד על פני כל הקבצים — רק הכותרת מתחלפת', () async {
       final tempDir = await Directory.systemTemp.createTemp(

--- a/test/library/view/book_versions_dialog_test.dart
+++ b/test/library/view/book_versions_dialog_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/library/view/book_versions_dialog.dart';
+import 'package:otzaria/models/book_version.dart';
+import 'package:otzaria/models/books.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  final book = TextBook(title: 'כתובות');
+
+  testWidgets('הערות גרסה עם HTML מוצגות כטקסט מרונדר ולא כתגיות גולמיות', (
+    tester,
+  ) async {
+    const notes =
+        'הטקסט הארמי מתוך <a href="https://www.korenpub.com/">מהדורת קורן</a> '
+        'עם ביאור מאת <a href="/adin-even-israel-steinsaltz">הרב שטיינזלץ</a>';
+    await tester.pumpWidget(
+      _wrap(
+        BookVersionTile(
+          book: book,
+          version: const BookVersionInfo(
+            versionTitle: 'William Davidson Edition - Aramaic',
+            heVersionTitle: 'מהדורת דיווידסון - ארמית',
+            heVersionNotes: notes,
+            hasContent: true,
+          ),
+          isOnlyVersion: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('a href', findRichText: true), findsNothing);
+    expect(
+      find.textContaining('מהדורת קורן', findRichText: true),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('הרב שטיינזלץ', findRichText: true),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('גרסה ללא הערות מציגה רק את שורת הסטטוס', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        BookVersionTile(
+          book: book,
+          version: const BookVersionInfo(
+            versionTitle: 'Wikisource Talmud Bavli',
+            heVersionTitle: 'תלמוד בבלי (ויקיטקסט)',
+            hasContent: false,
+          ),
+          isOnlyVersion: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('טקסט הגרסה אינו כלול במאגר הנוכחי'), findsOneWidget);
+  });
+}

--- a/test/library/view/library_browser_flat_tree_test.dart
+++ b/test/library/view/library_browser_flat_tree_test.dart
@@ -38,9 +38,9 @@ TextBook _book(String title, {int order = 999}) =>
 /// סדר קטגוריות עליונות לפי מיקום ברשימה קבועה — מדמה את
 /// _getTopCategoryOrder של המסך בלי תלות ב-State.
 int Function(Category) _topOrderOf(List<String> orderedTitles) => (category) {
-      final idx = orderedTitles.indexOf(category.title);
-      return idx >= 0 ? idx : orderedTitles.length + category.order;
-    };
+  final idx = orderedTitles.indexOf(category.title);
+  return idx >= 0 ? idx : orderedTitles.length + category.order;
+};
 
 int _normalizeOrder(int order) => order >= 0 ? order : 1000 + order.abs();
 
@@ -48,13 +48,14 @@ List<FlatLibraryRow> _rows(
   Category root, {
   Set<String> expanded = const {},
   List<String> topOrder = const [],
-}) =>
-    buildFlatLibraryRows(
-      category: root,
-      expandedPaths: expanded,
-      topCategoryOrder: _topOrderOf(topOrder),
-      normalizeOrder: _normalizeOrder,
-    );
+  Set<String> talmudTextTitles = const {},
+}) => buildFlatLibraryRows(
+  category: root,
+  expandedPaths: expanded,
+  topCategoryOrder: _topOrderOf(topOrder),
+  normalizeOrder: _normalizeOrder,
+  talmudTextTitles: talmudTextTitles,
+);
 
 void main() {
   group('buildFlatLibraryRows — עץ הספרייה המשוטח', () {
@@ -68,13 +69,19 @@ void main() {
 
       expect(rows, hasLength(2));
       expect(rows[0].kind, FlatLibraryRowKind.categoryHeader);
-      expect(rows[0].category!.title, 'תנ"ך',
-          reason: 'סדר קטגוריות עליונות לפי הרשימה הקבועה, לא לפי order');
+      expect(
+        rows[0].category!.title,
+        'תנ"ך',
+        reason: 'סדר קטגוריות עליונות לפי הרשימה הקבועה, לא לפי order',
+      );
       expect(rows[1].category!.title, 'הלכה');
       for (final row in rows) {
         expect(row.isGroupStart, isTrue);
-        expect(row.isGroupEnd, isTrue,
-            reason: 'כרטיס מכווץ = קבוצה בת שורה אחת');
+        expect(
+          row.isGroupEnd,
+          isTrue,
+          reason: 'כרטיס מכווץ = קבוצה בת שורה אחת',
+        );
       }
     });
 
@@ -90,45 +97,52 @@ void main() {
       expect(rows.single.category!.title, 'מלאה');
     });
 
-    test('קטגוריה מורחבת: תת-קטגוריות לפני ספרים, ממוינים, ודגלי קצה נכונים',
-        () {
-      final expanded = _category(
-        'הלכה',
-        subCategories: [
-          _category('שו"ת', order: 2, books: [_book('שות א')]),
-          _category('פסק', order: 1, books: [_book('פסק א')]),
-        ],
-        books: [
-          _book('ספר מאוחר', order: 5),
-          _book('ספר מוקדם', order: 1),
-        ],
-      );
-      final root = _library([expanded]);
+    test(
+      'קטגוריה מורחבת: תת-קטגוריות לפני ספרים, ממוינים, ודגלי קצה נכונים',
+      () {
+        final expanded = _category(
+          'הלכה',
+          subCategories: [
+            _category('שו"ת', order: 2, books: [_book('שות א')]),
+            _category('פסק', order: 1, books: [_book('פסק א')]),
+          ],
+          books: [
+            _book('ספר מאוחר', order: 5),
+            _book('ספר מוקדם', order: 1),
+          ],
+        );
+        final root = _library([expanded]);
 
-      final rows = _rows(root, expanded: {expanded.path});
+        final rows = _rows(root, expanded: {expanded.path});
 
-      expect(
-        rows.map((r) => r.kind).toList(),
-        [
-          FlatLibraryRowKind.categoryHeader, // הלכה
-          FlatLibraryRowKind.categoryHeader, // פסק (order 1)
-          FlatLibraryRowKind.categoryHeader, // שו"ת (order 2)
-          FlatLibraryRowKind.book, // ספר מוקדם
-          FlatLibraryRowKind.book, // ספר מאוחר
-        ],
-      );
-      expect(rows[1].category!.title, 'פסק');
-      expect(rows[2].category!.title, 'שו"ת');
-      expect(rows[3].book!.title, 'ספר מוקדם');
-      expect(rows[4].book!.title, 'ספר מאוחר');
+        expect(
+          rows.map((r) => r.kind).toList(),
+          [
+            FlatLibraryRowKind.categoryHeader, // הלכה
+            FlatLibraryRowKind.categoryHeader, // פסק (order 1)
+            FlatLibraryRowKind.categoryHeader, // שו"ת (order 2)
+            FlatLibraryRowKind.book, // ספר מוקדם
+            FlatLibraryRowKind.book, // ספר מאוחר
+          ],
+        );
+        expect(rows[1].category!.title, 'פסק');
+        expect(rows[2].category!.title, 'שו"ת');
+        expect(rows[3].book!.title, 'ספר מוקדם');
+        expect(rows[4].book!.title, 'ספר מאוחר');
 
-      expect(rows.first.isGroupStart, isTrue);
-      expect(rows.first.isGroupEnd, isFalse);
-      expect(rows.sublist(1, 4).every((r) => !r.isGroupStart && !r.isGroupEnd),
-          isTrue);
-      expect(rows.last.isGroupEnd, isTrue,
-          reason: 'השורה האחרונה בקבוצה עליונה סוגרת את הכרטיס');
-    });
+        expect(rows.first.isGroupStart, isTrue);
+        expect(rows.first.isGroupEnd, isFalse);
+        expect(
+          rows.sublist(1, 4).every((r) => !r.isGroupStart && !r.isGroupEnd),
+          isTrue,
+        );
+        expect(
+          rows.last.isGroupEnd,
+          isTrue,
+          reason: 'השורה האחרונה בקבוצה עליונה סוגרת את הכרטיס',
+        );
+      },
+    );
 
     test('רמות: ספר ברמה 0 הוא rootBook, ספר בקטגוריה הוא book', () {
       final sub = _category('תת', books: [_book('פנימי')]);
@@ -156,18 +170,59 @@ void main() {
 
       final rows = _rows(root, expanded: {big.path});
 
-      final bookRows =
-          rows.where((r) => r.kind == FlatLibraryRowKind.book).toList();
+      final bookRows = rows
+          .where((r) => r.kind == FlatLibraryRowKind.book)
+          .toList();
       expect(bookRows, hasLength(500));
       expect(bookRows.first.book!.title, 'ספר 0');
       expect(bookRows.last.book!.title, 'ספר 499');
 
       final showMore = rows.last;
       expect(showMore.kind, FlatLibraryRowKind.showMore);
-      expect(showMore.showMoreBooks, hasLength(502),
-          reason: 'דיאלוג "הצג עוד" מקבל את הרשימה המלאה');
-      expect(showMore.isGroupEnd, isTrue,
-          reason: '"הצג עוד" היא השורה הסוגרת של הכרטיס');
+      expect(
+        showMore.showMoreBooks,
+        hasLength(502),
+        reason: 'דיאלוג "הצג עוד" מקבל את הרשימה המלאה',
+      );
+      expect(
+        showMore.isGroupEnd,
+        isTrue,
+        reason: '"הצג עוד" היא השורה הסוגרת של הכרטיס',
+      );
+    });
+
+    test('מהדורות PDF כפולות של מסכתות הבבלי מסוננות מהעץ', () {
+      final pdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\books\תלמוד בבלי\ברכות.pdf',
+      );
+      final orphanPdf = PdfBook(
+        title: 'שבת',
+        path: r'C:\books\תלמוד בבלי\שבת.pdf',
+      );
+      final seder = _category('סדר זרעים', books: [_book('ברכות')]);
+      final bavli = _category(
+        'תלמוד בבלי',
+        subCategories: [seder],
+        books: [pdf, orphanPdf],
+      );
+      final root = _library([bavli]);
+
+      final rows = _rows(
+        root,
+        expanded: {bavli.path, seder.path},
+        talmudTextTitles: {'ברכות'},
+      );
+
+      final pdfRows = rows.where((r) => r.book is PdfBook).toList();
+      expect(
+        pdfRows.single.book!.title,
+        'שבת',
+        reason:
+            'מסכת עם מהדורת טקסט מוצגת פעם אחת — דרך הטקסט; '
+            'PDF ללא מהדורת טקסט נשאר מוצג',
+      );
+      expect(rows.where((r) => r.book is TextBook).single.book!.title, 'ברכות');
     });
 
     test('parentPath משקף את הקטגוריה המכילה (ייחודיות keys)', () {
@@ -182,8 +237,9 @@ void main() {
         expanded: {catA.path, catB.path, subA.path, subB.path},
       );
 
-      final bookRows =
-          rows.where((r) => r.kind == FlatLibraryRowKind.book).toList();
+      final bookRows = rows
+          .where((r) => r.kind == FlatLibraryRowKind.book)
+          .toList();
       expect(bookRows, hasLength(2));
       expect(bookRows[0].parentPath, isNot(bookRows[1].parentPath));
     });

--- a/test/library_update/companion_assets_service_test.dart
+++ b/test/library_update/companion_assets_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -772,6 +773,150 @@ void main() {
       expect(readMarker(), tag);
     });
 
+    test(
+      'הנכס חסר ב-release האחרון → נלקח מה-release הקודם שמכיל אותו',
+      () async {
+        final requested = <Uri>[];
+        final client = MockClient((request) async {
+          requested.add(request.url);
+          // release אחרון בסגנון fordb — בלי נכס תלמוד.
+          if (request.url.path.endsWith('/releases/latest')) {
+            return http.Response(
+              jsonEncode({
+                'tag_name': 'fordb-latest',
+                'assets': [
+                  {
+                    'name': 'fordb_latest.zip',
+                    'browser_download_url': 'https://x/fordb_latest.zip',
+                  },
+                ],
+              }),
+              200,
+            );
+          }
+          if (request.url.path.endsWith('/releases')) {
+            return http.Response(
+              jsonEncode([
+                {
+                  'tag_name': 'fordb-latest',
+                  'prerelease': false,
+                  'assets': [
+                    {
+                      'name': 'fordb_latest.zip',
+                      'browser_download_url': 'https://x/fordb_latest.zip',
+                    },
+                  ],
+                },
+                {
+                  'tag_name': tag,
+                  'prerelease': false,
+                  'assets': [
+                    {
+                      'name': DatabaseConstants.talmudBavliArchiveFileName,
+                      'browser_download_url': assetUrl,
+                    },
+                  ],
+                },
+              ]),
+              200,
+            );
+          }
+          if (request.url.toString() == assetUrl) {
+            return http.Response.bytes([1, 2, 3], 200);
+          }
+          return http.Response('not found', 404);
+        });
+
+        final extractions = <({String archive, String outputDir})>[];
+        await service(
+          client: client,
+          extractions: extractions,
+        ).verifyAndUpdate();
+
+        expect(extractions, hasLength(1));
+        expect(readMarker(), tag);
+        expect(
+          requested.any((u) => u.path.endsWith('/releases')),
+          isTrue,
+          reason: 'הנכס חסר ב-latest — נדרשת סריקת רשימת ה-releases',
+        );
+      },
+    );
+
+    test('הנכס נמצא רק בעמוד השני של רשימת ה-releases', () async {
+      Map<String, dynamic> fordbRelease(String tagName) => {
+        'tag_name': tagName,
+        'prerelease': false,
+        'assets': [
+          {
+            'name': 'fordb_latest.zip',
+            'browser_download_url': 'https://x/fordb_latest.zip',
+          },
+        ],
+      };
+      final client = MockClient((request) async {
+        if (request.url.path.endsWith('/releases/latest')) {
+          return http.Response(jsonEncode(fordbRelease('fordb-latest')), 200);
+        }
+        if (request.url.path.endsWith('/releases')) {
+          if (request.url.queryParameters['page'] == '1') {
+            return http.Response(
+              jsonEncode([fordbRelease('fordb-1'), fordbRelease('fordb-2')]),
+              200,
+            );
+          }
+          return http.Response(
+            jsonEncode([
+              {
+                'tag_name': tag,
+                'prerelease': false,
+                'assets': [
+                  {
+                    'name': DatabaseConstants.talmudBavliArchiveFileName,
+                    'browser_download_url': assetUrl,
+                  },
+                ],
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('not found', 404);
+      });
+
+      final release = await CompanionAssetsService.findLatestTalmudRelease(
+        client,
+      );
+      expect(release.tag, tag);
+      expect(release.assetUrl, assetUrl);
+    });
+
+    test('הנכס לא קיים באף release → TalmudAssetNotFoundException', () async {
+      final client = MockClient((request) async {
+        if (request.url.path.endsWith('/releases/latest')) {
+          return http.Response(
+            jsonEncode({'tag_name': 'fordb-latest', 'assets': []}),
+            200,
+          );
+        }
+        if (request.url.path.endsWith('/releases')) {
+          // עמוד ראשון בלי הנכס, עמוד שני ריק — הסריקה הסתיימה.
+          final body = request.url.queryParameters['page'] == '1'
+              ? [
+                  {'tag_name': 'fordb-1', 'prerelease': false, 'assets': []},
+                ]
+              : <Object>[];
+          return http.Response(jsonEncode(body), 200);
+        }
+        return http.Response('not found', 404);
+      });
+
+      await expectLater(
+        CompanionAssetsService.findLatestTalmudRelease(client),
+        throwsA(isA<TalmudAssetNotFoundException>()),
+      );
+    });
+
     test('כשל ב-API של התלמוד לא עוצר את הקטלוג והמילון', () async {
       final catalog = _FakeCatalogRepository(exists: true);
       final dictionary = _FakeDictionaryDownloader();
@@ -791,6 +936,144 @@ void main() {
       final catalog = _FakeCatalogRepository(exists: true);
       await service(catalog: catalog).verifyAndUpdate(isCancelled: () => true);
       expect(catalog.updateCalled, isFalse);
+    });
+  });
+
+  group('תלמוד בבלי — השוואת digest', () {
+    // תגי otzaria-library מתחלפים כמעט יומית עם אותו קובץ תלמוד — הזיהוי חייב
+    // להשוות תוכן (digest) ולא תג, אחרת כל release גורר הורדת ~440MB מיותרת.
+    final bodyDigest = sha256.convert([1, 2, 3]).toString();
+    const otherDigest =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    MockClient digestClient({
+      required String latestDigest,
+      String? installedTagDigest,
+      List<Uri>? requested,
+    }) {
+      return MockClient((request) async {
+        requested?.add(request.url);
+        if (request.url.path.contains('/releases/tags/')) {
+          if (installedTagDigest == null) {
+            return http.Response('not found', 404);
+          }
+          return http.Response(
+            jsonEncode({
+              'tag_name': request.url.pathSegments.last,
+              'assets': [
+                {
+                  'name': DatabaseConstants.talmudBavliArchiveFileName,
+                  'browser_download_url': assetUrl,
+                  'digest': 'sha256:$installedTagDigest',
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        if (request.url.path.contains('releases/latest')) {
+          return http.Response(
+            jsonEncode({
+              'tag_name': tag,
+              'assets': [
+                {
+                  'name': DatabaseConstants.talmudBavliArchiveFileName,
+                  'browser_download_url': assetUrl,
+                  'digest': 'sha256:$latestDigest',
+                  'size': 3,
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        if (request.url.toString() == assetUrl) {
+          return http.Response.bytes([1, 2, 3], 200);
+        }
+        return http.Response('not found', 404);
+      });
+    }
+
+    File talmudTempFile() => File(
+      p.join(
+        Directory.systemTemp.path,
+        'otzaria_${DatabaseConstants.talmudBavliArchiveFileName}',
+      ),
+    );
+
+    test('תג התחלף אך ה-digest זהה → מחתים digest בלי להוריד', () async {
+      createTalmudDir(markerTag: 'v1.0.0');
+      final requested = <Uri>[];
+      final extractions = <({String archive, String outputDir})>[];
+      final changed = await service(
+        client: digestClient(
+          latestDigest: bodyDigest,
+          installedTagDigest: bodyDigest,
+          requested: requested,
+        ),
+        extractions: extractions,
+      ).verifyAndUpdate();
+
+      expect(extractions, isEmpty);
+      expect(requested.map((u) => u.toString()), isNot(contains(assetUrl)));
+      expect(readMarker(), bodyDigest);
+      expect(changed, isFalse, reason: 'החתמת digest בלבד אינה שינוי בספרייה');
+    });
+
+    test('תג התחלף וה-digest שונה → מוריד ומחתים את ה-digest החדש', () async {
+      createTalmudDir(markerTag: 'v1.0.0');
+      cleanupTalmudTemp(talmudTempFile());
+      addTearDown(() => cleanupTalmudTemp(talmudTempFile()));
+      final extractions = <({String archive, String outputDir})>[];
+      await service(
+        client: digestClient(
+          latestDigest: bodyDigest,
+          installedTagDigest: otherDigest,
+        ),
+        extractions: extractions,
+      ).verifyAndUpdate();
+
+      expect(extractions, hasLength(1));
+      expect(readMarker(), bodyDigest);
+    });
+
+    test('סימון digest תואם → לא מוריד ולא פונה ל-API של התג', () async {
+      createTalmudDir(markerTag: bodyDigest);
+      final requested = <Uri>[];
+      final extractions = <({String archive, String outputDir})>[];
+      await service(
+        client: digestClient(latestDigest: bodyDigest, requested: requested),
+        extractions: extractions,
+      ).verifyAndUpdate();
+
+      expect(extractions, isEmpty);
+      expect(
+        requested.where((u) => u.path.contains('/releases/tags/')),
+        isEmpty,
+      );
+      expect(readMarker(), bodyDigest);
+    });
+
+    test('התג המותקן כבר לא קיים ב-GitHub (404) → מוריד', () async {
+      createTalmudDir(markerTag: 'v1.0.0');
+      cleanupTalmudTemp(talmudTempFile());
+      addTearDown(() => cleanupTalmudTemp(talmudTempFile()));
+      final extractions = <({String archive, String outputDir})>[];
+      await service(
+        client: digestClient(latestDigest: bodyDigest),
+        extractions: extractions,
+      ).verifyAndUpdate();
+
+      expect(extractions, hasLength(1));
+      expect(readMarker(), bodyDigest);
+    });
+
+    test('תיקייה קיימת ללא סימון → מחתים digest ולא תג', () async {
+      createTalmudDir();
+      await service(
+        client: digestClient(latestDigest: bodyDigest),
+      ).verifyAndUpdate();
+      expect(readMarker(), bodyDigest);
     });
   });
 

--- a/test/library_update/companion_assets_service_test.dart
+++ b/test/library_update/companion_assets_service_test.dart
@@ -150,7 +150,7 @@ void main() {
       expect(progress, contains(5000));
     });
 
-    test('תיקייה קיימת ללא סימון → מחתים את התג בלי להוריד', () async {
+    test('תיקייה קיימת ללא סימון → מוריד ומחתים את התג', () async {
       createTalmudDir();
       final requested = <Uri>[];
       final extractions = <({String archive, String outputDir})>[];
@@ -160,9 +160,9 @@ void main() {
       ).verifyAndUpdate();
 
       expect(readMarker(), tag);
-      expect(extractions, isEmpty);
-      expect(requested.map((u) => u.toString()), isNot(contains(assetUrl)));
-      expect(changed, isFalse, reason: 'החתמה בלבד אינה שינוי בספרייה');
+      expect(extractions, hasLength(1));
+      expect(requested.map((u) => u.toString()), contains(assetUrl));
+      expect(changed, isTrue);
     });
 
     test('סימון תואם לתג → לא מוריד ולא נוגע', () async {
@@ -1068,11 +1068,17 @@ void main() {
       expect(readMarker(), bodyDigest);
     });
 
-    test('תיקייה קיימת ללא סימון → מחתים digest ולא תג', () async {
+    test('תיקייה קיימת ללא סימון → מוריד ומחתים את ה-digest הנוכחי', () async {
       createTalmudDir();
+      cleanupTalmudTemp(talmudTempFile());
+      addTearDown(() => cleanupTalmudTemp(talmudTempFile()));
+      final extractions = <({String archive, String outputDir})>[];
       await service(
         client: digestClient(latestDigest: bodyDigest),
+        extractions: extractions,
       ).verifyAndUpdate();
+
+      expect(extractions, hasLength(1));
       expect(readMarker(), bodyDigest);
     });
   });

--- a/test/library_update/companion_assets_service_test.dart
+++ b/test/library_update/companion_assets_service_test.dart
@@ -59,6 +59,7 @@ void main() {
     void Function()? invalidate,
     void Function()? invalidateLibrary,
     bool failExtraction = false,
+    Object? extractionError,
   }) {
     return CompanionAssetsService(
       clientFactory: () => client ?? releaseClient(),
@@ -66,6 +67,7 @@ void main() {
       dictionaryFactory: () => dictionary ?? _FakeDictionaryDownloader(),
       extractTarArchive: (archive, outputDir, onProgress) async {
         if (failExtraction) throw Exception('החילוץ נקטע');
+        if (extractionError != null) throw extractionError;
         extractions?.add((archive: archive, outputDir: outputDir));
         onProgress?.call(0.5);
         onProgress?.call(1.0);
@@ -248,6 +250,128 @@ void main() {
           isFalse,
           reason: 'אחרי חילוץ מוצלח הקובץ הזמני נמחק',
         );
+      },
+    );
+
+    test(
+      'FileSystemException בשלב החילוץ משאיר את ה-temp — '
+      'בלי הורדת גוף מלאה חוזרת',
+      () async {
+        final talmudTemp = File(
+          p.join(
+            Directory.systemTemp.path,
+            'otzaria_${DatabaseConstants.talmudBavliArchiveFileName}',
+          ),
+        );
+        cleanupTalmudTemp(talmudTemp);
+        addTearDown(() => cleanupTalmudTemp(talmudTemp));
+
+        final ranges = <String?>[];
+        final client = MockClient((request) async {
+          if (request.url.path.contains('releases/latest')) {
+            return http.Response(
+              jsonEncode({
+                'tag_name': tag,
+                'assets': [
+                  {
+                    'name': DatabaseConstants.talmudBavliArchiveFileName,
+                    'browser_download_url': assetUrl,
+                    'size': 100,
+                    'id': 1,
+                    'updated_at': 't1',
+                  },
+                ],
+              }),
+              200,
+            );
+          }
+          if (request.url.toString() == assetUrl) {
+            ranges.add(request.headers['range']);
+            if (request.headers['range'] != null) {
+              return http.Response(
+                '',
+                416,
+                headers: const {'content-range': 'bytes */100'},
+              );
+            }
+            return http.Response.bytes(
+              List.filled(100, 5),
+              200,
+              headers: const {'etag': '"e1"'},
+            );
+          }
+          return http.Response('not found', 404);
+        });
+
+        // הרצה 1: ההורדה מצליחה אך המחלץ זורק FileSystemException (מדמה קובץ
+        // יעד נעול) — הארכיון הזמני נשמר כדי שההרצה הבאה לא תוריד שוב ~440MB.
+        await service(
+          client: client,
+          extractionError: const FileSystemException('קובץ נעול'),
+        ).verifyAndUpdate();
+        expect(readMarker(), CompanionAssetsService.talmudInstallingMarker);
+        expect(
+          talmudTemp.existsSync(),
+          isTrue,
+          reason: 'כשל נעילה אינו ארכיון פגום — אין למחוק את ההורדה',
+        );
+
+        // הרצה 2: הנעילה שוחררה — החילוץ מצליח מהשריד, בלי הורדת גוף נוספת.
+        final extractions = <({String archive, String outputDir})>[];
+        await service(
+          client: client,
+          extractions: extractions,
+        ).verifyAndUpdate();
+        expect(extractions, hasLength(1));
+        expect(readMarker(), tag);
+        expect(
+          ranges.where((r) => r == null),
+          hasLength(1),
+          reason: 'הגוף המלא הורד פעם אחת בלבד — ההרצה השנייה השתמשה בשריד',
+        );
+        expect(
+          talmudTemp.existsSync(),
+          isFalse,
+          reason: 'אחרי חילוץ מוצלח הקובץ הזמני נמחק',
+        );
+      },
+    );
+
+    test(
+      'קובץ יעד נעול באמת בזמן ניקוי הקבצים הישנים משאיר את ה-temp',
+      skip: Platform.isWindows ? null : 'נעילת קבצים חוסמת מחיקה רק ב-Windows',
+      () async {
+        final talmudTemp = File(
+          p.join(
+            Directory.systemTemp.path,
+            'otzaria_${DatabaseConstants.talmudBavliArchiveFileName}',
+          ),
+        );
+        cleanupTalmudTemp(talmudTemp);
+        addTearDown(() => cleanupTalmudTemp(talmudTemp));
+
+        // handle פתוח על קובץ קיים — deleteSync של ניקוי הישנים ייכשל עליו.
+        createTalmudDir(markerTag: 'v1.0.0');
+        final lock = File(p.join(talmudDir(), 'ברכות.pdf')).openSync();
+        var locked = true;
+        addTearDown(() {
+          if (locked) lock.closeSync();
+        });
+
+        await service().verifyAndUpdate();
+        expect(readMarker(), CompanionAssetsService.talmudInstallingMarker);
+        expect(
+          talmudTemp.existsSync(),
+          isTrue,
+          reason: 'הנעילה נכשלה אחרי ההורדה — הארכיון חייב להישמר ל-resume',
+        );
+
+        lock.closeSync();
+        locked = false;
+        final extractions = <({String archive, String outputDir})>[];
+        await service(extractions: extractions).verifyAndUpdate();
+        expect(extractions, hasLength(1));
+        expect(readMarker(), tag);
       },
     );
 

--- a/test/utils/talmud_bavli_library_open_test.dart
+++ b/test/utils/talmud_bavli_library_open_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/history/bloc/history_bloc.dart';
+import 'package:otzaria/history/bloc/history_event.dart';
+import 'package:otzaria/history/bloc/history_state.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
+import 'package:otzaria/navigation/bloc/navigation_event.dart';
+import 'package:otzaria/navigation/bloc/navigation_state.dart';
+import 'package:otzaria/settings/engine/settings_repository.dart';
+import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
+import 'package:otzaria/tabs/bloc/tabs_event.dart';
+import 'package:otzaria/tabs/bloc/tabs_state.dart';
+import 'package:otzaria/tabs/models/pdf_tab.dart';
+import 'package:otzaria/tabs/models/resolving_tab.dart';
+import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/utils/navigation/talmud_bavli_open_format.dart';
+
+import '../helpers/memory_settings_cache.dart';
+
+class _RecordingTabsBloc extends Fake implements TabsBloc {
+  final added = <TabsEvent>[];
+
+  @override
+  TabsState get state => TabsState.initial();
+
+  @override
+  Stream<TabsState> get stream => const Stream.empty();
+
+  @override
+  void add(TabsEvent event) => added.add(event);
+}
+
+class _RecordingHistoryBloc extends Fake implements HistoryBloc {
+  final added = <HistoryEvent>[];
+
+  @override
+  HistoryState get state => HistoryLoaded(const []);
+
+  @override
+  Stream<HistoryState> get stream => const Stream.empty();
+
+  @override
+  void add(HistoryEvent event) => added.add(event);
+}
+
+class _RecordingNavigationBloc extends Fake implements NavigationBloc {
+  final added = <NavigationEvent>[];
+
+  @override
+  Stream<NavigationState> get stream => const Stream.empty();
+
+  @override
+  void add(NavigationEvent event) => added.add(event);
+}
+
+Category _category(String title, {Category? parent}) {
+  final category = Category(
+    title: title,
+    description: '',
+    shortDescription: '',
+    order: 0,
+    subCategories: [],
+    books: [],
+    parent: parent,
+  );
+  parent?.subCategories.add(category);
+  return category;
+}
+
+/// ספרייה עם מסכת ברכות: מהדורת טקסט תחת סדר זרעים, ואופציונלית PDF נלווה.
+({Library library, TextBook text}) _buildLibrary({bool withPdf = true}) {
+  final bavliRoot = _category('תלמוד בבלי');
+  final seder = _category('סדר זרעים', parent: bavliRoot);
+  final text = TextBook(title: 'ברכות', category: seder, categoryId: 10);
+  seder.books.add(text);
+  if (withPdf) {
+    bavliRoot.books.add(
+      PdfBook(
+        title: 'ברכות',
+        path: r'C:\books\תלמוד בבלי\ברכות.pdf',
+        category: bavliRoot,
+      ),
+    );
+  }
+  return (library: Library(categories: [bavliRoot]), text: text);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _RecordingTabsBloc tabsBloc;
+  late _RecordingHistoryBloc historyBloc;
+  late _RecordingNavigationBloc navigationBloc;
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+    tabsBloc = _RecordingTabsBloc();
+    historyBloc = _RecordingHistoryBloc();
+    navigationBloc = _RecordingNavigationBloc();
+  });
+
+  Future<bool> run(WidgetTester tester, Book book, int index) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<TabsBloc>.value(value: tabsBloc),
+          BlocProvider<HistoryBloc>.value(value: historyBloc),
+          BlocProvider<NavigationBloc>.value(value: navigationBloc),
+        ],
+        child: Builder(
+          builder: (ctx) {
+            capturedContext = ctx;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return openLibraryBookPerTalmudBavliFormat(capturedContext, book, index);
+  }
+
+  group('openLibraryBookPerTalmudBavliFormat', () {
+    testWidgets('הגדרת PDF: מסכת טקסט בלי מיקום נפתחת כ-PDF בדף 1', (
+      tester,
+    ) async {
+      await Settings.setValue(
+        SettingsRepository.keyTalmudBavliOpenFormat,
+        'pdf',
+      );
+      final built = _buildLibrary();
+      DataRepository.instance.library = Future.value(built.library);
+
+      final handled = await run(tester, built.text, 0);
+
+      expect(handled, isTrue);
+      final event = tabsBloc.added.single as OpenOrFocusTab;
+      final tab = event.tab as PdfBookTab;
+      expect(tab.book.title, 'ברכות');
+      expect(tab.pageNumber, 1);
+      expect(
+        navigationBloc.added.single,
+        isA<NavigateToScreen>().having(
+          (e) => e.screen,
+          'screen',
+          Screen.reading,
+        ),
+      );
+    });
+
+    testWidgets('הגדרת PDF עם מיקום מפורש: נפתח טאב-טעינה עם מיפוי עמוד', (
+      tester,
+    ) async {
+      await Settings.setValue(
+        SettingsRepository.keyTalmudBavliOpenFormat,
+        'pdf',
+      );
+      final built = _buildLibrary();
+      DataRepository.instance.library = Future.value(built.library);
+
+      final handled = await run(tester, built.text, 7);
+
+      expect(handled, isTrue);
+      final event = tabsBloc.added.single as OpenOrFocusTab;
+      final tab = event.tab as ResolvingTab;
+      expect(
+        tab.fallbackTab,
+        isA<TextBookTab>().having((t) => t.book.title, 'title', 'ברכות'),
+      );
+    });
+
+    testWidgets('הגדרת טקסט (ברירת מחדל): הפתיחה לא מטופלת — נשארת רגילה', (
+      tester,
+    ) async {
+      final built = _buildLibrary();
+      DataRepository.instance.library = Future.value(built.library);
+
+      final handled = await run(tester, built.text, 0);
+
+      expect(handled, isFalse);
+      expect(tabsBloc.added, isEmpty);
+      expect(navigationBloc.added, isEmpty);
+    });
+
+    testWidgets('הגדרת PDF אך אין מהדורת PDF בספרייה: fallback לפתיחה רגילה', (
+      tester,
+    ) async {
+      await Settings.setValue(
+        SettingsRepository.keyTalmudBavliOpenFormat,
+        'pdf',
+      );
+      final built = _buildLibrary(withPdf: false);
+      DataRepository.instance.library = Future.value(built.library);
+
+      final handled = await run(tester, built.text, 0);
+
+      expect(handled, isFalse);
+      expect(tabsBloc.added, isEmpty);
+    });
+
+    testWidgets('ספר שאינו טקסט (PDF) לא מנותב — נפתח כרגיל', (tester) async {
+      await Settings.setValue(
+        SettingsRepository.keyTalmudBavliOpenFormat,
+        'pdf',
+      );
+      final built = _buildLibrary();
+      DataRepository.instance.library = Future.value(built.library);
+      final pdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\books\תלמוד בבלי\ברכות.pdf',
+      );
+
+      final handled = await run(tester, pdf, 1);
+
+      expect(handled, isFalse);
+      expect(tabsBloc.added, isEmpty);
+    });
+  });
+}

--- a/test/utils/talmud_bavli_open_format_test.dart
+++ b/test/utils/talmud_bavli_open_format_test.dart
@@ -22,12 +22,14 @@ void main() {
     test('זיהוי לפי categoryPath', () {
       expect(
         isTalmudBavliBook(
-            TextBook(title: 'ברכות', categoryPath: 'תלמוד בבלי/סדר זרעים')),
+          TextBook(title: 'ברכות', categoryPath: 'תלמוד בבלי/סדר זרעים'),
+        ),
         isTrue,
       );
       expect(
         isTalmudBavliBook(
-            TextBook(title: 'ברכות', categoryPath: 'משנה/סדר זרעים')),
+          TextBook(title: 'ברכות', categoryPath: 'משנה/סדר זרעים'),
+        ),
         isFalse,
       );
     });
@@ -42,8 +44,12 @@ void main() {
 
       final otherRoot = _category('הלכה');
       expect(
-        isTalmudBavliBook(TextBook(
-            title: 'ברכות', category: _category('ברכות', parent: otherRoot))),
+        isTalmudBavliBook(
+          TextBook(
+            title: 'ברכות',
+            category: _category('ברכות', parent: otherRoot),
+          ),
+        ),
         isFalse,
       );
     });
@@ -57,18 +63,21 @@ void main() {
       );
       expect(
         isTalmudBavliBook(
-            TextBook(title: 'רש"י', categoryPath: 'תלמוד בבלי/ראשונים')),
+          TextBook(title: 'רש"י', categoryPath: 'תלמוד בבלי/ראשונים'),
+        ),
         isFalse,
       );
     });
 
     test('PDF בקטגוריית השורש תלמוד בבלי (מסכתות סרוקות) — מסכת', () {
       expect(
-        isTalmudBavliBook(PdfBook(
-          title: 'ברכות',
-          path: r'C:\books\תלמוד בבלי\ברכות.pdf',
-          category: _category('תלמוד בבלי'),
-        )),
+        isTalmudBavliBook(
+          PdfBook(
+            title: 'ברכות',
+            path: r'C:\books\תלמוד בבלי\ברכות.pdf',
+            category: _category('תלמוד בבלי'),
+          ),
+        ),
         isTrue,
       );
     });
@@ -76,20 +85,136 @@ void main() {
     test('PDF ללא קטגוריה — זיהוי לפי נתיב הקובץ', () {
       expect(
         isTalmudBavliBook(
-            PdfBook(title: 'ברכות', path: r'C:\books\תלמוד בבלי\ברכות.pdf')),
+          PdfBook(title: 'ברכות', path: r'C:\books\תלמוד בבלי\ברכות.pdf'),
+        ),
         isTrue,
       );
       expect(
         isTalmudBavliBook(
-            PdfBook(title: 'ברכות', path: r'C:\books\הלכה\ברכות.pdf')),
+          PdfBook(title: 'ברכות', path: r'C:\books\הלכה\ברכות.pdf'),
+        ),
         isFalse,
       );
       // קובץ בתת-תיקייה של תלמוד בבלי אינו מסכת.
       expect(
-        isTalmudBavliBook(PdfBook(
-            title: 'רש"י', path: r'C:\books\תלמוד בבלי\מפרשים\רשי.pdf')),
+        isTalmudBavliBook(
+          PdfBook(title: 'רש"י', path: r'C:\books\תלמוד בבלי\מפרשים\רשי.pdf'),
+        ),
         isFalse,
       );
+    });
+  });
+
+  group('isTalmudBavliPdfLibraryDuplicate', () {
+    const textTitles = {'ברכות'};
+
+    test('PDF נלווה של מסכת עם מהדורת טקסט הוא כפילות-תצוגה; טקסט אינו', () {
+      expect(
+        isTalmudBavliPdfLibraryDuplicate(
+          PdfBook(title: 'ברכות', path: r'C:\books\תלמוד בבלי\ברכות.pdf'),
+          textTitles,
+        ),
+        isTrue,
+      );
+      expect(
+        isTalmudBavliPdfLibraryDuplicate(
+          TextBook(title: 'ברכות', categoryPath: 'תלמוד בבלי/סדר זרעים'),
+          textTitles,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'התאמת כותרות מנורמלת — גרשיים ורווחים כפולים לא שוברים את הסינון',
+      () {
+        final bavliRoot = _category('תלמוד בבלי');
+        final seder = _category('סדר זרעים', parent: bavliRoot);
+        seder.books.add(TextBook(title: 'ע״ז', category: seder));
+        final titles = talmudBavliTextTitles(Library(categories: [bavliRoot]));
+
+        expect(
+          isTalmudBavliPdfLibraryDuplicate(
+            PdfBook(title: 'ע"ז', path: r'C:\books\תלמוד בבלי\עז.pdf'),
+            titles,
+          ),
+          isTrue,
+        );
+        expect(
+          isTalmudBavliPdfLibraryDuplicate(
+            PdfBook(
+              title: 'בבא  קמא',
+              path: r'C:\books\תלמוד בבלי\בבא קמא.pdf',
+            ),
+            {normalizeBookTitle('בבא קמא')},
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('PDF של מסכת ללא מהדורת טקסט — לא מוסתר (לא נעלם מהספרייה)', () {
+      expect(
+        isTalmudBavliPdfLibraryDuplicate(
+          PdfBook(title: 'שבת', path: r'C:\books\תלמוד בבלי\שבת.pdf'),
+          textTitles,
+        ),
+        isFalse,
+      );
+    });
+
+    test('ספרי משתמש, קטלוג חיצוני ומפרשי PDF — אינם מסוננים', () {
+      expect(
+        isTalmudBavliPdfLibraryDuplicate(
+          PdfBook(
+            title: 'ברכות',
+            path: r'C:\books\תלמוד בבלי\ברכות.pdf',
+            isUserBook: true,
+          ),
+          textTitles,
+        ),
+        isFalse,
+      );
+      expect(
+        isTalmudBavliPdfLibraryDuplicate(
+          PdfBook(
+            title: 'ברכות',
+            path: r'C:\books\תלמוד בבלי\ברכות.pdf',
+            externalLibraryId: 'otzar',
+          ),
+          textTitles,
+        ),
+        isFalse,
+      );
+      expect(
+        isTalmudBavliPdfLibraryDuplicate(
+          PdfBook(title: 'רש"י', path: r'C:\books\תלמוד בבלי\מפרשים\רשי.pdf'),
+          {'רש"י', ...textTitles},
+        ),
+        isFalse,
+      );
+    });
+
+    test('talmudBavliTextTitles אוסף רק מהדורות טקסט רשמיות של מסכתות', () {
+      final bavliRoot = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavliRoot);
+      seder.books.add(TextBook(title: 'ברכות', category: seder));
+      // טקסט אישי לא מייצג את ה-PDF המובנה — אסור שיגרום להסתרתו.
+      seder.books.add(
+        TextBook(title: 'עירובין', category: seder, isUserBook: true),
+      );
+      bavliRoot.books.add(
+        PdfBook(
+          title: 'שבת',
+          path: r'C:\books\תלמוד בבלי\שבת.pdf',
+          category: bavliRoot,
+        ),
+      );
+      final halacha = _category('הלכה');
+      halacha.books.add(TextBook(title: 'משנה ברורה', category: halacha));
+      final library = Library(categories: [bavliRoot, halacha]);
+
+      expect(talmudBavliTextTitles(library), {'ברכות'});
     });
   });
 
@@ -99,10 +224,12 @@ void main() {
       final seder = _category('סדר זרעים', parent: bavliRoot);
       final otherRoot = _category('הלכה');
       final otherCat = _category('ענייני ברכות', parent: otherRoot);
-      seder.books
-          .add(TextBook(title: 'ברכות', category: seder, categoryId: 10));
-      otherCat.books
-          .add(TextBook(title: 'ברכות', category: otherCat, categoryId: 20));
+      seder.books.add(
+        TextBook(title: 'ברכות', category: seder, categoryId: 10),
+      );
+      otherCat.books.add(
+        TextBook(title: 'ברכות', category: otherCat, categoryId: 20),
+      );
       return Library(categories: [bavliRoot, otherRoot]);
     }
 


### PR DESCRIPTION
מהדורות ה-PDF הנלוות של מסכתות הבבלי מוסתרות מתצוגת הספרייה כשקיימת
מהדורת טקסט (התאמה בנרמול כותרות משותף עם getCompanionBook), ולחיצה
על מסכת פותחת טקסט או PDF לפי ההגדרה, כולל מיפוי עמוד ממיקום מפורש.
ניסוח ההגדרה עודכן לציין שהיא חלה גם על הספרייה.
