### PR TITLE
בחירה מרובה של כרטיסיות וסגירה קבוצתית (Ctrl/Cmd/Shift+לחיצה)

### DIFF
--- a/lib/history/bloc/history_bloc.dart
+++ b/lib/history/bloc/history_bloc.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/bookmarks/models/bookmark.dart';
@@ -144,7 +145,7 @@ class HistoryBloc extends Bloc<HistoryEvent, HistoryState> {
     on<SetCurrentWorkspaceName>(_onSetCurrentWorkspaceName);
     on<AddHistory>(_onAddHistory);
     on<AddHistoryForTabs>(_onAddHistoryForTabs);
-    on<BulkAddHistory>(_onBulkAddHistory);
+    on<BulkAddHistory>(_onBulkAddHistory, transformer: sequential());
     on<RemoveHistory>(_onRemoveHistory);
     on<ClearHistory>(_onClearHistory);
     on<CaptureStateForHistory>(_onCaptureStateForHistory);

--- a/lib/history/bloc/history_bloc.dart
+++ b/lib/history/bloc/history_bloc.dart
@@ -143,6 +143,7 @@ class HistoryBloc extends Bloc<HistoryEvent, HistoryState> {
     on<LoadHistory>(_onLoadHistory);
     on<SetCurrentWorkspaceName>(_onSetCurrentWorkspaceName);
     on<AddHistory>(_onAddHistory);
+    on<AddHistoryForTabs>(_onAddHistoryForTabs);
     on<BulkAddHistory>(_onBulkAddHistory);
     on<RemoveHistory>(_onRemoveHistory);
     on<ClearHistory>(_onClearHistory);
@@ -430,6 +431,23 @@ class HistoryBloc extends Bloc<HistoryEvent, HistoryState> {
       );
       if (bookmark == null) return;
       add(BulkAddHistory([bookmark]));
+    } catch (e) {
+      emit(HistoryError(state.history, e.toString()));
+    }
+  }
+
+  Future<void> _onAddHistoryForTabs(
+    AddHistoryForTabs event,
+    Emitter<HistoryState> emit,
+  ) async {
+    try {
+      final snapshots = <Bookmark>[];
+      for (final tab in event.tabs) {
+        final bookmark = await _bookmarkFromTab(tab);
+        if (bookmark != null) snapshots.add(bookmark);
+      }
+      if (snapshots.isEmpty) return;
+      add(BulkAddHistory(snapshots));
     } catch (e) {
       emit(HistoryError(state.history, e.toString()));
     }

--- a/lib/history/bloc/history_event.dart
+++ b/lib/history/bloc/history_event.dart
@@ -26,6 +26,14 @@ class AddHistory extends HistoryEvent {
   AddHistory(this.tab, {this.scopeFacets, this.proximityScope});
 }
 
+/// הוספת כמה כרטיסיות להיסטוריה בשמירה אחת (סגירה קבוצתית). אירועי
+/// AddHistory נפרדים מעובדים במקביל ועלולים לדרוס זה את שמירתו של זה.
+class AddHistoryForTabs extends HistoryEvent {
+  final List<OpenedTab> tabs;
+
+  AddHistoryForTabs(this.tabs);
+}
+
 class CaptureStateForHistory extends HistoryEvent {
   final OpenedTab tab;
   CaptureStateForHistory(this.tab);

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
@@ -105,6 +106,14 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
 
   // הרוחבים המחושבים האחרונים לטאב, לשימוש כערך הקפיאה בסגירה.
   _TabWidths? _lastComputedTabWidths;
+
+  /// המקש שמפעיל בחירה מרובה: Ctrl בכל הפלטפורמות, Command במק.
+  bool get _isMultiSelectModifierPressed {
+    final keyboard = HardwareKeyboard.instance;
+    return defaultTargetPlatform == TargetPlatform.macOS
+        ? keyboard.isMetaPressed
+        : keyboard.isControlPressed;
+  }
 
   // רוחב אזור הטאבים שנמדד בפריים הקודם (ע"י LayoutBuilder נפרד). הרשימה
   // נבנית עם הערך הזה ולא תחת ה-LayoutBuilder — אחרת Tooltip/OverlayPortal
@@ -723,6 +732,12 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   }
 
   void closeTab(OpenedTab tab, BuildContext context) {
+    // סגירת טאב שנכלל בבחירה מרובה סוגרת את כל הקבוצה יחד.
+    final selectedTabs = context.read<TabsBloc>().state.selectedTabs;
+    if (selectedTabs.length > 1 && selectedTabs.contains(tab)) {
+      closeSelectedTabs(context);
+      return;
+    }
     // קופאים את רוחב הטאבים כל עוד העכבר מעל השורה, כדי שכפתור ה-X של הטאב הבא
     // יישאר בדיוק תחת הסמן וסגירות רצופות יפעלו (כמו כרום). נועלים רק בסגירה
     // הראשונה (??=) — אחרת כל סגירה הייתה דורסת בערך הרחב יותר. השחרור ביציאת העכבר.
@@ -731,6 +746,20 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
     }
     context.read<HistoryBloc>().add(AddHistory(tab));
     context.read<TabsBloc>().add(RemoveTab(tab));
+  }
+
+  /// סוגר את כל הכרטיסיות שבבחירה המרובה בפעולה אחת.
+  void closeSelectedTabs(BuildContext context) {
+    final tabsBloc = context.read<TabsBloc>();
+    final tabsToClose = List<OpenedTab>.from(tabsBloc.state.selectedTabs);
+    if (tabsToClose.isEmpty) return;
+    if (_pointerInsideTabStrip && _lastComputedTabWidths != null) {
+      _pinnedTabWidths ??= _lastComputedTabWidths;
+    }
+    // אירוע קבוצתי אחד — אירועי AddHistory נפרדים מעובדים במקביל ועלולים
+    // לדרוס זה את זה.
+    context.read<HistoryBloc>().add(AddHistoryForTabs(tabsToClose));
+    tabsBloc.add(RemoveTabs(tabsToClose));
   }
 
   void closeAllTabs(TabsState state, BuildContext context) {
@@ -906,7 +935,11 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                 right: index == 0 ? 0 : outerPad,
               ),
               child: CustomPaint(
-                painter: isSelected
+                // טאב בבחירה מרובה נצבע ב-secondaryContainer כדי לסמן שהוא
+                // חלק מהקבוצה שתיסגר יחד.
+                painter: state.selectedTabs.contains(tab)
+                    ? _TabBackgroundPainter(colorScheme.secondaryContainer)
+                    : isSelected
                     ? _TabBackgroundPainter(
                         AppSurfaces.topBarBackground(context),
                       )
@@ -991,9 +1024,26 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
       onPointerDown: (PointerDownEvent event) {
         if (event.buttons == 4) {
           closeTab(tab, context);
-        } else if (event.buttons == 1 &&
-            index != state.currentTabIndex &&
-            !_hitTestCloseButton(context, event.position)) {
+          return;
+        }
+        if (event.buttons != 1 ||
+            _hitTestCloseButton(context, event.position)) {
+          return;
+        }
+        // Ctrl/Cmd/Shift+לחיצה בונים בחירה מרובה לסגירה קבוצתית (כמו בדפדפן)
+        // בלי להחליף את הטאב הפעיל.
+        if (_isMultiSelectModifierPressed) {
+          context.read<TabsBloc>().add(ToggleTabSelection(tab));
+          return;
+        }
+        if (HardwareKeyboard.instance.isShiftPressed) {
+          context.read<TabsBloc>().add(SelectTabRange(tab));
+          return;
+        }
+        if (state.selectedTabs.isNotEmpty) {
+          context.read<TabsBloc>().add(const ClearTabSelection());
+        }
+        if (index != state.currentTabIndex) {
           context.read<TabsBloc>().add(SetCurrentTab(index));
         }
       },
@@ -1088,10 +1138,17 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         label: tab.isPinned ? 'בטל הצמדת כרטיסיה' : 'הצמד כרטיסיה',
         onTap: () => context.read<TabsBloc>().add(TogglePinTab(tab)),
       ),
