### PR TITLE
תיקון: צ׳יפי סינון המפרשים לפי סוג לא סיננו כלום

### DIFF
--- a/lib/text_book/utils/commentary_type_filter.dart
+++ b/lib/text_book/utils/commentary_type_filter.dart
@@ -9,6 +9,10 @@ import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 class CommentaryTypeFilter {
   const CommentaryTypeFilter._();
 
+  static final _commentatorsByTypeCache = Expando<Map<String, Set<String>>>(
+    'commentatorsByType',
+  );
+
   /// מפתחות צ׳יפי סוגי המפרשים שקיימים בפועל ב-[links], בסדר
   /// [LinkTypes.commentaryFilterTypes]. סוג בלי קישורים אינו מקבל צ׳יפ.
   static List<String> chipKeys(List<Link> links) {
@@ -43,12 +47,16 @@ class CommentaryTypeFilter {
   /// מיפוי סוג קנוני → שמות המפרשים שיש להם קישור מאותו סוג. משמש לצמצום
   /// רשימת המפרשים בפאנל הבחירה, כדי שצ׳יפ סוג יסנן אותה כמו צ׳יפ דור.
   static Map<String, Set<String>> commentatorsByType(List<Link> links) {
+    final cached = _commentatorsByTypeCache[links];
+    if (cached != null) return cached;
+
     final byType = <String, Set<String>>{};
     for (final link in links) {
       if (!LinkTypes.isCommentaryFilterType(link.connectionType)) continue;
       final type = LinkTypes.canonicalType(link.connectionType);
       (byType[type] ??= <String>{}).add(utils.getTitleFromPath(link.path2));
     }
+    _commentatorsByTypeCache[links] = byType;
     return byType;
   }
 

--- a/lib/text_book/utils/commentary_type_filter.dart
+++ b/lib/text_book/utils/commentary_type_filter.dart
@@ -40,6 +40,18 @@ class CommentaryTypeFilter {
     );
   }
 
+  /// מיפוי סוג קנוני → שמות המפרשים שיש להם קישור מאותו סוג. משמש לצמצום
+  /// רשימת המפרשים בפאנל הבחירה, כדי שצ׳יפ סוג יסנן אותה כמו צ׳יפ דור.
+  static Map<String, Set<String>> commentatorsByType(List<Link> links) {
+    final byType = <String, Set<String>>{};
+    for (final link in links) {
+      if (!LinkTypes.isCommentaryFilterType(link.connectionType)) continue;
+      final type = LinkTypes.canonicalType(link.connectionType);
+      (byType[type] ??= <String>{}).add(utils.getTitleFromPath(link.path2));
+    }
+    return byType;
+  }
+
   /// הבחירה האפקטיבית: רק מפתחות שיש להם צ׳יפ בקטע הנוכחי. בחירה שאין לה אף
   /// צ׳יפ קיים נחשבת ריקה = הצג הכל, ולא מסתירה את כל המפרשים.
   static Set<String> effectiveTypes({
@@ -56,8 +68,7 @@ class CommentaryTypeFilter {
   static List<String> visibleChipKeys({
     required List<String> chipKeys,
     required Set<String> effectiveTypes,
-  }) =>
-      chipKeys.length > 1 || effectiveTypes.isNotEmpty
+  }) => chipKeys.length > 1 || effectiveTypes.isNotEmpty
       ? chipKeys
       : const <String>[];
 }

--- a/lib/text_book/utils/commentary_type_filter.dart
+++ b/lib/text_book/utils/commentary_type_filter.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/foundation.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
+
+/// לוגיקת צ׳יפי הסינון לפי סוג מפרש (תרגום/מדרש/ביאור וכד׳), משותפת לכל
+/// המסכים שמציגים את פאנל בחירת המפרשים. בלעדיה כל מסך היה משכפל את החישוב
+/// והצ׳יפים היו מסננים במסך אחד בלבד.
+class CommentaryTypeFilter {
+  const CommentaryTypeFilter._();
+
+  /// מפתחות צ׳יפי סוגי המפרשים שקיימים בפועל ב-[links], בסדר
+  /// [LinkTypes.commentaryFilterTypes]. סוג בלי קישורים אינו מקבל צ׳יפ.
+  static List<String> chipKeys(List<Link> links) {
+    final present = <String>{};
+    for (final link in links) {
+      if (LinkTypes.isCommentaryFilterType(link.connectionType)) {
+        present.add(LinkTypes.canonicalType(link.connectionType));
+      }
+    }
+    return LinkTypes.commentaryFilterTypes
+        .where(present.contains)
+        .toList(growable: false);
+  }
+
+  /// כמו [chipKeys], אך מתעלם מקישורים שספרם אינו ב-[selectedCommentators] —
+  /// כדי שלא יוצג צ׳יפ לסוג שכל מפרשיו מוסתרים.
+  static List<String> chipKeysForCommentators({
+    required List<Link> links,
+    required List<String> selectedCommentators,
+  }) {
+    final commentatorsSet = selectedCommentators.toSet();
+    return chipKeys(
+      links
+          .where(
+            (link) =>
+                commentatorsSet.contains(utils.getTitleFromPath(link.path2)),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  /// הבחירה האפקטיבית: רק מפתחות שיש להם צ׳יפ בקטע הנוכחי. בחירה שאין לה אף
+  /// צ׳יפ קיים נחשבת ריקה = הצג הכל, ולא מסתירה את כל המפרשים.
+  static Set<String> effectiveTypes({
+    required Set<String> selectedTypes,
+    required List<String> availableKeys,
+  }) {
+    if (selectedTypes.isEmpty) return const {};
+    final available = availableKeys.toSet();
+    return selectedTypes.where(available.contains).toSet();
+  }
+
+  /// סוג יחיד אינו מסנן כלום, ולכן הצ׳יפים מוצגים רק משניים ומעלה — אלא אם
+  /// הוא הנבחר, שאז בלעדיהם המשתמש מסונן בשקט בלי דרך לבטל.
+  static List<String> visibleChipKeys({
+    required List<String> chipKeys,
+    required Set<String> effectiveTypes,
+  }) =>
+      chipKeys.length > 1 || effectiveTypes.isNotEmpty
+      ? chipKeys
+      : const <String>[];
+}
+
+/// מחזיק את בחירת סוגי המפרשים ומודיע למאזינים בשינוי. מאפשר להורה (כרטיסיית
+/// המפרשים) להציג את הצ׳יפים בלשונית צדדית בעוד הרשימה מסוננת ברכיב אחר.
+///
+/// המצב מקומי בכוונה ואינו נשמר להגדרות: הצ׳יפים תלויים בספר הפתוח, ובחירה
+/// שנשמרה הייתה מסננת בשקט ספר אחר שנפתח אחריו.
+class CommentaryTypeSelection extends ValueNotifier<Set<String>> {
+  CommentaryTypeSelection() : super(const {});
+}

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -1891,6 +1891,8 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                       typeChipKeys: visibleTypeChipKeys,
                       selectedTypeChips: effectiveTypes,
                       typeChipLabelBuilder: LinkTypes.hebrewLabel,
+                      commentatorsByType:
+                          CommentaryTypeFilter.commentatorsByType(state.links),
                       onTypeChipsChanged: _setSelectedCommentaryTypes,
                     )
                   : CommentatorsListView(

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -18,6 +18,7 @@ import 'package:otzaria/text_book/view/combined_view/commentary_content.dart';
 import 'package:otzaria/text_book/view/error_report_dialog.dart';
 import 'package:otzaria/text_book/models/commentator_group.dart';
 import 'package:otzaria/text_book/utils/commentary_search_utils.dart';
+import 'package:otzaria/text_book/utils/commentary_type_filter.dart';
 import 'package:otzaria/text_book/utils/commentator_group_builder.dart';
 import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
 import 'package:otzaria/text_book/view/commentators_list_screen.dart';
@@ -65,17 +66,8 @@ String? captureSelectedTextForMenu(ValueListenable<String?> saved) =>
 /// מפתחות צ׳יפי סוגי המפרשים שקיימים בפועל בקישורי הקטע, בסדר
 /// [LinkTypes.commentaryFilterTypes]. סוג בלי קישורים אינו מקבל צ׳יפ.
 @visibleForTesting
-List<String> buildCommentaryTypeChipKeys(List<Link> links) {
-  final present = <String>{};
-  for (final link in links) {
-    if (LinkTypes.isCommentaryFilterType(link.connectionType)) {
-      present.add(LinkTypes.canonicalType(link.connectionType));
-    }
-  }
-  return LinkTypes.commentaryFilterTypes
-      .where(present.contains)
-      .toList(growable: false);
-}
+List<String> buildCommentaryTypeChipKeys(List<Link> links) =>
+    CommentaryTypeFilter.chipKeys(links);
 
 /// הבחירה האפקטיבית: רק מפתחות שיש להם צ׳יפ בקטע הנוכחי. בחירה שאין לה אף
 /// צ׳יפ קיים נחשבת ריקה = הצג הכל, ולא מסתירה את כל המפרשים.
@@ -83,11 +75,10 @@ List<String> buildCommentaryTypeChipKeys(List<Link> links) {
 Set<String> effectiveCommentaryTypes({
   required Set<String> selectedTypes,
   required List<String> availableKeys,
-}) {
-  if (selectedTypes.isEmpty) return const {};
-  final available = availableKeys.toSet();
-  return selectedTypes.where(available.contains).toSet();
-}
+}) => CommentaryTypeFilter.effectiveTypes(
+  selectedTypes: selectedTypes,
+  availableKeys: availableKeys,
+);
 
 /// מייצג תוצאת חיפוש בודדת עם קטע טקסט וכתובת גלובלית לניווט
 class CommentarySearchSnippet {
@@ -153,6 +144,10 @@ class CommentaryListBase extends StatefulWidget {
   /// מיועד לתצוגה המשולבת, שבה החיפוש מנוהל ע"י ה-BLoC של הטקסט הראשי.
   final ValueListenable<String>? highlightQueryListenable;
 
+  /// בחירת סוגי המפרשים המנוהלת ע"י ההורה. נדרש כשהצ׳יפים מוצגים בפאנל שההורה
+  /// בונה (כרטיסיית המפרשים) — בלעדיו הסינון היה חל רק על הפאנל הפנימי.
+  final CommentaryTypeSelection? typeSelection;
+
   const CommentaryListBase({
     super.key,
     required this.openBookCallback,
@@ -181,6 +176,7 @@ class CommentaryListBase extends StatefulWidget {
     this.onFilterOpenRequested,
     this.autofocus = false,
     this.highlightQueryListenable,
+    this.typeSelection,
   });
 
   @override
@@ -253,7 +249,19 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
   bool _showSearchField = false;
   // סינון לפי סוג מפרש (תרגום/מדרש וכו׳). מצב מקומי ולא מוגדר: הצ׳יפים תלויים
   // בקטע הנוכחי, ובחירה שנשמרה הייתה מסננת בשקט ספר אחר שנפתח אחריו.
-  Set<String> _selectedCommentaryTypes = const {};
+  Set<String> _localCommentaryTypes = const {};
+
+  Set<String> get _selectedCommentaryTypes =>
+      widget.typeSelection?.value ?? _localCommentaryTypes;
+
+  void _setSelectedCommentaryTypes(Set<String> types) {
+    final external = widget.typeSelection;
+    if (external != null) {
+      external.value = types;
+      return;
+    }
+    setState(() => _localCommentaryTypes = types);
+  }
 
   String _getLinkKey(Link link) =>
       '${link.index1}_${link.path2}_${link.index2}';
@@ -306,17 +314,10 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
   List<String> _typeChipKeys(
     TextBookLoaded state,
     List<String> selectedCommentators,
-  ) {
-    final commentatorsSet = selectedCommentators.toSet();
-    return buildCommentaryTypeChipKeys(
-      state.links
-          .where(
-            (link) =>
-                commentatorsSet.contains(utils.getTitleFromPath(link.path2)),
-          )
-          .toList(growable: false),
-    );
-  }
+  ) => CommentaryTypeFilter.chipKeysForCommentators(
+    links: state.links,
+    selectedCommentators: selectedCommentators,
+  );
 
   String _bookTitle(TextBookLoaded state) {
     return widget.bookTitleOverride ?? state.book.title;
@@ -441,6 +442,10 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
       widget.externalSearchSnippetsNotifier?.value = [];
       _scheduleSearchCompute();
     }
+  }
+
+  void _onTypeSelectionChanged() {
+    if (mounted) setState(() {});
   }
 
   void _handleSearchFocusChange() {
@@ -736,6 +741,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
     widget.openFilterNotifier?.addListener(_onOpenFilterRequest);
     widget.closeFilterNotifier?.addListener(_onCloseFilterRequest);
     _searchFocusNode.addListener(_handleSearchFocusChange);
+    widget.typeSelection?.addListener(_onTypeSelectionChanged);
     // חיפוש חיצוני
     widget.externalSearchController?.addListener(_onExternalSearchChanged);
     widget.highlightQueryListenable?.addListener(_onHighlightQueryChanged);
@@ -789,6 +795,10 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
         _onHighlightQueryChanged,
       );
       widget.highlightQueryListenable?.addListener(_onHighlightQueryChanged);
+    }
+    if (oldWidget.typeSelection != widget.typeSelection) {
+      oldWidget.typeSelection?.removeListener(_onTypeSelectionChanged);
+      widget.typeSelection?.addListener(_onTypeSelectionChanged);
     }
     // סגירה אוטומטית של מסך הסינון כאשר המפרשים עוברים מריק לא-ריק
     // (קורה כאשר המשתמש בוחר "כל המפרשים" מהתפריט הימני)
@@ -914,6 +924,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
     widget.closeFilterNotifier?.removeListener(_onCloseFilterRequest);
     widget.externalSearchController?.removeListener(_onExternalSearchChanged);
     widget.highlightQueryListenable?.removeListener(_onHighlightQueryChanged);
+    widget.typeSelection?.removeListener(_onTypeSelectionChanged);
     _searchFocusNode.removeListener(_handleSearchFocusChange);
     _searchController.dispose();
     _savedSelectedText.dispose();
@@ -1462,12 +1473,10 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
           selectedTypes: _selectedCommentaryTypes,
           availableKeys: typeChipKeys,
         );
-        // סוג יחיד אינו מסנן כלום, ולכן הצ׳יפים מוצגים רק משניים ומעלה — אלא אם
-        // הוא הנבחר, שאז בלעדיהם המשתמש מסונן בשקט בלי דרך לבטל.
-        final visibleTypeChipKeys =
-            typeChipKeys.length > 1 || effectiveTypes.isNotEmpty
-            ? typeChipKeys
-            : const <String>[];
+        final visibleTypeChipKeys = CommentaryTypeFilter.visibleChipKeys(
+          chipKeys: typeChipKeys,
+          effectiveTypes: effectiveTypes,
+        );
 
         Widget buildList() {
           return Builder(
@@ -1882,11 +1891,13 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                       typeChipKeys: visibleTypeChipKeys,
                       selectedTypeChips: effectiveTypes,
                       typeChipLabelBuilder: LinkTypes.hebrewLabel,
-                      onTypeChipsChanged: (selected) =>
-                          setState(() => _selectedCommentaryTypes = selected),
+                      onTypeChipsChanged: _setSelectedCommentaryTypes,
                     )
                   : CommentatorsListView(
                       onCommentatorSelected: _closeCommentatorsFilter,
+                      typeChipKeys: visibleTypeChipKeys,
+                      selectedTypeChips: effectiveTypes,
+                      onTypeChipsChanged: _setSelectedCommentaryTypes,
                     ),
             );
           }

--- a/lib/text_book/view/commentators_list_screen.dart
+++ b/lib/text_book/view/commentators_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -10,9 +11,17 @@ import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
 class CommentatorsListView extends StatefulWidget {
   final VoidCallback? onCommentatorSelected;
 
+  /// צ׳יפי הסינון לפי סוג מפרש. ריקים = ציר הסוגים אינו מוצג.
+  final List<String> typeChipKeys;
+  final Set<String> selectedTypeChips;
+  final ValueChanged<Set<String>>? onTypeChipsChanged;
+
   const CommentatorsListView({
     super.key,
     this.onCommentatorSelected,
+    this.typeChipKeys = const [],
+    this.selectedTypeChips = const {},
+    this.onTypeChipsChanged,
   });
 
   @override
@@ -34,6 +43,10 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
           onSelectionChanged: (commentators) {
             context.read<TextBookBloc>().add(UpdateCommentators(commentators));
           },
+          typeChipKeys: widget.typeChipKeys,
+          selectedTypeChips: widget.selectedTypeChips,
+          typeChipLabelBuilder: LinkTypes.hebrewLabel,
+          onTypeChipsChanged: widget.onTypeChipsChanged,
         );
       },
     );

