### PR TITLE
תיקון: קיצור מותאם אישית שהוקלט בפריסת מקלדת לא-לטינית לא עבד

### DIFF
--- a/lib/settings/engine/settings_repository.dart
+++ b/lib/settings/engine/settings_repository.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/theme_exports.dart';
+import 'package:otzaria/shortcuts/shortcut_helper.dart';
 import 'package:otzaria/shortcuts/shortcut_validator.dart';
 import 'package:otzaria/settings/engine/settings_wrapper.dart';
 import 'package:crypto/crypto.dart';
@@ -144,6 +145,7 @@ class SettingsRepository {
   Future<Map<String, dynamic>> loadSettings() async {
     // Initialize default settings to disk if needed
     await _initializeDefaultsIfNeeded();
+    await removeUnrecognizedShortcuts();
 
     return {
       'isDarkMode': _settings.getValue<bool>(keyDarkMode, defaultValue: false),
@@ -799,6 +801,36 @@ class SettingsRepository {
     }
 
     return Map<String, String>.unmodifiable(shortcuts);
+  }
+
+  /// מוחק קיצורים שמורים שהמקש שלהם אינו מוכר, כך שהפעולה חוזרת לקיצור
+  /// ברירת המחדל שעובד. קיצור שהוקלט בפריסה לא-לטינית לפני שההקלטה נורמלה
+  /// נשמר עם התו המקומי (`ctrl+shift+כ`) ולעולם אינו נתפס.
+  Future<void> removeUnrecognizedShortcuts() async {
+    final storedRaw = _settings.getValue<Map<dynamic, dynamic>>(
+      'shortcuts',
+      defaultValue: <dynamic, dynamic>{},
+    );
+    final stored = Map<String, dynamic>.from(storedRaw).cast<String, String>();
+
+    final keysToCheck = <String>{
+      ...ShortcutValidator.shortcutKeys,
+      ...ShortcutValidator.legacyShortcutAliases.values.expand((keys) => keys),
+      ...stored.keys,
+    };
+
+    for (final key in keysToCheck) {
+      final value = _settings.getValue<String?>(key, defaultValue: null);
+      if (value != null && !ShortcutHelper.isRecognized(value)) {
+        await _settings.remove(key);
+      }
+    }
+
+    final cleaned = Map<String, String>.from(stored)
+      ..removeWhere((_, value) => !ShortcutHelper.isRecognized(value));
+    if (cleaned.length != stored.length) {
+      await _settings.setValue('shortcuts', cleaned);
+    }
   }
 
   Future<void> resetShortcuts() async {

--- a/lib/shortcuts/shortcut_helper.dart
+++ b/lib/shortcuts/shortcut_helper.dart
@@ -102,6 +102,41 @@ class ShortcutHelper {
     return expectedKey != null && event.logicalKey == expectedKey;
   }
 
+  /// האם [shortcut] ניתן לזיהוי בפועל — כלומר המקש הראשי שבו מוכר ל-
+  /// [matchesShortcut]. קיצור ריק תקין (פעולה ללא קיצור).
+  ///
+  /// קיצור שהוקלט בפריסה לא-לטינית לפני שההקלטה נורמלה נשמר עם התו המקומי
+  /// (`ctrl+shift+כ`) ולכן לעולם אינו נתפס — כזה מוחזר כאן כלא-מוכר.
+  static bool isRecognized(String shortcut) {
+    if (shortcut.isEmpty) return true;
+
+    final parts = shortcut.toLowerCase().split('+');
+    final mainKey = parts.where((p) => !_modifiers.contains(p)).firstOrNull;
+    if (mainKey == null) return false;
+
+    if (mainKey.length == 1 &&
+        mainKey.codeUnitAt(0) >= 97 &&
+        mainKey.codeUnitAt(0) <= 122) {
+      return true;
+    }
+
+    return KeyMap.keyFor(mainKey) != null;
+  }
+
+  /// מחזיר את המקש הלוגי שיש לשמור עבור [event].
+  ///
+  /// בפריסה לא-לטינית `logicalKey` של מקש אות הוא התו המקומי (למשל `'כ'`),
+  /// שאינו ניתן להשוואה ב-[matchesShortcut] — לכן מקשי אות מתורגמים למקש
+  /// הלטיני לפי מיקומם הפיזי, בסימטריה מלאה לבדיקת ה-physicalKey שם.
+  static LogicalKeyboardKey logicalKeyToStore(KeyEvent event) {
+    final letterOffset =
+        event.physicalKey.usbHidUsage - PhysicalKeyboardKey.keyA.usbHidUsage;
+    if (letterOffset >= 0 && letterOffset <= 25) {
+      return LogicalKeyboardKey(LogicalKeyboardKey.keyA.keyId + letterOffset);
+    }
+    return event.logicalKey;
+  }
+
   /// ממיר קבוצה של [LogicalKeyboardKey] למחרוזת קיצור (כגון `'ctrl+shift+f'`).
   ///
   /// ב-Mac, לחיצה על מקש Command נשמרת כ-`ctrl` בפורמט הקנוני, כך שאותו

--- a/lib/shortcuts/view/custom_shortcut_dialog.dart
+++ b/lib/shortcuts/view/custom_shortcut_dialog.dart
@@ -92,7 +92,7 @@ class _CustomShortcutDialogState extends State<CustomShortcutDialog>
 
         if (event is KeyDownEvent) {
           setState(() {
-            _pressedKeys.add(event.logicalKey);
+            _pressedKeys.add(ShortcutHelper.logicalKeyToStore(event));
           });
           _updateDisplay();
         } else if (event is KeyUpEvent) {

--- a/test/settings/engine/unrecognized_shortcuts_cleanup_test.dart
+++ b/test/settings/engine/unrecognized_shortcuts_cleanup_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/settings/engine/settings_repository.dart';
+import 'package:otzaria/shortcuts/shortcut_validator.dart';
+
+import '../../helpers/memory_settings_cache.dart';
+
+/// ניקוי קיצורים שהמקש שלהם אינו מוכר. קיצור שהוקלט בפריסה לא-לטינית לפני
+/// שההקלטה נורמלה נשמר עם התו המקומי (`ctrl+shift+כ`) ולעולם לא נתפס —
+/// מחיקתו מחזירה את הפעולה לקיצור ברירת המחדל שעובד.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const newSearchKey = 'key-shortcut-open-new-search';
+  const closeTabKey = 'key-shortcut-close-tab';
+
+  late MemorySettingsCache cache;
+  late SettingsRepository repository;
+
+  setUp(() async {
+    cache = MemorySettingsCache();
+    await Settings.init(cacheProvider: cache);
+    repository = SettingsRepository();
+  });
+
+  Future<void> storeShortcut(String key, String value) async {
+    await cache.setString(key, value);
+    final stored = Map<String, String>.from(
+      (cache.getValue<Map<dynamic, dynamic>>('shortcuts') ??
+              <dynamic, dynamic>{})
+          .cast<String, String>(),
+    );
+    stored[key] = value;
+    await cache.setObject('shortcuts', stored);
+  }
+
+  Map<String, String> storedMap() => Map<String, String>.from(
+    (cache.getValue<Map<dynamic, dynamic>>('shortcuts') ?? <dynamic, dynamic>{})
+        .cast<String, String>(),
+  );
+
+  group('removeUnrecognizedShortcuts', () {
+    test('מוחק קיצור עם תו עברי ומחזיר את ברירת המחדל', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+כ');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(cache.getString(newSearchKey), isNull);
+      expect(storedMap(), isNot(contains(newSearchKey)));
+
+      final shortcuts = await repository.getShortcuts();
+      expect(shortcuts[newSearchKey], 'ctrl+shift+f');
+      expect(ShortcutValidator.getShortcutValue(newSearchKey), 'ctrl+shift+f');
+    });
+
+    test('מוחק קיצור שנשמר בלי מקש ראשי כלל', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(cache.getString(newSearchKey), isNull);
+      expect((await repository.getShortcuts())[newSearchKey], 'ctrl+shift+f');
+    });
+
+    test('אינו נוגע בקיצור מותאם אישית תקין', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+d');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(cache.getString(newSearchKey), 'ctrl+shift+d');
+      expect(storedMap()[newSearchKey], 'ctrl+shift+d');
+      expect((await repository.getShortcuts())[newSearchKey], 'ctrl+shift+d');
+    });
+
+    test('אינו נוגע בקיצורים שאינם אות (F11, Alt+חץ, Ctrl+פסיק)', () async {
+      await storeShortcut(newSearchKey, 'f11');
+      await storeShortcut(closeTabKey, 'alt+arrowup');
+      await storeShortcut('key-shortcut-open-settings', 'ctrl+comma');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      final shortcuts = await repository.getShortcuts();
+      expect(shortcuts[newSearchKey], 'f11');
+      expect(shortcuts[closeTabKey], 'alt+arrowup');
+      expect(shortcuts['key-shortcut-open-settings'], 'ctrl+comma');
+    });
+
+    test('אינו מוחק קיצור ריק (פעולה שהמשתמש השאיר בלי קיצור)', () async {
+      await storeShortcut(ShortcutValidator.openAdvancedSearchKey, '');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(
+        (await repository
+            .getShortcuts())[ShortcutValidator.openAdvancedSearchKey],
+        '',
+      );
+    });
+
+    test('מוחק את השבורים בלבד כששמורים גם תקינים וגם שבורים', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+כ');
+      await storeShortcut(closeTabKey, 'ctrl+shift+d');
+      await storeShortcut('key-shortcut-open-history', 'alt+ש');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(storedMap().keys, contains(closeTabKey));
+      expect(storedMap().keys, isNot(contains(newSearchKey)));
+      expect(storedMap().keys, isNot(contains('key-shortcut-open-history')));
+
+      final shortcuts = await repository.getShortcuts();
+      expect(shortcuts[closeTabKey], 'ctrl+shift+d');
+      expect(shortcuts[newSearchKey], 'ctrl+shift+f');
+      expect(shortcuts['key-shortcut-open-history'], 'ctrl+h');
+    });
+
+    test('מוחק קיצור שבור גם ממפתח legacy', () async {
+      await storeShortcut(ShortcutValidator.legacySearchInBookKey, 'ctrl+כ');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(cache.getString(ShortcutValidator.legacySearchInBookKey), isNull);
+      expect(
+        (await repository
+            .getShortcuts())[ShortcutValidator.currentWindowSearchKey],
+        'ctrl+f',
+      );
+    });
+
+    test('מוחק קיצור שבור של תוסף שאינו רשום כרגע', () async {
+      final pluginKey = ShortcutValidator.openPluginShortcutKey('some.plugin');
+      await storeShortcut(pluginKey, 'ctrl+shift+ע');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      expect(cache.getString(pluginKey), isNull);
+      expect(storedMap(), isNot(contains(pluginKey)));
+    });
+
+    test('פעולה חוזרת אינה משנה דבר (idempotent)', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+כ');
+      await storeShortcut(closeTabKey, 'ctrl+shift+d');
+
+      await repository.removeUnrecognizedShortcuts();
+      final afterFirst = await repository.getShortcuts();
+
+      await repository.removeUnrecognizedShortcuts();
+      final afterSecond = await repository.getShortcuts();
+
+      expect(afterSecond, afterFirst);
+      expect(afterSecond[closeTabKey], 'ctrl+shift+d');
+    });
+
+    test('ללא קיצורים שמורים כלל אינו זורק ואינו משנה ברירות מחדל', () async {
+      await repository.removeUnrecognizedShortcuts();
+
+      final shortcuts = await repository.getShortcuts();
+      expect(shortcuts[newSearchKey], 'ctrl+shift+f');
+      expect(shortcuts[closeTabKey], 'ctrl+w');
+    });
+
+    test('loadSettings מריץ את הניקוי אוטומטית בעליית האפליקציה', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+כ');
+
+      final settings = await repository.loadSettings();
+
+      final shortcuts = settings['shortcuts'] as Map<String, String>;
+      expect(shortcuts[newSearchKey], 'ctrl+shift+f');
+      expect(cache.getString(newSearchKey), isNull);
+    });
+
+    test('הקיצורים שנותרו לאחר הניקוי כולם ניתנים לזיהוי', () async {
+      await storeShortcut(newSearchKey, 'ctrl+shift+כ');
+      await storeShortcut(closeTabKey, 'ctrl+ד');
+      await storeShortcut('key-shortcut-open-more', 'ctrl+shift+d');
+
+      await repository.removeUnrecognizedShortcuts();
+
+      final shortcuts = await repository.getShortcuts();
+      for (final entry in shortcuts.entries) {
+        expect(
+          ShortcutValidator.getShortcutValue(entry.key),
+          isNotNull,
+          reason: '${entry.key} נותר ללא ערך תקין',
+        );
+      }
+    });
+  });
+}