-      AppContextMenuEntry(
-        label: 'סגור',
-        onTap: () => closeTab(tab, context),
-      ),
+      // על טאב שנכלל בבחירה מרובה "סגור" הופך לסגירת כל הקבוצה (כמו בדפדפן).
+      if (state.selectedTabs.length > 1 && state.selectedTabs.contains(tab))
+        AppContextMenuEntry(
+          label: 'סגור ${state.selectedTabs.length} כרטיסיות',
+          onTap: () => closeSelectedTabs(context),
+        )
+      else
+        AppContextMenuEntry(
+          label: 'סגור',
+          onTap: () => closeTab(tab, context),
+        ),
       AppContextMenuEntry(
         label: 'סגור הכל',
         onTap: () => closeAllTabs(state, context),

--- a/lib/shortcuts/keyboard_shortcuts.dart
+++ b/lib/shortcuts/keyboard_shortcuts.dart
@@ -292,9 +292,12 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
         ShortcutHelper.matchesShortcut(event, closeTabShortcut)) {
       final tabsBloc = context.read<TabsBloc>();
       final historyBloc = context.read<HistoryBloc>();
-      if (tabsBloc.state.tabs.isNotEmpty) {
-        final currentTab = tabsBloc.state.tabs[tabsBloc.state.currentTabIndex];
-        historyBloc.add(AddHistory(currentTab));
+      // הקיצור סוגר את כל הבחירה המרובה כשהכרטיסיה הפעילה חלק ממנה.
+      final closeGroup = tabsBloc.state.currentCloseGroup;
+      if (closeGroup.length > 1) {
+        historyBloc.add(AddHistoryForTabs(closeGroup));
+      } else if (closeGroup.isNotEmpty) {
+        historyBloc.add(AddHistory(closeGroup.first));
       }
       tabsBloc.add(const CloseCurrentTab());
       return KeyEventResult.handled;

--- a/lib/tabs/bloc/tabs_bloc.dart
+++ b/lib/tabs/bloc/tabs_bloc.dart
@@ -48,6 +48,10 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     on<OpenOrFocusTab>(_onOpenOrFocusTab, transformer: sequential());
     on<ReplaceTab>(_onReplaceTab, transformer: sequential());
     on<RemoveTab>(_onRemoveTab, transformer: sequential());
+    on<RemoveTabs>(_onRemoveTabs, transformer: sequential());
+    on<ToggleTabSelection>(_onToggleTabSelection, transformer: sequential());
+    on<SelectTabRange>(_onSelectTabRange, transformer: sequential());
+    on<ClearTabSelection>(_onClearTabSelection, transformer: sequential());
     on<SetCurrentTab>(_onSetCurrentTab, transformer: sequential());
     on<CloseAllTabs>(_onCloseAllTabs, transformer: sequential());
     on<CloseOtherTabs>(_onCloseOtherTabs, transformer: sequential());
@@ -169,6 +173,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         tabs: event.tabs,
         currentTabIndex: event.currentTabIndex,
         clearSideBySide: true,
+        selectedTabs: const <OpenedTab>[],
       ),
     );
     await _repository.saveTabs(event.tabs, event.currentTabIndex, null);