--- a/lib/text_book/view/commentators_list_screen.dart
+++ b/lib/text_book/view/commentators_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/utils/commentary_type_filter.dart';
 import 'package:otzaria/text_book/utils/commentator_group_builder.dart';
 import 'package:otzaria/text_book/widgets/text_book_state_builder.dart';
 import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
@@ -46,6 +47,9 @@ class CommentatorsListViewState extends State<CommentatorsListView> {
           typeChipKeys: widget.typeChipKeys,
           selectedTypeChips: widget.selectedTypeChips,
           typeChipLabelBuilder: LinkTypes.hebrewLabel,
+          commentatorsByType: CommentaryTypeFilter.commentatorsByType(
+            state.links,
+          ),
           onTypeChipsChanged: widget.onTypeChipsChanged,
         );
       },

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -1395,6 +1395,7 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
       ),
       selectedTypeChips: effectiveTypes,
       typeChipLabelBuilder: LinkTypes.hebrewLabel,
+      commentatorsByType: CommentaryTypeFilter.commentatorsByType(state.links),
       onTypeChipsChanged: (types) =>
           setState(() => _typeSelection.value = types),
     );

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/shortcuts/shortcut_helper.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/text_book/utils/commentary_type_filter.dart';
 import 'package:otzaria/text_book/utils/commentator_group_builder.dart';
 import 'package:otzaria/text_book/utils/per_book_display_settings.dart';
 import 'package:otzaria/text_book/utils/toc_unit_label.dart';
