### PR TITLE
תיקון הבהוב תצוגה מקדימה של קישור בריחוף ליד שולי המסך

### DIFF
--- a/lib/widgets/misc/link_preview_overlay.dart
+++ b/lib/widgets/misc/link_preview_overlay.dart
@@ -425,30 +425,36 @@ class _LinkPreviewPanelState extends State<_LinkPreviewPanel> {
         Positioned(
           left: position.dx,
           top: position.dy,
-          child: Opacity(
-            opacity: _visible ? 1 : 0,
-            child: MouseRegion(
-              onEnter: (_) => _cancelHide(),
-              onExit: (_) => _scheduleHide(),
-              // התוכן נטען אסינכרונית (FutureBuilder); כשהוא מגיע החלונית גדלה
-              // אחרי המדידה הראשונית ועלולה לחרוג מהמסך — שינוי גודל מפעיל
-              // מיקום מחדש (בסוף הפריים, כי עדכון overlay אסור בזמן layout).
-              child: NotificationListener<SizeChangedLayoutNotification>(
-                onNotification: (_) {
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    if (mounted) _reposition();
-                  });
-                  return true;
-                },
-                child: SizeChangedLayoutNotifier(
-                  child: Listener(
-                    onPointerDown: (_) => _pin(),
-                    child: Material(
-                      key: _panelKey,
-                      elevation: 8,
-                      color: colorScheme.surface,
-                      borderRadius: AppTokens.borderRadiusAll,
-                      child: _buildPanelChild(maxWidth),
+          // בזמן המדידה הראשונית (טרם _visible) החלונית יושבת בפינה ב-hit-test
+          // ומכסה את נקודת הריחוף — היה גונב את ה-hover מהעוגן ומזניק לולאת
+          // סגירה-פתיחה (הבהוב). IgnorePointer מוציא אותה מ-hit-test עד שמוצבה.
+          child: IgnorePointer(
+            ignoring: !_visible,
+            child: Opacity(
+              opacity: _visible ? 1 : 0,
+              child: MouseRegion(
+                onEnter: (_) => _cancelHide(),
+                onExit: (_) => _scheduleHide(),
+                // התוכן נטען אסינכרונית (FutureBuilder); כשהוא מגיע החלונית גדלה
+                // אחרי המדידה הראשונית ועלולה לחרוג מהמסך — שינוי גודל מפעיל
+                // מיקום מחדש (בסוף הפריים, כי עדכון overlay אסור בזמן layout).
+                child: NotificationListener<SizeChangedLayoutNotification>(
+                  onNotification: (_) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (mounted) _reposition();
+                    });
+                    return true;
+                  },
+                  child: SizeChangedLayoutNotifier(
+                    child: Listener(
+                      onPointerDown: (_) => _pin(),
+                      child: Material(
+                        key: _panelKey,
+                        elevation: 8,
+                        color: colorScheme.surface,
+                        borderRadius: AppTokens.borderRadiusAll,
+                        child: _buildPanelChild(maxWidth),
+                      ),
                     ),
                   ),
                 ),

--- a/test/widgets/link_preview_overlay_test.dart
+++ b/test/widgets/link_preview_overlay_test.dart
@@ -72,6 +72,41 @@ void main() {
     expect(find.text('תוכן הערה'), findsOneWidget);
   });
 
+  testWidgets(
+    'בפריים המדידה החלונית מתעלמת מ-pointer ואחרי המיקום מפסיקה',
+    (tester) async {
+      final hostContext = await pumpListHost(tester);
+
+      LinkPreviewOverlay.showContent(
+        hostContext,
+        contentBuilder: (_) => const Text('תוכן הערה'),
+        globalPosition: const Offset(200, 300),
+        hoverMode: true,
+      );
+
+      // פריים ראשון (טרם מיקום): החלונית בפינה, חייבת להתעלם מ-pointer כדי לא
+      // לגנוב hover מהעוגן ולגרום לה להיסגר-ולהיפתח בלולאה (הבהוב).
+      await tester.pump();
+      final ignoreDuringMeasure = tester.widget<IgnorePointer>(
+        find.ancestor(
+          of: find.text('תוכן הערה'),
+          matching: find.byType(IgnorePointer),
+        ),
+      );
+      expect(ignoreDuringMeasure.ignoring, isTrue);
+
+      // אחרי המיקום — שוב מגיבה ל-pointer (לסימון/העתקה בתוך החלונית).
+      await tester.pump();
+      final ignoreAfterPlaced = tester.widget<IgnorePointer>(
+        find.ancestor(
+          of: find.text('תוכן הערה'),
+          matching: find.byType(IgnorePointer),
+        ),
+      );
+      expect(ignoreAfterPlaced.ignoring, isFalse);
+    },
+  );
+
   testWidgets('לחיצה ימנית מחוץ לחלונית מקובעת סוגרת אותה', (tester) async {
     final hostContext = await pumpListHost(tester);
 


### PR DESCRIPTION
## הבעיה
בתצוגה משולבת/רגילה, ריחוף על קישור שפותח תצוגה מקדימה (LinkPreviewOverlay) ליד שולי המסך גרם לחלונית התצוגה המקדימה **להבהב** — להיפתח ולהיסגר בלולאה מהירה.

## שורש הבעיה (אובחן מלוגים בזמן ריצה)
חלונית התצוגה המקדימה נבנית בפריים הראשון בפינה השמאלית-העליונה `(8, 8)` לצורך מדידת גודלה, עם `MouseRegion` פעיל ב-hit-test אך בלתי-נראה (`opacity: 0`). כאשר נקודת הריחוף נפלה בשטח שהחלונית כיסתה בזמן המדידה, החלונית **גנבה את ה-hover מהעוגן** → העוגן קיבל `onExit` → תוזמנה סגירה → החלונית קפצה למיקומה הסופי והחזירה את ה-hover → העוגן קיבל `onEnter` → סגירה+פתיחה מחדש. לולאה = הבהוב.

הרצף שנצפה בלוג חזר על עצמו:
```
show/insert → reposition → anchor onExit → scheduleHide
→ panel onEnter → panel onExit → anchor onEnter → dismiss → show ...
```

## התיקון
עטיפת החלונית ב-`IgnorePointer(ignoring: !_visible)` — כל עוד היא טרם מוצבה (בזמן המדידה) היא אינה משתתפת ב-hit-test, ולכן אינה גונבת hover. ברגע שהיא נראית וממוקמת היא שבה להגיב ל-pointer (לסימון/העתקה בתוכה).

תיקון בשורש, בקובץ אחד, בלי לגעת בהתנהגות הכפתור הצף או במנגנון הסגירה המתוזמן.

## בדיקות
נוספה בדיקה שמוודאת ש-`IgnorePointer.ignoring` הוא `true` בפריים המדידה ו-`false` אחרי המיקום. כל בדיקות `link_preview_overlay` עוברות (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)