@@ -282,7 +287,13 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     final newTabs = List<OpenedTab>.from(state.tabs);
     newTabs[index] = event.newTab;
 
-    emit(state.copyWith(tabs: newTabs, forceUpdate: true));
+    emit(
+      state.copyWith(
+        tabs: newTabs,
+        forceUpdate: true,
+        selectedTabs: _normalizedSelection(newTabs),
+      ),
+    );
     await _repository.saveTabs(
       newTabs,
       state.currentTabIndex,
@@ -703,6 +714,13 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     );
   }
 
+  /// מנרמל את הבחירה המרובה מול רשימת טאבים חדשה: כרטיסיות שנסגרו/הוחלפו
+  /// יוצאות, וקבוצה שהצטמקה לאחת מתפרקת.
+  List<OpenedTab> _normalizedSelection(List<OpenedTab> newTabs) {
+    final selected = state.selectedTabs.where(newTabs.contains).toList();
+    return selected.length > 1 ? selected : const <OpenedTab>[];
+  }
+
   Future<void> _onRemoveTab(RemoveTab event, Emitter<TabsState> emit) async {
     final removedTabIndex = state.tabs.indexOf(event.tab);
     if (removedTabIndex == -1) return;
@@ -734,6 +752,8 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
       }
     }
 
+    final prunedSelection = _normalizedSelection(newTabs);
+
     // אם אין טאבים נותרים, נשאיר את האינדקס ב-0
     if (newTabs.isEmpty) {
       emit(
@@ -741,6 +761,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
           tabs: newTabs,
           currentTabIndex: 0,
           clearSideBySide: true,
+          selectedTabs: prunedSelection,
         ),
       );
       await _repository.saveTabs(newTabs, 0, null);
@@ -763,10 +784,114 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         currentTabIndex: newIndex,
         sideBySideMode: newSideBySideMode,
         clearSideBySide: newSideBySideMode == null,
+        selectedTabs: prunedSelection,
       ),
     );
     await _repository.saveTabs(newTabs, newIndex, newSideBySideMode);
     _disposeTabLater(event.tab);
+  }
+
+  Future<void> _onRemoveTabs(RemoveTabs event, Emitter<TabsState> emit) async {
+    final toRemove = event.tabs.where(state.tabs.contains).toSet();
+    if (toRemove.isEmpty) return;
+
+    // נזכרים בסדר אינדקס יורד: השחזור הוא LIFO, וכך שחזור סדרתי מחזיר כל
+    // כרטיסיה למקומה המקורי.
+    for (var i = state.tabs.length - 1; i >= 0; i--) {
+      if (toRemove.contains(state.tabs[i])) {
+        _rememberClosedTab(state.tabs[i], i);
+      }
+    }
+
+    final newTabs = state.tabs.where((t) => !toRemove.contains(t)).toList();
+
+    // side-by-side: אם אחד מצדדיו נסגר המצב מבוטל, אחרת האינדקסים מתעדכנים.
+    SideBySideMode? newSideBySideMode = state.sideBySideMode;
+    if (newSideBySideMode != null) {
+      final leftTab = state.tabs[newSideBySideMode.leftTabIndex];
+      final rightTab = state.tabs[newSideBySideMode.rightTabIndex];
+      if (toRemove.contains(leftTab) || toRemove.contains(rightTab)) {
+        newSideBySideMode = null;
+      } else {
+        newSideBySideMode = newSideBySideMode.copyWith(
+          leftTabIndex: newTabs.indexOf(leftTab),
+          rightTabIndex: newTabs.indexOf(rightTab),
+        );
+      }
+    }
+
+    // הטאב הפעיל נשאר אם שרד; אחרת עוברים לטאב שנכנס תחת אותו אינדקס
+    // (כמו בסגירה בודדת), בניכוי הטאבים שנסגרו לפניו.
+    final currentTab = state.currentTab;
+    int newIndex;
+    if (currentTab != null && !toRemove.contains(currentTab)) {
+      newIndex = newTabs.indexOf(currentTab);
+    } else {
+      var removedBefore = 0;
+      for (var i = 0; i < state.currentTabIndex; i++) {
+        if (toRemove.contains(state.tabs[i])) removedBefore++;
+      }
+      newIndex = newTabs.isEmpty
+          ? 0
+          : (state.currentTabIndex - removedBefore).clamp(
+              0,
+              newTabs.length - 1,
+            );
+    }
+
+    emit(
+      state.copyWith(
+        tabs: newTabs,
+        currentTabIndex: newIndex,
+        sideBySideMode: newSideBySideMode,
+        clearSideBySide: newSideBySideMode == null,
+        selectedTabs: _normalizedSelection(newTabs),
+      ),
+    );
+    await _repository.saveTabs(newTabs, newIndex, newSideBySideMode);
+
+    for (final tab in toRemove) {
+      _disposeTabLater(tab);
+    }
+  }
+
+  void _onToggleTabSelection(
+    ToggleTabSelection event,
+    Emitter<TabsState> emit,
+  ) {
+    if (!state.tabs.contains(event.tab)) return;
+    final selected = state.selectedTabs.where(state.tabs.contains).toList();
+    // הכרטיסיה הפעילה היא חלק מהקבוצה: הלחיצה הראשונה מצרפת גם אותה
+    // (כמו בדפדפן).
+    final current = state.currentTab;
+    if (selected.isEmpty && current != null && event.tab != current) {
+      selected.add(current);
+    }
+    if (!selected.remove(event.tab)) selected.add(event.tab);
+    // קבוצה של כרטיסיה אחת חסרת משמעות — הבחירה מתפרקת.
+    emit(
+      state.copyWith(
+        selectedTabs: selected.length > 1 ? selected : const <OpenedTab>[],
+      ),
+    );
+  }
+
+  void _onSelectTabRange(SelectTabRange event, Emitter<TabsState> emit) {
+    final index = state.tabs.indexOf(event.tab);
+    if (index == -1) return;
+    final start = min(state.currentTabIndex, index);
+    final end = max(state.currentTabIndex, index);
+    final selected = state.tabs.sublist(start, end + 1);
+    emit(
+      state.copyWith(
+        selectedTabs: selected.length > 1 ? selected : const <OpenedTab>[],
+      ),
+    );
+  }
+
+  void _onClearTabSelection(ClearTabSelection event, Emitter<TabsState> emit) {
+    if (state.selectedTabs.isEmpty) return;
+    emit(state.copyWith(selectedTabs: const <OpenedTab>[]));
   }
 
   Future<void> _onSetCurrentTab(
@@ -788,7 +913,13 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     if (state.tabs.isEmpty || state.currentTabIndex >= state.tabs.length) {
       return;
     }
-    add(RemoveTab(state.tabs[state.currentTabIndex]));
+    // כשהכרטיסיה הפעילה חלק מבחירה מרובה, הקיצור סוגר את כל הקבוצה.
+    final group = state.currentCloseGroup;
+    if (group.length > 1) {
+      add(RemoveTabs(group));
+    } else {
+      add(RemoveTab(state.tabs[state.currentTabIndex]));
+    }
   }
 
   Future<void> _onRestoreLastClosedTab(
@@ -856,6 +987,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         tabs: pinnedTabs,
         currentTabIndex: newIndex,
         clearSideBySide: true,
+        selectedTabs: const <OpenedTab>[],
       ),
     );
     await _repository.saveTabs(pinnedTabs, newIndex, null);