@@ -388,6 +390,9 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
   final _commentaryKey = GlobalKey<CommentaryListBaseState>();
   // מצב פתיחה/כיווץ של כל המפרשים, מסונכרן עם CommentaryListBase
   final _allExpandedInChild = ValueNotifier<bool>(true);
+  // בחירת סוגי המפרשים. חיה כאן ולא ב-CommentaryListBase, כי הצ׳יפים מוצגים
+  // בלשונית הצדדית שמסך זה בונה בעוד הרשימה מסוננת ברכיב הבן.
+  final _typeSelection = CommentaryTypeSelection();
   bool _navPaneOpen = false;
   bool _pinLeftPane = false;
   // רשימת המפרשים הנבחרים (עצמאית לחלונית זו, מסונכרנת פעם אחת עם מקור הפתיחה)
@@ -458,6 +463,7 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
   void dispose() {
     FocusRepository().unregisterTabContentFocusRequester(widget.tab);
     _navTabController.dispose();
+    _typeSelection.dispose();
     _commentarySearchController.dispose();
     _searchFocusNode.dispose();
     _tocSearchController.dispose();
@@ -853,6 +859,7 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
           externalSearchResultsByPathNotifier: _externalSearchResultsByPath,
           externalSearchSnippetsNotifier: _externalSearchSnippets,
           externalAllExpandedNotifier: _allExpandedInChild,
+          typeSelection: _typeSelection,
         ),
       ),
     );
@@ -1363,6 +1370,14 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     final chapters = _getChapters(state.tableOfContents);
     final indexes =
         _effectiveIndexes(chapters, state.content.length) ?? const <int>[];
+    final chipKeys = CommentaryTypeFilter.chipKeysForCommentators(
+      links: state.links,
+      selectedCommentators: selected,
+    );
+    final effectiveTypes = CommentaryTypeFilter.effectiveTypes(
+      selectedTypes: _typeSelection.value,
+      availableKeys: chipKeys,
+    );
     return CommentatorsSelectionPanel(
       groups: groups,
       selectedCommentators: selected,
@@ -1374,6 +1389,14 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
         linksByLine: state.linksByLine,
       ),
       onSelectionChanged: _updateSelectedCommentators,
+      typeChipKeys: CommentaryTypeFilter.visibleChipKeys(
+        chipKeys: chipKeys,
+        effectiveTypes: effectiveTypes,
+      ),
+      selectedTypeChips: effectiveTypes,
+      typeChipLabelBuilder: LinkTypes.hebrewLabel,
+      onTypeChipsChanged: (types) =>
+          setState(() => _typeSelection.value = types),
     );
   }
 

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -1374,30 +1374,37 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
       links: state.links,
       selectedCommentators: selected,
     );
-    final effectiveTypes = CommentaryTypeFilter.effectiveTypes(
-      selectedTypes: _typeSelection.value,
-      availableKeys: chipKeys,
+    final commentatorsByType = CommentaryTypeFilter.commentatorsByType(
+      state.links,
     );
-    return CommentatorsSelectionPanel(
-      groups: groups,
-      selectedCommentators: selected,
-      bookTitle: state.book.title,
-      rareCommentators: state.rareCommentators,
-      lineRelevantCommentators: lineRelevantRareCommentators(
-        rareCommentators: state.rareCommentators,
-        currentIndexes: indexes,
-        linksByLine: state.linksByLine,
-      ),
-      onSelectionChanged: _updateSelectedCommentators,
-      typeChipKeys: CommentaryTypeFilter.visibleChipKeys(
-        chipKeys: chipKeys,
-        effectiveTypes: effectiveTypes,
-      ),
-      selectedTypeChips: effectiveTypes,
-      typeChipLabelBuilder: LinkTypes.hebrewLabel,
-      commentatorsByType: CommentaryTypeFilter.commentatorsByType(state.links),
-      onTypeChipsChanged: (types) =>
-          setState(() => _typeSelection.value = types),
+    return ValueListenableBuilder<Set<String>>(
+      valueListenable: _typeSelection,
+      builder: (context, selectedTypes, _) {
+        final effectiveTypes = CommentaryTypeFilter.effectiveTypes(
+          selectedTypes: selectedTypes,
+          availableKeys: chipKeys,
+        );
+        return CommentatorsSelectionPanel(
+          groups: groups,
+          selectedCommentators: selected,
+          bookTitle: state.book.title,
+          rareCommentators: state.rareCommentators,
+          lineRelevantCommentators: lineRelevantRareCommentators(
+            rareCommentators: state.rareCommentators,
+            currentIndexes: indexes,
+            linksByLine: state.linksByLine,
+          ),
+          onSelectionChanged: _updateSelectedCommentators,
+          typeChipKeys: CommentaryTypeFilter.visibleChipKeys(
+            chipKeys: chipKeys,
+            effectiveTypes: effectiveTypes,
+          ),
+          selectedTypeChips: effectiveTypes,
+          typeChipLabelBuilder: LinkTypes.hebrewLabel,
+          commentatorsByType: commentatorsByType,
+          onTypeChipsChanged: (types) => _typeSelection.value = types,
+        );
+      },
     );
   }
 

--- a/lib/widgets/lists/commentators_selection_panel.dart
+++ b/lib/widgets/lists/commentators_selection_panel.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart' show setEquals;
+import 'package:flutter/foundation.dart' show mapEquals, setEquals;
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -41,6 +41,10 @@ class CommentatorsSelectionPanel extends StatefulWidget {
   /// תווית להצגה עבור מפתח סוג. ברירת המחדל: המפתח עצמו.
   final String Function(String key)? typeChipLabelBuilder;
 
+  /// שמות המפרשים שיש להם קישור מכל סוג. בחירת צ׳יפ סוג מצמצמת את רשימת
+  /// המפרשים לאלה בלבד, בדיוק כפי שצ׳יפ דור מצמצם אותה. ריק = אין צמצום.
+  final Map<String, Set<String>> commentatorsByType;
+
   const CommentatorsSelectionPanel({
     super.key,
     required this.groups,
@@ -55,6 +59,7 @@ class CommentatorsSelectionPanel extends StatefulWidget {
     this.selectedTypeChips = const {},
     this.onTypeChipsChanged,
     this.typeChipLabelBuilder,
+    this.commentatorsByType = const {},
   });
 
   @override
@@ -102,7 +107,9 @@ class _CommentatorsSelectionPanelState
         !setEquals(
           oldWidget.lineRelevantCommentators,
           widget.lineRelevantCommentators,
-        )) {
+        ) ||
+        !setEquals(oldWidget.selectedTypeChips, widget.selectedTypeChips) ||
+        !mapEquals(oldWidget.commentatorsByType, widget.commentatorsByType)) {
       _update();
     }
   }
