### PR TITLE
תיקון: כותרות DOCX לא זוהו בקבצים עם styleId מספרי

### DIFF
--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -16,8 +16,8 @@ import 'dart:convert';
 /// v6: תיבות-טקסט (`w:txbxContent`) — טקסט בתוך מסגרת, אולי על תמונת-רקע.
 /// v7: דילוג על מסגרות-רקע דקורטיביות (`behindDoc`) שאינן ניתנות לרינדור.
 /// v8: תמונות inline בתוך תיבת-טקסט אינן מזוהות בטעות כתמונת-רקע של התיבה.
-/// v9: כותרות עם styleId מספרי (Word בעברית / המרה מ-HTML) לפי styles.xml,
-/// ו-`outlineLvl=9` ("Body Text") אינו נחשב עוד לכותרת.
+/// v9: כותרות עם styleId מספרי (Word בעברית / המרה מ-HTML) לפי styles.xml
+/// כולל ירושת `w:basedOn`, ו-`outlineLvl=9` ("Body Text") אינו נחשב לכותרת.
 const int kDocxConverterVersion = 9;
 
 // Windows-1255 Hebrew range: 0xC0–0xD8 and 0xE0–0xFA map to Unicode with offset 1264.
@@ -265,6 +265,10 @@ Map<String, Map<int, _NumLevel>> _extractNumbering(Archive archive) {
 /// Word בעברית (וקבצים שהומרו מ-HTML) שומר styleId מספרי (`"2"`) בעוד שהשם
 /// (`heading 2`) וה-`w:outlineLvl` יושבים רק בהגדרת הסגנון — בלי המפה הזו כל
 /// הכותרות במסמכים כאלה מפוספסות.
+///
+/// שרשרת `w:basedOn` נפתרת: סגנון מותאם המבוסס על `Heading1` יורש ממנו את
+/// ה-`outlineLvl` ואין לו משלו. `outlineLvl` מפורש *עוצר* את הירושה — גם
+/// הערך 9 ("Body Text"), שהוא ביטול מכוון של רמת האב.
 Map<String, int> _extractHeadingStyles(Archive archive) {
   ArchiveFile? stylesFile;
   for (final f in archive) {
@@ -282,23 +286,41 @@ Map<String, int> _extractHeadingStyles(Archive archive) {
     return const {};
   }
 
-  final result = <String, int>{};
+  final defs = <String, ({String? name, String? outline, String? basedOn})>{};
   for (final style in doc.findAllElements('w:style')) {
     final type = style.getAttribute('w:type');
     if (type != null && type != 'paragraph') continue;
     final id = style.getAttribute('w:styleId');
     if (id == null) continue;
+    defs[id] = (
+      name: style.getElement('w:name')?.getAttribute('w:val'),
+      outline: style
+          .getElement('w:pPr')
+          ?.getElement('w:outlineLvl')
+          ?.getAttribute('w:val'),
+      basedOn: style.getElement('w:basedOn')?.getAttribute('w:val'),
+    );
+  }
 
-    final level =
-        _headingLevelFromStyleName(
-          style.getElement('w:name')?.getAttribute('w:val'),
-        ) ??
-        _headingLevelFromOutline(
-          style
-              .getElement('w:pPr')
-              ?.getElement('w:outlineLvl')
-              ?.getAttribute('w:val'),
-        );
+  final resolved = <String, int?>{};
+  int? levelOf(String id, Set<String> chain) {
+    if (resolved.containsKey(id)) return resolved[id];
+    if (!chain.add(id)) return null; // basedOn מעגלי בקובץ פגום
+    final def = defs[id];
+    if (def == null) return null;
+    var level =
+        _headingLevelFromStyleName(def.name) ??
+        _headingLevelFromOutline(def.outline);
+    if (level == null && def.outline == null && def.basedOn != null) {
+      level = levelOf(def.basedOn!, chain);
+    }
+    resolved[id] = level;
+    return level;
+  }
+
+  final result = <String, int>{};
+  for (final id in defs.keys) {
+    final level = levelOf(id, <String>{});
     if (level != null) result[id] = level;
   }
   return result;

--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -616,10 +616,11 @@ int? _headingLevelFromStyleName(String? styleVal) {
   return null;
 }
 
-/// האם `w:outlineLvl` קיים עם ערך מספרי — כלומר קביעה *מפורשת* של רמת מתאר
-/// (או ביטולה ע"י 9). ערך פגום נחשב כאילו אינו קיים, כדי לא לחסום את הגיבוי
-/// לפי שם הסגנון.
-bool _hasOutlineValue(String? val) => val != null && int.tryParse(val) != null;
+/// האם `w:outlineLvl` קיים עם ערך חוקי (0–9), כולל 9 שמבטל רמת מתאר.
+bool _hasOutlineValue(String? val) {
+  final level = val != null ? int.tryParse(val) : null;
+  return level != null && level >= 0 && level <= 9;
+}
 
 /// ממיר `w:outlineLvl` לרמת כותרת 1–6, או `null` אם אינו כותרת.
 ///

--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -16,7 +16,9 @@ import 'dart:convert';
 /// v6: תיבות-טקסט (`w:txbxContent`) — טקסט בתוך מסגרת, אולי על תמונת-רקע.
 /// v7: דילוג על מסגרות-רקע דקורטיביות (`behindDoc`) שאינן ניתנות לרינדור.
 /// v8: תמונות inline בתוך תיבת-טקסט אינן מזוהות בטעות כתמונת-רקע של התיבה.
-const int kDocxConverterVersion = 8;
+/// v9: כותרות עם styleId מספרי (Word בעברית / המרה מ-HTML) לפי styles.xml,
+/// ו-`outlineLvl=9` ("Body Text") אינו נחשב עוד לכותרת.
+const int kDocxConverterVersion = 9;
 
 // Windows-1255 Hebrew range: 0xC0–0xD8 and 0xE0–0xFA map to Unicode with offset 1264.
 // 0xE0 (224) + 1264 = 1488 = U+05D0 = א, ... 0xFA (250) + 1264 = 1514 = U+05EA = ת
@@ -73,12 +75,20 @@ class _DocxContext {
   /// `numId` → (`ilvl` → הגדרת הרמה). מקובץ numbering.xml.
   final Map<String, Map<int, _NumLevel>> numbering;
 
+  /// `styleId` → רמת כותרת 1–6, מקובץ styles.xml.
+  final Map<String, int> headingStyles;
+
   final _FootnoteCounter footnoteCounter = _FootnoteCounter();
 
   /// מונים רצים לרשימות: `numId` → (`ilvl` → הערך הנוכחי).
   final Map<String, Map<int, int>> _listCounters = {};
 
-  _DocxContext(this.footnotes, this.images, this.numbering);
+  _DocxContext(
+    this.footnotes,
+    this.images,
+    this.numbering,
+    this.headingStyles,
+  );
 
   /// מחזיר את תווית המספור/תבליט לפריט רשימה (למשל `1.`, `1.1.`, `א.`, `•`).
   /// מקדם את המונה המתאים ומאפס רמות עמוקות יותר (מבנה multilevel תקין).
@@ -246,6 +256,50 @@ Map<String, Map<int, _NumLevel>> _extractNumbering(Archive archive) {
     if (numId != null && aid != null && abstracts.containsKey(aid)) {
       result[numId] = abstracts[aid]!;
     }
+  }
+  return result;
+}
+
+/// בונה מפת `styleId` → רמת כותרת 1–6 מקובץ styles.xml.
+///
+/// Word בעברית (וקבצים שהומרו מ-HTML) שומר styleId מספרי (`"2"`) בעוד שהשם
+/// (`heading 2`) וה-`w:outlineLvl` יושבים רק בהגדרת הסגנון — בלי המפה הזו כל
+/// הכותרות במסמכים כאלה מפוספסות.
+Map<String, int> _extractHeadingStyles(Archive archive) {
+  ArchiveFile? stylesFile;
+  for (final f in archive) {
+    if (f.isFile && f.name == 'word/styles.xml') {
+      stylesFile = f;
+      break;
+    }
+  }
+  if (stylesFile == null) return const {};
+
+  final xml.XmlDocument doc;
+  try {
+    doc = xml.XmlDocument.parse(_decodeXmlBytes(stylesFile.content));
+  } catch (_) {
+    return const {};
+  }
+
+  final result = <String, int>{};
+  for (final style in doc.findAllElements('w:style')) {
+    final type = style.getAttribute('w:type');
+    if (type != null && type != 'paragraph') continue;
+    final id = style.getAttribute('w:styleId');
+    if (id == null) continue;
+
+    final level =
+        _headingLevelFromStyleName(
+          style.getElement('w:name')?.getAttribute('w:val'),
+        ) ??
+        _headingLevelFromOutline(
+          style
+              .getElement('w:pPr')
+              ?.getElement('w:outlineLvl')
+              ?.getAttribute('w:val'),
+        );
+    if (level != null) result[id] = level;
   }
   return result;
 }
@@ -532,6 +586,16 @@ int? _headingLevelFromStyleName(String? styleVal) {
   return null;
 }
 
+/// ממיר `w:outlineLvl` לרמת כותרת 1–6, או `null` אם אינו כותרת.
+///
+/// ב-OOXML הערך 9 פירושו "Body Text" — ביטול *מפורש* של רמת מתאר, ולא כותרת
+/// עמוקה. בלי הבדיקה כל פסקה כזו הייתה הופכת ל-`<h6>` ומזהמת את תוכן העניינים.
+int? _headingLevelFromOutline(String? val) {
+  final o = val != null ? int.tryParse(val) : null;
+  if (o == null || o < 0 || o >= 9) return null;
+  return (o + 1).clamp(1, 6);
+}
+
 /// מעבד run בודד ל-[_Seg] (עטיפה + טקסט), או `null` אם הוא ריק/מוסתר.
 ///
 /// תומך ב-`w:br`/`w:tab` בתוך ה-run, ומזהה הדגשה/נטייה גם בווריאנט
@@ -707,18 +771,18 @@ void _processParagraph(
 
   final pPr = paragraph.getElement('w:pPr');
 
-  // כותרת: קודם לפי שם הסגנון, אחרת גיבוי שפה-אגנוסטי דרך outlineLvl.
+  // כותרת: קודם לפי שם הסגנון, אחרת לפי הגדרת הסגנון ב-styles.xml (styleId
+  // מספרי), ולבסוף גיבוי שפה-אגנוסטי דרך outlineLvl של הפסקה עצמה.
   final styleVal = pPr?.getElement('w:pStyle')?.getAttribute('w:val');
-  var level = _headingLevelFromStyleName(styleVal);
-  if (level == null) {
-    final outline = pPr?.getElement('w:outlineLvl')?.getAttribute('w:val');
-    final o = outline != null ? int.tryParse(outline) : null;
-    if (o != null) level = o + 1;
-  }
+  final level =
+      _headingLevelFromStyleName(styleVal) ??
+      (styleVal != null ? ctx.headingStyles[styleVal] : null) ??
+      _headingLevelFromOutline(
+        pPr?.getElement('w:outlineLvl')?.getAttribute('w:val'),
+      );
 
   if (level != null) {
-    final clamped = level.clamp(1, 6);
-    output.add('<h$clamped>$text</h$clamped>');
+    output.add('<h$level>$text</h$level>');
     return;
   }
 
@@ -933,6 +997,7 @@ String docxToText(Uint8List bytes, String title) {
     _extractFootnotes(archive),
     _extractImages(archive),
     _extractNumbering(archive),
+    _extractHeadingStyles(archive),
   );
   final List<String> list = ['<h1>${_escapeHtml(title)}</h1>'];
 

--- a/lib/utils/file/docx_to_otzaria.dart
+++ b/lib/utils/file/docx_to_otzaria.dart
@@ -308,10 +308,18 @@ Map<String, int> _extractHeadingStyles(Archive archive) {
     if (!chain.add(id)) return null; // basedOn מעגלי בקובץ פגום
     final def = defs[id];
     if (def == null) return null;
-    var level =
-        _headingLevelFromStyleName(def.name) ??
-        _headingLevelFromOutline(def.outline);
-    if (level == null && def.outline == null && def.basedOn != null) {
+
+    // `outlineLvl` מפורש הוא המידע האמין וגובר על השם: סגנון בשם
+    // "Heading 1 Draft" עם `outlineLvl=9` אינו כותרת. השם הוא פרוקסי בלבד,
+    // ומשמש רק כשאין `outlineLvl` — ואז גם הירושה מ-basedOn נכנסת לתוקף.
+    if (_hasOutlineValue(def.outline)) {
+      final byOutline = _headingLevelFromOutline(def.outline);
+      resolved[id] = byOutline;
+      return byOutline;
+    }
+
+    var level = _headingLevelFromStyleName(def.name);
+    if (level == null && def.basedOn != null) {
       level = levelOf(def.basedOn!, chain);
     }
     resolved[id] = level;
@@ -608,6 +616,11 @@ int? _headingLevelFromStyleName(String? styleVal) {
   return null;
 }
 
+/// האם `w:outlineLvl` קיים עם ערך מספרי — כלומר קביעה *מפורשת* של רמת מתאר
+/// (או ביטולה ע"י 9). ערך פגום נחשב כאילו אינו קיים, כדי לא לחסום את הגיבוי
+/// לפי שם הסגנון.
+bool _hasOutlineValue(String? val) => val != null && int.tryParse(val) != null;
+
 /// ממיר `w:outlineLvl` לרמת כותרת 1–6, או `null` אם אינו כותרת.
 ///
 /// ב-OOXML הערך 9 פירושו "Body Text" — ביטול *מפורש* של רמת מתאר, ולא כותרת
@@ -793,15 +806,15 @@ void _processParagraph(
 
   final pPr = paragraph.getElement('w:pPr');
 
-  // כותרת: קודם לפי שם הסגנון, אחרת לפי הגדרת הסגנון ב-styles.xml (styleId
-  // מספרי), ולבסוף גיבוי שפה-אגנוסטי דרך outlineLvl של הפסקה עצמה.
+  // כותרת: `outlineLvl` על הפסקה עצמה הוא עיצוב ישיר וגובר על הסגנון (כולל
+  // 9 = "Body Text" שמבטל כותרת). בהיעדרו — שם הסגנון, ואז הגדרת הסגנון
+  // ב-styles.xml (styleId מספרי / ירושת basedOn).
   final styleVal = pPr?.getElement('w:pStyle')?.getAttribute('w:val');
-  final level =
-      _headingLevelFromStyleName(styleVal) ??
-      (styleVal != null ? ctx.headingStyles[styleVal] : null) ??
-      _headingLevelFromOutline(
-        pPr?.getElement('w:outlineLvl')?.getAttribute('w:val'),
-      );
+  final outlineVal = pPr?.getElement('w:outlineLvl')?.getAttribute('w:val');
+  final level = _hasOutlineValue(outlineVal)
+      ? _headingLevelFromOutline(outlineVal)
+      : _headingLevelFromStyleName(styleVal) ??
+            (styleVal != null ? ctx.headingStyles[styleVal] : null);
 
   if (level != null) {
     output.add('<h$level>$text</h$level>');

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/utils/file/docx_to_otzaria.dart';
 Uint8List _buildDocx(
   List<int> documentXmlBytes, {
   List<int>? footnotesXmlBytes,
+  List<int>? stylesXmlBytes,
 }) {
   final encoder = ZipEncoder();
   final archive = Archive();
@@ -28,6 +29,11 @@ Uint8List _buildDocx(
         footnotesXmlBytes.length,
         footnotesXmlBytes,
       ),
+    );
+  }
+  if (stylesXmlBytes != null) {
+    archive.addFile(
+      ArchiveFile('word/styles.xml', stylesXmlBytes.length, stylesXmlBytes),
     );
   }
   return Uint8List.fromList(encoder.encode(archive));
@@ -301,6 +307,206 @@ void main() {
 </w:document>''';
       final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
       expect(result, contains('<h1>כותרת מתאר</h1>'));
+    });
+
+    test('outlineLvl=9 ("Body Text") אינו כותרת', () {
+      final xml =
+          '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr><w:outlineLvl w:val="9"/></w:pPr>
+      <w:r><w:t>גוף הטקסט</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('גוף הטקסט'));
+      expect(result, isNot(contains('<h6>גוף הטקסט')));
+    });
+
+    test('outlineLvl=8 (הרמה החוקית העמוקה ביותר) נחתך ל-<h6>', () {
+      final xml =
+          '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr><w:outlineLvl w:val="8"/></w:pPr>
+      <w:r><w:t>רמה תשיעית</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<h6>רמה תשיעית</h6>'));
+    });
+  });
+
+  group('docxToText - כותרות לפי styles.xml (styleId מספרי)', () {
+    // Word בעברית / המרה מ-HTML: styleId מספרי, השם והמתאר רק בהגדרת הסגנון.
+    String docWithStyles(List<(String, String)> paragraphs) {
+      final body = paragraphs
+          .map(
+            (p) =>
+                '<w:p><w:pPr><w:pStyle w:val="${p.$1}"/></w:pPr>'
+                '<w:r><w:t>${p.$2}</w:t></w:r></w:p>',
+          )
+          .join();
+      return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+          '<w:document $_xmlNs><w:body>$body</w:body></w:document>';
+    }
+
+    String stylesXml(String inner) =>
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:styles $_xmlNs>$inner</w:styles>';
+
+    String headingStyle(String id, String name, int outlineLvl) =>
+        '<w:style w:type="paragraph" w:styleId="$id">'
+        '<w:name w:val="$name"/>'
+        '<w:pPr><w:outlineLvl w:val="$outlineLvl"/></w:pPr>'
+        '</w:style>';
+
+    test('styleId מספרי עם w:name "heading N" מומר ל-<hN>', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(
+            docWithStyles([('1', 'פרק'), ('2', 'סימן'), ('3', 'סעיף')]),
+          ),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              headingStyle('1', 'heading 1', 0) +
+                  headingStyle('2', 'heading 2', 1) +
+                  headingStyle('3', 'heading 3', 2),
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h1>פרק</h1>'));
+      expect(result, contains('<h2>סימן</h2>'));
+      expect(result, contains('<h3>סעיף</h3>'));
+    });
+
+    test('styleId מספרי מזוהה דרך outlineLvl גם כשהשם אינו "heading"', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('a5', 'כותרת מותאמת')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="a5">'
+              '<w:name w:val="כותרת שלי"/>'
+              '<w:pPr><w:outlineLvl w:val="1"/></w:pPr>'
+              '</w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h2>כותרת מותאמת</h2>'));
+    });
+
+    test('שם סגנון בעברית ("כותרת 2") ב-styles.xml מומר ל-<h2>', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('7', 'שער')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="7">'
+              '<w:name w:val="כותרת 2"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h2>שער</h2>'));
+    });
+
+    test('סגנון תו (character) עם שם heading אינו הופך פסקה לכותרת', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('10', 'טקסט רגיל')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="character" w:styleId="10">'
+              '<w:name w:val="heading 1 Char"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('טקסט רגיל'));
+      expect(result, isNot(contains('<h1>טקסט רגיל')));
+    });
+
+    test('סגנון ללא outlineLvl ובלי שם כותרת נשאר פסקה רגילה', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('NormalWeb', 'גוף'), ('TOC2', 'תוכן')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="NormalWeb">'
+              '<w:name w:val="Normal (Web)"/></w:style>'
+              '<w:style w:type="paragraph" w:styleId="TOC2">'
+              '<w:name w:val="toc 2"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('גוף'));
+      expect(result, contains('תוכן'));
+      expect(result, isNot(contains('<h1>גוף')));
+      expect(result, isNot(contains('<h2>תוכן')));
+    });
+
+    test('outlineLvl גבוה (>5) נחתך ל-<h6>', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('9', 'עמוק')])),
+          stylesXmlBytes: _utf8Xml(stylesXml(headingStyle('9', 'x', 8))),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h6>עמוק</h6>'));
+    });
+
+    test('styleId שמי (Heading1) עדיין עובד גם כשקיים styles.xml', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('Heading1', 'פרק')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(headingStyle('Heading1', 'heading 1', 0)),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h1>פרק</h1>'));
+    });
+
+    test('סגנון עם outlineLvl=9 ("Body Text") אינו הופך לכותרת', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('BodyText', 'פסקת גוף')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(headingStyle('BodyText', 'Body Text', 9)),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('פסקת גוף'));
+      expect(result, isNot(contains('<h6>פסקת גוף')));
+    });
+
+    test('styles.xml פגום — ההמרה ממשיכה בלי לקרוס', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('1', 'טקסט')])),
+          stylesXmlBytes: _utf8Xml('<w:styles<<< not xml'),
+        ),
+        'ב',
+      );
+      expect(result, contains('טקסט'));
     });
   });
 

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -381,6 +381,25 @@ void main() {
       expect(result, contains('<h3>סעיף</h3>'));
       expect(result, isNot(contains('<h1>סעיף')));
     });
+
+    test('outlineLvl מחוץ לטווח על הפסקה אינו חוסם את pStyle', () {
+      final xml =
+          '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Heading1"/>
+        <w:outlineLvl w:val="-1"/>
+      </w:pPr>
+      <w:r><w:t>פרק</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<h1>פרק</h1>'));
+    });
   });
 
   group('docxToText - כותרות לפי styles.xml (styleId מספרי)', () {
@@ -707,6 +726,23 @@ void main() {
               '<w:style w:type="paragraph" w:styleId="Q">'
               '<w:name w:val="heading 1"/>'
               '<w:pPr><w:outlineLvl w:val="abc"/></w:pPr></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h1>פרק</h1>'));
+    });
+
+    test('outlineLvl מספרי מחוץ לטווח אינו חוסם את שם הסגנון', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('Q', 'פרק')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="Q">'
+              '<w:name w:val="heading 1"/>'
+              '<w:pPr><w:outlineLvl w:val="10"/></w:pPr></w:style>',
             ),
           ),
         ),

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -341,6 +341,46 @@ void main() {
       final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
       expect(result, contains('<h6>רמה תשיעית</h6>'));
     });
+
+    test('outlineLvl=9 על הפסקה גובר על pStyle="Heading1"', () {
+      final xml =
+          '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Heading1"/>
+        <w:outlineLvl w:val="9"/>
+      </w:pPr>
+      <w:r><w:t>גוף</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('גוף'));
+      expect(result, isNot(contains('<h1>גוף')));
+    });
+
+    test('outlineLvl על הפסקה גובר על רמת שם הסגנון', () {
+      final xml =
+          '''
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document $_xmlNs>
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Heading1"/>
+        <w:outlineLvl w:val="2"/>
+      </w:pPr>
+      <w:r><w:t>סעיף</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>''';
+      final result = docxToText(_buildDocx(_utf8Xml(xml)), 'ב');
+      expect(result, contains('<h3>סעיף</h3>'));
+      expect(result, isNot(contains('<h1>סעיף')));
+    });
   });
 
   group('docxToText - כותרות לפי styles.xml (styleId מספרי)', () {
@@ -627,6 +667,52 @@ void main() {
       );
       expect(result, contains('טקסט'));
       expect(result, isNot(contains('<h1>טקסט')));
+    });
+
+    test('outlineLvl=9 מפורש גובר על שם סגנון דמוי-כותרת', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('1', 'Body')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(headingStyle('1', 'Heading 1 Draft', 9)),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('Body'));
+      expect(result, isNot(contains('<h1>Body')));
+      expect(result, isNot(contains('<h6>Body')));
+    });
+
+    test('outlineLvl תקף גובר על רמה אחרת שבשם הסגנון', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('9', 'סימן')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(headingStyle('9', 'heading 1', 1)),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h2>סימן</h2>'));
+      expect(result, isNot(contains('<h1>סימן')));
+    });
+
+    test('outlineLvl פגום אינו חוסם את הגיבוי לפי שם הסגנון', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('Q', 'פרק')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="Q">'
+              '<w:name w:val="heading 1"/>'
+              '<w:pPr><w:outlineLvl w:val="abc"/></w:pPr></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h1>פרק</h1>'));
     });
 
     test('styles.xml פגום — ההמרה ממשיכה בלי לקרוס', () {

--- a/test/utils/file/docx_to_otzaria_test.dart
+++ b/test/utils/file/docx_to_otzaria_test.dart
@@ -498,6 +498,137 @@ void main() {
       expect(result, isNot(contains('<h6>פסקת גוף')));
     });
 
+    test('סגנון יורש (basedOn) מקבל את רמת האב', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('CustomChapter', 'פרק')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '${headingStyle('Heading1', 'heading 1', 0)}'
+              '<w:style w:type="paragraph" w:styleId="CustomChapter">'
+              '<w:name w:val="Custom Chapter"/>'
+              '<w:basedOn w:val="Heading1"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h1>פרק</h1>'));
+    });
+
+    test('שרשרת basedOn רב-שלבית נפתרת עד הסוף', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('C', 'סימן')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '${headingStyle('2', 'heading 2', 1)}'
+              '<w:style w:type="paragraph" w:styleId="B">'
+              '<w:name w:val="B"/><w:basedOn w:val="2"/></w:style>'
+              '<w:style w:type="paragraph" w:styleId="C">'
+              '<w:name w:val="C"/><w:basedOn w:val="B"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h2>סימן</h2>'));
+    });
+
+    test('outlineLvl מפורש בסגנון היורש דוחה את רמת האב', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('Sub', 'תת-פרק')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '${headingStyle('Heading1', 'heading 1', 0)}'
+              '<w:style w:type="paragraph" w:styleId="Sub">'
+              '<w:name w:val="Sub"/><w:basedOn w:val="Heading1"/>'
+              '<w:pPr><w:outlineLvl w:val="2"/></w:pPr></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('<h3>תת-פרק</h3>'));
+      expect(result, isNot(contains('<h1>תת-פרק')));
+    });
+
+    test('סגנון יורש עם outlineLvl=9 מפורש אינו כותרת', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('NotHeading', 'גוף')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '${headingStyle('Heading1', 'heading 1', 0)}'
+              '<w:style w:type="paragraph" w:styleId="NotHeading">'
+              '<w:name w:val="Not Heading"/>'
+              '<w:basedOn w:val="Heading1"/>'
+              '<w:pPr><w:outlineLvl w:val="9"/></w:pPr></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('גוף'));
+      expect(result, isNot(contains('<h1>גוף')));
+      expect(result, isNot(contains('<h6>גוף')));
+    });
+
+    test('שרשרת basedOn מעגלית אינה תוקעת את ההמרה', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('X', 'טקסט')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="X">'
+              '<w:name w:val="X"/><w:basedOn w:val="Y"/></w:style>'
+              '<w:style w:type="paragraph" w:styleId="Y">'
+              '<w:name w:val="Y"/><w:basedOn w:val="X"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('טקסט'));
+      expect(result, isNot(contains('<h1>טקסט')));
+    });
+
+    test('basedOn על סגנון שאינו קיים אינו קורס', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('Orphan', 'טקסט')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="paragraph" w:styleId="Orphan">'
+              '<w:name w:val="Orphan"/><w:basedOn w:val="Missing"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('טקסט'));
+    });
+
+    test('basedOn על סגנון תו אינו הופך את היורש לכותרת', () {
+      final result = docxToText(
+        _buildDocx(
+          _utf8Xml(docWithStyles([('P', 'טקסט')])),
+          stylesXmlBytes: _utf8Xml(
+            stylesXml(
+              '<w:style w:type="character" w:styleId="HChar">'
+              '<w:name w:val="heading 1"/></w:style>'
+              '<w:style w:type="paragraph" w:styleId="P">'
+              '<w:name w:val="P"/><w:basedOn w:val="HChar"/></w:style>',
+            ),
+          ),
+        ),
+        'ב',
+      );
+      expect(result, contains('טקסט'));
+      expect(result, isNot(contains('<h1>טקסט')));
+    });
+
     test('styles.xml פגום — ההמרה ממשיכה בלי לקרוס', () {
       final result = docxToText(
         _buildDocx(


### PR DESCRIPTION
## הבעיה

בקבצי DOCX מסוימים הכותרות לא זוהו כלל — הספר נפתח בלי תוכן עניינים. דוגמה: `מגלה עמוקות חלק ב.docx` (38 פסקאות כותרת, 0 זוהו).

## שורש הבעיה

`w:pStyle w:val` הוא **מזהה** הסגנון (styleId) ולא **שמו**. הזיהוי הקיים חיפש בו את המחרוזת `heading N`:

```dart
final en = RegExp(r'heading\s*([1-6])').firstMatch(lower);
```

Word באנגלית ו-python-docx אכן כותבים `styleId="Heading1"` — ולכן חלק מהקבצים עבדו. אבל **Word בעברית** ומסמכים שהומרו מ-HTML כותבים styleId מספרי, והשם יושב רק ב-`word/styles.xml`:

```xml
<w:p><w:pPr><w:pStyle w:val="2"/></w:pPr>…   <!-- document.xml -->

<w:style w:type="paragraph" w:styleId="2">    <!-- styles.xml -->
  <w:name w:val="heading 2"/>
  <w:pPr><w:outlineLvl w:val="1"/></w:pPr>
```

גם הגיבוי דרך `outlineLvl` נכשל, כי הוא מוגדר **בסגנון** ולא בפסקה (0 מתוך 38 פסקאות הכילו `outlineLvl` inline).

הרגרסיה נכנסה ב-`022581c6a` — לפניה הקוד השתמש ב-`double.tryParse(style)` שתפס דווקא את המספריים ולא את השמיים.

## התיקון

`_extractHeadingStyles(Archive)` — בונה מפת `styleId → רמת כותרת` מ-`word/styles.xml` (לפי `w:name` ואז `w:outlineLvl`, רק סגנונות `w:type="paragraph"`). סדר הזיהוי ב-`_processParagraph`:

1. שם הסגנון ב-`w:pStyle` (התנהגות קיימת)
2. **חדש** — המפה מ-`styles.xml`
3. `outlineLvl` של הפסקה עצמה (גיבוי קיים)

### באג קיים שתוקן דרך אגב

ב-OOXML הערך `w:outlineLvl w:val="9"` פירושו **"Body Text"** — ביטול *מפורש* של רמת מתאר, כלומר לא כותרת. הקוד חישב `9+1=10` ואז `clamp(1,6)` והפיק `<h6>` שגוי. `_headingLevelFromOutline` מסננת אותו.

זה קריטי במיוחד עכשיו: ברמת הפסקה זו הייתה פסקה בודדת, אבל ברמת הסגנון סגנון יחיד עם `outlineLvl=9` היה הופך את **כל** הפסקאות שלו לכותרות ומציף את תוכן העניינים.

### מטמון

`kDocxConverterVersion` הועלה 8→9, כך שספרים שכבר נפתחו יומרו מחדש אוטומטית ולא יישארו עם המטמון הישן.

## אימות

| קובץ | לפני | אחרי |
|---|---|---|
| מגלה עמוקות ח״ב | 0 כותרות | h1:5, h2:32, h3:1 |
| חזון למועד | 0 כותרות | h1:30, h2:28, h3:31 |
| formatting-demo | עבד | ללא שינוי |
| otzaria_formatting_showcase | עבד | ללא שינוי |

הספירות תואמות בדיוק את מספר פסקאות-הסגנון ב-XML.

**ללא false positives:** `TOC2` (28 פסקאות), `ListParagraph` ו-`NormalWeb` **לא** זוהו ככותרות — אין זיהום של תוכן העניינים.

## טסטים

10 טסטים חדשים ב-`test/utils/file/docx_to_otzaria_test.dart`:

- styleId מספרי עם `w:name` "heading N" → `<hN>`
- styleId מזוהה דרך `outlineLvl` כשהשם אינו "heading"
- שם סגנון בעברית ("כותרת 2")
- **סגנון תו** (`w:type="character"`) עם שם heading אינו הופך פסקה לכותרת
- `TOC2`/`NormalWeb` נשארים פסקה רגילה
- `outlineLvl` גבוה נחתך ל-`<h6>`
- styleId שמי (`Heading1`) עדיין עובד גם כשקיים `styles.xml`
- `styles.xml` פגום — ההמרה ממשיכה בלי לקרוס
- `outlineLvl=9` אינו כותרת (ברמת פסקה וברמת סגנון)
- `outlineLvl=8` (הרמה החוקית העמוקה ביותר) → `<h6>`

`flutter analyze` נקי · 94 טסטים עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