@@ -887,6 +1019,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         tabs: newTabs,
         currentTabIndex: 0,
         clearSideBySide: true,
+        selectedTabs: const <OpenedTab>[],
       ),
     );
     await _repository.saveTabs(newTabs, 0, null);
@@ -1051,6 +1184,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         currentTabIndex: newCurrentIndex,
         clearSideBySide: true,
         forceUpdate: true,
+        selectedTabs: _normalizedSelection(newTabs),
       ),
     );
     await _repository.saveTabs(newTabs, newCurrentIndex, null);
@@ -1087,6 +1221,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
           currentTabIndex: newCurrentIndex,
           clearSideBySide: true,
           forceUpdate: true,
+          selectedTabs: _normalizedSelection(newTabs),
         ),
       );
       await _repository.saveTabs(newTabs, newCurrentIndex, null);
@@ -1154,6 +1289,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         state.copyWith(
           tabs: newTabs,
           forceUpdate: true,
+          selectedTabs: _normalizedSelection(newTabs),
         ),
       );
       await _repository.saveTabs(newTabs, indexToSave, null);

--- a/lib/tabs/bloc/tabs_event.dart
+++ b/lib/tabs/bloc/tabs_event.dart
@@ -85,6 +85,40 @@ class RemoveTab extends TabsEvent {
   List<Object?> get props => [tab];
 }
 