--- a/test/shortcuts/custom_shortcut_dialog_test.dart
+++ b/test/shortcuts/custom_shortcut_dialog_test.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/focus_repository.dart';
+import 'package:otzaria/shortcuts/shortcut_helper.dart';
+import 'package:otzaria/shortcuts/view/custom_shortcut_dialog.dart';
+
+/// אירוע מקש אות בפריסה עברית כפי ש-Flutter מדווח ב-Windows: `physicalKey`
+/// תקין ו-`logicalKey` הוא התו העברי.
+KeyDownEvent _hebrewLetter(PhysicalKeyboardKey physicalKey, int hebrewKeyId) =>
+    KeyDownEvent(
+      physicalKey: physicalKey,
+      logicalKey: LogicalKeyboardKey(hebrewKeyId),
+      timeStamp: Duration.zero,
+    );
+
+KeyDownEvent _modifier(LogicalKeyboardKey key, PhysicalKeyboardKey physical) =>
+    KeyDownEvent(
+      physicalKey: physical,
+      logicalKey: key,
+      timeStamp: Duration.zero,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // הטסטים שולחים Control פיזי; ב-macOS `ctrl` מתורגם ל-Meta ולכן הפלטפורמה
+  // מקובעת כדי שהערך הקנוני יהיה זהה בכל סביבת ריצה.
+  setUp(() {
+    ShortcutHelper.isMacForTesting = false;
+    FocusRepository().resetForTesting();
+  });
+  tearDown(() {
+    ShortcutHelper.isMacForTesting = null;
+    FocusRepository().resetForTesting();
+  });
+
+  /// פותח את דיאלוג ההקלטה ומחזיר את ה-Future של הערך שיוחזר ממנו.
+  Future<Future<String?>> openDialog(
+    WidgetTester tester, {
+    String? initialShortcut,
+    bool startRecording = true,
+  }) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: SizedBox(width: 100, height: 100)),
+      ),
+    );
+
+    final result = showDialog<String>(
+      context: navigatorKey.currentContext!,
+      builder: (_) => CustomShortcutDialog(
+        initialShortcut: initialShortcut,
+        actionName: 'חיפוש חדש בכל הספרים',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    if (startRecording) {
+      await tester.tap(find.text('התחל הקלטה'));
+      await tester.pump();
+    }
+    return result;
+  }
+
+  /// מזריק אירועי מקלדת ישירות ל-KeyboardListener של הדיאלוג — הדרך היחידה
+  /// לדמות logicalKey לא-לטיני, שסימולטור המקלדת של Flutter אינו מכיר.
+  void sendKeys(WidgetTester tester, List<KeyEvent> events) {
+    final listener = tester.widget<KeyboardListener>(
+      find.descendant(
+        of: find.byType(CustomShortcutDialog),
+        matching: find.byType(KeyboardListener),
+      ),
+    );
+    for (final event in events) {
+      listener.onKeyEvent!(event);
+    }
+  }
+
+  Future<void> confirm(WidgetTester tester) async {
+    await tester.tap(find.text('עצור הקלטה'));
+    await tester.pump();
+    await tester.tap(find.text('אישור'));
+    await tester.pumpAndSettle();
+  }
+
+  List<KeyEvent> ctrlShift(KeyEvent mainKey) => [
+    _modifier(LogicalKeyboardKey.control, PhysicalKeyboardKey.controlLeft),
+    _modifier(LogicalKeyboardKey.shift, PhysicalKeyboardKey.shiftLeft),
+    mainKey,
+  ];
+
+  group('CustomShortcutDialog — הקלטה בפריסת מקלדת עברית', () {
+    testWidgets('Ctrl+Shift+F בפריסה עברית נשמר כ-ctrl+shift+f', (
+      tester,
+    ) async {
+      final result = await openDialog(tester);
+
+      sendKeys(
+        tester,
+        ctrlShift(_hebrewLetter(PhysicalKeyboardKey.keyF, 0x2000000f3)),
+      );
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'ctrl+shift+f');
+    });
+
+    testWidgets('התצוגה בזמן ההקלטה מציגה את האות הלטינית ולא את התו העברי', (
+      tester,
+    ) async {
+      await openDialog(tester);
+
+      sendKeys(
+        tester,
+        ctrlShift(_hebrewLetter(PhysicalKeyboardKey.keyG, 0x2000000e2)),
+      );
+      await tester.pump();
+
+      expect(find.text('CTRL + SHIFT + G'), findsOneWidget);
+      // 'ע' הוא התו שמקש G מייצר בפריסה עברית — הוא לא אמור להגיע לתצוגה.
+      expect(find.text('CTRL + SHIFT + ע'), findsNothing);
+    });
+
+    testWidgets('הקיצור שנשמר מזוהה על ידי matchesShortcut באותו אירוע', (
+      tester,
+    ) async {
+      final event = _hebrewLetter(PhysicalKeyboardKey.keyD, 0x2000000d2);
+      final result = await openDialog(tester);
+
+      sendKeys(tester, ctrlShift(event));
+      await tester.pump();
+      await confirm(tester);
+
+      final shortcut = await result;
+      expect(shortcut, 'ctrl+shift+d');
+      expect(
+        ShortcutHelper.matchesShortcut(
+          event,
+          shortcut!,
+          isControlPressed: true,
+          isShiftPressed: true,
+        ),
+        isTrue,
+      );
+    });
+
+    testWidgets('Ctrl בלבד + אות עברית נשמר כ-ctrl+<אות לטינית>', (
+      tester,
+    ) async {
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(LogicalKeyboardKey.control, PhysicalKeyboardKey.controlLeft),
+        _hebrewLetter(PhysicalKeyboardKey.keyY, 0x2000000d8),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'ctrl+y');
+    });
+
+    testWidgets('Alt + אות עברית נשמר כ-alt+<אות לטינית>', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(LogicalKeyboardKey.alt, PhysicalKeyboardKey.altLeft),
+        _hebrewLetter(PhysicalKeyboardKey.keyQ, 0x2000000e9),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'alt+q');
+    });
+  });
+
+  group('CustomShortcutDialog — הקלטה בפריסה לטינית (ללא שינוי התנהגות)', () {
+    testWidgets('Ctrl+Shift+F נשמר כ-ctrl+shift+f', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(
+        tester,
+        ctrlShift(
+          const KeyDownEvent(
+            physicalKey: PhysicalKeyboardKey.keyF,
+            logicalKey: LogicalKeyboardKey.keyF,
+            character: 'F',
+            timeStamp: Duration.zero,
+          ),
+        ),
+      );
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'ctrl+shift+f');
+    });
+
+    testWidgets('מקש F שאינו אות נשמר כ-f8', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.f8,
+          logicalKey: LogicalKeyboardKey.f8,
+          timeStamp: Duration.zero,
+        ),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'f8');
+    });
+
+    testWidgets('Alt + חץ למעלה נשמר כ-alt+arrowup', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(LogicalKeyboardKey.alt, PhysicalKeyboardKey.altLeft),
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.arrowUp,
+          logicalKey: LogicalKeyboardKey.arrowUp,
+          timeStamp: Duration.zero,
+        ),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'alt+arrowup');
+    });
+
+    testWidgets('Ctrl + פסיק נשמר כ-ctrl+comma', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(LogicalKeyboardKey.control, PhysicalKeyboardKey.controlLeft),
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.comma,
+          logicalKey: LogicalKeyboardKey.comma,
+          character: ',',
+          timeStamp: Duration.zero,
+        ),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'ctrl+comma');
+    });
+  });
+
+  group('CustomShortcutDialog — מצב הדיאלוג', () {
+    testWidgets('מציג את הקיצור הקיים בפתיחה ואת שם הפעולה', (tester) async {
+      await openDialog(
+        tester,
+        initialShortcut: 'ctrl+shift+f',
+        startRecording: false,
+      );
+
+      expect(find.text('CTRL + SHIFT + F'), findsOneWidget);
+      expect(find.text('חיפוש חדש בכל הספרים'), findsOneWidget);
+    });
+
+    testWidgets('אירועי מקלדת לפני "התחל הקלטה" אינם נקלטים', (tester) async {
+      await openDialog(
+        tester,
+        initialShortcut: 'ctrl+shift+f',
+        startRecording: false,
+      );
+
+      sendKeys(
+        tester,
+        ctrlShift(_hebrewLetter(PhysicalKeyboardKey.keyG, 0x2000000e2)),
+      );
+      await tester.pump();
+
+      expect(find.text('CTRL + SHIFT + F'), findsOneWidget);
+      expect(find.text('CTRL + SHIFT + G'), findsNothing);
+    });
+
+    testWidgets('התחלת הקלטה מחדש מאפסת קיצור שהוקלט קודם', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(
+        tester,
+        ctrlShift(_hebrewLetter(PhysicalKeyboardKey.keyG, 0x2000000e2)),
+      );
+      await tester.pump();
+      await tester.tap(find.text('עצור הקלטה'));
+      await tester.pump();
+
+      await tester.tap(find.text('התחל הקלטה'));
+      await tester.pump();
+      sendKeys(tester, [
+        _modifier(LogicalKeyboardKey.control, PhysicalKeyboardKey.controlLeft),
+        _hebrewLetter(PhysicalKeyboardKey.keyY, 0x2000000d8),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'ctrl+y');
+    });
+
+    testWidgets('ביטול אינו מחזיר קיצור', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(
+        tester,
+        ctrlShift(_hebrewLetter(PhysicalKeyboardKey.keyG, 0x2000000e2)),
+      );
+      await tester.pump();
+      await tester.tap(find.text('עצור הקלטה'));
+      await tester.pump();
+      await tester.tap(find.text('ביטול'));
+      await tester.pumpAndSettle();
+
+      expect(await result, isNull);
+    });
+  });
+}

