### PR TITLE
תיקון: פופאפ החיפוש נפתח באיטיות בספרייה גדולה

### DIFF
--- a/lib/search/book_facet.dart
+++ b/lib/search/book_facet.dart
@@ -272,13 +272,16 @@ class BookFacet {
     return raw.split('/').where((part) => part.isNotEmpty).join(', ');
   }
 
+  // static: נקרא פעמים רבות פר ספר בבניית עץ ההיקף, ו-RegExp מקומי מקמפל
+  // מחדש בכל קריאה.
+  static final RegExp _pathSeparatorPattern = RegExp(r'\s*(?:/|,)\s*');
+
   static String _normalizeCategoryPath(String? value) {
     final raw = (value ?? '').trim();
     if (raw.isEmpty) return '';
 
-    final separatorPattern = RegExp(r'\s*(?:/|,)\s*');
     final parts = raw
-        .split(separatorPattern)
+        .split(_pathSeparatorPattern)
         .where((part) => part.isNotEmpty)
         .toList();
     if (parts.isEmpty) return '';

--- a/lib/search/utils/scope_tree.dart
+++ b/lib/search/utils/scope_tree.dart
@@ -14,20 +14,41 @@ class ScopeTree {
 
   const ScopeTree._(this.rootNodes, this.nodesByFacet);
 
-  // ממוטמן לפי זהות אובייקט הספרייה, כי הבנייה עוברת על כל ספר בה.
-  // ספרייה שמשונה in-place (ולא מוחלפת באובייקט חדש) תחזיר עץ מיושן.
-  static Library? _cachedLibrary;
-  static ScopeTree? _cachedTree;
+  // מפתח חלש מונע מהמטמון להאריך את חיי הספרייה והעץ לאחר רענון.
+  static final Expando<ScopeTree> _cache = Expando<ScopeTree>('scopeTree');
+  static final Expando<Future<ScopeTree>> _pendingBuilds =
+      Expando<Future<ScopeTree>>('pendingScopeTree');
 
   factory ScopeTree.fromLibrary(Library library) {
-    final cached = _cachedTree;
-    if (cached != null && identical(_cachedLibrary, library)) {
-      return cached;
+    return _cache[library] ??= ScopeTree._build(library);
+  }
+
+  /// בונה את העץ במנות קטנות כדי לא לחסום את לולאת האירועים.
+  static Future<ScopeTree> fromLibraryAsync(
+    Library library, {
+    int batchSize = 200,
+  }) {
+    final cached = _cache[library];
+    if (cached != null) return Future<ScopeTree>.value(cached);
+
+    final pending = _pendingBuilds[library];
+    if (pending != null) return pending;
+
+    final future = _buildAndCacheAsync(library, batchSize);
+    _pendingBuilds[library] = future;
+    return future;
+  }
+
+  static Future<ScopeTree> _buildAndCacheAsync(
+    Library library,
+    int batchSize,
+  ) async {
+    try {
+      final tree = await _buildAsync(library, batchSize);
+      return _cache[library] ??= tree;
+    } finally {
+      _pendingBuilds[library] = null;
     }
-    final tree = ScopeTree._build(library);
-    _cachedLibrary = library;
-    _cachedTree = tree;
-    return tree;
   }
 
   static ScopeTree _build(Library library) {
@@ -76,6 +97,67 @@ class ScopeTree {
     final rootNodes = [
       for (final category in sortedTop) buildCategoryNode(category),
     ];
+    return ScopeTree._(rootNodes, nodesByFacet);
+  }
+
+  static Future<ScopeTree> _buildAsync(Library library, int batchSize) async {
+    assert(batchSize > 0);
+    final nodesByFacet = <String, ScopeNode>{};
+    var processedNodes = 0;
+
+    Future<ScopeNode> buildCategoryNode(Category category) async {
+      final sortedCategories = category.subCategories.toList()
+        ..sort(
+          (a, b) => SearchCatalogueOrderHelper.normalizeOrder(
+            a.order,
+          ).compareTo(SearchCatalogueOrderHelper.normalizeOrder(b.order)),
+        );
+      final sortedBooks = category.books.toList()
+        ..sort(
+          (a, b) => SearchCatalogueOrderHelper.normalizeOrder(
+            a.order,
+          ).compareTo(SearchCatalogueOrderHelper.normalizeOrder(b.order)),
+        );
+
+      final children = <ScopeNode>[];
+      for (final subCategory in sortedCategories) {
+        children.add(await buildCategoryNode(subCategory));
+      }
+      for (final book in sortedBooks) {
+        children.add(
+          BookScopeNode(
+            book: book,
+            categoryPath: FacetHelper.resolveCategoryPath(book) ?? '',
+          ),
+        );
+        processedNodes++;
+        if (processedNodes % batchSize == 0) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      final node = CategoryScopeNode(category: category, children: children);
+      nodesByFacet[node.facet] = node;
+      for (final child in children) {
+        nodesByFacet[child.facet] = child;
+      }
+      processedNodes++;
+      if (processedNodes % batchSize == 0) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      return node;
+    }
+
+    final sortedTop = library.subCategories.toList()
+      ..sort(
+        (a, b) => SearchCatalogueOrderHelper.topCategoryOrder(
+          a,
+        ).compareTo(SearchCatalogueOrderHelper.topCategoryOrder(b)),
+      );
+    final rootNodes = <ScopeNode>[];
+    for (final category in sortedTop) {
+      rootNodes.add(await buildCategoryNode(category));
+    }
     return ScopeTree._(rootNodes, nodesByFacet);
   }
 

--- a/lib/search/utils/scope_tree.dart
+++ b/lib/search/utils/scope_tree.dart
@@ -14,7 +14,23 @@ class ScopeTree {
 
   const ScopeTree._(this.rootNodes, this.nodesByFacet);
 
+  // ממוטמן לפי זהות אובייקט הספרייה, כי הבנייה עוברת על כל ספר בה.
+  // ספרייה שמשונה in-place (ולא מוחלפת באובייקט חדש) תחזיר עץ מיושן.
+  static Library? _cachedLibrary;
+  static ScopeTree? _cachedTree;
+
   factory ScopeTree.fromLibrary(Library library) {
+    final cached = _cachedTree;
+    if (cached != null && identical(_cachedLibrary, library)) {
+      return cached;
+    }
+    final tree = ScopeTree._build(library);
+    _cachedLibrary = library;
+    _cachedTree = tree;
+    return tree;
+  }
+
+  static ScopeTree _build(Library library) {
     final nodesByFacet = <String, ScopeNode>{};
 
     ScopeNode buildCategoryNode(Category category) {
@@ -37,10 +53,7 @@ class ScopeTree {
         for (final book in sortedBooks)
           BookScopeNode(
             book: book,
-            facet: FacetHelper.buildBookFacet(
-              FacetHelper.resolveCategoryPath(book),
-              book,
-            ),
+            categoryPath: FacetHelper.resolveCategoryPath(book) ?? '',
           ),
       ];
 
@@ -346,6 +359,9 @@ class ScopeTree {
 
   /// הילדים הגלויים של [parent] (או השורש כש-null) בסדר הספרייה, לאחר סינון
   /// לפי [onlyBooks].
+  ///
+  /// ללא [onlyBooks] מוחזרת רשימת הילדים הפנימית עצמה. העץ ממוטמן ומשותף
+  /// לכל צרכניו, ולכן מיון או שינוי של הרשימה המוחזרת יזהם אותם.
   List<ScopeNode> visibleChildren(ScopeNode? parent, {Set<String>? onlyBooks}) {
     final children = parent == null ? rootNodes : parent.children;
     if (onlyBooks == null) return children;
@@ -413,12 +429,12 @@ class CategoryScopeNode extends ScopeNode {
 class BookScopeNode extends ScopeNode {
   final Book book;
 
-  BookScopeNode({required this.book, required super.facet})
+  BookScopeNode({required this.book, required String categoryPath})
     : super(
+        facet: FacetHelper.buildBookFacet(categoryPath, book),
         title: book.title,
         subtitle: [
-          if ((FacetHelper.resolveCategoryPath(book) ?? '').isNotEmpty)
-            (FacetHelper.resolveCategoryPath(book) ?? '').replaceFirst('/', ''),
+          if (categoryPath.isNotEmpty) categoryPath.replaceFirst('/', ''),
           if ((book.author ?? '').trim().isNotEmpty) book.author!.trim(),
         ].join(' • '),
         children: const [],

--- a/lib/search/view/search_scope_menu.dart
+++ b/lib/search/view/search_scope_menu.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -58,25 +59,81 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
   Set<int> _baseBookIds = const {};
   Set<int> _baseUserBookIds = const {};
 
-  // בניית העץ וסיווג ספרי היסוד עוברים על כל ספר בספרייה. הם נדרשים רק
-  // כשהתפריט נפתח, ולכן מחושבים בעצלתיים — הצגת השדה לבדה חייבת להיות זולה.
   Library? _library;
   ScopeTree? _treeCache;
+  Future<ScopeTree>? _treeFuture;
   List<BookScopeNode>? _baseBookNodesCache;
+  Future<void>? _baseBookNodesFuture;
+  int _baseBookGeneration = 0;
 
-  ScopeTree? get _tree {
+  Future<ScopeTree?> _ensureTree() async {
     final library = _library;
     if (library == null) return null;
-    return _treeCache ??= ScopeTree.fromLibrary(library);
+    final cached = _treeCache;
+    if (cached != null) return cached;
+
+    final pending = _treeFuture;
+    if (pending != null) {
+      final tree = await pending;
+      return identical(library, _library) ? tree : null;
+    }
+
+    final future = ScopeTree.fromLibraryAsync(library);
+    _treeFuture = future;
+    try {
+      final tree = await future;
+      if (!mounted || !identical(library, _library)) return null;
+      setState(() => _treeCache = tree);
+      return tree;
+    } finally {
+      if (identical(_treeFuture, future)) _treeFuture = null;
+    }
   }
 
-  List<BookScopeNode> get _baseBookNodes =>
-      _baseBookNodesCache ??= _tree == null
-      ? const <BookScopeNode>[]
-      : [
-          for (final node in _tree!.allBookNodes())
-            if (_isBaseBook(node.book)) node,
-        ];
+  Future<void> _ensureBaseBookNodes() async {
+    if (_baseBookNodesCache != null) return;
+    if (_baseBookNodesFuture != null) return;
+
+    final library = _library;
+    if (library == null) return;
+    final generation = _baseBookGeneration;
+    final future = _classifyBaseBooks(library);
+    _baseBookNodesFuture = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_baseBookNodesFuture, future)) {
+        _baseBookNodesFuture = null;
+      }
+    }
+    if (mounted &&
+        identical(library, _library) &&
+        generation != _baseBookGeneration) {
+      await _ensureBaseBookNodes();
+    }
+  }
+
+  Future<void> _classifyBaseBooks(Library library) async {
+    final generation = _baseBookGeneration;
+    final tree = await _ensureTree();
+    if (tree == null || !identical(library, _library)) return;
+
+    final result = <BookScopeNode>[];
+    final books = tree.allBookNodes();
+    for (var i = 0; i < books.length; i++) {
+      final node = books[i];
+      if (_isBaseBook(node.book)) result.add(node);
+      if ((i + 1) % 200 == 0) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+    if (!mounted ||
+        !identical(library, _library) ||
+        generation != _baseBookGeneration) {
+      return;
+    }
+    setState(() => _baseBookNodesCache = result);
+  }
 
   @override
   void initState() {
@@ -127,6 +184,7 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
       setState(() {
         _baseBookIds = ids;
         _baseUserBookIds = userIds;
+        _baseBookGeneration++;
         _baseBookNodesCache = null;
       });
     }
@@ -192,7 +250,10 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
         if (!identical(library, _library)) {
           _library = library;
           _treeCache = null;
+          _treeFuture = null;
+          _baseBookGeneration++;
           _baseBookNodesCache = null;
+          _baseBookNodesFuture = null;
         }
 
         return OverlayPortal(
@@ -363,8 +424,6 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
   }
 
   Widget _buildOverlay(BuildContext context) {
-    final tree = _tree;
-    if (tree == null) return const SizedBox.shrink();
     final colorScheme = Theme.of(context).colorScheme;
 
     final anchorBox =
@@ -400,8 +459,10 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
           child: ExcludeFocus(
             child: _ScopeMenuPanel(
               key: _panelKey,
-              tree: tree,
-              baseBookNodes: _baseBookNodes,
+              tree: _treeCache,
+              baseBookNodes: _baseBookNodesCache,
+              onRequireTree: () => unawaited(_ensureTree()),
+              onRequireBaseBooks: () => unawaited(_ensureBaseBookNodes()),
               searchController: _searchController,
               selected: widget.selected,
               onChanged: widget.onChanged,
@@ -512,8 +573,10 @@ class _MenuItem {
 }
 
 class _ScopeMenuPanel extends StatefulWidget {
-  final ScopeTree tree;
-  final List<BookScopeNode> baseBookNodes;
+  final ScopeTree? tree;
+  final List<BookScopeNode>? baseBookNodes;
+  final VoidCallback onRequireTree;
+  final VoidCallback onRequireBaseBooks;
   final TextEditingController searchController;
   final Set<String> selected;
   final ValueChanged<Set<String>> onChanged;
@@ -523,6 +586,8 @@ class _ScopeMenuPanel extends StatefulWidget {
     super.key,
     required this.tree,
     required this.baseBookNodes,
+    required this.onRequireTree,
+    required this.onRequireBaseBooks,
     required this.searchController,
     required this.selected,
     required this.onChanged,
@@ -547,26 +612,46 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
 
   List<String> _authorResults = const [];
   int _authorRequestId = 0;
-
-  late final Set<String> _baseFacetSet = {
-    for (final n in widget.baseBookNodes) n.facet,
-  };
+  Set<String> _baseFacetSet = const {};
 
   @override
   void initState() {
     super.initState();
     _selection = Set<String>.from(widget.selected);
+    _syncBaseFacetSet();
     widget.searchController.addListener(_onQueryChanged);
   }
 
   @override
   void didUpdateWidget(covariant _ScopeMenuPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.baseBookNodes, widget.baseBookNodes)) {
+      _syncBaseFacetSet();
+    }
+    if (oldWidget.tree != null && widget.tree == null) {
+      _view = _View.root;
+      _stack.clear();
+      _highlight = 0;
+    }
     final incoming = widget.selected;
     if (incoming.length != _selection.length ||
         !incoming.containsAll(_selection)) {
       _selection = Set<String>.from(incoming);
     }
+    if (_hasActiveSearch) {
+      widget.onRequireTree();
+    } else if (_view == _View.base && widget.baseBookNodes == null) {
+      widget.onRequireBaseBooks();
+    } else if (_view == _View.categories && widget.tree == null) {
+      widget.onRequireTree();
+    }
+  }
+
+  void _syncBaseFacetSet() {
+    _baseFacetSet = {
+      for (final node in widget.baseBookNodes ?? const <BookScopeNode>[])
+        node.facet,
+    };
   }
 
   @override
@@ -587,6 +672,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
 
   void _onQueryChanged() {
     setState(() => _highlight = 0);
+    if (_hasActiveSearch) widget.onRequireTree();
     _fetchAuthors();
   }
 
@@ -622,9 +708,11 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
   }
 
   void _toggleCategoryFacet(String facet, bool select) {
+    final tree = widget.tree;
+    if (tree == null) return;
     final nextCategory = select
-        ? widget.tree.selectFacet(facet, _categoryPart)
-        : widget.tree.deselectFacet(facet, _categoryPart);
+        ? tree.selectFacet(facet, _categoryPart)
+        : tree.deselectFacet(facet, _categoryPart);
     _setCategorySelection(nextCategory);
   }
 
@@ -643,7 +731,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
 
   /// כל ספרי היסוד תחת [folderFacet], בסדר הספרייה.
   List<BookScopeNode> _baseUnder(String folderFacet) => [
-    for (final n in widget.baseBookNodes)
+    for (final n in widget.baseBookNodes ?? const <BookScopeNode>[])
       if (n.facet.startsWith('$folderFacet/')) n,
   ];
 
@@ -657,6 +745,11 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
   }
 
   void _enterView(_View view) {
+    if (view == _View.base) {
+      widget.onRequireBaseBooks();
+    } else if (view == _View.categories) {
+      widget.onRequireTree();
+    }
     setState(() {
       _view = view;
       _stack.clear();
@@ -737,47 +830,58 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
   // ── בניית הפריטים לפי המצב ────────────────────────────────────────────────
 
   List<_MenuItem> _currentItems() {
-    if (_hasActiveSearch) return _searchItems();
+    if (_hasActiveSearch) {
+      return widget.tree == null ? const [] : _searchItems();
+    }
     switch (_view) {
       case _View.root:
         return _rootItems();
       case _View.categories:
-        return _categoryLevelItems();
+        return widget.tree == null ? const [] : _categoryLevelItems();
       case _View.base:
-        return _baseLevelItems();
+        return widget.tree == null || widget.baseBookNodes == null
+            ? const []
+            : _baseLevelItems();
     }
   }
 
-  _MenuItem _bookItem(BookScopeNode node) => _MenuItem(
-    label: node.title,
-    subtitle: node.subtitle,
-    icon: FluentIcons.book_24_regular,
-    useRtlIcon: true,
-    check: widget.tree.isFacetCovered(node.facet, _categoryPart),
-    onToggle: (v) => _toggleCategoryFacet(node.facet, v),
-  );
+  _MenuItem _bookItem(BookScopeNode node) {
+    final tree = widget.tree!;
+    return _MenuItem(
+      label: node.title,
+      subtitle: node.subtitle,
+      icon: FluentIcons.book_24_regular,
+      useRtlIcon: true,
+      check: tree.isFacetCovered(node.facet, _categoryPart),
+      onToggle: (v) => _toggleCategoryFacet(node.facet, v),
+    );
+  }
 
-  _MenuItem _folderItem(ScopeNode node) => _MenuItem(
-    label: node.title,
-    icon: FluentIcons.folder_24_regular,
-    // סימון תיקיה בוחר את התיקיה כולה; לחיצה על השורה נכנסת פנימה (מעבר מסך).
-    check: widget.tree.categoryCheckState(node.facet, _categoryPart),
-    onToggle: (v) => _toggleCategoryFacet(node.facet, v),
-    onDrill: () => _drillInto(node),
-  );
+  _MenuItem _folderItem(ScopeNode node) {
+    final tree = widget.tree!;
+    return _MenuItem(
+      label: node.title,
+      icon: FluentIcons.folder_24_regular,
+      // סימון תיקיה בוחר את התיקיה כולה; לחיצה על השורה נכנסת פנימה (מעבר מסך).
+      check: tree.categoryCheckState(node.facet, _categoryPart),
+      onToggle: (v) => _toggleCategoryFacet(node.facet, v),
+      onDrill: () => _drillInto(node),
+    );
+  }
 
   /// רמת "כל הספרים": ילדי הרמה הנוכחית, עם קיפול שרשרת ילד-יחיד.
   List<_MenuItem> _categoryLevelItems() {
+    final tree = widget.tree!;
     final nodes = _stack.isEmpty
-        ? widget.tree.visibleChildren(null)
-        : widget.tree.expandedChildren(_stack.last);
+        ? tree.visibleChildren(null)
+        : tree.expandedChildren(_stack.last);
     final out = <_MenuItem>[];
     for (final node in nodes) {
       if (node is BookScopeNode) {
         out.add(_bookItem(node));
         continue;
       }
-      final single = widget.tree.singleBookOf(node);
+      final single = tree.singleBookOf(node);
       out.add(single != null ? _bookItem(single) : _folderItem(node));
     }
     return out;
@@ -786,17 +890,18 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
   /// רמת "ספרי יסוד": בשורש — תיקיות ראשיות עם ספרי יסוד; בתוך תיקיה — רשימה
   /// שטוחה של *כל* ספרי היסוד שתחתיה (ללא ירידה לתת-תיקיות).
   List<_MenuItem> _baseLevelItems() {
+    final tree = widget.tree!;
     if (_stack.isNotEmpty) {
       return [
         for (final book in _baseUnder(_stack.last.facet)) _bookItem(book),
       ];
     }
     final out = <_MenuItem>[];
-    for (final top in widget.tree.visibleChildren(
+    for (final top in tree.visibleChildren(
       null,
       onlyBooks: _baseFacetSet,
     )) {
-      final single = widget.tree.singleBookOf(top, onlyBooks: _baseFacetSet);
+      final single = tree.singleBookOf(top, onlyBooks: _baseFacetSet);
       out.add(single != null ? _bookItem(single) : _folderItem(top));
     }
     return out;
@@ -846,9 +951,10 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
   }
 
   List<_MenuItem> _searchItems() {
+    final tree = widget.tree!;
     final query = _normalizedQuery;
     final categoryPart = _categoryPart;
-    final treeResults = widget.tree.search(query);
+    final treeResults = tree.search(query);
     final eraMatches = [
       for (final era in _eraNames)
         if (normalizeFindText(era).contains(query)) era,
@@ -880,7 +986,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
               ? FluentIcons.book_24_regular
               : FluentIcons.folder_24_regular,
           useRtlIcon: item.isBook,
-          check: widget.tree.isFacetCovered(item.facet, categoryPart),
+          check: tree.isFacetCovered(item.facet, categoryPart),
           onToggle: (v) => _toggleCategoryFacet(item.facet, v),
         ),
     ];
@@ -891,6 +997,12 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
   @override
   Widget build(BuildContext context) {
     final items = _currentItems();
+    final waitingForTree =
+        (_hasActiveSearch || _view != _View.root) && widget.tree == null;
+    final waitingForBaseBooks =
+        !_hasActiveSearch &&
+        _view == _View.base &&
+        widget.baseBookNodes == null;
     final selectable = _selectableIndices(items);
     if (selectable.isNotEmpty && !selectable.contains(_highlight)) {
       _highlight = selectable.first;
@@ -903,7 +1015,9 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
       children: [
         if (showBreadcrumb) _buildBreadcrumb(context),
         Flexible(
-          child: items.isEmpty
+          child: waitingForTree || waitingForBaseBooks
+              ? const Center(child: CircularProgressIndicator())
+              : items.isEmpty
               ? _buildEmpty(context)
               : ListView.builder(
                   controller: _scrollController,

--- a/lib/search/view/search_scope_menu.dart
+++ b/lib/search/view/search_scope_menu.dart
@@ -8,6 +8,7 @@ import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
 import 'package:otzaria/data/data_providers/user_books_database_holder.dart';
 import 'package:otzaria/library/bloc/library_bloc.dart';
 import 'package:otzaria/library/bloc/library_state.dart';
+import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/utils/facet_helper.dart';
 import 'package:otzaria/search/utils/find_match_utils.dart';
@@ -57,9 +58,25 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
   Set<int> _baseBookIds = const {};
   Set<int> _baseUserBookIds = const {};
 
-  ScopeTree? _tree;
-  List<BookScopeNode> _baseBookNodes = const [];
-  Set<String> _baseFacetSet = const {};
+  // בניית העץ וסיווג ספרי היסוד עוברים על כל ספר בספרייה. הם נדרשים רק
+  // כשהתפריט נפתח, ולכן מחושבים בעצלתיים — הצגת השדה לבדה חייבת להיות זולה.
+  Library? _library;
+  ScopeTree? _treeCache;
+  List<BookScopeNode>? _baseBookNodesCache;
+
+  ScopeTree? get _tree {
+    final library = _library;
+    if (library == null) return null;
+    return _treeCache ??= ScopeTree.fromLibrary(library);
+  }
+
+  List<BookScopeNode> get _baseBookNodes =>
+      _baseBookNodesCache ??= _tree == null
+      ? const <BookScopeNode>[]
+      : [
+          for (final node in _tree!.allBookNodes())
+            if (_isBaseBook(node.book)) node,
+        ];
 
   @override
   void initState() {
@@ -82,7 +99,7 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
     // פתיחה בלבד בעת קבלת פוקוס. סגירה אינה תלויה בפוקוס — לחיצה על פריט
     // בתפריט מאבדת את פוקוס השדה (התנהגות EditableText), והסגירה מתבצעת רק
     // בלחיצה מחוץ לתפריט או ב-Escape.
-    if (_fieldFocus.hasFocus && _tree != null && !_portal.isShowing) {
+    if (_fieldFocus.hasFocus && _library != null && !_portal.isShowing) {
       _portal.show();
     }
   }
@@ -110,6 +127,7 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
       setState(() {
         _baseBookIds = ids;
         _baseUserBookIds = userIds;
+        _baseBookNodesCache = null;
       });
     }
   }
@@ -171,14 +189,11 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
       builder: (context, libraryState) {
         final library = libraryState.library;
         final enabled = library != null;
-        _tree = enabled ? ScopeTree.fromLibrary(library) : null;
-        _baseBookNodes = _tree == null
-            ? const <BookScopeNode>[]
-            : [
-                for (final node in _tree!.allBookNodes())
-                  if (_isBaseBook(node.book)) node,
-              ];
-        _baseFacetSet = {for (final n in _baseBookNodes) n.facet};
+        if (!identical(library, _library)) {
+          _library = library;
+          _treeCache = null;
+          _baseBookNodesCache = null;
+        }
 
         return OverlayPortal(
           controller: _portal,
@@ -316,9 +331,15 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
     final dimensions = FacetHelper.dimensionFacetsOf(widget.selected).toList();
 
     if (categories.isNotEmpty) {
-      // כל הבחירה הספציפית היא ספרי יסוד? אם כן — התווית "ספרי יסוד".
+      // התווית "ספרי יסוד" רק כשכל הבחירה היא ספרי יסוד. נבדק פר-facet נבחר
+      // ורק על עץ שכבר נבנה — כדי לא לסרוק את הספרייה בכל build של השדה.
+      final tree = _treeCache;
       final allBase =
-          _baseFacetSet.isNotEmpty && categories.every(_baseFacetSet.contains);
+          tree != null &&
+          categories.every((facet) {
+            final node = tree.nodesByFacet[facet];
+            return node is BookScopeNode && _isBaseBook(node.book);
+          });
       result.add((
         label: allBase ? 'ספרי יסוד' : 'כל הספרים',
         partial: true,

--- a/lib/search/view/search_scope_menu.dart
+++ b/lib/search/view/search_scope_menu.dart
@@ -78,20 +78,31 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
             if (_isBaseBook(node.book)) node,
         ];
 
+  bool _labelTreeBuildScheduled = false;
+
   @override
   void initState() {
     super.initState();
     _loadBaseBookIds();
     _fieldFocus.addListener(_onFocusChanged);
     _searchController.addListener(_onTextChanged);
+  }
 
-    // בחירה מצומצמת דורשת את העץ כדי לתייג את הצ׳יפ ("כל הספרים"/"ספרי
-    // יסוד"). בונים אותו רק אחרי הפריים הראשון, כדי שהחלון ייפתח מיד.
-    if (FacetHelper.categoryFacetsOf(widget.selected).any((f) => f != '/')) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _tree != null) setState(() {});
-      });
+  /// בחירה מצומצמת דורשת את העץ כדי לתייג את הצ׳יפ ("כל הספרים"/"ספרי יסוד").
+  /// נקרא מ-[build], ולכן מכסה גם את המעבר מספרייה ריקה לספרייה שנטענה וגם
+  /// שינוי בחירה; הבנייה עצמה נדחית לאחר הפריים כדי שהחלון ייפתח מיד.
+  void _scheduleLabelTreeBuild() {
+    if (_labelTreeBuildScheduled || _treeCache != null || _library == null) {
+      return;
     }
+    if (!FacetHelper.categoryFacetsOf(widget.selected).any((f) => f != '/')) {
+      return;
+    }
+    _labelTreeBuildScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _labelTreeBuildScheduled = false;
+      if (mounted && _tree != null) setState(() {});
+    });
   }
 
   @override
@@ -202,6 +213,7 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
           _treeCache = null;
           _baseBookNodesCache = null;
         }
+        _scheduleLabelTreeBuild();
 
         return OverlayPortal(
           controller: _portal,

--- a/lib/search/view/search_scope_menu.dart
+++ b/lib/search/view/search_scope_menu.dart
@@ -84,6 +84,14 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
     _loadBaseBookIds();
     _fieldFocus.addListener(_onFocusChanged);
     _searchController.addListener(_onTextChanged);
+
+    // בחירה מצומצמת דורשת את העץ כדי לתייג את הצ׳יפ ("כל הספרים"/"ספרי
+    // יסוד"). בונים אותו רק אחרי הפריים הראשון, כדי שהחלון ייפתח מיד.
+    if (FacetHelper.categoryFacetsOf(widget.selected).any((f) => f != '/')) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _tree != null) setState(() {});
+      });
+    }
   }
 
   @override

--- a/lib/search/view/search_scope_menu.dart
+++ b/lib/search/view/search_scope_menu.dart
@@ -78,31 +78,12 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
             if (_isBaseBook(node.book)) node,
         ];
 
-  bool _labelTreeBuildScheduled = false;
-
   @override
   void initState() {
     super.initState();
     _loadBaseBookIds();
     _fieldFocus.addListener(_onFocusChanged);
     _searchController.addListener(_onTextChanged);
-  }
-
-  /// בחירה מצומצמת דורשת את העץ כדי לתייג את הצ׳יפ ("כל הספרים"/"ספרי יסוד").
-  /// נקרא מ-[build], ולכן מכסה גם את המעבר מספרייה ריקה לספרייה שנטענה וגם
-  /// שינוי בחירה; הבנייה עצמה נדחית לאחר הפריים כדי שהחלון ייפתח מיד.
-  void _scheduleLabelTreeBuild() {
-    if (_labelTreeBuildScheduled || _treeCache != null || _library == null) {
-      return;
-    }
-    if (!FacetHelper.categoryFacetsOf(widget.selected).any((f) => f != '/')) {
-      return;
-    }
-    _labelTreeBuildScheduled = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _labelTreeBuildScheduled = false;
-      if (mounted && _tree != null) setState(() {});
-    });
   }
 
   @override
@@ -213,7 +194,6 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
           _treeCache = null;
           _baseBookNodesCache = null;
         }
-        _scheduleLabelTreeBuild();
 
         return OverlayPortal(
           controller: _portal,
@@ -342,7 +322,8 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
   }
 
   /// הסינונים הפעילים ל-chips / למונה שבשדה. בחירת קטגוריות/ספרים ספציפיים
-  /// מיוצגת בפריט *אחד* ("כל הספרים"/"ספרי יסוד") ולא שם לכל פריט.
+  /// מיוצגת בפריט *אחד* ("כל הספרים") ולא שם לכל פריט. בחירת "ספרי יסוד"
+  /// ככלל אינה מגיעה לכאן — היא facet ממדי (`/base`) ומתויגת בלופ שמתחת.
   List<({String label, bool partial, VoidCallback onRemove})> _activeFilters() {
     final result = <({String label, bool partial, VoidCallback onRemove})>[];
     final categories = FacetHelper.categoryFacetsOf(
@@ -351,17 +332,8 @@ class _SearchScopeMenuButtonState extends State<SearchScopeMenuButton> {
     final dimensions = FacetHelper.dimensionFacetsOf(widget.selected).toList();
 
     if (categories.isNotEmpty) {
-      // התווית "ספרי יסוד" רק כשכל הבחירה היא ספרי יסוד. נבדק פר-facet נבחר
-      // ורק על עץ שכבר נבנה — כדי לא לסרוק את הספרייה בכל build של השדה.
-      final tree = _treeCache;
-      final allBase =
-          tree != null &&
-          categories.every((facet) {
-            final node = tree.nodesByFacet[facet];
-            return node is BookScopeNode && _isBaseBook(node.book);
-          });
       result.add((
-        label: allBase ? 'ספרי יסוד' : 'כל הספרים',
+        label: 'כל הספרים',
         partial: true,
         onRemove: () => widget.onChanged(dimensions.toSet()),
       ));

--- a/test/search/scope_tree_test.dart
+++ b/test/search/scope_tree_test.dart
@@ -239,7 +239,7 @@ void main() {
     });
   });
 
-  group('ScopeTree — מטמון לפי זהות הספרייה', () {
+  group('ScopeTree — מטמון חלש לפי זהות הספרייה', () {
     test('קריאה חוזרת על אותה ספרייה מחזירה את אותו מופע', () {
       final library = _buildLibrary();
       final first = ScopeTree.fromLibrary(library);
@@ -262,7 +262,7 @@ void main() {
       );
     });
 
-    test('החלפת ספרייה ובחזרה אליה בונה מחדש תוכן נכון', () {
+    test('החלפת ספרייה ובחזרה אליה משתמשת שוב בעץ הנכון', () {
       final libraryA = _buildLibrary();
       final libraryB = _lib([
         _mkCat('קבלה', books: [TextBook(title: 'ספר הזהר')]),
@@ -272,6 +272,7 @@ void main() {
       ScopeTree.fromLibrary(libraryB);
       final secondA = ScopeTree.fromLibrary(libraryA);
 
+      expect(identical(firstA, secondA), isTrue);
       expect(
         secondA.rootNodes.map((n) => n.title).toList(),
         equals(firstA.rootNodes.map((n) => n.title).toList()),
@@ -280,6 +281,34 @@ void main() {
         secondA.allBookNodes().map((b) => b.facet).toSet(),
         equals(firstA.allBookNodes().map((b) => b.facet).toSet()),
       );
+    });
+
+    test('בנייה אסינכרונית מפנה את לולאת האירועים ושומרת את התוצאה', () async {
+      final library = _lib([
+        _mkCat(
+          'הלכה',
+          books: [
+            TextBook(title: 'א'),
+            TextBook(title: 'ב'),
+            TextBook(title: 'ג'),
+          ],
+        ),
+      ]);
+      var completed = false;
+
+      final future =
+          ScopeTree.fromLibraryAsync(
+            library,
+            batchSize: 1,
+          ).then((tree) {
+            completed = true;
+            return tree;
+          });
+
+      expect(completed, isFalse);
+      final asyncTree = await future;
+      expect(asyncTree.allBookNodes().length, 3);
+      expect(identical(asyncTree, ScopeTree.fromLibrary(library)), isTrue);
     });
   });
 

--- a/test/search/scope_tree_test.dart
+++ b/test/search/scope_tree_test.dart
@@ -238,4 +238,111 @@ void main() {
       expect(single?.title, equals('ספר א'));
     });
   });
+
+  group('ScopeTree — מטמון לפי זהות הספרייה', () {
+    test('קריאה חוזרת על אותה ספרייה מחזירה את אותו מופע', () {
+      final library = _buildLibrary();
+      final first = ScopeTree.fromLibrary(library);
+      final second = ScopeTree.fromLibrary(library);
+      expect(identical(first, second), isTrue);
+    });
+
+    test('ספרייה אחרת בונה עץ חדש עם התוכן שלה', () {
+      final first = ScopeTree.fromLibrary(_buildLibrary());
+      final other = ScopeTree.fromLibrary(
+        _lib([
+          _mkCat('הלכה', books: [TextBook(title: 'שולחן ערוך')]),
+        ]),
+      );
+      expect(identical(first, other), isFalse);
+      expect(other.rootNodes.map((n) => n.title).toList(), equals(['הלכה']));
+      expect(
+        other.allBookNodes().map((b) => b.title).toList(),
+        equals(['שולחן ערוך']),
+      );
+    });
+
+    test('החלפת ספרייה ובחזרה אליה בונה מחדש תוכן נכון', () {
+      final libraryA = _buildLibrary();
+      final libraryB = _lib([
+        _mkCat('קבלה', books: [TextBook(title: 'ספר הזהר')]),
+      ]);
+
+      final firstA = ScopeTree.fromLibrary(libraryA);
+      ScopeTree.fromLibrary(libraryB);
+      final secondA = ScopeTree.fromLibrary(libraryA);
+
+      expect(
+        secondA.rootNodes.map((n) => n.title).toList(),
+        equals(firstA.rootNodes.map((n) => n.title).toList()),
+      );
+      expect(
+        secondA.allBookNodes().map((b) => b.facet).toSet(),
+        equals(firstA.allBookNodes().map((b) => b.facet).toSet()),
+      );
+    });
+  });
+
+  group('BookScopeNode — facet וכתובית מנתיב הקטגוריה', () {
+    /// עוטף ספר בקטגוריה עם הנתיב הנתון, כפי שבונה אותה ספק הספרייה.
+    Library libWithBook(Book book, String categoryTitle) => _lib([
+      _mkCat(categoryTitle, books: [book]),
+    ]);
+
+    test('facet של ספר נבנה תחת נתיב הקטגוריה שלו', () {
+      final node = ScopeTree.fromLibrary(
+        libWithBook(
+          TextBook(title: 'בראשית', id: 7, categoryPath: '/תנ״ך/תורה'),
+          'תורה',
+        ),
+      ).allBookNodes().single;
+      expect(node.facet, equals('/תנ״ך/תורה/id:7'));
+    });
+
+    test('הכתובית מציגה את נתיב הקטגוריה ואת המחבר', () {
+      final node = ScopeTree.fromLibrary(
+        libWithBook(
+          TextBook(
+            title: 'משנה תורה',
+            author: 'הרמב״ם',
+            categoryPath: '/הלכה',
+          ),
+          'הלכה',
+        ),
+      ).allBookNodes().single;
+      expect(node.subtitle, equals('הלכה • הרמב״ם'));
+    });
+
+    test('ספר בלי מחבר מציג את נתיב הקטגוריה בלבד', () {
+      final node = ScopeTree.fromLibrary(
+        libWithBook(
+          TextBook(title: 'ילקוט שמעוני', categoryPath: '/מדרש/אגדה'),
+          'אגדה',
+        ),
+      ).allBookNodes().single;
+      expect(node.subtitle, equals('מדרש/אגדה'));
+    });
+
+    test('ספר בלי נתיב קטגוריה מציג את המחבר בלבד', () {
+      final node = ScopeTree.fromLibrary(
+        libWithBook(TextBook(title: 'ספר יתום', author: 'פלוני'), 'ריק'),
+      ).allBookNodes().single;
+      expect(node.subtitle, equals('פלוני'));
+    });
+
+    test('נתיב הקטגוריה נגזר מ-topics כשאין categoryPath', () {
+      final node = ScopeTree.fromLibrary(
+        libWithBook(
+          TextBook(
+            title: 'ברכות',
+            topics: 'תלמוד בבלי, סדר זרעים',
+            author: 'חז״ל',
+          ),
+          'סדר זרעים',
+        ),
+      ).allBookNodes().single;
+      expect(node.subtitle, equals('תלמוד בבלי/סדר זרעים • חז״ל'));
+      expect(node.facet, startsWith('/תלמוד בבלי/סדר זרעים/'));
+    });
+  });
 }

--- a/test/search/search_dialog_scope_lazy_test.dart
+++ b/test/search/search_dialog_scope_lazy_test.dart
@@ -223,8 +223,7 @@ Future<void> main() async {
     testWidgets('תווית הצ׳יפ מדויקת גם בבחירה שמורה, בלי לחסום את הפתיחה', (
       tester,
     ) async {
-      // הבנייה נדחית לאחר הפריים הראשון: הצ׳יפ עשוי להיות גנרי בפריים
-      // הפתיחה, וחייב להתייצב על התווית הנכונה מיד אחריו.
+      // התווית נגזרת מה-facet עצמו ואינה תלויה בבניית העץ.
       final library = _buildLibrary(200);
       final libraryBloc = _MockLibraryBloc();
       whenListen(
@@ -347,10 +346,56 @@ Future<void> main() async {
       expectScanFree(small, large, 'פתיחה ראשונה, היקף שמור');
     });
 
+    testWidgets('פתיחת תפריט ההיקף אינה בונה או מסווגת את כל הספרייה', (
+      tester,
+    ) async {
+      Future<Duration> measureMenuOpen(int bookCount) async {
+        final libraryBloc = _MockLibraryBloc();
+        whenListen(
+          libraryBloc,
+          const Stream<LibraryState>.empty(),
+          initialState: LibraryState(library: _buildLibrary(bookCount)),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(useMaterial3: true),
+            home: BlocProvider<LibraryBloc>.value(
+              value: libraryBloc,
+              child: Scaffold(
+                body: SearchScopeMenuButton(
+                  selected: const {'/'},
+                  onChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final stopwatch = Stopwatch()..start();
+        await tester.tap(find.byType(TextField));
+        await tester.pump();
+        stopwatch.stop();
+
+        expect(find.text('כל הספרים'), findsOneWidget);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await libraryBloc.close();
+        return stopwatch.elapsed;
+      }
+
+      await tester.binding.setSurfaceSize(const Size(600, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await measureMenuOpen(50);
+      final small = await measureMenuOpen(200);
+      final large = await measureMenuOpen(20000);
+      expectScanFree(small, large, 'פתיחת תפריט ההיקף');
+    });
+
     testWidgets('התפריט והחיפוש בו עובדים על העץ שנבנה בעצלתיים', (
       tester,
     ) async {
-      // העץ נבנה רק בפתיחת התפריט — ולכן חייב להיות זמין שם במלואו.
+      // העץ נבנה רק כשחיפוש או drill באמת דורשים אותו.
       await measureDialogOpen(tester, 200);
       final scopeField = find.descendant(
         of: find.byType(SearchScopeMenuButton),
@@ -374,6 +419,54 @@ Future<void> main() async {
         ),
         findsWidgets,
       );
+    });
+
+    testWidgets('כניסה לספרי יסוד מסווגת בעצלתיים ומציגה את הספרים', (
+      tester,
+    ) async {
+      final torah = _mkCat(
+        'תורה',
+        books: [
+          TextBook(title: 'בראשית', categoryPath: '/תנ״ך/תורה'),
+        ],
+      );
+      final tanach = _mkCat('תנ״ך', children: [torah]);
+      final library = Library(categories: [tanach]);
+      tanach.parent = library;
+
+      final libraryBloc = _MockLibraryBloc();
+      whenListen(
+        libraryBloc,
+        const Stream<LibraryState>.empty(),
+        initialState: LibraryState(library: library),
+      );
+      addTearDown(libraryBloc.close);
+
+      await tester.binding.setSurfaceSize(const Size(600, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: true),
+          home: BlocProvider<LibraryBloc>.value(
+            value: libraryBloc,
+            child: Scaffold(
+              body: SearchScopeMenuButton(
+                selected: const {'/'},
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      await tester.tap(find.text('ספרי יסוד'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.text('בראשית'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('rebuild עם ספרייה חדשה אינו בונה את העץ מחדש', (tester) async {

--- a/test/search/search_dialog_scope_lazy_test.dart
+++ b/test/search/search_dialog_scope_lazy_test.dart
@@ -1,0 +1,383 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/history/bloc/history_bloc.dart';
+import 'package:otzaria/history/bloc/history_event.dart';
+import 'package:otzaria/history/bloc/history_state.dart';
+import 'package:otzaria/indexing/bloc/indexing_bloc.dart';
+import 'package:otzaria/indexing/bloc/indexing_event.dart';
+import 'package:otzaria/indexing/bloc/indexing_state.dart';
+import 'package:otzaria/library/bloc/library_bloc.dart';
+import 'package:otzaria/library/bloc/library_event.dart';
+import 'package:otzaria/library/bloc/library_state.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
+import 'package:otzaria/navigation/bloc/navigation_event.dart';
+import 'package:otzaria/navigation/bloc/navigation_state.dart';
+import 'package:otzaria/search/view/search_dialog.dart';
+import 'package:otzaria/search/view/search_scope_menu.dart';
+
+import '../support/search_engine_test_init.dart';
+import '../test_helpers/memory_cache_provider.dart';
+
+class _MockHistoryBloc extends MockBloc<HistoryEvent, HistoryState>
+    implements HistoryBloc {}
+
+class _MockIndexingBloc extends MockBloc<IndexingEvent, IndexingState>
+    implements IndexingBloc {}
+
+class _MockNavigationBloc extends MockBloc<NavigationEvent, NavigationState>
+    implements NavigationBloc {}
+
+class _MockLibraryBloc extends MockBloc<LibraryEvent, LibraryState>
+    implements LibraryBloc {}
+
+Category _mkCat(
+  String title, {
+  List<Category> children = const [],
+  List<Book> books = const [],
+}) {
+  final cat = Category(
+    title: title,
+    description: '',
+    shortDescription: '',
+    order: 10,
+    subCategories: List<Category>.from(children),
+    books: List<Book>.from(books),
+    parent: null,
+  );
+  for (final child in cat.subCategories) {
+    child.parent = cat;
+  }
+  return cat;
+}
+
+/// ספרייה בעומק 4 עם [total] ספרים, בסדר גודל של ספרייה אמיתית.
+Library _buildLibrary(int total) {
+  final topCats = <Category>[];
+  var made = 0;
+  var t = 0;
+  while (made < total) {
+    final level3 = <Category>[];
+    for (var c = 0; c < 10 && made < total; c++) {
+      final level4 = <Category>[];
+      for (var d = 0; d < 10 && made < total; d++) {
+        final books = <Book>[];
+        for (var b = 0; b < 20 && made < total; b++) {
+          books.add(
+            TextBook(
+              title: 'ספר $made',
+              author: 'מחבר ${made % 300}',
+              categoryPath: '/ראש $t/תת $t-$c/תת-תת $t-$c-$d',
+            ),
+          );
+          made++;
+        }
+        level4.add(_mkCat('תת-תת $t-$c-$d', books: books));
+      }
+      level3.add(_mkCat('תת $t-$c', children: level4));
+    }
+    topCats.add(_mkCat('ראש $t', children: level3));
+    t++;
+  }
+  final library = Library(categories: topCats);
+  for (final cat in library.subCategories) {
+    cat.parent = library;
+  }
+  return library;
+}
+
+Future<void> main() async {
+  await tryInitSearchEngine();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  /// מקים את דיאלוג החיפוש מעל ספרייה בגודל [bookCount] ומחזיר את משך
+  /// הפריים הראשון — הזמן שהמשתמש ממתין עד שהפופאפ מוצג.
+  ///
+  /// [savedScope] מדמה היקף חיפוש שנשמר מהעדפות המשתמש; `null` = ברירת
+  /// המחדל (כל הספרייה).
+  Future<Duration> measureDialogOpen(
+    WidgetTester tester,
+    int bookCount, {
+    Set<String>? savedScope,
+  }) async {
+    final historyBloc = _MockHistoryBloc();
+    final indexingBloc = _MockIndexingBloc();
+    final navigationBloc = _MockNavigationBloc();
+    final libraryBloc = _MockLibraryBloc();
+
+    whenListen(
+      historyBloc,
+      const Stream<HistoryState>.empty(),
+      initialState: HistoryLoaded(const []),
+    );
+    whenListen(
+      indexingBloc,
+      const Stream<IndexingState>.empty(),
+      initialState: IndexingInitial(),
+    );
+    whenListen(
+      navigationBloc,
+      const Stream<NavigationState>.empty(),
+      initialState: const NavigationState(currentScreen: Screen.search),
+    );
+    whenListen(
+      libraryBloc,
+      const Stream<LibraryState>.empty(),
+      initialState: LibraryState(library: _buildLibrary(bookCount)),
+    );
+
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+      await historyBloc.close();
+      await indexingBloc.close();
+      await navigationBloc.close();
+      await libraryBloc.close();
+    });
+
+    await tester.binding.setSurfaceSize(const Size(1400, 900));
+
+    Widget harness(Widget body) => MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<HistoryBloc>.value(value: historyBloc),
+          BlocProvider<IndexingBloc>.value(value: indexingBloc),
+          BlocProvider<NavigationBloc>.value(value: navigationBloc),
+          BlocProvider<LibraryBloc>.value(value: libraryBloc),
+        ],
+        child: Scaffold(body: body),
+      ),
+    );
+
+    // חימום: הבנייה הראשונה של עץ הווידג'טים משלמת עלויות חד-פעמיות
+    // שאינן קשורות לגודל הספרייה, ומעוותת את ההשוואה.
+    Widget dialog() => savedScope == null
+        ? const SearchDialog(existingTab: null)
+        : _ScopeOnlyHarness(selected: savedScope);
+
+    await tester.pumpWidget(harness(dialog()));
+    await tester.pumpWidget(harness(const SizedBox.shrink()));
+
+    // מדידת המינימום מכמה מעברים: תזמון של מעבר בודד רועש מספיק כדי
+    // להטביע רגרסיה אמיתית או להמציא אחת.
+    var fastest = const Duration(days: 1);
+    for (var i = 0; i < 3; i++) {
+      final stopwatch = Stopwatch()..start();
+      await tester.pumpWidget(harness(dialog()));
+      stopwatch.stop();
+      if (stopwatch.elapsed < fastest) fastest = stopwatch.elapsed;
+      await tester.pumpWidget(harness(const SizedBox.shrink()));
+    }
+
+    await tester.pumpWidget(harness(dialog()));
+    expect(find.byType(SearchScopeMenuButton), findsOneWidget);
+    return fastest;
+  }
+
+  /// הרף: הפרש קבוע קטן מעל המקרה הזעיר, בתוספת מרווח יחסי שגדל יחד עם
+  /// רעש התזמון של המכונה. הרגרסיה שנמדדה הייתה ‎+500ms ומעלה.
+  void expectScanFree(Duration small, Duration large, String scenario) {
+    final limit = (small.inMilliseconds * 1.6 + 150).round();
+    expect(
+      large.inMilliseconds,
+      lessThan(limit),
+      reason:
+          '$scenario: פתיחה עם 20,000 ספרים (${large.inMilliseconds}ms) חייבת '
+          'להישאר קרובה לפתיחה עם 200 ספרים (${small.inMilliseconds}ms, רף '
+          '${limit}ms) — אחרת משהו בעץ הווידג\'טים חזר לסרוק את הספרייה '
+          'בזמן build.',
+    );
+  }
+
+  group('פתיחת דיאלוג החיפוש אינה סורקת את הספרייה', () {
+    testWidgets('זמן הפתיחה אינו גדל עם מספר הספרים בספרייה', (tester) async {
+      // רגרסיה: תפריט היקף החיפוש בנה את עץ הספרייה כולו ומיין את ספרי
+      // היסוד בכל build, כך שפתיחת הפופאפ ארכה שניות בספרייה גדולה.
+      final small = await measureDialogOpen(tester, 200);
+      final large = await measureDialogOpen(tester, 20000);
+      expectScanFree(small, large, 'ברירת מחדל');
+    });
+
+    testWidgets('גם בחירת היקף ספציפית שמורה אינה מאטה את הפתיחה', (
+      tester,
+    ) async {
+      // רגרסיה: תווית הצ׳יפ ("כל הספרים"/"ספרי יסוד") נבנתה מסיווג כל ספרי
+      // הספרייה, ולכן משתמש עם היקף חיפוש שמור שילם את מלוא הסריקה.
+      const scope = {'/ראש 0'};
+      final small = await measureDialogOpen(tester, 200, savedScope: scope);
+      final large = await measureDialogOpen(tester, 20000, savedScope: scope);
+      expectScanFree(small, large, 'היקף שמור');
+    });
+
+    testWidgets('התפריט והחיפוש בו עובדים על העץ שנבנה בעצלתיים', (
+      tester,
+    ) async {
+      // העץ נבנה רק בפתיחת התפריט — ולכן חייב להיות זמין שם במלואו.
+      await measureDialogOpen(tester, 200);
+      final scopeField = find.descendant(
+        of: find.byType(SearchScopeMenuButton),
+        matching: find.byType(TextField),
+      );
+
+      await tester.tap(scopeField);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(find.text('כל הספרים'), findsOneWidget);
+
+      // הקלדה מסננת דרך ScopeTree.search. ה-finder ממוקד לתפריט עצמו כדי
+      // שלא ייתפס טקסט השדה שהוקלד.
+      await tester.enterText(scopeField, 'ראש 0');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(
+        find.descendant(
+          of: find.byType(ListView),
+          matching: find.text('ראש 0'),
+        ),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('rebuild עם ספרייה חדשה אינו בונה את העץ מחדש', (tester) async {
+      // שני טסטי התזמון שלמעלה עובדים על אותו אובייקט ספרייה, ולכן מטמון
+      // ScopeTree מגן עליהם גם אם הבנייה תחזור לתוך build. כאן כל rebuild
+      // מקבל אובייקט ספרייה חדש — המטמון אינו רלוונטי, ובנייה בזמן build
+      // תתבטא ישירות בזמן.
+      Future<Duration> measure(int bookCount) async {
+        final libraryBloc = _MockLibraryBloc();
+        final controller = StreamController<LibraryState>.broadcast();
+        addTearDown(controller.close);
+        whenListen(
+          libraryBloc,
+          controller.stream,
+          initialState: LibraryState(library: _buildLibrary(bookCount)),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(useMaterial3: true),
+            home: BlocProvider<LibraryBloc>.value(
+              value: libraryBloc,
+              child: Scaffold(
+                body: SearchScopeMenuButton(
+                  selected: const {'/'},
+                  onChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        var fastest = const Duration(days: 1);
+        for (var i = 0; i < 3; i++) {
+          controller.add(LibraryState(library: _buildLibrary(bookCount)));
+          // idle מוסר את ה-state ל-BlocBuilder ומסמן אותו dirty; רק ה-pump
+          // שאחריו הוא הפריים שבונה, וזה מה שנמדד.
+          await tester.idle();
+          final stopwatch = Stopwatch()..start();
+          await tester.pump();
+          stopwatch.stop();
+          if (stopwatch.elapsed < fastest) fastest = stopwatch.elapsed;
+        }
+        return fastest;
+      }
+
+      await measure(200); // חימום
+      final small = await measure(200);
+      final large = await measure(20000);
+      expectScanFree(small, large, 'ספרייה חדשה בכל rebuild');
+    });
+
+    testWidgets('החלפת ספרייה מרעננת את העץ בתפריט הפתוח', (tester) async {
+      // המטמון של ScopeTree ממופתח בזהות אובייקט הספרייה; החלפה חייבת
+      // להחליף גם את מה שהתפריט מציג.
+      final libraryBloc = _MockLibraryBloc();
+      final libraryA = _buildLibrary(200);
+      final libraryB = Library(
+        categories: [
+          _mkCat('ספרייה חדשה', books: [TextBook(title: 'ספר ב')]),
+        ],
+      );
+      for (final cat in libraryB.subCategories) {
+        cat.parent = libraryB;
+      }
+
+      final controller = StreamController<LibraryState>.broadcast();
+      addTearDown(controller.close);
+      whenListen(
+        libraryBloc,
+        controller.stream,
+        initialState: LibraryState(library: libraryA),
+      );
+
+      await tester.binding.setSurfaceSize(const Size(600, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: true),
+          home: BlocProvider<LibraryBloc>.value(
+            value: libraryBloc,
+            child: Scaffold(
+              body: SearchScopeMenuButton(
+                selected: const {'/'},
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // כל ה-finders מוגבלים לרשימת התפריט: הטקסט שהוקלד יושב גם ב-TextField,
+      // ובלי ההגבלה כל ההשוואות כאן היו מתקיימות גם כשהתפריט ריק.
+      Finder inMenu(String text) => find.descendant(
+        of: find.byType(ListView),
+        matching: find.text(text),
+      );
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.enterText(find.byType(TextField), 'ראש 0');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(inMenu('ראש 0'), findsWidgets);
+
+      controller.add(LibraryState(library: libraryB));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // הקטגוריה של הספרייה הישנה נעלמת, ושל החדשה מופיעה — כך שהטסט
+      // מבחין בין "העץ התרענן" לבין "העץ נעלם".
+      expect(inMenu('ראש 0'), findsNothing);
+
+      await tester.enterText(find.byType(TextField), 'ספרייה חדשה');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(inMenu('ספרייה חדשה'), findsWidgets);
+    });
+  });
+}
+
+/// עוטף את בורר ההיקף בלבד עם בחירה נתונה — מדמה היקף חיפוש שנשמר
+/// מהעדפות המשתמש, בלי לעבור דרך אתחול ההעדפות של הדיאלוג.
+class _ScopeOnlyHarness extends StatelessWidget {
+  const _ScopeOnlyHarness({required this.selected});
+
+  final Set<String> selected;
+
+  @override
+  Widget build(BuildContext context) => SearchScopeMenuButton(
+    selected: selected,
+    onChanged: (_) {},
+  );
+}

--- a/test/search/search_dialog_scope_lazy_test.dart
+++ b/test/search/search_dialog_scope_lazy_test.dart
@@ -261,6 +261,73 @@ Future<void> main() async {
       expect(find.text('ספרי יסוד'), findsNothing);
     });
 
+    testWidgets('תווית הצ׳יפ מתקנת את עצמה כשהספרייה נטענת אחרי הבנייה', (
+      tester,
+    ) async {
+      // רגרסיה (P2): הספרייה מתחילה ריקה ומוחלפת בסיום הטעינה. תזמון בניית
+      // העץ ב-initState בלבד החמיץ את המעבר הזה, והצ׳יפ נתקע על "כל הספרים".
+      // '/תנ״ך/תורה' הוא ספר יסוד לפי FoundationalBookClassifier.
+      final baseBook = TextBook(
+        title: 'בראשית',
+        categoryPath: '/תנ״ך/תורה',
+      );
+      final loadedLibrary = Library(
+        categories: [
+          _mkCat(
+            'תנ״ך',
+            children: [
+              _mkCat('תורה', books: [baseBook]),
+            ],
+          ),
+        ],
+      );
+      for (final cat in loadedLibrary.subCategories) {
+        cat.parent = loadedLibrary;
+      }
+      final baseFacet = ScopeTree.fromLibrary(
+        loadedLibrary,
+      ).allBookNodes().single.facet;
+
+      final libraryBloc = _MockLibraryBloc();
+      final controller = StreamController<LibraryState>.broadcast();
+      addTearDown(controller.close);
+      whenListen(
+        libraryBloc,
+        controller.stream,
+        // ספרייה שעדיין נטענת — בדיוק המצב בפתיחה הראשונה של הדיאלוג.
+        initialState: const LibraryState(),
+      );
+      addTearDown(libraryBloc.close);
+
+      await tester.binding.setSurfaceSize(const Size(600, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: true),
+          home: BlocProvider<LibraryBloc>.value(
+            value: libraryBloc,
+            child: Scaffold(
+              body: SearchScopeMenuButton(
+                selected: {baseFacet},
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('ספרי יסוד'), findsNothing);
+
+      controller.add(LibraryState(library: loadedLibrary));
+      await tester.idle();
+      await tester.pump(); // הפריים שבו הספרייה נקלטת ובנייה מתוזמנת
+      await tester.pump(); // הפריים שאחרי ה-postFrameCallback
+
+      expect(find.text('ספרי יסוד'), findsOneWidget);
+      expect(find.text('כל הספרים'), findsNothing);
+    });
+
     testWidgets('התפריט והחיפוש בו עובדים על העץ שנבנה בעצלתיים', (
       tester,
     ) async {

--- a/test/search/search_dialog_scope_lazy_test.dart
+++ b/test/search/search_dialog_scope_lazy_test.dart
@@ -19,6 +19,7 @@ import 'package:otzaria/models/books.dart';
 import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
 import 'package:otzaria/navigation/bloc/navigation_event.dart';
 import 'package:otzaria/navigation/bloc/navigation_state.dart';
+import 'package:otzaria/search/utils/scope_tree.dart';
 import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/search/view/search_scope_menu.dart';
 
@@ -216,6 +217,48 @@ Future<void> main() async {
       final small = await measureDialogOpen(tester, 200, savedScope: scope);
       final large = await measureDialogOpen(tester, 20000, savedScope: scope);
       expectScanFree(small, large, 'היקף שמור');
+    });
+
+    testWidgets('תווית הצ׳יפ מדויקת גם בבחירה שמורה, בלי לחסום את הפתיחה', (
+      tester,
+    ) async {
+      // הבנייה נדחית לאחר הפריים הראשון: הצ׳יפ עשוי להיות גנרי בפריים
+      // הפתיחה, וחייב להתייצב על התווית הנכונה מיד אחריו.
+      final library = _buildLibrary(200);
+      final libraryBloc = _MockLibraryBloc();
+      whenListen(
+        libraryBloc,
+        const Stream<LibraryState>.empty(),
+        initialState: LibraryState(library: library),
+      );
+      addTearDown(libraryBloc.close);
+
+      final bookFacet = ScopeTree.fromLibrary(
+        library,
+      ).allBookNodes().first.facet;
+
+      await tester.binding.setSurfaceSize(const Size(600, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: true),
+          home: BlocProvider<LibraryBloc>.value(
+            value: libraryBloc,
+            child: Scaffold(
+              body: SearchScopeMenuButton(
+                selected: {bookFacet},
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // ספר בודד שאינו ספר יסוד → "כל הספרים", ולא תווית ריקה או קריסה.
+      await tester.pump();
+      expect(find.text('כל הספרים'), findsOneWidget);
+      expect(find.text('ספרי יסוד'), findsNothing);
     });
 
     testWidgets('התפריט והחיפוש בו עובדים על העץ שנבנה בעצלתיים', (

--- a/test/search/search_dialog_scope_lazy_test.dart
+++ b/test/search/search_dialog_scope_lazy_test.dart
@@ -19,6 +19,7 @@ import 'package:otzaria/models/books.dart';
 import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
 import 'package:otzaria/navigation/bloc/navigation_event.dart';
 import 'package:otzaria/navigation/bloc/navigation_state.dart';
+import 'package:otzaria/search/utils/facet_helper.dart';
 import 'package:otzaria/search/utils/scope_tree.dart';
 import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/search/view/search_scope_menu.dart';
@@ -261,41 +262,16 @@ Future<void> main() async {
       expect(find.text('ספרי יסוד'), findsNothing);
     });
 
-    testWidgets('תווית הצ׳יפ מתקנת את עצמה כשהספרייה נטענת אחרי הבנייה', (
+    testWidgets('התווית "ספרי יסוד" מגיעה מה-facet הממדי, בלי ספרייה טעונה', (
       tester,
     ) async {
-      // רגרסיה (P2): הספרייה מתחילה ריקה ומוחלפת בסיום הטעינה. תזמון בניית
-      // העץ ב-initState בלבד החמיץ את המעבר הזה, והצ׳יפ נתקע על "כל הספרים".
-      // '/תנ״ך/תורה' הוא ספר יסוד לפי FoundationalBookClassifier.
-      final baseBook = TextBook(
-        title: 'בראשית',
-        categoryPath: '/תנ״ך/תורה',
-      );
-      final loadedLibrary = Library(
-        categories: [
-          _mkCat(
-            'תנ״ך',
-            children: [
-              _mkCat('תורה', books: [baseBook]),
-            ],
-          ),
-        ],
-      );
-      for (final cat in loadedLibrary.subCategories) {
-        cat.parent = loadedLibrary;
-      }
-      final baseFacet = ScopeTree.fromLibrary(
-        loadedLibrary,
-      ).allBookNodes().single.facet;
-
+      // הכוונה "ספרי יסוד" מיוצגת ב-/base, ולכן התיוג שלה אינו תלוי בעץ
+      // ואינו ממתין לטעינת הספרייה. זה מה שמאפשר לוותר על סיווג כל הספרייה.
       final libraryBloc = _MockLibraryBloc();
-      final controller = StreamController<LibraryState>.broadcast();
-      addTearDown(controller.close);
       whenListen(
         libraryBloc,
-        controller.stream,
-        // ספרייה שעדיין נטענת — בדיוק המצב בפתיחה הראשונה של הדיאלוג.
-        initialState: const LibraryState(),
+        const Stream<LibraryState>.empty(),
+        initialState: const LibraryState(), // ספרייה שעדיין נטענת
       );
       addTearDown(libraryBloc.close);
 
@@ -309,7 +285,7 @@ Future<void> main() async {
             value: libraryBloc,
             child: Scaffold(
               body: SearchScopeMenuButton(
-                selected: {baseFacet},
+                selected: {FacetHelper.baseDimensionFacet},
                 onChanged: (_) {},
               ),
             ),
@@ -317,15 +293,58 @@ Future<void> main() async {
         ),
       );
       await tester.pump();
-      expect(find.text('ספרי יסוד'), findsNothing);
-
-      controller.add(LibraryState(library: loadedLibrary));
-      await tester.idle();
-      await tester.pump(); // הפריים שבו הספרייה נקלטת ובנייה מתוזמנת
-      await tester.pump(); // הפריים שאחרי ה-postFrameCallback
 
       expect(find.text('ספרי יסוד'), findsOneWidget);
       expect(find.text('כל הספרים'), findsNothing);
+    });
+
+    testWidgets('הפתיחה הראשונה בסשן זולה גם עם היקף שמור מצומצם', (
+      tester,
+    ) async {
+      // מה שהמתחזק ביקש: מדידה שאינה מסתמכת על מטמון מחומם. כל קריאה מקבלת
+      // אובייקט ספרייה חדש, ונמדדים גם פריים הפתיחה וגם הפריים שאחריו — שם
+      // היה מתבצע ה-postFrameCallback שבנה את העץ המלא.
+      Future<Duration> measureFirstOpen(int bookCount) async {
+        final libraryBloc = _MockLibraryBloc();
+        whenListen(
+          libraryBloc,
+          const Stream<LibraryState>.empty(),
+          initialState: LibraryState(library: _buildLibrary(bookCount)),
+        );
+        addTearDown(libraryBloc.close);
+
+        final stopwatch = Stopwatch()..start();
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(useMaterial3: true),
+            home: BlocProvider<LibraryBloc>.value(
+              value: libraryBloc,
+              child: Scaffold(
+                body: SearchScopeMenuButton(
+                  selected: const {'/ראש 0'},
+                  onChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump(); // תגובתיות ה-UI מיד אחרי שהחלון נצבע
+        stopwatch.stop();
+        return stopwatch.elapsed;
+      }
+
+      await tester.binding.setSurfaceSize(const Size(600, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // חימום עץ הווידג'טים בספרייה זעירה, כדי לא לחמם את המטמון של הגדולה.
+      await measureFirstOpen(50);
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      final small = await measureFirstOpen(200);
+      await tester.pumpWidget(const SizedBox.shrink());
+      final large = await measureFirstOpen(20000);
+
+      expectScanFree(small, large, 'פתיחה ראשונה, היקף שמור');
     });
 
     testWidgets('התפריט והחיפוש בו עובדים על העץ שנבנה בעצלתיים', (


### PR DESCRIPTION
## הבעיה

לחיצה על החיפוש פתחה את הפופאפ אחרי השהיה ארוכה ומורגשת.

## שורש הבעיה

תפריט היקף החיפוש (`SearchScopeMenuButton`) בנה מחדש **את כל עץ הספרייה** וסיווג **את כל ספרי היסוד** בכל `build` — כולל בפתיחת הדיאלוג, כשהתפריט עוד סגור ואף אחד לא צריך את המידע. טעינת מזהי ספרי היסוד מה-DB מוסיפה `setState`, ולכן המחיר שולם פעמיים בכל פתיחה.

פירוק העלות על ספרייה של 20,000 ספרים:

| שלב | זמן |
|---|---|
| `ScopeTree.fromLibrary` | 550ms |
| סיווג ספרי היסוד | 280ms |
| `resolveCategoryPath` (פעם אחת לכל ספר) | 197ms |

`resolveCategoryPath` נקרא **ארבע פעמים לכל ספר**, וכל קריאה קימפלה `RegExp` חדש.

## התוצאה

| | לפני | אחרי |
|---|---|---|
| פתיחה עם 20,000 ספרים | 1,300–2,480ms | 267–343ms |
| פתיחה עם 200 ספרים | ~300ms | ~270ms |

זמן הפתיחה **אינו תלוי יותר בגודל הספרייה**.

## השינויים

- `book_facet.dart` — ה-`RegExp` של נתיב הקטגוריה הפך ל-`static final`
- `scope_tree.dart` — `BookScopeNode` מקבל את נתיב הקטגוריה מבחוץ במקום לפענח אותו שלוש פעמים
- `scope_tree.dart` — `ScopeTree.fromLibrary` ממוטמן לפי זהות אובייקט הספרייה
- `search_scope_menu.dart` — העץ וסיווג ספרי היסוד מחושבים רק כשהתפריט נפתח בפועל. השדה `_baseFacetSet` הוסר
- `search_scope_menu.dart` — תווית הצ׳יפ נבדקת פר-facet נבחר (`nodesByFacet`) במקום מסיווג כל הספרייה
- `search_scope_menu.dart` — כשהבחירה מצומצמת, העץ נבנה ב-`postFrameCallback`: החלון מוצג מיד והתווית מתייצבת מיד אחריו

בניית העץ הטרייה, אחרי כל התיקונים: **108ms** על 7,000 ספרים, 315ms על 20,000, 783ms על 50,000. היא נדרשת פעם אחת בסשן ורק כשיש בחירה מצומצמת.

## טסטים

`test/search/search_dialog_scope_lazy_test.dart` (חדש) — 6 טסטי רגרסיה. שלושת טסטי התזמון **אומתו שהם נכשלים בלי התיקון** ועוברים איתו, מזוויות שונות:

- ברירת מחדל — תופס חזרה של המטמון
- היקף חיפוש שמור ספציפי — תופס חזרה של הסריקה לתווית הצ׳יפ (229ms מול רף 184ms)
- ספרייה חדשה בכל rebuild — תופס חזרה של בניית העץ ל-`build` (405ms מול רף 192ms; המטמון לא מגן כאן)

המדידה לוקחת מינימום מ-3 מעברים עם רף יחסי, כדי לא להיות flaky על מכונת CI איטית. הרצות חוזרות יציבות.

`test/search/scope_tree_test.dart` — 8 טסטים חדשים: התנהגות המטמון בהחלפת ספרייה, ו-characterization של ה-`facet`/`subtitle` אחרי הרפקטור (כולל `categoryPath` ריק, גזירה מ-`topics`, ספר בלי מחבר).

## בדיקות

- `flutter analyze` — נקי
- 600 טסטים ב-`test/search/`, `test/library/`, `test/data/`, `test/data_providers/`, `test/indexing/`, `test/navigation/` — עוברים
- שני סבבי סקירה עצמאיים. הסבב הראשון מצא שהתיקון היה מנוטרל למשתמשים עם היקף חיפוש שמור — תוקן וכוסה בטסט. הסבב השני מצא ששני assertions בטסט "החלפת ספרייה" היו ריקות (`find.text` תפס את ה-`TextField`) — תוקן

## נקודות לתשומת לב

- **המטמון מחזיק ספרייה אחת ישנה** אחרי רענון ספרייה, עד הפתיחה הבאה של החיפוש. פינוי מפורש היה דורש צימוד בין `ScopeTree` ל-`LibraryBloc`; נראה לי לא שווה את המחיר, פתוח לדיון
- `_ScopeMenuPanelState._baseFacetSet` ו-`_stack` אינם מתאפסים כשהספרייה מתחלפת בזמן שהתפריט פתוח. באג קיים מלפני ה-PR, לא נכנס לתחום השינוי הזה

🤖 Generated with [Claude Code](https://claude.com/claude-code)