+/// סגירת קבוצת כרטיסיות בפעולה אחת (בחירה מרובה בשורת הכרטיסיות).
+class RemoveTabs extends TabsEvent {
+  final List<OpenedTab> tabs;
+
+  const RemoveTabs(this.tabs);
+
+  @override
+  List<Object?> get props => [tabs];
+}
+
+/// צירוף/הסרה של כרטיסיה מהבחירה המרובה (Ctrl/Cmd+לחיצה).
+class ToggleTabSelection extends TabsEvent {
+  final OpenedTab tab;
+
+  const ToggleTabSelection(this.tab);
+
+  @override
+  List<Object?> get props => [tab];
+}
+
+/// בחירת טווח מהכרטיסיה הפעילה עד [tab] (Shift+לחיצה).
+class SelectTabRange extends TabsEvent {
+  final OpenedTab tab;
+
+  const SelectTabRange(this.tab);
+
+  @override
+  List<Object?> get props => [tab];
+}
+
+class ClearTabSelection extends TabsEvent {
+  const ClearTabSelection();
+}
+
 class CloseCurrentTab extends TabsEvent {
   const CloseCurrentTab();
 

--- a/lib/tabs/bloc/tabs_state.dart
+++ b/lib/tabs/bloc/tabs_state.dart
@@ -51,11 +51,16 @@ class TabsState extends Equatable {
   final int updateCounter;
   final SideBySideMode? sideBySideMode;
 
+  /// בחירה מרובה לסגירה קבוצתית (Ctrl/Shift+לחיצה בשורת הכרטיסיות).
+  /// מצב זמני — אינו נשמר לדיסק.
+  final List<OpenedTab> selectedTabs;
+
   const TabsState({
     required this.tabs,
     required this.currentTabIndex,
     this.updateCounter = 0,
     this.sideBySideMode,
+    this.selectedTabs = const [],
   });
 
   factory TabsState.initial() {
@@ -73,6 +78,7 @@ class TabsState extends Equatable {
     bool forceUpdate = false,
     SideBySideMode? sideBySideMode,
     bool clearSideBySide = false,
+    List<OpenedTab>? selectedTabs,
   }) {
     return TabsState(
       tabs: tabs ?? this.tabs,
@@ -81,6 +87,7 @@ class TabsState extends Equatable {
       sideBySideMode: clearSideBySide
           ? null
           : (sideBySideMode ?? this.sideBySideMode),
+      selectedTabs: selectedTabs ?? this.selectedTabs,
     );
   }
 
@@ -88,11 +95,23 @@ class TabsState extends Equatable {
   OpenedTab? get currentTab => hasOpenTabs ? tabs[currentTabIndex] : null;
   bool get isSideBySideMode => sideBySideMode != null;
 
+  /// הקבוצה שסגירת הכרטיסיה הנוכחית סוגרת: הבחירה המרובה כשהכרטיסיה
+  /// הפעילה חלק ממנה, אחרת הכרטיסיה הפעילה לבדה.
+  List<OpenedTab> get currentCloseGroup {
+    final current = currentTab;
+    if (current == null) return const [];
+    if (selectedTabs.length > 1 && selectedTabs.contains(current)) {
+      return List<OpenedTab>.from(selectedTabs);
+    }
+    return [current];
+  }
+
   @override
   List<Object?> get props => [
     tabs,
     currentTabIndex,
     updateCounter,
     sideBySideMode,
+    selectedTabs,
   ];
 }

--- a/test/history/bloc/history_bloc_test.dart
+++ b/test/history/bloc/history_bloc_test.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/bookmarks/models/bookmark.dart';
+import 'package:otzaria/history/bloc/history_bloc.dart';
+import 'package:otzaria/history/bloc/history_event.dart';
+import 'package:otzaria/history/bloc/history_state.dart';
+import 'package:otzaria/history/history_repository.dart';
+import 'package:otzaria/models/books.dart';
+
+class _BlockingHistoryRepository extends HistoryRepository {
+  final loadStarted = Completer<void>();
+  final releaseLoad = Completer<List<Bookmark>>();
+  final firstSaveStarted = Completer<void>();
+  final releaseFirstSave = Completer<void>();
+  int saveCount = 0;
+
+  @override
+  Future<List<Bookmark>> load() {
+    loadStarted.complete();
+    return releaseLoad.future;
+  }
+
+  @override
+  Future<void> save(List<Bookmark> items) async {
+    saveCount++;
+    if (saveCount == 1) {
+      firstSaveStarted.complete();
+      await releaseFirstSave.future;
+    }
+  }
+}
+
+Bookmark _bookmark(String title) => Bookmark(
+  ref: title,
+  book: TextBook(title: title),
+  index: 0,
+);
+
+void main() {
+  test('כתיבות היסטוריה רצופות נשמרות בלי לדרוס זו את זו', () async {
+    final repository = _BlockingHistoryRepository();
+    final bloc = HistoryBloc(repository);
+    addTearDown(bloc.close);
+
+    await repository.loadStarted.future;
+    final loaded = bloc.stream.firstWhere((state) => state is HistoryLoaded);
+    repository.releaseLoad.complete([]);
+    await loaded;
+
+    final first = _bookmark('ספר א');
+    final second = _bookmark('ספר ב');
+    bloc.add(BulkAddHistory([first]));
+    await repository.firstSaveStarted.future;
+
+    bloc.add(BulkAddHistory([second]));
+    await Future<void>.delayed(Duration.zero);
+    expect(repository.saveCount, 1);
+
+    repository.releaseFirstSave.complete();
+    await bloc.stream.firstWhere((state) => state.history.length == 2);
+
+    expect(bloc.state.history.map((bookmark) => bookmark.book.title), [
+      'ספר ב',
+      'ספר א',
+    ]);
+  });
+}

--- a/test/navigation/custom_title_bar_test.dart
+++ b/test/navigation/custom_title_bar_test.dart
@@ -767,6 +767,198 @@ void main() {
     });
   });
 