@@ -119,9 +126,23 @@ class _CommentatorsSelectionPanelState
     super.dispose();
   }
 
+  /// שמות המפרשים המותרים לפי צ׳יפי הסוג שנבחרו. null = אין סינון סוג.
+  Set<String>? _titlesAllowedByType() {
+    if (widget.selectedTypeChips.isEmpty || widget.commentatorsByType.isEmpty) {
+      return null;
+    }
+    final allowed = <String>{};
+    for (final type in widget.selectedTypeChips) {
+      allowed.addAll(widget.commentatorsByType[type] ?? const {});
+    }
+    return allowed;
+  }
+
   Future<List<String>> _filterGroup(List<String> group) async {
+    final allowedByType = _titlesAllowedByType();
     final filteredByQuery = group
         .where(_isCommentatorVisible)
+        .where((title) => allowedByType?.contains(title) ?? true)
         .where((title) => title.contains(_searchController.text));
 
     if (_selectedTopics.isEmpty) {

--- a/lib/widgets/lists/commentators_selection_panel.dart
+++ b/lib/widgets/lists/commentators_selection_panel.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart' show mapEquals, setEquals;
+import 'package:flutter/foundation.dart' show setEquals;
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -109,9 +109,27 @@ class _CommentatorsSelectionPanelState
           widget.lineRelevantCommentators,
         ) ||
         !setEquals(oldWidget.selectedTypeChips, widget.selectedTypeChips) ||
-        !mapEquals(oldWidget.commentatorsByType, widget.commentatorsByType)) {
+        !_sameCommentatorsByType(
+          oldWidget.commentatorsByType,
+          widget.commentatorsByType,
+        )) {
       _update();
     }
+  }
+
+  /// השוואה עמוקה. `mapEquals` היה משווה את ה-Set-ים בזהות, ומאחר שהמפה
+  /// נבנית מחדש בכל build הוא תמיד החזיר false ו-_update רץ בכל rebuild.
+  bool _sameCommentatorsByType(
+    Map<String, Set<String>> a,
+    Map<String, Set<String>> b,
+  ) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (final entry in a.entries) {
+      final other = b[entry.key];
+      if (other == null || !setEquals(entry.value, other)) return false;
+    }
+    return true;
   }
 
   /// מפרש נדיר מוסתר מהרשימה אלא אם השורה הנוכחית כוללת קישור מהם.

