### PR TITLE
תיקון: שינוי מיון איבד את אפשרויות הניקוד והעלים את תוצאות התנ"ך

### DIFF
--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -42,6 +42,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   /// מפעילה חיפוש חוזר עם אותה שאילתה ואותן אפשרויות — התוצאה זהה ממילא.
   String? _facetCountsSignature;
 
+  /// מקור הפרמטרים המתקדמים בחיפוש-מחדש פנימי — הם חיים באירוע בלבד.
+  UpdateSearchQuery? _lastUserSearch;
+
   @visibleForTesting
   SearchRepository get repositoryForTesting => _repository;
 
@@ -78,6 +81,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
          ),
        ) {
     on<UpdateSearchQuery>(_onUpdateSearchQuery);
+    on<RerunSearch>((_, _) => _reSearch());
     on<UpdateDistance>(_onUpdateDistance);
     on<UpdateDistanceWithoutSearch>(_onUpdateDistanceWithoutSearch);
     on<UpdateProximityScope>(_onUpdateProximityScope);
@@ -117,6 +121,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     final requestId = ++_searchRequestId;
     final query = event.query;
     final negativeQuery = event.negativeQuery ?? state.negativeQuery;
+    // גם חיפוש שנעצר כאן מייצג את כוונת המשתמש העדכנית — שמירתו מונעת
+    // הרצה חוזרת עם אפשרויות של שאילתה קודמת.
+    _lastUserSearch = event.query.isEmpty ? null : event;
     if (event.query.isEmpty) {
       emit(
         state.copyWith(
@@ -327,6 +334,23 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     }
   }
 
+  /// אותו אירוע חייב לשמש גם לחתימת הספירות וגם לשליחה — אחרת החתימות
+  /// לא מתיישבות והמסלול המקומי נפסל תמיד.
+  UpdateSearchQuery _rerunEvent() {
+    final last = _lastUserSearch;
+    return UpdateSearchQuery(
+      state.searchQuery,
+      customSpacing: last?.customSpacing,
+      alternativeWords: last?.alternativeWords,
+      searchOptions: last?.searchOptions,
+      negativeCustomSpacing: last?.negativeCustomSpacing,
+      negativeAlternativeWords: last?.negativeAlternativeWords,
+      negativeSearchOptions: last?.negativeSearchOptions,
+    );
+  }
+
+  void _reSearch() => add(_rerunEvent());
+
   /// צילום סינכרוני של קלטי הספירה מתוך ה-state הנוכחי.
   _FacetRecountInputs _currentFacetRecountInputs() {
     return (
@@ -435,6 +459,8 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       bookByIndexedFilePath,
     );
 
+    // הספירה רצה ברקע (unawaited) ועלולה להסתיים אחרי סגירת טאב החיפוש.
+    if (isClosed) return;
     add(
       ReplaceFacetCounts(
         aggregated,
@@ -505,7 +531,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     if (!_updateDistanceConfiguration(event.distance, emit)) {
       return;
     }
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onUpdateDistanceWithoutSearch(
@@ -522,7 +548,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     if (!_updateProximityScopeConfiguration(event.scope, emit)) {
       return;
     }
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onUpdateProximityScopeWithoutSearch(
@@ -552,7 +578,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     if (!_updateWordMatchConfiguration(event.mode, event.count, emit)) {
       return;
     }
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onUpdateWordMatchModeWithoutSearch(
@@ -606,7 +632,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       ),
     );
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onSetSearchMode(
@@ -617,7 +643,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       return;
     }
 
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onSetSearchModeWithoutSearch(
@@ -663,7 +689,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     Emitter<SearchState> emit,
   ) {
     emit(state.copyWith(booksToSearch: event.books));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   Future<void> _onAddFacet(
@@ -675,16 +701,17 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       debugPrint('➕ AddFacet: ${event.facet} (before=$newFacets)');
       newFacets.add(event.facet);
       final newConfig = state.configuration.copyWith(currentFacets: newFacets);
+      final searchEvent = _rerunEvent();
       if (await _applyClientSideFacetNarrow(
         newFacets,
         newConfig,
-        UpdateSearchQuery(state.searchQuery),
+        searchEvent,
         emit,
       )) {
         return;
       }
       emit(state.copyWith(configuration: newConfig));
-      add(UpdateSearchQuery(state.searchQuery));
+      add(searchEvent);
     }
   }
 
@@ -697,16 +724,17 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       debugPrint('➖ RemoveFacet: ${event.facet} (before=$newFacets)');
       newFacets.remove(event.facet);
       final newConfig = state.configuration.copyWith(currentFacets: newFacets);
+      final searchEvent = _rerunEvent();
       if (await _applyClientSideFacetNarrow(
         newFacets,
         newConfig,
-        UpdateSearchQuery(state.searchQuery),
+        searchEvent,
         emit,
       )) {
         return;
       }
       emit(state.copyWith(configuration: newConfig));
-      add(UpdateSearchQuery(state.searchQuery));
+      add(searchEvent);
     }
   }
 
@@ -721,11 +749,17 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     final newConfig = state.configuration.copyWith(
       currentFacets: effectiveFacets,
     );
+    // SetFacet נושא רק את הפרמטרים החיוביים; השליליים נשמרים מהחיפוש האחרון
+    // כדי שלחיצה על קטגוריה לא תאבד אותם.
+    final last = _lastUserSearch;
     final searchEvent = UpdateSearchQuery(
       state.searchQuery,
       customSpacing: event.customSpacing,
       alternativeWords: event.alternativeWords,
       searchOptions: event.searchOptions,
+      negativeCustomSpacing: last?.negativeCustomSpacing,
+      negativeAlternativeWords: last?.negativeAlternativeWords,
+      negativeSearchOptions: last?.negativeSearchOptions,
     );
     if (await _applyClientSideFacetNarrow(
       effectiveFacets,
@@ -857,7 +891,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   ) {
     final newConfig = state.configuration.copyWith(sortBy: event.order);
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onUpdateResultGrouping(
@@ -869,7 +903,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       resultGrouping: event.grouping,
     );
     emit(state.copyWith(configuration: newConfig, totalGroups: null));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onUpdateNumResults(
@@ -880,7 +914,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       numResults: event.numResults,
     );
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onResetSearch(
@@ -888,6 +922,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     Emitter<SearchState> emit,
   ) {
     _facetCountsSignature = null;
+    _lastUserSearch = null;
     emit(const SearchState());
   }
 
@@ -1014,7 +1049,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       regexEnabled: !state.regexEnabled,
     );
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onToggleCaseSensitive(
@@ -1025,7 +1060,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       caseSensitive: !state.caseSensitive,
     );
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onToggleMultiline(
@@ -1034,7 +1069,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   ) {
     final newConfig = state.configuration.copyWith(multiline: !state.multiline);
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onToggleDotAll(
@@ -1043,7 +1078,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   ) {
     final newConfig = state.configuration.copyWith(dotAll: !state.dotAll);
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onToggleUnicode(
@@ -1052,7 +1087,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   ) {
     final newConfig = state.configuration.copyWith(unicode: !state.unicode);
     emit(state.copyWith(configuration: newConfig));
-    add(UpdateSearchQuery(state.searchQuery));
+    _reSearch();
   }
 
   void _onUpdateFacetCounts(

--- a/lib/search/bloc/search_event.dart
+++ b/lib/search/bloc/search_event.dart
@@ -15,6 +15,13 @@ class ClearFilter extends SearchEvent {
   ClearFilter();
 }
 
+/// הרצה מחדש של החיפוש הנוכחי אחרי שינוי הגדרה. שולחים אותו — ולא
+/// [UpdateSearchQuery] חשוף — כדי שהאפשרויות המתקדמות (ובראשן "ניקוד",
+/// שמעבירה לשדה המנוקד) לא יאבדו ויחזירו תוצאות של שאילתה אחרת.
+class RerunSearch extends SearchEvent {
+  const RerunSearch();
+}
+
 class UpdateSearchQuery extends SearchEvent {
   final String query;
   final String? negativeQuery;

--- a/lib/search/view/full_text_facet_filtering.dart
+++ b/lib/search/view/full_text_facet_filtering.dart
@@ -154,9 +154,6 @@ class _SearchFacetFilteringState extends State<SearchFacetFiltering>
       searchBloc,
       categories,
       dimensionFacets,
-      customSpacing: normalizedParameters.customSpacing,
-      alternativeWords: normalizedParameters.alternativeWords,
-      searchOptions: normalizedParameters.searchOptions,
     );
   }
 
@@ -166,23 +163,13 @@ class _SearchFacetFilteringState extends State<SearchFacetFiltering>
   void _dispatchCategoriesWithDimensions(
     SearchBloc searchBloc,
     List<String> categories,
-    List<String> dimensionFacets, {
-    Map<String, String>? customSpacing,
-    Map<int, List<String>>? alternativeWords,
-    Map<String, Map<String, bool>>? searchOptions,
-  }) {
+    List<String> dimensionFacets,
+  ) {
     final effectiveCategories = categories.isEmpty ? const ['/'] : categories;
     searchBloc.add(
       SetFacetsWithoutSearch([...effectiveCategories, ...dimensionFacets]),
     );
-    searchBloc.add(
-      UpdateSearchQuery(
-        searchBloc.state.searchQuery,
-        customSpacing: customSpacing,
-        alternativeWords: alternativeWords,
-        searchOptions: searchOptions,
-      ),
-    );
+    searchBloc.add(const RerunSearch());
   }
 
   /// התקופות המוצעות לסינון. 'שאר מפרשים' לעולם לא מוטבעת, ו'תורה שבכתב'
@@ -198,15 +185,6 @@ class _SearchFacetFilteringState extends State<SearchFacetFiltering>
   void _toggleDimension(BuildContext context, String dimFacet) {
     final searchBloc = context.read<SearchBloc>();
     final state = searchBloc.state;
-    final normalizedParameters = SearchQueryBuilder.normalizeParametersForMode(
-      state.configuration.searchMode,
-      customSpacing: widget.tab.spacingValues,
-      alternativeWords: widget.tab.alternativeWords,
-      searchOptions: widget.tab.effectiveSearchOptions(
-        query: state.searchQuery,
-      ),
-    );
-
     final categories = FacetHelper.categoryFacetsOf(state.currentFacets);
     final dimensions = FacetHelper.dimensionFacetsOf(
       state.currentFacets,
@@ -222,32 +200,17 @@ class _SearchFacetFilteringState extends State<SearchFacetFiltering>
       searchBloc,
       categories,
       dimensions.toList()..sort(),
-      customSpacing: normalizedParameters.customSpacing,
-      alternativeWords: normalizedParameters.alternativeWords,
-      searchOptions: normalizedParameters.searchOptions,
     );
   }
 
   /// מנקה את כל הסינון (קטגוריות + ממדים) — חזרה ל"כל הספרים".
   void _clearAllScope(BuildContext context) {
     final searchBloc = context.read<SearchBloc>();
-    final state = searchBloc.state;
-    final normalizedParameters = SearchQueryBuilder.normalizeParametersForMode(
-      state.configuration.searchMode,
-      customSpacing: widget.tab.spacingValues,
-      alternativeWords: widget.tab.alternativeWords,
-      searchOptions: widget.tab.effectiveSearchOptions(
-        query: state.searchQuery,
-      ),
-    );
     SearchScopePreferences.saveDimensionFacets(const {});
     _dispatchCategoriesWithDimensions(
       searchBloc,
       const ['/'],
       const [],
-      customSpacing: normalizedParameters.customSpacing,
-      alternativeWords: normalizedParameters.alternativeWords,
-      searchOptions: normalizedParameters.searchOptions,
     );
   }
 

--- a/lib/search/view/full_text_settings_widgets.dart
+++ b/lib/search/view/full_text_settings_widgets.dart
@@ -264,7 +264,7 @@ class _FuzzyDistanceState extends State<FuzzyDistance> {
                 bloc.add(UpdateProximityScopeWithoutSearch(selectedScope));
                 bloc.add(UpdateWordMatchModeWithoutSearch(selectedMode));
                 if (widget.triggerSearch) {
-                  bloc.add(UpdateSearchQuery(bloc.state.searchQuery));
+                  bloc.add(const RerunSearch());
                 }
               },
             ),

--- a/lib/search/view/tantivy_full_text_search.dart
+++ b/lib/search/view/tantivy_full_text_search.dart
@@ -272,12 +272,27 @@ class _TantivyFullTextSearchState extends State<TantivyFullTextSearch>
               query: pendingQuery,
             ),
           );
+      final negativeQuery = widget.tab.negativeQueryController.text;
+      final normalizedNegativeParameters =
+          SearchQueryBuilder.normalizeParametersForMode(
+            searchMode,
+            customSpacing: widget.tab.negativeSpacingValues,
+            alternativeWords: widget.tab.negativeAlternativeWords,
+            searchOptions: widget.tab.effectiveNegativeSearchOptions(
+              query: negativeQuery,
+            ),
+          );
       widget.tab.searchBloc.add(
         UpdateSearchQuery(
           pendingQuery,
+          negativeQuery: negativeQuery,
           customSpacing: normalizedParameters.customSpacing,
           alternativeWords: normalizedParameters.alternativeWords,
           searchOptions: normalizedParameters.searchOptions,
+          negativeCustomSpacing: normalizedNegativeParameters.customSpacing,
+          negativeAlternativeWords:
+              normalizedNegativeParameters.alternativeWords,
+          negativeSearchOptions: normalizedNegativeParameters.searchOptions,
         ),
       );
     }

--- a/test/search/search_bloc_advanced_options_test.dart
+++ b/test/search/search_bloc_advanced_options_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/bloc/search_bloc.dart';
+import 'package:otzaria/search/bloc/search_event.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_engine_gateway.dart';
+import 'package:otzaria/search/search_repository.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart';
+
+import '../helpers/memory_settings_cache.dart';
+import '../support/recording_search_engine.dart';
+import '../support/search_engine_test_init.dart';
+
+/// רגרסיה: חיפוש-מחדש פנימי (מיון/קיבוץ/היקף) חייב לשאת את האפשרויות
+/// פר-מילה. "ניקוד" מעביר את המנוע לשדה המנוקד, ובלעדיו תוצאות התנ"ך
+/// (הטקסט המנוקד בספרייה) נושרות.
+Future<void> main() async {
+  // sanitizeQuery מאציל למנוע ה-Rust הנייטיבי.
+  final engineReady = await tryInitSearchEngine();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const query = 'בראשית ברא';
+  const nikudOptions = {
+    'בראשית_0': {'ניקוד': true},
+  };
+  const spacing = {'0-1': '3'};
+  const alternatives = {
+    1: ['יצר'],
+  };
+  const negativeOptions = {
+    'תוהו_0': {'טעמים': true},
+  };
+
+  late RecordingSearchEngine engine;
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+  });
+
+  SearchBloc buildBloc() {
+    engine = RecordingSearchEngine();
+    return SearchBloc(
+      initialConfiguration: const SearchConfiguration(currentFacets: ['/']),
+      repository: SearchRepository(engineProvider: () async => engine),
+    );
+  }
+
+  /// מריץ חיפוש משתמש מלא ואז את [settingsChange], ומחזיר את הבקשה
+  /// האחרונה שהגיעה למנוע.
+  Future<SearchEngineRequest> requestAfter(
+    SearchEvent settingsChange, {
+    String negativeQuery = '',
+  }) async {
+    final bloc = buildBloc();
+    bloc.add(
+      UpdateSearchQuery(
+        query,
+        negativeQuery: negativeQuery,
+        searchOptions: nikudOptions,
+        customSpacing: spacing,
+        alternativeWords: alternatives,
+        negativeSearchOptions: negativeQuery.isEmpty ? null : negativeOptions,
+      ),
+    );
+    await bloc.stream.firstWhere((state) => !state.isLoading);
+
+    bloc.add(settingsChange);
+    await bloc.stream.firstWhere((state) => !state.isLoading);
+    await bloc.close();
+    return engine.lastRequest!;
+  }
+
+  group(
+    'חיפוש-מחדש פנימי משמר את האפשרויות המתקדמות',
+    () {
+      test('החיפוש הראשוני מעביר את האפשרויות למנוע', () async {
+        final request = await requestAfter(UpdateNumResults(200));
+        expect(request.searchOptions, nikudOptions);
+      });
+
+      test('שינוי סדר המיון אינו מאבד את אפשרויות הניקוד', () async {
+        final request = await requestAfter(
+          UpdateSortOrder(ResultsOrder.generation),
+        );
+
+        expect(request.order, ResultsOrder.generation);
+        expect(request.searchOptions, nikudOptions);
+        expect(request.customSpacing, spacing);
+        expect(request.alternativeWords, alternatives);
+      });
+
+      test('שינוי קיבוץ התוצאות אינו מאבד את האפשרויות', () async {
+        final request = await requestAfter(
+          UpdateResultGrouping(ResultGroupingMode.sameSection),
+        );
+
+        expect(request.searchOptions, nikudOptions);
+      });
+
+      // צמצום היקף עם תוצאות מלאות ביד מסונן מקומית ואינו פונה למנוע, ולכן
+      // נמדד כאן המיון שאחריו — הוא זה שחייב לשאת את האפשרויות.
+      test('צמצום היקף ואחריו מיון אינם מאבדים את האפשרויות', () async {
+        final bloc = buildBloc();
+        bloc.add(
+          UpdateSearchQuery(
+            query,
+            searchOptions: nikudOptions,
+            customSpacing: spacing,
+          ),
+        );
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+
+        bloc.add(AddFacet('/תנך'));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+        expect(bloc.state.currentFacets, contains('/תנך'));
+
+        bloc.add(UpdateSortOrder(ResultsOrder.catalogue));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+        await bloc.close();
+
+        expect(engine.lastRequest!.facets, contains('/תנך'));
+        expect(engine.lastRequest!.searchOptions, nikudOptions);
+        expect(engine.lastRequest!.customSpacing, spacing);
+      });
+
+      test('הפרמטרים השליליים שורדים לחיצת קטגוריה ואחריה מיון', () async {
+        final bloc = buildBloc();
+        bloc.add(
+          UpdateSearchQuery(
+            query,
+            negativeQuery: 'תוהו',
+            searchOptions: nikudOptions,
+            negativeSearchOptions: negativeOptions,
+          ),
+        );
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+
+        // SetFacet נושא רק את הפרמטרים החיוביים — השליליים חייבים להישמר.
+        bloc.add(SetFacet('/תנך', searchOptions: nikudOptions));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+
+        bloc.add(UpdateSortOrder(ResultsOrder.catalogue));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+        await bloc.close();
+
+        expect(engine.lastRequest!.searchOptions, nikudOptions);
+        expect(engine.lastRequest!.negativeSearchOptions, negativeOptions);
+      });
+
+      test('איפוס החיפוש אינו מדליף אפשרויות לחיפוש הבא', () async {
+        final bloc = buildBloc();
+        bloc.add(UpdateSearchQuery(query, searchOptions: nikudOptions));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+
+        bloc.add(ResetSearch());
+        bloc.add(
+          UpdateSearchQuery(
+            'שמות',
+            // חיפוש נקי, בלי אפשרויות.
+          ),
+        );
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+        await bloc.close();
+
+        expect(engine.lastRequest!.searchOptions, isEmpty);
+      });
+
+      test('חיפוש שנעצר בהיעדר היקף אינו מדליף אפשרויות לחיפוש הבא', () async {
+        final bloc = SearchBloc(
+          initialConfiguration: const SearchConfiguration(currentFacets: []),
+          repository: SearchRepository(
+            engineProvider: () async => engine = RecordingSearchEngine(),
+          ),
+        );
+        bloc.add(UpdateSearchQuery(query, searchOptions: nikudOptions));
+        await bloc.stream.first;
+
+        bloc.add(SetFacetsWithoutSearch(const ['/']));
+        bloc.add(UpdateSearchQuery('שמות'));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+        await bloc.close();
+
+        expect(engine.lastRequest!.searchOptions, isEmpty);
+      });
+    },
+    skip: engineReady ? null : searchEngineSkipReason,
+  );
+}

--- a/test/support/recording_search_engine.dart
+++ b/test/support/recording_search_engine.dart
@@ -1,0 +1,131 @@
+import 'package:otzaria/search/search_engine_gateway.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart';
+
+/// מנוע מזויף שלוכד את הבקשה האחרונה שהגיעה אליו.
+class RecordingSearchEngine extends SearchEngineOperations {
+  SearchEngineRequest? lastRequest;
+
+  SearchPageResult _page(SearchEngineRequest request) {
+    lastRequest = request;
+    return const SearchPageResult(totalCount: 0, results: [], truncated: false);
+  }
+
+  @override
+  Stream<SearchStreamUpdate> searchStreamWithCounts(
+    SearchEngineRequest request, {
+    required int chunkSize,
+  }) async* {
+    lastRequest = request;
+    yield const SearchStreamUpdate(
+      totalCount: 0,
+      bookCounts: {},
+      results: [],
+      truncated: false,
+    );
+  }
+
+  @override
+  Future<List<SearchResult>> searchExact(SearchEngineRequest request) async {
+    lastRequest = request;
+    return const [];
+  }
+
+  @override
+  Future<List<SearchResult>> searchAdvanced(
+    SearchEngineRequest request,
+  ) async {
+    lastRequest = request;
+    return const [];
+  }
+
+  @override
+  Future<List<SearchResult>> searchFuzzy(SearchEngineRequest request) async {
+    lastRequest = request;
+    return const [];
+  }
+
+  @override
+  Future<SearchPageResult> searchAndCountExact(SearchEngineRequest r) async =>
+      _page(r);
+
+  @override
+  Future<SearchPageResult> searchAndCountAdvanced(
+    SearchEngineRequest r,
+  ) async => _page(r);
+
+  @override
+  Future<SearchPageResult> searchAndCountFuzzy(SearchEngineRequest r) async =>
+      _page(r);
+
+  @override
+  Stream<List<SearchResult>> searchExactStream(
+    SearchEngineRequest request, {
+    required int chunkSize,
+  }) async* {
+    lastRequest = request;
+  }
+
+  @override
+  Stream<List<SearchResult>> searchAdvancedStream(
+    SearchEngineRequest request, {
+    required int chunkSize,
+  }) async* {
+    lastRequest = request;
+  }
+
+  @override
+  Stream<List<SearchResult>> searchFuzzyStream(
+    SearchEngineRequest request, {
+    required int chunkSize,
+  }) async* {
+    lastRequest = request;
+  }
+
+  @override
+  Future<int> countExact(SearchEngineRequest request) async => 0;
+
+  @override
+  Future<int> countAdvanced(SearchEngineRequest request) async => 0;
+
+  @override
+  Future<int> countFuzzy(SearchEngineRequest request) async => 0;
+
+  @override
+  Future<Map<String, int>> countByBookExact(SearchEngineRequest r) async {
+    lastRequest = r;
+    return const {};
+  }
+
+  @override
+  Future<Map<String, int>> countByBookAdvanced(SearchEngineRequest r) async {
+    lastRequest = r;
+    return const {};
+  }
+
+  @override
+  Future<Map<String, int>> countByBookFuzzy(SearchEngineRequest r) async {
+    lastRequest = r;
+    return const {};
+  }
+
+  @override
+  Future<List<FacetCount>> getFacetCountsExact(
+    SearchEngineRequest request, {
+    required String facetPrefix,
+  }) async => const [];
+
+  @override
+  Future<List<FacetCount>> getFacetCountsAdvanced(
+    SearchEngineRequest request, {
+    required String facetPrefix,
+  }) async => const [];
+
+  @override
+  Future<List<FacetCount>> getFacetCountsFuzzy(
+    SearchEngineRequest request, {
+    required String facetPrefix,
+  }) async => const [];
+
+  @override
+  void primeHighlightPattern(SearchEngineRequest request) {}
+}


### PR DESCRIPTION
## הבאג

חיפוש עם התאמת ניקוד מחזיר תוצאות תקינות — אבל ברגע ששינו את סדר המיון (קטלוגי / סדר הדורות / רלוונטיות), **תוצאות התנ"ך נעלמו**. לחיצה על תיקיית התנ"ך בעץ "החזירה" אותן, עד הסינון הבא.

## השורש

ששת הפרמטרים המתקדמים פר-מילה — `customSpacing`, `alternativeWords`, `searchOptions` ושלושת מקביליהם השליליים — חיים על אירוע `UpdateSearchQuery` בלבד, ואינם נשמרים ב-`SearchState`/`SearchConfiguration` (בצדק: אלה מפות ממופתחות לפי אינדקס-מילה, שמתבטלות כשהשאילתה משתנה).

כל חיפוש-מחדש פנימי שלח אירוע חשוף:

```dart
add(UpdateSearchQuery(state.searchQuery));   // כל 6 הפרמטרים → null
```

`searchOptions` נושא את מפתחות `'ניקוד'`/`'טעמים'`, ואלה **מעבירים את המנוע לשדה המנוקד**. איבודם הריץ את השאילתה על השדה הלא-מנוקד — ולכן דווקא התנ"ך, הטקסט המנוקד המרכזי בספרייה, נשר. `_onSetFacet` היה המסלול היחיד ששימר את הפרמטרים, ומכאן ש"לחיצה על תיקיית התנ"ך" נראתה כמתקנת.

## התיקון

- `_lastUserSearch` שומר את אירוע החיפוש האחרון; `_rerunEvent()` בונה ממנו אירוע מועשר, ו-`_reSearch()` מחליף את 16 האירועים החשופים
- `_onAddFacet`/`_onRemoveFacet` מעבירים את **אותו מופע** גם לחתימת הספירות וגם לשליחה — כך המסלול המקומי המהיר מתקבל שוב בחיפוש מתקדם (קודם נדחה תמיד)
- `_onSetFacet` יורש את שלושת הפרמטרים השליליים ש-`SetFacet` אינו נושא
- אירוע `RerunSearch` חדש מחליף את האירועים החשופים שנשלחו מה-UI (ומייתר 3 פרמטרים שהפכו מתים ב-`full_text_facet_filtering`)
- `tantivy_full_text_search` משלים את הפרמטרים השליליים בשחזור טאב
- הגנת `isClosed` לפני `add` ברקע — מנעה `StateError` בסגירת טאב חיפוש בזמן ספירת facets

## בדיקות

`test/search/search_bloc_advanced_options_test.dart` — 7 טסטים שמזריקים מנוע מזויף ובודקים את ה-`SearchEngineRequest` שמגיע בפועל למנוע (התנהגות, לא מימוש). אומת שהם **נכשלים בלי התיקון** (5 מ-7) ועוברים איתו. המנוע המזויף חולץ ל-`test/support/recording_search_engine.dart` לשימוש חוזר.

- `flutter analyze lib/search/` — נקי
- `flutter test test/search/ test/tabs/` — 340 עוברים

🤖 Generated with [Claude Code](https://claude.com/claude-code)