+  group('בחירה מרובה של כרטיסיות (Ctrl/Shift/Cmd+לחיצה)', () {
+    late TextBookTab first;
+    late TextBookTab second;
+    late TextBookTab third;
+    late _TestTabsBloc tabsBloc;
+    late _TestHistoryBloc historyBloc;
+
+    Future<void> pumpWithTabs(
+      WidgetTester tester, {
+      List<TextBookTab> selected = const [],
+    }) async {
+      first = _makeTextTab('ספר א');
+      second = _makeTextTab('ספר ב');
+      third = _makeTextTab('ספר ג');
+      tabsBloc = _TestTabsBloc(
+        TabsState(
+          tabs: [first, second, third],
+          currentTabIndex: 0,
+          selectedTabs: selected,
+        ),
+      );
+      final navigationBloc = _TestNavigationBloc(
+        const NavigationState(currentScreen: Screen.reading),
+      );
+      final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+      historyBloc = _TestHistoryBloc();
+
+      addTearDown(() async {
+        first.dispose();
+        second.dispose();
+        third.dispose();
+        await tabsBloc.close();
+        await navigationBloc.close();
+        await settingsBloc.close();
+        await historyBloc.close();
+      });
+
+      await _setSurfaceSize(tester, const Size(1200, 800));
+      await _pumpTitleBar(
+        tester,
+        tabsBloc: tabsBloc,
+        navigationBloc: navigationBloc,
+        settingsBloc: settingsBloc,
+        historyBloc: historyBloc,
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('Ctrl+לחיצה שולחת ToggleTabSelection ולא מחליפה טאב', (
+      tester,
+    ) async {
+      await pumpWithTabs(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.tap(find.text('ספר ב'), warnIfMissed: false);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pumpAndSettle();
+
+      final toggles = tabsBloc.addedEvents
+          .whereType<ToggleTabSelection>()
+          .toList();
+      expect(toggles, hasLength(1));
+      expect(toggles.single.tab, same(second));
+      expect(
+        tabsBloc.addedEvents.whereType<SetCurrentTab>(),
+        isEmpty,
+        reason: 'Ctrl+לחיצה בוחרת לקבוצה ואינה מחליפה את הטאב הפעיל',
+      );
+    });
+
+    testWidgets('Shift+לחיצה שולחת SelectTabRange', (tester) async {
+      await pumpWithTabs(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.tap(find.text('ספר ג'), warnIfMissed: false);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      final ranges = tabsBloc.addedEvents.whereType<SelectTabRange>().toList();
+      expect(ranges, hasLength(1));
+      expect(ranges.single.tab, same(third));
+      expect(tabsBloc.addedEvents.whereType<SetCurrentTab>(), isEmpty);
+    });
+
+    testWidgets(
+      'במק: Command+לחיצה שולחת ToggleTabSelection',
+      (tester) async {
+        await pumpWithTabs(tester);
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+        await tester.tap(find.text('ספר ב'), warnIfMissed: false);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+        await tester.pumpAndSettle();
+
+        final toggles = tabsBloc.addedEvents
+            .whereType<ToggleTabSelection>()
+            .toList();
+        expect(toggles, hasLength(1));
+        expect(toggles.single.tab, same(second));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
+    );
+
+    testWidgets('לחיצה רגילה מנקה בחירה קיימת ומחליפה טאב', (tester) async {
+      await pumpWithTabs(tester);
+      tabsBloc.emitState(
+        TabsState(
+          tabs: [first, second, third],
+          currentTabIndex: 0,
+          selectedTabs: [first, second],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('ספר ג'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(
+        tabsBloc.addedEvents.whereType<ClearTabSelection>(),
+        hasLength(1),
+      );
+      expect(
+        tabsBloc.addedEvents.whereType<SetCurrentTab>().last.index,
+        2,
+      );
+    });
+
+    testWidgets('לחיצה על ה-X של כרטיסיה נבחרת סוגרת את כל הקבוצה', (
+      tester,
+    ) async {
+      await pumpWithTabs(tester);
+      tabsBloc.emitState(
+        TabsState(
+          tabs: [first, second, third],
+          currentTabIndex: 0,
+          selectedTabs: [first, second],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // סימולציית tap נבלעת ע"י ה-reorder recognizer — קוראים ל-onPressed ישירות.
+      final closeButton = find.descendant(
+        of: find.ancestor(of: find.text('ספר א'), matching: find.byType(Tab)),
+        matching: find.byType(IconButton),
+      );
+      tester.widget<IconButton>(closeButton).onPressed!();
+      await tester.pump();
+
+      final removals = tabsBloc.addedEvents.whereType<RemoveTabs>().toList();
+      expect(removals, hasLength(1));
+      expect(removals.single.tabs, [first, second]);
+      expect(
+        tabsBloc.addedEvents.whereType<RemoveTab>(),
+        isEmpty,
+        reason: 'סגירת חבר בקבוצה סוגרת את כולה, לא כרטיסיה בודדת',
+      );
+      // ההיסטוריה נשלחת באירוע קבוצתי אחד — לא אירועי AddHistory מקביליים.
+      final historyEvents = historyBloc.addedEvents
+          .whereType<AddHistoryForTabs>()
+          .toList();
+      expect(historyEvents, hasLength(1));
+      expect(historyEvents.single.tabs, [first, second]);
+      expect(historyBloc.addedEvents.whereType<AddHistory>(), isEmpty);
+    });
+
+    testWidgets('כרטיסיות נבחרות מסומנות ברקע (painter)', (tester) async {
+      await pumpWithTabs(tester);
+      tabsBloc.emitState(
+        TabsState(
+          tabs: [first, second, third],
+          currentTabIndex: 0,
+          selectedTabs: [second, third],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // הנבחרות (2) + הפעילה (1) מצוירות ברקע טאב; ללא בחירה רק הפעילה.
+      final paintedTabs = tester
+          .widgetList<CustomPaint>(
+            find.descendant(
+              of: find.byType(ReorderableListView),
+              matching: find.byType(CustomPaint),
+            ),
+          )
+          .where(
+            (w) => w.painter.runtimeType.toString() == '_TabBackgroundPainter',
+          )
+          .length;
+      expect(paintedTabs, 3);
+    });
+  });
+
   group('סגירת טאב בלחיצה על כפתור ה-X', () {
     testWidgets('לחיצה על ה-X סוגרת מיד — בלי המתנה ל-timeout של לחיצה כפולה', (
       tester,
@@ -1409,8 +1601,11 @@ class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
 class _TestHistoryBloc extends Cubit<HistoryState> implements HistoryBloc {
   _TestHistoryBloc() : super(HistoryInitial());
 
+  /// מתעד את אירועי ההיסטוריה שנשלחו, לבדיקת סגירה קבוצתית.
+  final List<HistoryEvent> addedEvents = [];
+
   @override
-  void add(HistoryEvent event) {}
+  void add(HistoryEvent event) => addedEvents.add(event);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/tabs/bloc/tabs_bloc_test.dart
+++ b/test/tabs/bloc/tabs_bloc_test.dart
@@ -739,6 +739,384 @@ void main() {
     });
   });
 
+  group('TabsBloc remove multiple tabs', () {
+    setUp(() async {
+      await Settings.init(cacheProvider: _MemoryCacheProvider());
+    });
+
+    test('RemoveTabs סוגר קבוצה ומשאיר את הטאב הפעיל ששרד', () async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final third = _createTextTab('ספר ג', categoryId: 3);
+      final fourth = _createTextTab('ספר ד', categoryId: 4);
+
+      bloc.add(AddTab(first));
+      bloc.add(AddTab(second));
+      bloc.add(AddTab(third));
+      bloc.add(AddTab(fourth));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 4);
+
+      bloc.add(const SetCurrentTab(2));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 2);
+
+      bloc.add(RemoveTabs([first, fourth]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+
+      expect(bloc.state.tabs.map((t) => t.title), ['ספר ב', 'ספר ג']);
+      expect(bloc.state.currentTab, same(third));
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('RemoveTabs שכולל את הטאב הפעיל מעביר לטאב הסמוך ששרד', () async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final third = _createTextTab('ספר ג', categoryId: 3);
+
+      bloc.add(AddTab(first));
+      bloc.add(AddTab(second));
+      bloc.add(AddTab(third));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 3);
+
+      bloc.add(const SetCurrentTab(1));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 1);
+
+      bloc.add(RemoveTabs([first, second]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 1);
+
+      expect(bloc.state.tabs.single.title, 'ספר ג');
+      expect(bloc.state.currentTabIndex, 0);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('RemoveTabs של כל הטאבים מרוקן את הרשימה בלי לקרוס', () async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+
+      bloc.add(AddTab(first));
+      bloc.add(AddTab(second));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+
+      bloc.add(RemoveTabs([first, second]));
+      await bloc.stream.firstWhere((s) => s.tabs.isEmpty);
+
+      expect(bloc.state.currentTabIndex, 0);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('RemoveTabs מתעלם מטאבים שכבר אינם ברשימה', () async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final ghost = _createTextTab('רפאים', categoryId: 9);
+
+      bloc.add(AddTab(first));
+      bloc.add(AddTab(second));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+
+      bloc.add(RemoveTabs([second, ghost]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 1);
+
+      expect(bloc.state.tabs.single, same(first));
+      ghost.dispose();
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('RemoveTabs שסוגר צד של side-by-side מבטל את המצב', () async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final third = _createTextTab('ספר ג', categoryId: 3);
+
+      bloc.add(AddTab(first));
+      bloc.add(AddTab(second));
+      bloc.add(AddTab(third));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 3);
+
+      // side-by-side נשמר כאינדקסים ב-state (בנפרד מ-CombinedTab).
+      bloc.emit(
+        bloc.state.copyWith(
+          sideBySideMode: const SideBySideMode(
+            leftTabIndex: 0,
+            rightTabIndex: 1,
+          ),
+        ),
+      );
+
+      bloc.add(RemoveTabs([second, third]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 1);
+
+      expect(bloc.state.sideBySideMode, isNull);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('שחזור אחרי RemoveTabs מחזיר את הטאבים שנסגרו', () async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final third = _createTextTab('ספר ג', categoryId: 3);
+
+      bloc.add(AddTab(first));
+      bloc.add(AddTab(second));
+      bloc.add(AddTab(third));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 3);
+
+      bloc.add(RemoveTabs([first, second]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 1);
+
+      bloc.add(const RestoreLastClosedTab());
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+      bloc.add(const RestoreLastClosedTab());
+      await bloc.stream.firstWhere((s) => s.tabs.length == 3);
+
+      expect(
+        bloc.state.tabs.map((t) => t.title).toList(),
+        ['ספר א', 'ספר ב', 'ספר ג'],
+      );
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+  });
+
+  group('TabsBloc tab selection', () {
+    setUp(() async {
+      await Settings.init(cacheProvider: _MemoryCacheProvider());
+    });
+
+    Future<TabsBloc> createBlocWithTabs(List<TextBookTab> tabs) async {
+      final bloc = TabsBloc(repository: _FakeTabsRepository());
+      for (final tab in tabs) {
+        bloc.add(AddTab(tab));
+      }
+      await bloc.stream.firstWhere((s) => s.tabs.length == tabs.length);
+      return bloc;
+    }
+
+    test('ToggleTabSelection ראשון מצרף גם את הכרטיסיה הפעילה', () async {
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final third = _createTextTab('ספר ג', categoryId: 3);
+      final bloc = await createBlocWithTabs([first, second, third]);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+
+      bloc.add(ToggleTabSelection(third));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.isNotEmpty);
+
+      expect(bloc.state.selectedTabs, containsAll([first, third]));
+      expect(bloc.state.selectedTabs, hasLength(2));
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('הסרה שמותירה כרטיסיה בודדת מפרקת את הבחירה', () async {
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final bloc = await createBlocWithTabs([first, second]);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+
+      bloc.add(ToggleTabSelection(second));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 2);
+
+      bloc.add(ToggleTabSelection(second));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.isEmpty);
+
+      expect(bloc.state.selectedTabs, isEmpty);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('SelectTabRange בוחר טווח מהכרטיסיה הפעילה', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+        _createTextTab('ספר ג', categoryId: 3),
+        _createTextTab('ספר ד', categoryId: 4),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(1));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 1);
+
+      bloc.add(SelectTabRange(tabs[3]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.isNotEmpty);
+
+      expect(bloc.state.selectedTabs, [tabs[1], tabs[2], tabs[3]]);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('ClearTabSelection מנקה את הבחירה', () async {
+      final first = _createTextTab('ספר א', categoryId: 1);
+      final second = _createTextTab('ספר ב', categoryId: 2);
+      final bloc = await createBlocWithTabs([first, second]);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+      bloc.add(ToggleTabSelection(second));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.isNotEmpty);
+
+      bloc.add(const ClearTabSelection());
+      await bloc.stream.firstWhere((s) => s.selectedTabs.isEmpty);
+
+      expect(bloc.state.selectedTabs, isEmpty);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('CloseCurrentTab סוגר את כל הקבוצה כשהפעילה נבחרה', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+        _createTextTab('ספר ג', categoryId: 3),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+
+      bloc.add(ToggleTabSelection(tabs[1]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 2);
+
+      // Ctrl+W: הכרטיסיה הפעילה בבחירה — הקיצור סוגר את כל הקבוצה.
+      bloc.add(const CloseCurrentTab());
+      await bloc.stream.firstWhere((s) => s.tabs.length == 1);
+
+      expect(bloc.state.tabs.single.title, 'ספר ג');
+      expect(bloc.state.selectedTabs, isEmpty);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('CloseCurrentTab סוגר רק את הפעילה כשאינה חלק מהבחירה', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+        _createTextTab('ספר ג', categoryId: 3),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+      bloc.add(ToggleTabSelection(tabs[1]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 2);
+
+      // מעבר לכרטיסיה שמחוץ לבחירה — הקיצור סוגר רק אותה.
+      bloc.add(const SetCurrentTab(2));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 2);
+
+      bloc.add(const CloseCurrentTab());
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+
+      expect(bloc.state.tabs.map((t) => t.title), ['ספר א', 'ספר ב']);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('RemoveTab שמותיר נבחרת יחידה מפרק את הבחירה כולה', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+        _createTextTab('ספר ג', categoryId: 3),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+      bloc.add(ToggleTabSelection(tabs[1]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 2);
+
+      // "העבר לשולחן עבודה" שולח RemoveTab; הנבחרת שנותרה לבדה אינה קבוצה.
+      bloc.add(RemoveTab(tabs[1]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+
+      expect(bloc.state.selectedTabs, isEmpty);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('ReplaceTab מנרמל את הבחירה מול הטאב המוחלף', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+      bloc.add(ToggleTabSelection(tabs[1]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 2);
+
+      final replacement = _createTextTab('ספר ב מעודכן', categoryId: 2);
+      bloc.add(ReplaceTab(oldTab: tabs[1], newTab: replacement));
+      await bloc.stream.firstWhere((s) => identical(s.tabs[1], replacement));
+
+      expect(
+        bloc.state.selectedTabs,
+        isEmpty,
+        reason: 'המוחלף יצא מהבחירה והקבוצה שנותרה בת אחת מתפרקת',
+      );
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('EnableSideBySideMode מנרמל בחירה שכללה את הטאבים שאוחדו', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+        _createTextTab('ספר ג', categoryId: 3),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+      bloc.add(SelectTabRange(tabs[2]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 3);
+
+      bloc.add(EnableSideBySideMode(rightTab: tabs[0], leftTab: tabs[1]));
+      await bloc.stream.firstWhere((s) => s.currentTab is CombinedTab);
+
+      expect(
+        bloc.state.selectedTabs,
+        isEmpty,
+        reason: 'שני הטאבים שאוחדו הוחלפו ב-CombinedTab; נותרה אחת — מתפרקת',
+      );
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+
+    test('RemoveTab מנקה את הכרטיסיה שנסגרה מהבחירה', () async {
+      final tabs = [
+        _createTextTab('ספר א', categoryId: 1),
+        _createTextTab('ספר ב', categoryId: 2),
+        _createTextTab('ספר ג', categoryId: 3),
+      ];
+      final bloc = await createBlocWithTabs(tabs);
+
+      bloc.add(const SetCurrentTab(0));
+      await bloc.stream.firstWhere((s) => s.currentTabIndex == 0);
+      bloc.add(SelectTabRange(tabs[2]));
+      await bloc.stream.firstWhere((s) => s.selectedTabs.length == 3);
+
+      bloc.add(RemoveTab(tabs[1]));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+
+      expect(bloc.state.selectedTabs, [tabs[0], tabs[2]]);
+
+      await _closeBlocAndAllowDeferredDispose(bloc);
+    });
+  });
+
   group('TabsBloc restore closed tab', () {
     setUp(() async {
       await Settings.init(cacheProvider: _MemoryCacheProvider());


### PR DESCRIPTION
מימוש בקשת פורום 1992: Ctrl/Cmd+לחיצה מצרפת כרטיסיות לבחירה
(כולל הפעילה), Shift+לחיצה בוחרת טווח, והקבוצה נסגרת יחד דרך
ה-X, לחצן אמצעי, תפריט ההקשר או קיצור סגירת הכרטיסיה.

הבחירה מנוהלת ב-TabsState כדי שגם קיצור המקלדת יכיר אותה,
מנורמלת בכל שינוי ברשימת הטאבים (סגירה/החלפה/side-by-side),
וההיסטוריה נשמרת באירוע קבוצתי אחד למניעת דריסת שמירות מקביליות.