--- a/test/shortcuts/keyboard_shortcuts_test.dart
+++ b/test/shortcuts/keyboard_shortcuts_test.dart
@@ -391,6 +391,203 @@ void main() {
     });
   });
 
+  group('KeyboardShortcuts - חיפוש חדש', () {
+    late MockSettingsBloc settingsBlocLocal;
+    late MockIndexingBloc indexingBloc;
+    late MockLibraryBloc libraryBloc;
+    late StreamController<SettingsState> settingsControllerLocal;
+
+    setUpAll(() async {
+      await Settings.init(cacheProvider: MemorySettingsCache());
+    });
+
+    void useShortcut(String shortcut) {
+      whenListen(
+        settingsBlocLocal,
+        settingsControllerLocal.stream,
+        initialState: SettingsState.initial().copyWith(
+          shortcuts: {'key-shortcut-open-new-search': shortcut},
+        ),
+      );
+    }
+
+    setUp(() {
+      FocusRepository().resetForTesting();
+      settingsBlocLocal = MockSettingsBloc();
+      indexingBloc = MockIndexingBloc();
+      libraryBloc = MockLibraryBloc();
+      settingsControllerLocal = StreamController<SettingsState>.broadcast();
+
+      whenListen(
+        indexingBloc,
+        const Stream<IndexingState>.empty(),
+        initialState: IndexingInitial(),
+      );
+      whenListen(
+        libraryBloc,
+        const Stream<LibraryState>.empty(),
+        initialState: const LibraryState(),
+      );
+    });
+
+    tearDown(() async {
+      await settingsControllerLocal.close();
+      await indexingBloc.close();
+      await libraryBloc.close();
+      FocusRepository().resetForTesting();
+    });
+
+    /// מרים את עץ הקיצורים ומחזיר מונה חי של הפעלות "חיפוש חדש".
+    /// `withCallback: false` משאיר את ה-callback null כדי לבדוק את מסלול הדיאלוג.
+    Future<ValueNotifier<int>> pumpShortcuts(
+      WidgetTester tester, {
+      bool withCallback = true,
+    }) async {
+      final tabsBloc = _StubTabsBloc(
+        const TabsState(tabs: [], currentTabIndex: 0),
+      );
+      final historyBloc = _StubHistoryBloc();
+      final navigationBloc = _StubNavigationBloc();
+      final calls = ValueNotifier<int>(0);
+      addTearDown(() async {
+        await tabsBloc.close();
+        await historyBloc.close();
+        await navigationBloc.close();
+        calls.dispose();
+      });
+
+      await tester.pumpWidget(
+        MultiBlocProvider(
+          providers: [
+            BlocProvider<SettingsBloc>.value(value: settingsBlocLocal),
+            BlocProvider<TabsBloc>.value(value: tabsBloc),
+            BlocProvider<HistoryBloc>.value(value: historyBloc),
+            BlocProvider<NavigationBloc>.value(value: navigationBloc),
+            BlocProvider<IndexingBloc>.value(value: indexingBloc),
+            BlocProvider<LibraryBloc>.value(value: libraryBloc),
+            Provider<FocusRepository>.value(value: FocusRepository()),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: KeyboardShortcuts(
+                onFindRefRequested: () {},
+                onNewSearchRequested: withCallback ? () => calls.value++ : null,
+                child: const SizedBox(width: 100, height: 100),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      return calls;
+    }
+
+    Future<void> sendKeys(
+      WidgetTester tester,
+      List<LogicalKeyboardKey> modifiers,
+      LogicalKeyboardKey key,
+    ) async {
+      for (final modifier in modifiers) {
+        await tester.sendKeyDownEvent(modifier);
+      }
+      await tester.sendKeyDownEvent(key);
+      await tester.sendKeyUpEvent(key);
+      for (final modifier in modifiers.reversed) {
+        await tester.sendKeyUpEvent(modifier);
+      }
+      await tester.pump();
+    }
+
+    testWidgets('קיצור ברירת המחדל Ctrl+Shift+F מפעיל את החיפוש החדש', (
+      tester,
+    ) async {
+      useShortcut('ctrl+shift+f');
+      final calls = await pumpShortcuts(tester);
+
+      await sendKeys(
+        tester,
+        [LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.shiftLeft],
+        LogicalKeyboardKey.keyF,
+      );
+
+      expect(calls.value, 1);
+    });
+
+    // רגרסיה: קיצור מותאם אישית שהוקלט בפריסה עברית נשמר בעבר עם התו העברי
+    // ולכן לא נתפס. כעת הוא נשמר קנוני, ואותה לחיצה פיזית מפעילה את הפעולה.
+    testWidgets('קיצור מותאם אישית Ctrl+Shift+D מפעיל את החיפוש החדש', (
+      tester,
+    ) async {
+      useShortcut('ctrl+shift+d');
+      final calls = await pumpShortcuts(tester);
+
+      await sendKeys(
+        tester,
+        [LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.shiftLeft],
+        LogicalKeyboardKey.keyD,
+      );
+      expect(calls.value, 1);
+
+      // מקש אחר עם אותם modifiers אינו מפעיל את הפעולה
+      await sendKeys(
+        tester,
+        [LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.shiftLeft],
+        LogicalKeyboardKey.keyF,
+      );
+      expect(calls.value, 1);
+    });
+
+    testWidgets('קיצור מותאם אישית שאינו אות (F8) מפעיל את החיפוש החדש', (
+      tester,
+    ) async {
+      useShortcut('f8');
+      final calls = await pumpShortcuts(tester);
+
+      await sendKeys(tester, const [], LogicalKeyboardKey.f8);
+      expect(calls.value, 1);
+    });
+
+    testWidgets('קיצור מותאם אישית Alt+חץ למעלה מפעיל את החיפוש החדש', (
+      tester,
+    ) async {
+      useShortcut('alt+arrowup');
+      final calls = await pumpShortcuts(tester);
+
+      await sendKeys(
+        tester,
+        [LogicalKeyboardKey.altLeft],
+        LogicalKeyboardKey.arrowUp,
+      );
+      expect(calls.value, 1);
+    });
+
+    testWidgets('קיצור ריק אינו מפעיל את החיפוש החדש', (tester) async {
+      useShortcut('');
+      final calls = await pumpShortcuts(tester);
+
+      await sendKeys(
+        tester,
+        [LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.shiftLeft],
+        LogicalKeyboardKey.keyF,
+      );
+      expect(calls.value, 0);
+    });
+
+    testWidgets('ללא callback הקיצור פותח את דיאלוג החיפוש', (tester) async {
+      useShortcut('ctrl+shift+d');
+      await pumpShortcuts(tester, withCallback: false);
+
+      await sendKeys(
+        tester,
+        [LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.shiftLeft],
+        LogicalKeyboardKey.keyD,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SearchDialog), findsOneWidget);
+    });
+  });
+
   group('KeyboardShortcuts - Ctrl+Shift+T', () {
     late MockSettingsBloc settingsBlocLocal;
     late StreamController<SettingsState> settingsControllerLocal;

--- a/test/shortcuts/shortcut_helper_test.dart
+++ b/test/shortcuts/shortcut_helper_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/shortcuts/shortcut_helper.dart';
+import 'package:otzaria/shortcuts/shortcut_validator.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -249,4 +250,342 @@ void main() {
       expect(activator.meta, isFalse);
     });
   });
+
+  group('ShortcutHelper.isRecognized', () {
+    test('קיצורים תקינים מזוהים', () {
+      const valid = [
+        'ctrl+f',
+        'ctrl+shift+f',
+        'ctrl+alt+shift+z',
+        'f11',
+        'escape',
+        'alt+arrowup',
+        'alt+pagedown',
+        'ctrl+comma',
+        'ctrl+3',
+        'meta+l',
+        'CTRL+SHIFT+F',
+      ];
+      for (final shortcut in valid) {
+        expect(
+          ShortcutHelper.isRecognized(shortcut),
+          isTrue,
+          reason: '$shortcut אמור להיות מוכר',
+        );
+      }
+    });
+
+    test('כל ברירות המחדל של האפליקציה מזוהות', () {
+      for (final entry in ShortcutValidator.defaultShortcuts.entries) {
+        expect(
+          ShortcutHelper.isRecognized(entry.value),
+          isTrue,
+          reason: 'ברירת המחדל של ${entry.key} (${entry.value}) אינה מוכרת',
+        );
+      }
+    });
+
+    test('קיצור ריק נחשב תקין — פעולה ללא קיצור', () {
+      expect(ShortcutHelper.isRecognized(''), isTrue);
+    });
+
+    test('קיצור עם תו לא-לטיני אינו מוכר', () {
+      const broken = [
+        'ctrl+shift+כ',
+        'ctrl+ע',
+        'alt+ש',
+        'ф',
+        'ctrl+shift+ب',
+      ];
+      for (final shortcut in broken) {
+        expect(
+          ShortcutHelper.isRecognized(shortcut),
+          isFalse,
+          reason: '$shortcut אינו אמור להיות מוכר',
+        );
+      }
+    });
+
+    test('קיצור עם modifiers בלבד או מקש חסר אינו מוכר', () {
+      expect(ShortcutHelper.isRecognized('ctrl'), isFalse);
+      expect(ShortcutHelper.isRecognized('ctrl+shift'), isFalse);
+      expect(ShortcutHelper.isRecognized('ctrl+shift+'), isFalse);
+    });
+
+    test('קיצור עם שם מקש שאינו ב-KeyMap אינו מוכר', () {
+      expect(ShortcutHelper.isRecognized('ctrl+capslock'), isFalse);
+      expect(ShortcutHelper.isRecognized('f13'), isFalse);
+    });
+
+    test('כל קיצור מוכר שאינו ריק ניתן גם להמרה ל-ShortcutActivator', () {
+      for (final shortcut in ['ctrl+f', 'f11', 'alt+arrowup', 'ctrl+comma']) {
+        expect(ShortcutHelper.isRecognized(shortcut), isTrue);
+        expect(ShortcutHelper.activatorFromShortcut(shortcut), isNotNull);
+      }
+    });
+  });
+
+  group('ShortcutHelper.logicalKeyToStore', () {
+    test('כל 26 מקשי האותיות מנורמלים לאות הלטינית לפי מיקומם הפיזי', () {
+      for (var offset = 0; offset < 26; offset++) {
+        final letter = String.fromCharCode('a'.codeUnitAt(0) + offset);
+        final event = nonLatinLetterEvent(
+          PhysicalKeyboardKey(
+            PhysicalKeyboardKey.keyA.usbHidUsage + offset,
+          ),
+        );
+
+        expect(
+          ShortcutHelper.logicalKeyToStore(event),
+          LogicalKeyboardKey(LogicalKeyboardKey.keyA.keyId + offset),
+          reason: 'מקש פיזי במיקום $offset אמור להישמר כ-$letter',
+        );
+        expect(
+          ShortcutHelper.getKeyLabel(ShortcutHelper.logicalKeyToStore(event)),
+          letter,
+        );
+      }
+    });
+
+    test('מקש אות בפריסה עברית נשמר כאות לטינית לפי מיקומו הפיזי', () {
+      expect(
+        ShortcutHelper.logicalKeyToStore(
+          hebrewLetterEvent(PhysicalKeyboardKey.keyF, 0x2000000f3),
+        ),
+        LogicalKeyboardKey.keyF,
+      );
+      expect(
+        ShortcutHelper.logicalKeyToStore(
+          hebrewLetterEvent(PhysicalKeyboardKey.keyZ, 0x2000000d6),
+        ),
+        LogicalKeyboardKey.keyZ,
+      );
+    });
+
+    test('מקש אות בפריסה לטינית נשמר כמו שהוא (ללא שינוי התנהגות)', () {
+      final event = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.keyF,
+        logicalKey: LogicalKeyboardKey.keyF,
+        character: 'f',
+        timeStamp: Duration.zero,
+      );
+      expect(ShortcutHelper.logicalKeyToStore(event), LogicalKeyboardKey.keyF);
+    });
+
+    test('מקשים שאינם אות נשמרים לפי logicalKey כרגיל', () {
+      final nonLetterKeys = <PhysicalKeyboardKey, LogicalKeyboardKey>{
+        PhysicalKeyboardKey.f8: LogicalKeyboardKey.f8,
+        PhysicalKeyboardKey.digit3: LogicalKeyboardKey.digit3,
+        PhysicalKeyboardKey.arrowUp: LogicalKeyboardKey.arrowUp,
+        PhysicalKeyboardKey.pageDown: LogicalKeyboardKey.pageDown,
+        PhysicalKeyboardKey.comma: LogicalKeyboardKey.comma,
+        PhysicalKeyboardKey.space: LogicalKeyboardKey.space,
+        PhysicalKeyboardKey.escape: LogicalKeyboardKey.escape,
+        PhysicalKeyboardKey.numpad5: LogicalKeyboardKey.numpad5,
+        PhysicalKeyboardKey.home: LogicalKeyboardKey.home,
+      };
+
+      for (final entry in nonLetterKeys.entries) {
+        final event = KeyDownEvent(
+          physicalKey: entry.key,
+          logicalKey: entry.value,
+          timeStamp: Duration.zero,
+        );
+        expect(
+          ShortcutHelper.logicalKeyToStore(event),
+          entry.value,
+          reason: '${entry.key.debugName} אינו מקש אות ואינו אמור להשתנות',
+        );
+      }
+    });
+
+    test('מקשי modifier נשמרים כמו שהם', () {
+      final modifiers = <PhysicalKeyboardKey, LogicalKeyboardKey>{
+        PhysicalKeyboardKey.controlLeft: LogicalKeyboardKey.controlLeft,
+        PhysicalKeyboardKey.shiftLeft: LogicalKeyboardKey.shiftLeft,
+        PhysicalKeyboardKey.altLeft: LogicalKeyboardKey.altLeft,
+        PhysicalKeyboardKey.metaLeft: LogicalKeyboardKey.metaLeft,
+      };
+
+      for (final entry in modifiers.entries) {
+        final event = KeyDownEvent(
+          physicalKey: entry.key,
+          logicalKey: entry.value,
+          timeStamp: Duration.zero,
+        );
+        expect(ShortcutHelper.logicalKeyToStore(event), entry.value);
+      }
+    });
+  });
+
+  // הרגרסיה שהתיקון סוגר: הקלטה בפריסה לא-לטינית שמרה את התו המקומי,
+  // ואילו matchesShortcut משווה physicalKey — כך שהקיצור לא נתפס לעולם.
+  group('הקלטה → שמירה → זיהוי בפריסה לא-לטינית', () {
+    String recordShortcut(Set<LogicalKeyboardKey> modifiers, KeyEvent event) =>
+        ShortcutHelper.formatKeysToShortcut({
+          ...modifiers,
+          ShortcutHelper.logicalKeyToStore(event),
+        });
+
+    test(
+      'ctrl+shift+G שהוקלט בעברית נשמר קנוני ונתפס על ידי matchesShortcut',
+      () {
+        final event = hebrewLetterEvent(PhysicalKeyboardKey.keyG, 0x2000000e2);
+
+        final shortcut = recordShortcut({
+          LogicalKeyboardKey.control,
+          LogicalKeyboardKey.shift,
+        }, event);
+
+        expect(shortcut, 'ctrl+shift+g');
+        expect(
+          ShortcutHelper.matchesShortcut(
+            event,
+            shortcut,
+            isControlPressed: true,
+            isShiftPressed: true,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('הקיצור שנשמר זהה בין הקלטה בעברית להקלטה באנגלית', () {
+      final hebrew = recordShortcut(
+        {LogicalKeyboardKey.control},
+        hebrewLetterEvent(PhysicalKeyboardKey.keyK, 0x2000000dc),
+      );
+      final latin = recordShortcut(
+        {LogicalKeyboardKey.control},
+        {
+          KeyDownEvent(
+            physicalKey: PhysicalKeyboardKey.keyK,
+            logicalKey: LogicalKeyboardKey.keyK,
+            character: 'k',
+            timeStamp: Duration.zero,
+          ),
+        }.first,
+      );
+
+      expect(hebrew, latin);
+      expect(hebrew, 'ctrl+k');
+    });
+
+    test('קיצור שהוקלט בעברית נתפס גם כשהמשתמש מחליף לפריסה לטינית', () {
+      final shortcut = recordShortcut(
+        {LogicalKeyboardKey.control, LogicalKeyboardKey.shift},
+        hebrewLetterEvent(PhysicalKeyboardKey.keyD, 0x2000000d2),
+      );
+
+      final latinEvent = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.keyD,
+        logicalKey: LogicalKeyboardKey.keyD,
+        character: 'D',
+        timeStamp: Duration.zero,
+      );
+
+      expect(shortcut, 'ctrl+shift+d');
+      expect(
+        ShortcutHelper.matchesShortcut(
+          latinEvent,
+          shortcut,
+          isControlPressed: true,
+          isShiftPressed: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('כל שילובי ה-modifiers נשמרים ונתפסים בפריסה עברית', () {
+      final combinations =
+          <(Set<LogicalKeyboardKey>, String, bool, bool, bool)>[
+            ({LogicalKeyboardKey.control}, 'ctrl+m', true, false, false),
+            (
+              {LogicalKeyboardKey.control, LogicalKeyboardKey.shift},
+              'ctrl+shift+m',
+              true,
+              true,
+              false,
+            ),
+            ({LogicalKeyboardKey.alt}, 'alt+m', false, false, true),
+            (
+              {LogicalKeyboardKey.control, LogicalKeyboardKey.alt},
+              'ctrl+alt+m',
+              true,
+              false,
+              true,
+            ),
+          ];
+
+      final event = hebrewLetterEvent(PhysicalKeyboardKey.keyM, 0x2000000e6);
+
+      for (final (modifiers, expected, ctrl, shift, alt) in combinations) {
+        final shortcut = recordShortcut(modifiers, event);
+        expect(shortcut, expected);
+        expect(
+          ShortcutHelper.matchesShortcut(
+            event,
+            shortcut,
+            isControlPressed: ctrl,
+            isShiftPressed: shift,
+            isAltPressed: alt,
+          ),
+          isTrue,
+          reason: '$expected אמור להיתפס בפריסה עברית',
+        );
+      }
+    });
+
+    test('קיצור שנשמר עם תו לא-לטיני אינו נתפס — לכן ההקלטה חייבת לנרמל', () {
+      final event = hebrewLetterEvent(PhysicalKeyboardKey.keyF, 0x2000000f3);
+
+      expect(
+        ShortcutHelper.matchesShortcut(
+          event,
+          'ctrl+shift+כ',
+          isControlPressed: true,
+          isShiftPressed: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('קיצור ריק או מודיפיירים בלבד אינם נתפסים', () {
+      final event = hebrewLetterEvent(PhysicalKeyboardKey.keyF, 0x2000000f3);
+
+      expect(
+        ShortcutHelper.matchesShortcut(event, '', isControlPressed: true),
+        isFalse,
+      );
+      expect(
+        ShortcutHelper.matchesShortcut(
+          event,
+          'ctrl+shift',
+          isControlPressed: true,
+          isShiftPressed: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }
+
+/// אירוע מקש אות בפריסה עברית: `physicalKey` תקין, `logicalKey` הוא התו העברי
+/// שאינו ניתן להשוואה — בדיוק כפי ש-Flutter מדווח ב-Windows.
+KeyDownEvent hebrewLetterEvent(
+  PhysicalKeyboardKey physicalKey,
+  int hebrewKeyId,
+) => KeyDownEvent(
+  physicalKey: physicalKey,
+  logicalKey: LogicalKeyboardKey(hebrewKeyId),
+  timeStamp: Duration.zero,
+);
+
+/// אירוע מקש אות בפריסה לא-לטינית שרירותית, כש-`logicalKey` נגזר מ-usbHidUsage
+/// ולכן אינו אחת מאותיות a–z המוכרות.
+KeyDownEvent nonLatinLetterEvent(PhysicalKeyboardKey physicalKey) =>
+    KeyDownEvent(
+      physicalKey: physicalKey,
+      logicalKey: LogicalKeyboardKey(0x200000000 + physicalKey.usbHidUsage),
+      timeStamp: Duration.zero,
+    );


### PR DESCRIPTION
## הבאג

משתמש דיווח שהקיצור לחיפוש חדש לא עובד אצלו אחרי שהגדיר קיצור **מותאם אישית**, בעוד שאצל מפתחים הוא עבד.

הסיבה: אסימטריה בין הקלטת הקיצור לזיהוי שלו.

| | מה עשה | מקום |
|---|---|---|
| **זיהוי** (לחיצה בפועל) | משווה `physicalKey` — מיקום פיזי במקלדת | `shortcut_helper.dart:88-98` |
| **הקלטה** (הגדרת הקיצור) | קרא `event.logicalKey` — **התו שהמקש מייצר** | `custom_shortcut_dialog.dart:95` |

בפריסת מקלדת עברית ב-Windows `logicalKey` של מקש F הוא `'כ'`, ולכן נשמר `ctrl+shift+כ`. בזיהוי, `KeyMap.keyFor('כ')` מחזיר `null` — **הקיצור לא נתפס בשום פריסה**. גם התצוגה בהגדרות הראתה `CTRL + SHIFT + כ`, שנראה תקין, ולכן לא היה חשד.

## רגרסיה מגרסה 0.9.91

- `e899f5ecc` (9.11.2025) — נוספה אופציית "התאמה אישית". ההקלטה שמרה `'כ'`, אבל גם *הזיהוי* השווה `logicalKey.keyLabel` → `'כ' == 'כ'` → הקיצור **עבד** בפריסה עברית.
- `f255de211` (10.5.2026, גרסה **0.9.91**) — תוקן זיהוי ברירות המחדל בפריסה לא-לטינית ע"י מעבר ל-`physicalKey`. התיקון נכון, אבל צד ההקלטה לא עודכן — ומאז קיצור מותאם שהוקלט בעברית הפסיק לעבוד.

## התיקון

**1. ההקלטה מנרמלת מקש אות לאות הלטינית לפי מיקומו הפיזי** — בסימטריה מדויקת לבדיקה:
- `ShortcutHelper.logicalKeyToStore(KeyEvent)`
- `CustomShortcutDialog` משתמש בו

הקיצור נשמר זהה בין הקלטה בעברית להקלטה באנגלית, וממשיך לעבוד גם כשהמשתמש מחליף פריסה.

**2. ניקוי חד-פעמי לקיצורים שכבר שמורים** — הערך השבור בדיסק לא מתקן את עצמו, ומשתמש שלא ידע לא היה מקליט מחדש. `SettingsRepository.removeUnrecognizedShortcuts()` רץ ב-`loadSettings()` ומוחק קיצור שהמקש שלו אינו מוכר, כך שהפעולה חוזרת לקיצור ברירת המחדל שעובד. הפעולה idempotent, בלי טבלת מיפוי פריסות, ועובדת לכל פריסת מקלדת (עברית, רוסית, ערבית).

נבחרה מחיקה ולא תרגום מהפריסה העברית, כי הקיצור השבור לא עבד מאז 0.9.91 — אין הגדרה פעילה שצריך לשמר, ותרגום היה מניח שהפריסה שהוקלטה היא עברית.

## טסטים — 128 בסך הכל בקבצים המושפעים (+46)

- `shortcut_helper_test.dart` — כל 26 האותיות, מקשים שאינם אות (ספרות/חצים/F/numpad/סימנים), modifiers, כל שילובי ה-modifiers בעברית, זהות בין הקלטה בעברית לאנגלית, החלפת פריסה לאחר הקלטה, `isRecognized` מול כל ברירות המחדל של האפליקציה, ותיעוד שקיצור עם תו לא-לטיני *אינו* נתפס
- `custom_shortcut_dialog_test.dart` (חדש, 13) — end-to-end של דיאלוג ההקלטה עם הזרקת אירועי מקלדת עבריים: הערך המוחזר, התצוגה, איפוס הקלטה, ביטול
- `unrecognized_shortcuts_cleanup_test.dart` (חדש, 12) — הניקוי: תו עברי, ערך בלי מקש ראשי, אי-נגיעה בתקינים ובקיצור ריק, מפתחות legacy, קיצור תוסף שאינו רשום, idempotency, והרצה אוטומטית מ-`loadSettings`
- `keyboard_shortcuts_test.dart` — 6 טסטים לקיצור "חיפוש חדש" עצמו: ברירת מחדל, מותאם אישית, F8, Alt+חץ, קיצור ריק, ומסלול פתיחת הדיאלוג

`flutter analyze` נקי, כל 317 טסטי `test/settings` עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)