### PR TITLE
תיקון: כותרת נשלפת מקובץ בולד נפרד ונראית כגופן אחר מהגוף

### DIFF
--- a/lib/library/view/book_versions_dialog.dart
+++ b/lib/library/view/book_versions_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:otzaria/data/data_providers/database_library_provider.dart';
 import 'package:otzaria/models/book_version.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/utils/navigation/open_book.dart';
 import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
@@ -147,6 +148,13 @@ class BookVersionTile extends StatelessWidget {
                   HtmlWidget(
                     notes!,
                     textStyle: theme.textTheme.bodySmall,
+                    customStylesBuilder: (element) {
+                      final weight = AppFonts.headingFontWeightOverride(
+                        element.localName,
+                        theme.textTheme.bodySmall?.fontFamily,
+                      );
+                      return weight == null ? null : {'font-weight': weight};
+                    },
                     onTapUrl: _openNoteUrl,
                   ),
               ],

--- a/lib/text_book/editing/services/preview_renderer.dart
+++ b/lib/text_book/editing/services/preview_renderer.dart
@@ -89,6 +89,9 @@ class PreviewRenderer {
       element.localName,
       baseStyle.fontFamily,
     );
+    if (headingWeight != null) {
+      styles['font-weight'] = headingWeight;
+    }
 
     switch (element.localName) {
       case 'code':

--- a/lib/text_book/editing/services/preview_renderer.dart
+++ b/lib/text_book/editing/services/preview_renderer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:html/dom.dart' as dom;
+import 'package:otzaria/theme/app_fonts.dart';
 
 import '../models/editor_settings.dart';
 import 'markdown_processor.dart';
@@ -82,6 +83,13 @@ class PreviewRenderer {
     styles['direction'] = 'rtl';
     styles['text-align'] = 'justify';
 
+    // הכותרות מקבלות 'bold' למטה; במשפחה עם face בולד נפרד זה שולף אותן
+    // מקובץ אחר מהגוף, ואז התצוגה המקדימה לא תואמת למה שיוצג בספר.
+    final headingWeight = AppFonts.headingFontWeightOverride(
+      element.localName,
+      baseStyle.fontFamily,
+    );
+
     switch (element.localName) {
       case 'code':
       case 'pre':
@@ -102,21 +110,21 @@ class PreviewRenderer {
 
       case 'h1':
         styles['font-size'] = '${baseStyle.fontSize! * 1.5}px';
-        styles['font-weight'] = 'bold';
+        styles['font-weight'] = headingWeight ?? 'bold';
         styles['margin-top'] = '6px'; // רווח קטן לפני הכותרת
         styles['margin-bottom'] = '3px'; // רווח קטן אחרי הכותרת
         break;
 
       case 'h2':
         styles['font-size'] = '${baseStyle.fontSize! * 1.3}px';
-        styles['font-weight'] = 'bold';
+        styles['font-weight'] = headingWeight ?? 'bold';
         styles['margin-top'] = '4px';
         styles['margin-bottom'] = '2px';
         break;
 
       case 'h3':
         styles['font-size'] = '${baseStyle.fontSize! * 1.1}px';
-        styles['font-weight'] = 'bold';
+        styles['font-weight'] = headingWeight ?? 'bold';
         styles['margin-top'] = '3px';
         styles['margin-bottom'] = '2px';
         break;

--- a/lib/text_book/view/error_report_dialog.dart
+++ b/lib/text_book/view/error_report_dialog.dart
@@ -1340,7 +1340,8 @@ class _RegularReportTabState extends State<RegularReportTab> {
                       style: TextStyle(
                         fontSize: widget.fontSize,
                         fontFamily:
-                            Settings.getValue('key-font-family') ?? 'candara',
+                            Settings.getValue('key-font-family') ??
+                            AppFonts.defaultFont,
                       ),
                       textAlign: TextAlign.right,
                     ),

--- a/lib/theme/app_fonts.dart
+++ b/lib/theme/app_fonts.dart
@@ -57,6 +57,21 @@ class AppFonts {
     return [FontVariation('wght', weight.value.toDouble())];
   }
 
+  /// גופנים מובנים שנרשמו ב-pubspec עם קובץ בולד נפרד. ב-face נפרד ציור האות
+  /// שונה מה-regular, ולכן כותרת מודגשת נראית כגופן אחר מהגוף.
+  static const Set<String> _separateBoldFaceFonts = {'FrankRuhlCLM'};
+
+  /// גופני מערכת שנטען עבורם קובץ בולד אחי ב-[_augmentSystemFontWeights].
+  /// מאוכלס בזמן ריצה — אצל משתמש אחד לגופן יש קובץ בולד מותקן ואצל אחר לא.
+  static final Set<String> _separateBoldSystemFonts = {};
+
+  /// האם הבולד של [fontFamily] מגיע מקובץ נפרד (ולא מעיבוי/ציר של אותו קובץ).
+  /// גופן משתנה מחזיר false — הבולד שלו הוא אותו ציור אות על ציר wght.
+  static bool hasSeparateBoldFace(String? fontFamily) =>
+      fontFamily != null &&
+      (_separateBoldFaceFonts.contains(fontFamily) ||
+          _separateBoldSystemFonts.contains(fontFamily));
+
   static bool get _supportsSystemFonts {
     if (kIsWeb) return false;
     return defaultTargetPlatform == TargetPlatform.windows ||
@@ -578,6 +593,7 @@ class AppFonts {
         await (FontLoader(
           fontFamily,
         )..addFont(Future.value(ByteData.sublistView(bytes)))).load();
+        _separateBoldSystemFonts.add(fontFamily);
         return;
       }
     } catch (_) {
@@ -762,11 +778,18 @@ class AppFonts {
   @visibleForTesting
   static Future<void>? get debugWarmUpFuture => _warmUpFuture;
 
+  /// מדמה גופן מערכת שנטען לו קובץ בולד אחי, בלי תלות בגופנים מותקנים.
+  @visibleForTesting
+  static void debugMarkSeparateBoldSystemFont(String fontFamily) {
+    _separateBoldSystemFonts.add(fontFamily);
+  }
+
   @visibleForTesting
   static void debugResetSystemFontsCache() {
     _systemFontsHebrewCache = null;
     _warmUpFuture = null;
     _variableSystemFonts.clear();
+    _separateBoldSystemFonts.clear();
   }
 
   @visibleForTesting

--- a/lib/theme/app_fonts.dart
+++ b/lib/theme/app_fonts.dart
@@ -72,6 +72,20 @@ class AppFonts {
       (_separateBoldFaceFonts.contains(fontFamily) ||
           _separateBoldSystemFonts.contains(fontFamily));
 
+  static const Set<String> headingTags = {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'};
+
+  /// משקל הכותרת ל-`customStylesBuilder` של fwfh, או null כשאין מה לשנות.
+  /// fwfh מדגיש כל `<h1>`-`<h6>` אוטומטית; במשפחה עם face בולד נפרד הכותרת
+  /// נשלפת מקובץ אחר מהגוף — שני ציורי אות באותו מסך.
+  /// '400' ולא 'normal' — fontWeightTryParse של fwfh מזהה רק מספר או 'bold'.
+  static String? headingFontWeightOverride(
+    String? elementTag,
+    String? fontFamily,
+  ) {
+    if (elementTag == null || !headingTags.contains(elementTag)) return null;
+    return hasSeparateBoldFace(fontFamily) ? '400' : null;
+  }
+
   static bool get _supportsSystemFonts {
     if (kIsWeb) return false;
     return defaultTargetPlatform == TargetPlatform.windows ||

--- a/lib/theme/app_theme_data.dart
+++ b/lib/theme/app_theme_data.dart
@@ -63,7 +63,7 @@ class AppThemeData {
       fontFamily: 'Roboto',
       colorScheme: cs,
       textTheme: const TextTheme(
-        bodyMedium: TextStyle(fontSize: 18.0, fontFamily: 'candara'),
+        bodyMedium: TextStyle(fontSize: 18.0),
       ),
       cardTheme: const CardThemeData(shape: AppTokens.roundedShape),
       iconButtonTheme: _iconButtonTheme(cs),
@@ -109,10 +109,7 @@ class AppThemeData {
       fontFamily: 'Roboto',
       colorScheme: cs,
       textTheme: const TextTheme(
-        bodyMedium: TextStyle(
-          fontSize: 18.0,
-          fontFamily: 'candara',
-        ),
+        bodyMedium: TextStyle(fontSize: 18.0),
       ),
       cardTheme: const CardThemeData(shape: AppTokens.roundedShape),
       iconButtonTheme: _iconButtonTheme(cs),

--- a/lib/widgets/misc/phone_report_tab.dart
+++ b/lib/widgets/misc/phone_report_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
@@ -148,7 +149,9 @@ class _PhoneReportTabState extends State<PhoneReportTab> {
               widget.selectedText,
               style: TextStyle(
                 fontSize: widget.fontSize,
-                fontFamily: Settings.getValue('key-font-family') ?? 'candara',
+                fontFamily:
+                    Settings.getValue('key-font-family') ??
+                    AppFonts.defaultFont,
               ),
               textAlign: TextAlign.right,
             ),

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -224,6 +224,14 @@ class SmartTextWidget extends StatelessWidget {
           onAnchorHoverExit: onAnchorHoverExit,
         ),
         customStylesBuilder: (dom.Element element) {
+          // fwfh נותן לכל <h1>-<h6> font-weight:bold. במשפחה עם face בולד נפרד
+          // הכותרת נשלפת מקובץ אחר מהגוף — שני ציורי אות באותו מסך. שאר
+          // הגופנים משאירים כותרת מודגשת (אותו ציור אות, מעובה או ציר wght).
+          // 'normal' אינו נתמך ב-fontWeightTryParse של fwfh — רק מספר או 'bold'.
+          if (_headingTags.contains(element.localName) &&
+              AppFonts.hasSeparateBoldFace(settings.fontFamily)) {
+            return const {'font-weight': '400'};
+          }
           if (element.localName == 'span' &&
               element.classes.contains('footnote-marker-number')) {
             return {
@@ -409,6 +417,8 @@ class _SmartTextWidgetFactory extends WidgetFactory {
     super.reset(state);
   }
 }
+
+const _headingTags = {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'};
 
 /// גרסה פשוטה יותר של SmartTextWidget שמקבלת פרמטרים בודדים
 /// במקום RenderSettings - נוחה למקרים פשוטים

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -224,13 +224,12 @@ class SmartTextWidget extends StatelessWidget {
           onAnchorHoverExit: onAnchorHoverExit,
         ),
         customStylesBuilder: (dom.Element element) {
-          // fwfh נותן לכל <h1>-<h6> font-weight:bold. במשפחה עם face בולד נפרד
-          // הכותרת נשלפת מקובץ אחר מהגוף — שני ציורי אות באותו מסך. שאר
-          // הגופנים משאירים כותרת מודגשת (אותו ציור אות, מעובה או ציר wght).
-          // 'normal' אינו נתמך ב-fontWeightTryParse של fwfh — רק מספר או 'bold'.
-          if (_headingTags.contains(element.localName) &&
-              AppFonts.hasSeparateBoldFace(settings.fontFamily)) {
-            return const {'font-weight': '400'};
+          final headingWeight = AppFonts.headingFontWeightOverride(
+            element.localName,
+            settings.fontFamily,
+          );
+          if (headingWeight != null) {
+            return {'font-weight': headingWeight};
           }
           if (element.localName == 'span' &&
               element.classes.contains('footnote-marker-number')) {
@@ -418,7 +417,6 @@ class _SmartTextWidgetFactory extends WidgetFactory {
   }
 }
 
-const _headingTags = {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'};
 
 /// גרסה פשוטה יותר של SmartTextWidget שמקבלת פרמטרים בודדים
 /// במקום RenderSettings - נוחה למקרים פשוטים

--- a/test/theme/fonts_test.dart
+++ b/test/theme/fonts_test.dart
@@ -385,6 +385,33 @@ void main() {
       expect(AppFonts.debugFontIsItalic(b), isFalse);
     });
 
+    // hasSeparateBoldFace מוקשח ברשימה; אם יירשם ב-pubspec קובץ בולד נוסף
+    // למשפחה אחרת, הכותרות שלה יחזרו להישלף מקובץ אחר מהגוף.
+    test('hasSeparateBoldFace תואם למשפחות עם יותר מ-face אחד ב-pubspec', () {
+      final pubspec = File(
+        'pubspec.yaml',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+      final fontsBlock = pubspec.substring(pubspec.indexOf('\n  fonts:'));
+
+      final multiFace = <String>{};
+      for (final m in RegExp(
+        r'- family: (\S+)\n((?:[ \t]+.*\n)+?)(?=\s*- family:|\s*\n|$)',
+      ).allMatches(fontsBlock)) {
+        final family = m.group(1)!;
+        final assets = RegExp(r'- asset:').allMatches(m.group(2)!).length;
+        if (assets > 1) multiFace.add(family);
+      }
+
+      expect(multiFace, isNotEmpty, reason: 'הפרסור של pubspec נכשל');
+      for (final family in multiFace) {
+        expect(
+          AppFonts.hasSeparateBoldFace(family),
+          isTrue,
+          reason: '$family נרשם עם כמה faces אך אינו ב-hasSeparateBoldFace',
+        );
+      }
+    });
+
     test('Medium ו-Bold חולקים שם משפחה זהה', () {
       expect(
         AppFonts.debugFontFamilyName(_bundledFont('FrankRuehlCLM-Medium.ttf')),

--- a/test/theme/heading_font_weight_test.dart
+++ b/test/theme/heading_font_weight_test.dart
@@ -189,13 +189,20 @@ void main() {
       );
     }
 
-    testWidgets('כותרת בפרנק-רוהל אינה מודגשת — תואם לספר', (tester) async {
-      await tester.pumpWidget(buildPreview('<h1>דף ה.</h1>', 'FrankRuhlCLM'));
-      await tester.pumpAndSettle();
-      expect(
-        _findHeading(tester, 'דף ה.').text.style?.fontWeight,
-        FontWeight.w400,
-      );
+    testWidgets('כל רמות הכותרת בפרנק-רוהל אינן מודגשות — תואם לספר', (
+      tester,
+    ) async {
+      for (final tag in AppFonts.headingTags) {
+        await tester.pumpWidget(
+          buildPreview('<$tag>דף ה.</$tag>', 'FrankRuhlCLM'),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          _findHeading(tester, 'דף ה.').text.style?.fontWeight,
+          FontWeight.w400,
+          reason: tag,
+        );
+      }
     });
 
     testWidgets('כותרת בגופן ללא face נפרד נשארת מודגשת', (tester) async {

--- a/test/theme/heading_font_weight_test.dart
+++ b/test/theme/heading_font_weight_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+import 'package:otzaria/library/view/book_versions_dialog.dart';
+import 'package:otzaria/models/book_version.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/text_book/editing/services/preview_renderer.dart';
+import 'package:otzaria/theme/app_fonts.dart';
+import 'package:otzaria/widgets/smart_text/render_settings.dart';
+import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
+
+/// גופנים שהבולד שלהם הוא אותו ציור אות (מעובה או ציר wght) — הכותרת
+/// אצלם נשארת מודגשת.
+const _sameFaceFonts = [
+  'TaameyDavidCLM',
+  'KeterYG',
+  'Shofar',
+  'Tinos',
+  'NotoRashiHebrew',
+  'Rubik',
+  'NotoSerifHebrew',
+];
+
+Widget _wrap(Widget child, {ThemeData? theme}) {
+  return MaterialApp(
+    theme: theme,
+    home: Directionality(
+      textDirection: TextDirection.rtl,
+      child: Scaffold(body: child),
+    ),
+  );
+}
+
+RichText _findHeading(WidgetTester tester, String text) {
+  return tester
+      .widgetList<RichText>(find.byType(RichText))
+      .firstWhere((w) => w.text.toPlainText().contains(text));
+}
+
+void main() {
+  group('AppFonts.headingFontWeightOverride', () {
+    test('מחזיר 400 לכותרת בגופן עם face בולד נפרד', () {
+      for (final tag in AppFonts.headingTags) {
+        expect(
+          AppFonts.headingFontWeightOverride(tag, 'FrankRuhlCLM'),
+          '400',
+          reason: tag,
+        );
+      }
+    });
+
+    test('מחזיר null לכותרת בגופן ללא face בולד נפרד', () {
+      for (final font in _sameFaceFonts) {
+        expect(
+          AppFonts.headingFontWeightOverride('h2', font),
+          isNull,
+          reason: font,
+        );
+      }
+    });
+
+    test('מחזיר null לתגים שאינם כותרת, גם בגופן עם face נפרד', () {
+      for (final tag in const ['p', 'div', 'b', 'strong', 'span', 'a']) {
+        expect(
+          AppFonts.headingFontWeightOverride(tag, 'FrankRuhlCLM'),
+          isNull,
+          reason: tag,
+        );
+      }
+    });
+
+    test('תג null או גופן null אינם קורסים', () {
+      expect(AppFonts.headingFontWeightOverride(null, 'FrankRuhlCLM'), isNull);
+      expect(AppFonts.headingFontWeightOverride('h1', null), isNull);
+      expect(AppFonts.headingFontWeightOverride(null, null), isNull);
+    });
+
+    test('גופן מערכת שנטען לו bold אחי מקבל 400', () {
+      addTearDown(AppFonts.debugResetSystemFontsCache);
+      expect(AppFonts.headingFontWeightOverride('h1', 'Guttman Rashi'), isNull);
+      AppFonts.debugMarkSeparateBoldSystemFont('Guttman Rashi');
+      expect(AppFonts.headingFontWeightOverride('h1', 'Guttman Rashi'), '400');
+    });
+
+    // '400' ולא 'normal' — fontWeightTryParse של fwfh מזהה רק מספר או 'bold',
+    // ולכן 'normal' נבלע בשקט וההוראה לא מיושמת.
+    test('הערך הוא מספר, לא המילה normal', () {
+      final value = AppFonts.headingFontWeightOverride('h1', 'FrankRuhlCLM');
+      expect(int.tryParse(value!), isNotNull);
+    });
+  });
+
+  group('SmartTextWidget — כותרות בכל רמות התגים', () {
+    testWidgets('h1-h6 בפרנק-רוהל אינן מודגשות', (tester) async {
+      for (final tag in AppFonts.headingTags) {
+        await tester.pumpWidget(
+          _wrap(
+            SmartTextWidget(
+              text: '<$tag>דף ה.</$tag>',
+              settings: const RenderSettings(
+                fontSize: 20,
+                fontFamily: 'FrankRuhlCLM',
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          _findHeading(tester, 'דף ה.').text.style?.fontWeight,
+          FontWeight.w400,
+          reason: tag,
+        );
+      }
+    });
+
+    testWidgets('h1-h6 בגופן ללא face נפרד נשארות מודגשות', (tester) async {
+      for (final font in _sameFaceFonts) {
+        await tester.pumpWidget(
+          _wrap(
+            SmartTextWidget(
+              text: '<h3>דף ה.</h3>',
+              settings: RenderSettings(fontSize: 20, fontFamily: font),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          _findHeading(tester, 'דף ה.').text.style?.fontWeight,
+          FontWeight.bold,
+          reason: font,
+        );
+      }
+    });
+
+    testWidgets('גודל הכותרת נשמר — רק ההדגשה יורדת', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: '<h1>דף ה.</h1>',
+            settings: RenderSettings(
+              fontSize: 20,
+              fontFamily: 'FrankRuhlCLM',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final style = _findHeading(tester, 'דף ה.').text.style;
+      expect(style?.fontWeight, FontWeight.w400);
+      expect(style?.fontSize, greaterThan(20));
+    });
+
+    testWidgets('טקסט רגיל (ללא כותרת) אינו מושפע', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: '<p>שורה <b>מודגשת</b> בפסקה</p>',
+            settings: RenderSettings(
+              fontSize: 20,
+              fontFamily: 'FrankRuhlCLM',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      var foundBold = false;
+      _findHeading(tester, 'מודגשת').text.visitChildren((span) {
+        if (span is TextSpan &&
+            span.text?.contains('מודגשת') == true &&
+            span.style?.fontWeight == FontWeight.bold) {
+          foundBold = true;
+        }
+        return true;
+      });
+      expect(foundBold, isTrue);
+    });
+  });
+
+  group('PreviewRenderer — תצוגה מקדימה בעורך', () {
+    Widget buildPreview(String markdown, String font) {
+      return _wrap(
+        PreviewRenderer().renderPreview(
+          markdown: markdown,
+          textStyle: TextStyle(fontSize: 18, fontFamily: font),
+          fontFamily: font,
+        ),
+      );
+    }
+
+    testWidgets('כותרת בפרנק-רוהל אינה מודגשת — תואם לספר', (tester) async {
+      await tester.pumpWidget(buildPreview('<h1>דף ה.</h1>', 'FrankRuhlCLM'));
+      await tester.pumpAndSettle();
+      expect(
+        _findHeading(tester, 'דף ה.').text.style?.fontWeight,
+        FontWeight.w400,
+      );
+    });
+
+    testWidgets('כותרת בגופן ללא face נפרד נשארת מודגשת', (tester) async {
+      await tester.pumpWidget(buildPreview('<h1>דף ה.</h1>', 'TaameyDavidCLM'));
+      await tester.pumpAndSettle();
+      expect(
+        _findHeading(tester, 'דף ה.').text.style?.fontWeight,
+        FontWeight.bold,
+      );
+    });
+
+    testWidgets('גודל הכותרת נשמר גם כשההדגשה יורדת', (tester) async {
+      await tester.pumpWidget(buildPreview('<h1>דף ה.</h1>', 'FrankRuhlCLM'));
+      await tester.pumpAndSettle();
+      expect(
+        _findHeading(tester, 'דף ה.').text.style?.fontSize,
+        greaterThan(18),
+      );
+    });
+  });
+
+  group('BookVersionTile — הערות גרסה מספריא', () {
+    Widget buildTile(String notes, String font) {
+      return _wrap(
+        BookVersionTile(
+          book: TextBook(title: 'ברכות'),
+          version: BookVersionInfo(
+            versionTitle: 'נוסח א',
+            heVersionNotes: notes,
+            hasContent: true,
+          ),
+          isOnlyVersion: false,
+        ),
+        theme: ThemeData(
+          textTheme: TextTheme(bodySmall: TextStyle(fontFamily: font)),
+        ),
+      );
+    }
+
+    testWidgets('כותרת בהערה אינה מודגשת בגופן עם face נפרד', (tester) async {
+      await tester.pumpWidget(buildTile('<h2>מקור</h2>', 'FrankRuhlCLM'));
+      await tester.pumpAndSettle();
+      expect(
+        _findHeading(tester, 'מקור').text.style?.fontWeight,
+        FontWeight.w400,
+      );
+    });
+
+    testWidgets('כותרת בהערה נשארת מודגשת בגופן ללא face נפרד', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTile('<h2>מקור</h2>', 'TaameyDavidCLM'));
+      await tester.pumpAndSettle();
+      expect(
+        _findHeading(tester, 'מקור').text.style?.fontWeight,
+        FontWeight.bold,
+      );
+    });
+
+    testWidgets('הערה בלי כותרת מוצגת כרגיל', (tester) async {
+      await tester.pumpWidget(buildTile('הערה <b>חשובה</b>', 'FrankRuhlCLM'));
+      await tester.pumpAndSettle();
+      expect(find.byType(HtmlWidget), findsOneWidget);
+      expect(_findHeading(tester, 'חשובה'), isNotNull);
+    });
+  });
+}

--- a/test/widgets/smart_text/smart_text_widget_fast_path_test.dart
+++ b/test/widgets/smart_text/smart_text_widget_fast_path_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/widgets/smart_text/render_settings.dart';
 import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
 
@@ -123,6 +124,123 @@ Future<void> main() async {
 
       final richText = tester.widget<RichText>(find.byType(RichText));
       expect(richText.textAlign, TextAlign.right);
+    });
+  });
+
+  group('SmartTextWidget — גופן הכותרות', () {
+    // רגרסיה: fwfh נותן ל-<h1>-<h6> font-weight:bold, ואז משפחה עם face בולד
+    // נפרד (פרנק-רוהל) שולפת את הכותרת מקובץ אחר מהגוף — שני גופנים במסך.
+    testWidgets('כותרת נשארת במשקל הגוף ולא עוברת ל-face הבולד', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: '<h2>דף ה.</h2>',
+            settings: RenderSettings(
+              fontSize: 20,
+              fontFamily: 'FrankRuhlCLM',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final heading = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .firstWhere((w) => w.text.toPlainText().contains('דף ה.'));
+      final style = heading.text.style;
+      expect(style?.fontFamily, 'FrankRuhlCLM');
+      expect(style?.fontWeight, FontWeight.w400);
+    });
+
+    // גופן מערכת שנמצא לו קובץ בולד אחי — אותה תקלה כמו פרנק-רוהל.
+    testWidgets('גופן מערכת עם קובץ בולד אחי — הכותרת אינה מודגשת', (
+      tester,
+    ) async {
+      addTearDown(AppFonts.debugResetSystemFontsCache);
+      AppFonts.debugMarkSeparateBoldSystemFont('Some Installed Serif');
+
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: '<h2>דף ה.</h2>',
+            settings: RenderSettings(
+              fontSize: 20,
+              fontFamily: 'Some Installed Serif',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final heading = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .firstWhere((w) => w.text.toPlainText().contains('דף ה.'));
+      expect(heading.text.style?.fontWeight, FontWeight.w400);
+    });
+
+    // גופן בלי face בולד נפרד — הבולד הוא אותו ציור אות, ולכן נשמר.
+    testWidgets('גופן ללא face בולד נפרד — הכותרת נשארת מודגשת', (
+      tester,
+    ) async {
+      for (final font in const [
+        'TaameyDavidCLM',
+        'KeterYG',
+        'Shofar',
+        'NotoRashiHebrew',
+      ]) {
+        await tester.pumpWidget(
+          _wrap(
+            SmartTextWidget(
+              text: '<h2>דף ה.</h2>',
+              settings: RenderSettings(fontSize: 20, fontFamily: font),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final heading = tester
+            .widgetList<RichText>(find.byType(RichText))
+            .firstWhere((w) => w.text.toPlainText().contains('דף ה.'));
+        expect(
+          heading.text.style?.fontWeight,
+          FontWeight.bold,
+          reason: '$font: הכותרת אמורה להישאר מודגשת',
+        );
+      }
+    });
+
+    testWidgets('<b> עדיין מקבל בולד — התיקון לא מבטל הדגשה אמיתית', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: '<h2>דף <b>ה.</b></h2>',
+            settings: RenderSettings(
+              fontSize: 20,
+              fontFamily: 'FrankRuhlCLM',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final heading = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .firstWhere((w) => w.text.toPlainText().contains('ה.'));
+      var foundBold = false;
+      heading.text.visitChildren((span) {
+        if (span is TextSpan &&
+            span.text != null &&
+            span.text!.contains('ה.') &&
+            span.style?.fontWeight == FontWeight.bold) {
+          foundBold = true;
+        }
+        return true;
+      });
+      expect(foundBold, isTrue);
     });
   });
 }


### PR DESCRIPTION
## הבעיה

הכותרת בגוף הספר (למשל "דף קמז:") מוצגת בציור אות שונה מהטקסט שמתחתיה — לא רק כבדה יותר, אלא גופן אחר למראה.

הסיבה: fwfh נותן לכל `<h1>`–`<h6>` ‏`font-weight: bold` כברירת מחדל. אחרי קומיט `90e4c1daf`, שרשם את `FrankRuehlCLM-Bold.ttf` כ-weight 700, הכותרת התחילה להישלף מ**קובץ אחר** מזה של הגוף. פרנק-רוהל הוא הגופן המובנה היחיד עם שני קבצים, ולכן היחיד שמפגין את זה.

בתצוגה רציפה זה בולט במיוחד: `!segment.isHeader` מחריג כותרת ממנוע הפסקאות, ולכן הכותרת עוברת ב-fwfh בזמן שהפסקה עוברת ב-`Text.rich` — שני מנועים, שני קבצי גופן, באותו מסך.

## התיקון

`AppFonts.headingFontWeightOverride` כמקור אמת יחיד, ושלושת מסלולי ה-HtmlWidget קוראים לה. מזהה משפחות שבהן הבולד הוא קובץ נפרד:
- **רשימה קבועה** לגופנים מובנים (`FrankRuhlCLM`)
- **רשימת ריצה** שמתמלאת ב-`_augmentSystemFontWeights` כשנטען בפועל קובץ בולד אחי של גופן מערכת

השנייה חייבת להיות דינמית — זה תלוי-מחשב. סריקה על מכונת פיתוח מצאה 12 גופנים עבריים מותקנים עם קובץ בולד אחי, בהם David‏ (`david`→`davidbd`), Guttman Rashi ו-Guttman Vilna.

הבולד מנוטרל **רק בכותרות ורק במשפחות כאלה**:

| מצב | כותרת |
|---|---|
| דוד, כתר, שופר, טינוס | מודגשת ✅ |
| רש"י, רוביק, נוטו (Variable) | מודגשת ✅ |
| גופן מערכת בלי קובץ בולד | מודגשת ✅ |
| גופן מערכת **עם** קובץ בולד | לא מודגשת |
| פרנק-רוהל | לא מודגשת |

הכלל: הכותרת מודגשת תמיד, חוץ ממקרה שבו ההדגשה מחליפה את ציור האות. גודל הכותרת נשמר — רק ההדגשה יורדת.

**קומיט `90e4c1daf` נשמר במלואו** — הדגשת `<b>`/`<strong>` בתוך הטקסט לא הושפעה. בוטל רק הבולד ש-fwfh מוסיף לכותרות מעצמו.

## כיסוי שני מסלולים נוספים

- **דיאלוג הגרסאות** (`book_versions_dialog.dart`) — לא העביר `customStylesBuilder` כלל; הערות ספריא עם כותרת קיבלו בולד ללא סינון.
- **תצוגה מקדימה בעורך** (`preview_renderer.dart`) — קבע `'bold'` מפורשות, כך שהעורך הבטיח כותרת מודגשת בעוד הספר מציג אותה רגילה. (העורך אינו נגיש כיום — נקודת הכניסה מנוטרלת ב-`text_book_screen.dart` — אבל הקוד חי.)

## ניקוי אגב

הוסר `fontFamily: 'candara'` — גופן שאינו מוצהר ב-pubspec ואינו קיים בפרויקט, כלומר נפתר לברירת מחדל אקראית של הפלטפורמה. הוסר מהתמה (light+dark) והוחלף ב-`AppFonts.defaultFont` בשני דיאלוגים. אומת שלא דלף לתוכן הספרים.

## הערות למבקר

- `'normal'` אינו נתמך ב-`fontWeightTryParse` של fwfh (רק מספר או `'bold'`), ולכן מוזרק `'400'`. ניסיון עם `'normal'` נבלע בשקט ולא עובד.
- נשקל להוסיף `weight: 500` להצהרת ה-Medium ב-pubspec, אך **נזנח**: מנוע Flutter מתעלם מהערך (`font_collection.cc` — `TODO(chinmaygarde): Handle weights and styles`) והמשקל נקרא מהקובץ עצמו. השינוי היה no-op.
- **קישורים נבדקו ואין בהם באג** — הרצה בפועל מראה שקישור וגוף חולקים `fontFamily` ומשקל זהים; fwfh נותן ל-`<a>` רק `text-decoration: underline`. תחושת "גופן אחר" נובעת מהצבע והקו התחתון.
- אין race condition: כל מסלולי `ensureFontLoaded` עושים `await` לפני `emit` ב-SettingsBloc, והמצב ההתחלתי הוא גופן מובנה.

## מה שלא נכלל

הדגשה **ידנית** (`<b>`, כותרות מפרשים, והגדרת "כתב מודגש") בפרנק-רוהל עדיין שולפת את ה-face הנפרד — אותה סיבת שורש, אך שינוי רחב יותר שמשמעותו ביטול מטרת `90e4c1daf`. הושאר להחלטה נפרדת.

## בדיקות

חבילה חדשה `test/theme/heading_font_weight_test.dart` (16 טסטים) — הפונקציה עצמה על כל 6 תגי הכותרת, 7 גופנים ללא face נפרד, תגים שאינם כותרת, ערכי `null`, גופן מערכת; ושלושת המשטחים: SmartTextWidget, PreviewRenderer, BookVersionTile. בנוסף טסטים ב-`smart_text_widget_fast_path_test.dart`.

אומת שהחבילה **נכשלת** (7 טסטים) כשמנטרלים את התיקון — לא טסטים ריקים.

`flutter analyze` נקי · `dart format` נקי · **183 טסטים עוברים** (`test/theme/`, `test/widgets/smart_text/`, `test/library/`).

מבוסס-rebase על `dev` העדכני. שני כשלים ב-`test/text_book/` (`commentators_list_view_type_chips_test`, `inline_notes_commentator_test`) קיימים גם על `dev` נקי ללא שינויי ה-PR — אומת בנפרד.

לא נבדק ידנית על המסך.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