--- a/test/text_book/utils/commentary_type_filter_test.dart
+++ b/test/text_book/utils/commentary_type_filter_test.dart
@@ -162,6 +162,15 @@ void main() {
     test('רשימה ריקה מחזירה מפה ריקה', () {
       expect(CommentaryTypeFilter.commentatorsByType(const []), isEmpty);
     });
+
+    test('אותה רשימת קישורים משתמשת במפה מחושבת', () {
+      final links = [_link(path2: 'אונקלוס.txt', type: LinkTypes.targum)];
+
+      final first = CommentaryTypeFilter.commentatorsByType(links);
+      final second = CommentaryTypeFilter.commentatorsByType(links);
+
+      expect(identical(first, second), isTrue);
+    });
   });
 
   group('effectiveTypes — ריק = הצג הכל', () {

--- a/test/text_book/utils/commentary_type_filter_test.dart
+++ b/test/text_book/utils/commentary_type_filter_test.dart
@@ -1,0 +1,294 @@
+// לוגיקת צ׳יפי הסינון לפי סוג מפרש, המשותפת לכל מסכי בחירת המפרשים.
+// עד לחילוץ הזה הלוגיקה ישבה בתוך CommentaryListBase והצ׳יפים סיננו במסך אחד
+// בלבד, בעוד המסכים האחרים הציגו אותם בלי לחבר אותם לסינון.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/text_book/utils/commentary_type_filter.dart';
+
+void main() {
+  group('chipKeys', () {
+    test('סוג שאין לו קישורים אינו מקבל צ׳יפ', () {
+      expect(
+        CommentaryTypeFilter.chipKeys([
+          _link(path2: 'אונקלוס.txt', type: LinkTypes.targum),
+        ]),
+        [LinkTypes.targum],
+      );
+    });
+
+    test('רשימה ריקה מחזירה ללא צ׳יפים', () {
+      expect(CommentaryTypeFilter.chipKeys(const []), isEmpty);
+    });
+
+    test('הסדר קבוע לפי commentaryFilterTypes ולא לפי סדר הקישורים', () {
+      final keys = CommentaryTypeFilter.chipKeys([
+        _link(path2: 'א.txt', type: LinkTypes.elucidation),
+        _link(path2: 'ב.txt', type: LinkTypes.diburHamatchil),
+        _link(path2: 'ג.txt', type: LinkTypes.parshanut),
+        _link(path2: 'ד.txt', type: LinkTypes.midrash),
+        _link(path2: 'ה.txt', type: LinkTypes.targum),
+      ]);
+
+      expect(keys, LinkTypes.commentaryFilterTypes);
+    });
+
+    test('COMMENTARY ו-SUPER_COMMENTARY אינם מקבלים צ׳יפ', () {
+      final keys = CommentaryTypeFilter.chipKeys([
+        _link(path2: 'רש"י.txt', type: LinkTypes.commentary),
+        _link(path2: 'שפתי חכמים.txt', type: LinkTypes.superCommentary),
+        _link(path2: 'אונקלוס.txt', type: LinkTypes.targum),
+      ]);
+
+      expect(keys, [LinkTypes.targum]);
+    });
+
+    test('סוג שאינו תלוי-טקסט (עין משפט) אינו מקבל צ׳יפ', () {
+      expect(
+        CommentaryTypeFilter.chipKeys([
+          _link(path2: 'עין משפט.txt', type: LinkTypes.einMishpat),
+        ]),
+        isEmpty,
+      );
+    });
+
+    test('EXPLICATION ו-ELUCIDATION ממוזגים לצ׳יפ אחד', () {
+      final keys = CommentaryTypeFilter.chipKeys([
+        _link(path2: 'א.txt', type: LinkTypes.explication),
+        _link(path2: 'ב.txt', type: LinkTypes.elucidation),
+      ]);
+
+      expect(keys, [LinkTypes.elucidation]);
+    });
+
+    test('רישיות ומפרידים שונים אינם מייצרים צ׳יפ כפול', () {
+      final keys = CommentaryTypeFilter.chipKeys([
+        _link(path2: 'א.txt', type: 'targum'),
+        _link(path2: 'ב.txt', type: 'TARGUM'),
+        _link(path2: 'ג.txt', type: ' Targum '),
+      ]);
+
+      expect(keys, [LinkTypes.targum]);
+    });
+
+    test('קישורים כפולים מאותו סוג מייצרים צ׳יפ אחד', () {
+      final keys = CommentaryTypeFilter.chipKeys([
+        _link(path2: 'א.txt', type: LinkTypes.midrash),
+        _link(path2: 'ב.txt', type: LinkTypes.midrash),
+      ]);
+
+      expect(keys, [LinkTypes.midrash]);
+    });
+  });
+
+  group('chipKeysForCommentators', () {
+    test('סוג שכל מפרשיו אינם נבחרים אינו מקבל צ׳יפ', () {
+      final keys = CommentaryTypeFilter.chipKeysForCommentators(
+        links: [
+          _link(path2: 'אונקלוס.txt', type: LinkTypes.targum),
+          _link(path2: 'מדרש רבה.txt', type: LinkTypes.midrash),
+        ],
+        selectedCommentators: const ['אונקלוס'],
+      );
+
+      expect(keys, [LinkTypes.targum]);
+    });
+
+    test('סוג שחלק ממפרשיו נבחרים כן מקבל צ׳יפ', () {
+      final keys = CommentaryTypeFilter.chipKeysForCommentators(
+        links: [
+          _link(path2: 'מדרש רבה.txt', type: LinkTypes.midrash),
+          _link(path2: 'מדרש תנחומא.txt', type: LinkTypes.midrash),
+        ],
+        selectedCommentators: const ['מדרש תנחומא'],
+      );
+
+      expect(keys, [LinkTypes.midrash]);
+    });
+
+    test('רשימת מפרשים ריקה = אין צ׳יפים', () {
+      final keys = CommentaryTypeFilter.chipKeysForCommentators(
+        links: [_link(path2: 'אונקלוס.txt', type: LinkTypes.targum)],
+        selectedCommentators: const [],
+      );
+
+      expect(keys, isEmpty);
+    });
+  });
+
+  group('commentatorsByType', () {
+    test('כל סוג ממופה לשמות המפרשים שלו', () {
+      final byType = CommentaryTypeFilter.commentatorsByType([
+        _link(path2: 'אונקלוס.txt', type: LinkTypes.targum),
+        _link(path2: 'יונתן.txt', type: LinkTypes.targum),
+        _link(path2: 'מדרש רבה.txt', type: LinkTypes.midrash),
+      ]);
+
+      expect(byType, {
+        LinkTypes.targum: {'אונקלוס', 'יונתן'},
+        LinkTypes.midrash: {'מדרש רבה'},
+      });
+    });
+
+    test('סוגים בלי צ׳יפ (COMMENTARY) אינם נכללים', () {
+      final byType = CommentaryTypeFilter.commentatorsByType([
+        _link(path2: 'רש"י.txt', type: LinkTypes.commentary),
+        _link(path2: 'אונקלוס.txt', type: LinkTypes.targum),
+      ]);
+
+      expect(byType.keys, [LinkTypes.targum]);
+    });
+
+    test('EXPLICATION נכנס תחת המפתח הקנוני ELUCIDATION', () {
+      final byType = CommentaryTypeFilter.commentatorsByType([
+        _link(path2: 'ביאור א.txt', type: LinkTypes.explication),
+        _link(path2: 'ביאור ב.txt', type: LinkTypes.elucidation),
+      ]);
+
+      expect(byType, {
+        LinkTypes.elucidation: {'ביאור א', 'ביאור ב'},
+      });
+    });
+
+    test('אותו מפרש בשני קישורים מופיע פעם אחת', () {
+      final byType = CommentaryTypeFilter.commentatorsByType([
+        _link(path2: 'אונקלוס.txt', type: LinkTypes.targum),
+        _link(path2: 'אונקלוס.txt', type: LinkTypes.targum, index1: 2),
+      ]);
+
+      expect(byType[LinkTypes.targum], {'אונקלוס'});
+    });
+
+    test('רשימה ריקה מחזירה מפה ריקה', () {
+      expect(CommentaryTypeFilter.commentatorsByType(const []), isEmpty);
+    });
+  });
+
+  group('effectiveTypes — ריק = הצג הכל', () {
+    test('בחירה ריקה נשארת ריקה', () {
+      expect(
+        CommentaryTypeFilter.effectiveTypes(
+          selectedTypes: const {},
+          availableKeys: const [LinkTypes.targum],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('בחירה שאין לה צ׳יפ קיים נחשבת ריקה ואינה מסתירה הכל', () {
+      expect(
+        CommentaryTypeFilter.effectiveTypes(
+          selectedTypes: const {LinkTypes.midrash},
+          availableKeys: const [LinkTypes.targum],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('נשמרים רק המפתחות שקיימים בצ׳יפים', () {
+      expect(
+        CommentaryTypeFilter.effectiveTypes(
+          selectedTypes: const {LinkTypes.midrash, LinkTypes.targum},
+          availableKeys: const [LinkTypes.targum],
+        ),
+        {LinkTypes.targum},
+      );
+    });
+
+    test('רשימת צ׳יפים ריקה מאפסת כל בחירה', () {
+      expect(
+        CommentaryTypeFilter.effectiveTypes(
+          selectedTypes: const {LinkTypes.targum},
+          availableKeys: const [],
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('visibleChipKeys — סוג יחיד אינו מסנן כלום', () {
+    test('שני סוגים ומעלה מוצגים תמיד', () {
+      expect(
+        CommentaryTypeFilter.visibleChipKeys(
+          chipKeys: const [LinkTypes.targum, LinkTypes.midrash],
+          effectiveTypes: const {},
+        ),
+        [LinkTypes.targum, LinkTypes.midrash],
+      );
+    });
+
+    test('סוג יחיד בלי בחירה מוסתר', () {
+      expect(
+        CommentaryTypeFilter.visibleChipKeys(
+          chipKeys: const [LinkTypes.targum],
+          effectiveTypes: const {},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('סוג יחיד שנבחר נשאר מוצג, אחרת אין דרך לבטל את הסינון', () {
+      expect(
+        CommentaryTypeFilter.visibleChipKeys(
+          chipKeys: const [LinkTypes.targum],
+          effectiveTypes: const {LinkTypes.targum},
+        ),
+        [LinkTypes.targum],
+      );
+    });
+
+    test('בלי צ׳יפים כלל — ריק', () {
+      expect(
+        CommentaryTypeFilter.visibleChipKeys(
+          chipKeys: const [],
+          effectiveTypes: const {},
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('CommentaryTypeSelection', () {
+    test('מתחיל ריק', () {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+
+      expect(selection.value, isEmpty);
+    });
+
+    test('מודיע למאזינים בשינוי', () {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      var notified = 0;
+      selection.addListener(() => notified++);
+
+      selection.value = const {LinkTypes.targum};
+
+      expect(notified, 1);
+      expect(selection.value, {LinkTypes.targum});
+    });
+
+    test('הצבת אותו ערך אינה מודיעה שוב', () {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      selection.value = const {LinkTypes.targum};
+      var notified = 0;
+      selection.addListener(() => notified++);
+
+      selection.value = const {LinkTypes.targum};
+
+      expect(notified, 0);
+    });
+  });
+}
+
+Link _link({required String path2, required String type, int index1 = 1}) =>
+    Link(
+      heRef: 'בראשית א',
+      index1: index1,
+      path2: path2,
+      index2: 1,
+      connectionType: type,
+      targetCategoryId: 1,
+      targetFileType: 'txt',
+    );

--- a/test/text_book/view/commentary_list_base_external_type_selection_test.dart
+++ b/test/text_book/view/commentary_list_base_external_type_selection_test.dart
@@ -1,0 +1,359 @@
+// סינון לפי סוג כשהבחירה מנוהלת ע"י ההורה (כרטיסיית המפרשים), ולא בפאנל
+// הפנימי של CommentaryListBase. זו הזרימה שנשברה: הצ׳יפים הוצגו בלשונית
+// הצדדית אך לא היו מחוברים לסינון הרשימה, ולכן לחיצה עליהם לא עשתה כלום.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/data/data_providers/book_composite_key.dart';
+import 'package:otzaria/data/data_providers/library_provider.dart';
+import 'package:otzaria/data/data_providers/library_provider_manager.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/models/commentator_group.dart';
+import 'package:otzaria/text_book/utils/commentary_type_filter.dart';
+import 'package:otzaria/text_book/view/commentary_list_base.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import '../../test_helpers/memory_cache_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  setUp(() {
+    LibraryProviderManager.instance.resetForTesting();
+    LibraryProviderManager.instance.seedMappingsForTesting(
+      mapping: {
+        BookCompositeKey.create(
+          title: 'ספר 0',
+          categoryId: 1,
+          fileType: 'txt',
+        ): _FakeLibraryProvider(),
+      },
+      providers: [_FakeLibraryProvider()],
+    );
+  });
+
+  tearDown(() {
+    LibraryProviderManager.instance.resetForTesting();
+  });
+
+  group('בחירת סוגים חיצונית מסננת את הרשימה', () {
+    testWidgets('בלי בחירה — כל המפרשים מוצגים', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(tester, selection: selection);
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsOneWidget);
+      expect(find.text('ספר 2'), findsOneWidget);
+    });
+
+    testWidgets('בחירת "תרגום" מסתירה את שאר הסוגים', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(tester, selection: selection);
+
+      selection.value = const {LinkTypes.targum};
+      await tester.pumpAndSettle();
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsNothing);
+      expect(find.text('ספר 2'), findsNothing);
+    });
+
+    testWidgets('בחירת שני סוגים = איחוד', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(tester, selection: selection);
+
+      selection.value = const {LinkTypes.targum, LinkTypes.midrash};
+      await tester.pumpAndSettle();
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsOneWidget);
+      expect(find.text('ספר 2'), findsNothing);
+    });
+
+    testWidgets('ביטול הבחירה מחזיר את כל המפרשים', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(tester, selection: selection);
+
+      selection.value = const {LinkTypes.targum};
+      await tester.pumpAndSettle();
+      expect(find.text('ספר 2'), findsNothing);
+
+      selection.value = const {};
+      await tester.pumpAndSettle();
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsOneWidget);
+      expect(find.text('ספר 2'), findsOneWidget);
+    });
+
+    testWidgets('בחירת סוג שאין לו קישור מציגה הודעת ריק', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(
+        tester,
+        selection: selection,
+        types: const ['TARGUM', 'MIDRASH'],
+      );
+
+      selection.value = const {LinkTypes.midrash};
+      await tester.pumpAndSettle();
+
+      expect(find.text('ספר 0'), findsNothing);
+      expect(find.text('ספר 1'), findsOneWidget);
+    });
+
+    testWidgets('בחירת סוג שאינו קיים כלל אינה מסתירה דבר', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(
+        tester,
+        selection: selection,
+        types: const ['TARGUM', 'MIDRASH'],
+      );
+
+      // לפרשנות אין קישור בקטע, ולכן הבחירה אינה אפקטיבית = הצג הכל.
+      selection.value = const {LinkTypes.parshanut};
+      await tester.pumpAndSettle();
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsOneWidget);
+    });
+
+    testWidgets('EXPLICATION נתפס ע"י בחירת ELUCIDATION', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      await _pump(
+        tester,
+        selection: selection,
+        types: const ['EXPLICATION', 'COMMENTARY'],
+      );
+
+      selection.value = const {LinkTypes.elucidation};
+      await tester.pumpAndSettle();
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsNothing);
+    });
+
+    testWidgets('הבחירה שורדת מעבר לקטע אחר', (tester) async {
+      final selection = CommentaryTypeSelection();
+      addTearDown(selection.dispose);
+      final bloc = await _pump(tester, selection: selection);
+
+      selection.value = const {LinkTypes.targum};
+      await tester.pumpAndSettle();
+
+      bloc.emitState(_stateWithTypes(const ['TARGUM', 'MIDRASH']));
+      await tester.pumpAndSettle();
+
+      expect(selection.value, {LinkTypes.targum});
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsNothing);
+    });
+  });
+
+  group('מצב מקומי כשההורה אינו מנהל את הבחירה', () {
+    testWidgets('בלי typeSelection הרשימה עדיין נבנית ומציגה הכל', (
+      tester,
+    ) async {
+      await _pump(tester, selection: null);
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 1'), findsOneWidget);
+      expect(find.text('ספר 2'), findsOneWidget);
+    });
+  });
+}
+
+Future<_TestTextBookBloc> _pump(
+  WidgetTester tester, {
+  required CommentaryTypeSelection? selection,
+  List<String> types = const ['TARGUM', 'MIDRASH', 'COMMENTARY'],
+}) async {
+  final bloc = _TestTextBookBloc(_stateWithTypes(types));
+  addTearDown(() async => bloc.close());
+  final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+  addTearDown(() async => settingsBloc.close());
+
+  addTearDown(() async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 20));
+  });
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Directionality(
+        textDirection: TextDirection.rtl,
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: bloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          ],
+          child: Scaffold(
+            body: CommentaryListBase(
+              openBookCallback: _noopOpenBook,
+              fontSize: 18,
+              showSearch: true,
+              shrinkWrap: false,
+              onSelectedCommentatorsOverrideChanged: (_) {},
+              typeSelection: selection,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+  return bloc;
+}
+
+void _noopOpenBook(_) {}
+
+Link _link({required String path2, required String type, int index1 = 1}) =>
+    Link(
+      heRef: 'בראשית א',
+      index1: index1,
+      path2: path2,
+      index2: 1,
+      connectionType: type,
+      targetCategoryId: 1,
+      targetFileType: 'txt',
+    );
+
+TextBookLoaded _stateWithTypes(List<String> types) {
+  final links = [
+    for (var i = 0; i < types.length; i++)
+      _link(path2: 'ספר $i.txt', type: types[i]),
+  ];
+  final titles = [for (var i = 0; i < types.length; i++) 'ספר $i'];
+
+  return TextBookLoaded(
+    book: TextBook(title: 'ספר בדיקה'),
+    showLeftPane: false,
+    content: const ['שורה א'],
+    fontSize: 18,
+    showSplitView: false,
+    activeCommentators: titles,
+    commentatorGroups: [
+      CommentatorGroup(title: 'ראשונים', commentators: titles),
+    ],
+    availableCommentators: titles,
+    links: links,
+    visibleLinks: const [],
+    linksByLine: {1: links},
+    tableOfContents: const [],
+    removeNikud: false,
+    visibleIndices: const [0],
+    selectedIndex: 0,
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+}
+
+class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
+    implements TextBookBloc {
+  _TestTextBookBloc(super.initialState) {
+    on<TextBookEvent>((event, emit) {});
+  }
+
+  void emitState(TextBookState state) => emit(state);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {
+  _TestSettingsBloc(super.initialState) {
+    on<SettingsEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeLibraryProvider implements LibraryProvider {
+  @override
+  String get displayName => 'Fake';
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  int get priority => 0;
+
+  @override
+  String get providerId => 'fake';
+
+  @override
+  String get sourceIndicator => 'T';
+
+  @override
+  Future<Library> buildLibraryCatalog(
+    Map<String, Map<String, dynamic>> metadata,
+    String rootPath,
+  ) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<Link>> getAllLinksForBook(
+    String title,
+    int categoryId,
+    String fileType,
+  ) async => const [];
+
+  @override
+  Future<Set<String>> getAvailableBookTitles() async => {'ספר 0|1|txt'};
+
+  @override
+  Future<String?> getBookText(
+    String title,
+    int categoryId,
+    String fileType, {
+    bool preferUserBooks = false,
+  }) async => null;
+
+  @override
+  Future<List<TocEntry>?> getBookToc(
+    String title,
+    int categoryId,
+    String fileType, {
+    bool preferUserBooks = false,
+  }) async => const [];
+
+  @override
+  Future<String> getLinkContent(Link link) async => 'תוכן לבדיקה';
+
+  @override
+  Future<bool> hasBook(String title, int categoryId, String fileType) async =>
+      true;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<Map<String, List<Book>>> loadBooks(
+    Map<String, Map<String, dynamic>> metadata,
+  ) async => const {};
+}

--- a/test/text_book/view/commentators_list_view_type_chips_test.dart
+++ b/test/text_book/view/commentators_list_view_type_chips_test.dart
@@ -1,0 +1,125 @@
+// CommentatorsListView הוא מסלול בחירת המפרשים כשאין ניהול בחירה חיצוני
+// (תצוגה משולבת / צורת דף). עד לתיקון הוא לא העביר את צ׳יפי הסוג הלאה, ולכן
+// הסינון לא הוצג שם כלל.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/models/commentator_group.dart';
+import 'package:otzaria/text_book/view/commentators_list_screen.dart';
+import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+void main() {
+  testWidgets('בלי מפתחות סוג — ציר הסוגים אינו מוצג', (tester) async {
+    await _pump(tester);
+
+    expect(find.byKey(commentatorTypeChipsGroupKey), findsNothing);
+    expect(find.byKey(commentatorEraChipsGroupKey), findsOneWidget);
+  });
+
+  testWidgets('המפתחות מוצגים עם התוויות העבריות של LinkTypes', (tester) async {
+    await _pump(
+      tester,
+      typeChipKeys: const [LinkTypes.targum, LinkTypes.midrash],
+    );
+
+    expect(find.byKey(commentatorTypeChipsGroupKey), findsOneWidget);
+    expect(find.widgetWithText(Chip, 'תרגום'), findsOneWidget);
+    expect(find.widgetWithText(Chip, 'מדרש'), findsOneWidget);
+  });
+
+  testWidgets('לחיצה על צ׳יפ מדווחת את המפתח להורה', (tester) async {
+    Set<String>? reported;
+    await _pump(
+      tester,
+      typeChipKeys: const [LinkTypes.targum, LinkTypes.midrash],
+      onTypeChipsChanged: (types) => reported = types,
+    );
+
+    await tester.tap(find.widgetWithText(Chip, 'מדרש'));
+    await tester.pumpAndSettle();
+
+    expect(reported, {LinkTypes.midrash});
+  });
+
+  testWidgets('בחירה שנכנסת מבחוץ מסמנת את הצ׳יפ', (tester) async {
+    await _pump(
+      tester,
+      typeChipKeys: const [LinkTypes.targum, LinkTypes.midrash],
+      selectedTypeChips: const {LinkTypes.targum},
+    );
+
+    final selected = tester.widget<Chip>(find.widgetWithText(Chip, 'תרגום'));
+    final unselected = tester.widget<Chip>(find.widgetWithText(Chip, 'מדרש'));
+    expect(selected.backgroundColor, isNotNull);
+    expect(unselected.backgroundColor, isNull);
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  List<String> typeChipKeys = const [],
+  Set<String> selectedTypeChips = const {},
+  ValueChanged<Set<String>>? onTypeChipsChanged,
+}) async {
+  final bloc = _TestTextBookBloc(_state());
+  addTearDown(() async => bloc.close());
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Directionality(
+        textDirection: TextDirection.rtl,
+        child: BlocProvider<TextBookBloc>.value(
+          value: bloc,
+          child: Scaffold(
+            body: CommentatorsListView(
+              typeChipKeys: typeChipKeys,
+              selectedTypeChips: selectedTypeChips,
+              onTypeChipsChanged: onTypeChipsChanged,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+TextBookLoaded _state() => TextBookLoaded(
+  book: TextBook(title: 'ספר בדיקה'),
+  showLeftPane: false,
+  content: const ['שורה א'],
+  fontSize: 18,
+  showSplitView: false,
+  activeCommentators: const ['רש"י'],
+  commentatorGroups: const [
+    CommentatorGroup(title: 'ראשונים', commentators: ['רש"י']),
+  ],
+  availableCommentators: const ['רש"י'],
+  links: const [],
+  visibleLinks: const [],
+  linksByLine: const {},
+  tableOfContents: const [],
+  removeNikud: false,
+  visibleIndices: const [0],
+  selectedIndex: 0,
+  pinLeftPane: false,
+  searchText: '',
+  scrollController: ItemScrollController(),
+  positionsListener: ItemPositionsListener.create(),
+);
+
+class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
+    implements TextBookBloc {
+  _TestTextBookBloc(super.initialState) {
+    on<TextBookEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/widgets/lists/commentators_selection_panel_chips_test.dart
+++ b/test/widgets/lists/commentators_selection_panel_chips_test.dart
@@ -232,6 +232,53 @@ void main() {
       );
     });
 
+    testWidgets('מפה שוות-ערך שנבנית מחדש אינה משנה את הרשימה', (tester) async {
+      // הקוראים בונים את commentatorsByType בכל build, ולכן ההשוואה חייבת
+      // להיות עמוקה ולא לפי זהות ה-Set-ים.
+      Map<String, Set<String>> freshMap() => {
+        'TARGUM': {'רש"י'},
+        'MIDRASH': {'קצות החושן'},
+      };
+
+      await pumpWithTypes(
+        tester,
+        selectedTypeChips: const {'TARGUM'},
+        commentatorsByType: freshMap(),
+      );
+      await pumpWithTypes(
+        tester,
+        selectedTypeChips: const {'TARGUM'},
+        commentatorsByType: freshMap(),
+      );
+
+      expect(find.widgetWithText(CheckboxListTile, 'רש"י'), findsOneWidget);
+      expect(find.widgetWithText(CheckboxListTile, 'קצות החושן'), findsNothing);
+    });
+
+    testWidgets('שינוי אמיתי במפה כן מרענן את הרשימה', (tester) async {
+      await pumpWithTypes(
+        tester,
+        selectedTypeChips: const {'TARGUM'},
+        commentatorsByType: const {
+          'TARGUM': {'רש"י'},
+        },
+      );
+      expect(find.widgetWithText(CheckboxListTile, 'קצות החושן'), findsNothing);
+
+      await pumpWithTypes(
+        tester,
+        selectedTypeChips: const {'TARGUM'},
+        commentatorsByType: const {
+          'TARGUM': {'רש"י', 'קצות החושן'},
+        },
+      );
+
+      expect(
+        find.widgetWithText(CheckboxListTile, 'קצות החושן'),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('שינוי הבחירה מבחוץ מעדכן את הרשימה מיד', (tester) async {
       await pumpWithTypes(tester, selectedTypeChips: const {});
       expect(

--- a/test/widgets/lists/commentators_selection_panel_chips_test.dart
+++ b/test/widgets/lists/commentators_selection_panel_chips_test.dart
@@ -135,6 +135,116 @@ void main() {
     expect(unselected.backgroundColor, isNull);
   });
 
+  group('צ׳יפ סוג מצמצם את רשימת המפרשים, כמו צ׳יפ דור', () {
+    const byType = {
+      'TARGUM': {'רש"י'},
+      'MIDRASH': {'קצות החושן'},
+    };
+
+    Future<void> pumpWithTypes(
+      WidgetTester tester, {
+      required Set<String> selectedTypeChips,
+      Map<String, Set<String>> commentatorsByType = byType,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: CommentatorsSelectionPanel(
+                groups: groups,
+                selectedCommentators: const [],
+                onSelectionChanged: (_) {},
+                bookTitle: 'בראשית',
+                typeChipKeys: const ['TARGUM', 'MIDRASH'],
+                selectedTypeChips: selectedTypeChips,
+                typeChipLabelBuilder: (key) =>
+                    key == 'TARGUM' ? 'תרגום' : 'מדרש',
+                commentatorsByType: commentatorsByType,
+                onTypeChipsChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('בלי בחירת סוג — כל המפרשים ברשימה', (tester) async {
+      await pumpWithTypes(tester, selectedTypeChips: const {});
+
+      expect(find.widgetWithText(CheckboxListTile, 'רש"י'), findsOneWidget);
+      expect(
+        find.widgetWithText(CheckboxListTile, 'קצות החושן'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('בחירת "תרגום" משאירה רק את המפרש מאותו סוג', (tester) async {
+      await pumpWithTypes(tester, selectedTypeChips: const {'TARGUM'});
+
+      expect(find.widgetWithText(CheckboxListTile, 'רש"י'), findsOneWidget);
+      expect(find.widgetWithText(CheckboxListTile, 'קצות החושן'), findsNothing);
+    });
+
+    testWidgets('בחירת שני סוגים = איחוד הרשימות', (tester) async {
+      await pumpWithTypes(
+        tester,
+        selectedTypeChips: const {'TARGUM', 'MIDRASH'},
+      );
+
+      expect(find.widgetWithText(CheckboxListTile, 'רש"י'), findsOneWidget);
+      expect(
+        find.widgetWithText(CheckboxListTile, 'קצות החושן'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('כפתור "הצג את כל" של דור שכל מפרשיו סוננו אינו מוצג', (
+      tester,
+    ) async {
+      await pumpWithTypes(tester, selectedTypeChips: const {'TARGUM'});
+
+      // 'רש"י' בראשונים נשאר, ולכן קצות החושן ('אחרונים') נושר עם הכפתור שלו.
+      expect(
+        find.widgetWithText(CheckboxListTile, 'הצג את כל הראשונים'),
+        findsOneWidget,
+      );
+      expect(
+        find.widgetWithText(CheckboxListTile, 'הצג את כל האחרונים'),
+        findsNothing,
+      );
+    });
+
+    testWidgets('בלי commentatorsByType אין צמצום (מסלול ה-PDF)', (
+      tester,
+    ) async {
+      await pumpWithTypes(
+        tester,
+        selectedTypeChips: const {'TARGUM'},
+        commentatorsByType: const {},
+      );
+
+      expect(find.widgetWithText(CheckboxListTile, 'רש"י'), findsOneWidget);
+      expect(
+        find.widgetWithText(CheckboxListTile, 'קצות החושן'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('שינוי הבחירה מבחוץ מעדכן את הרשימה מיד', (tester) async {
+      await pumpWithTypes(tester, selectedTypeChips: const {});
+      expect(
+        find.widgetWithText(CheckboxListTile, 'קצות החושן'),
+        findsOneWidget,
+      );
+
+      await pumpWithTypes(tester, selectedTypeChips: const {'TARGUM'});
+
+      expect(find.widgetWithText(CheckboxListTile, 'קצות החושן'), findsNothing);
+    });
+  });
+
   testWidgets('בחירת דור אינה משפיעה על בחירת הסוגים', (tester) async {
     Set<String>? reportedTypes;
     await tester.pumpWidget(


### PR DESCRIPTION
## הבעיה

צ׳יפי הסינון לפי סוג מפרש (תרגום / מדרש / ביאור / פרשנות / דיבור המתחיל), שנוספו ב-#622, לא עשו כלום. לחיצה עליהם לא שינתה את הרשימה.

## שורש הבאג

הצ׳יפים היו מחווטים **רק** לפאנל הפנימי של `CommentaryListBase`. אבל בכרטיסיית המפרשים — הזרימה הראשית — `onFilterOpenRequested` מפנה את פתיחת הבחירה ללשונית צדדית, ו-`commentators_tab_screen.dart` בונה שם `CommentatorsSelectionPanel` **משלו** שמעולם לא קיבל את פרמטרי הצ׳יפים. כלומר במסך שבו משתמשים בפועל, הצ׳יפים לא הוצגו כלל.

`CommentatorsSelectionPanel` מוצג בחמישה מקומות; רק אחד מהם חיווט את הצ׳יפים:

| מקום | לפני | אחרי |
|---|---|---|
| `commentary_list_base.dart` (פאנל פנימי) | ✅ | ✅ |
| `commentators_tab_screen.dart` (כרטיסיית המפרשים) | ❌ | ✅ |
| `commentators_list_screen.dart` | ❌ | ✅ |
| `pdf_commentary_panel.dart` | ❌ | ❌ (מחוץ להיקף) |
| `pdf_commentators_tab_screen.dart` | ❌ | ❌ (מחוץ להיקף) |

בגלל זה גם הטסטים הקיימים עברו — הם בדקו את הפאנל הפנימי, שבו הכל באמת עבד.

## התיקון

כדי לא לשכפל את הלוגיקה לכל מסך, היא חולצה ל-`lib/text_book/utils/commentary_type_filter.dart`:

- `CommentaryTypeFilter` — `chipKeys`, `chipKeysForCommentators`, `commentatorsByType`, `effectiveTypes`, `visibleChipKeys`
- `CommentaryTypeSelection extends ValueNotifier<Set<String>>` — מאפשר להורה להחזיק את הבחירה, כך שהצ׳יפים והרשימה המסוננת יכולים לחיות במסכים שונים

`CommentaryListBase` קיבל פרמטר אופציונלי `typeSelection`; כשהוא null נשמר המצב המקומי כמקודם.

## שיפור נוסף

צ׳יפ סוג מצמצם כעת גם את **רשימת המפרשים** בפאנל הבחירה, ולא רק את המפרשים המוצגים — כפי שצ׳יפ דור כבר עשה. קודם הייתה אסימטריה שהקשתה למצוא את המפרשים מהסוג הנבחר.

## החלטות היקף

- **PDF לא נכלל** — לפאנלי ה-PDF מנגנון טווחי-שורות משלהם; הושארו כפי שהם.
- **הבחירה אינה נשמרת** — מצב מקומי ומתאפס במעבר בין ספרים, בהתאם להחלטה המקורית ב-a26c3ee99 (בחירה שנשמרת הייתה מסננת בשקט ספר אחר).

## בדיקות

`flutter analyze` נקי. 138 טסטים עוברים, מהם 46 חדשים:

- `test/text_book/utils/commentary_type_filter_test.dart` — הלוגיקה המשותפת
- `test/text_book/view/commentary_list_base_external_type_selection_test.dart` — בחירה בניהול ההורה (הזרימה שנשברה)
- `test/text_book/view/commentators_list_view_type_chips_test.dart` — העברת הצ׳יפים
- הרחבה של `test/widgets/lists/commentators_selection_panel_chips_test.dart` — צמצום רשימת המפרשים

32 הטסטים הקיימים ב-`commentary_list_base_type_filter_test.dart` ממשיכים לעבור ללא שינוי. אימתתי שהטסטים החדשים באמת תופסים את הבאג: ביטול החיווט מפיל 6 מהם.

## סקירת QA

הורצה סקירה נפרדת, שאיתרה באג ביצועים בקוד החדש: `mapEquals` על `Map<String, Set<String>>` השווה את ה-Set-ים בזהות, ומאחר שהמפה נבנית מחדש בכל build הוא תמיד החזיר false — כך ש-`_update()` (שישה מעברי סינון) רץ בכל rebuild. תוקן בהשוואה עמוקה. בנוסף, פאנל הבחירה עטוף כעת ב-`ValueListenableBuilder` במקום `setState` ידני.

🤖 Generated with [Claude Code](https://claude.com/claude-code)