### PR TITLE
הצרת פאנל הגדרות תצוגת הספרים והידוק המרווחים

### DIFF
--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -3181,7 +3181,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
                           onClose: _toggleReadingSettingsPanel,
                           deferChildBuildOnOpen: true,
                           preserveChildStateOnClose: true,
-                          width: 520,
+                          width: 400,
                           title: 'הגדרות תצוגת הספרים',
                           child: const Expanded(
                             child: ReadingSettingsPanel(),

--- a/lib/settings/tabs/text_settings_tab.dart
+++ b/lib/settings/tabs/text_settings_tab.dart
@@ -242,7 +242,7 @@ class TextSettingsTab extends StatelessWidget {
       children: [
         // שורה 1: גודל גופן הספר + גופן טקסט
         Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
           child: AdaptiveRow(
             children: [
               _FontSizeSlider(
@@ -275,7 +275,7 @@ class TextSettingsTab extends StatelessWidget {
 
         // שורה 2: גודל גופן מפרשים + גופן מפרשים
         Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
           child: AdaptiveRow(
             children: [
               if (!hideCommentaryFontSize)
@@ -318,7 +318,8 @@ class TextSettingsTab extends StatelessWidget {
           builder: (context, constraints) {
             final isNarrow = constraints.maxWidth < LayoutBreakpoints.compact;
             return Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
               child: isNarrow
                   ? _FontSizeSlider(
                       icon: FluentIcons


### PR DESCRIPTION
## הבעיה

פאנל "הגדרות תצוגת הספרים" (הנפתח מכפתור ההגדרות בסרגל העליון של מסך העיון) נראה גדול וחסר פרופורציה, עם מרווחים אנכיים מוגזמים בין השורות.

## שורש הבעיה

**1. רוחב חריג**

הפאנל נפתח ברוחב `520`, בעוד **כל** שאר הפאנלים הצפים באפליקציה משתמשים ב-`400`:

| פאנל | רוחב |
|---|---|
| לוח שנה | 400 |
| ספריה | 400 |
| צורת הדף | 400 |
| **הגדרות תצוגת הספרים** | **520** ← חריגה |

**2. מרווח אנכי מוגזם**

בכרטיס "הגדרות גופן ועיצוב", כל אחת משלוש השורות (גודל גופן הספר, גופן מפרשים, מרווח בין שורות) עטופה ב-`EdgeInsets.all(16.0)` — 16px אנכי סביב כל שורה, בעוד שאר שורות ההגדרות (`SettingsActionTile`) משתמשות ב-`vertical: 12`.

## הפתרון

שינוי מינימלי בלבד — 4 שורות:

- `main_window_screen.dart` — רוחב הפאנל `520` → `400` (עקביות עם שאר הפאנלים)
- `text_settings_tab.dart` — שלוש השורות: `EdgeInsets.all(16)` → `EdgeInsets.symmetric(horizontal: 16, vertical: 8)`

הרוחב נותר ניתן לגרירה על ידי המשתמש (`ResizableDragHandle`) כמו קודם.

## בדיקות

- `flutter analyze` — No issues found
- `flutter test` — 16/16 עוברות (`reading_settings_commentary_font_test`, `context_overlay_panel_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
