### PR TITLE
תיקון: מחיקת הגדרות פר-ספר מול כתיבה שלא ממתינים לה

### DIFF
--- a/lib/core/messages/settings_messages.dart
+++ b/lib/core/messages/settings_messages.dart
@@ -147,6 +147,8 @@ abstract class SettingsMessages {
   // ── הגדרות טקסט (text_settings_tab) ────────────────────────────────────
 
   static const String perBookSettingsReset = 'כל ההגדרות המיוחדות אופסו בהצלחה';
+  static const String perBookSettingsResetFailed =
+      'איפוס ההגדרות המיוחדות נכשל';
 
   // ── קטלוג חיצוני (external_catalog_settings_helper) ────────────────────
 

--- a/lib/settings/services/per_book_settings_service.dart
+++ b/lib/settings/services/per_book_settings_service.dart
@@ -57,6 +57,22 @@ class PerBookSettings {
     Future<T> Function() action,
   ) => runLocked(_hashKey(key), action);
 
+  /// ממתין לסיום כל פעולות ההגדרות הפר-ספריות שיצאו לדרך.
+  ///
+  /// חובה לפני מחיקת תיקיית ההגדרות: שמירה שלא ממתינים לה מחזיקה את הקובץ
+  /// פתוח (המחיקה נכשלת ב-Windows) ומחזירה אותו לחיים אחרי המחיקה.
+  /// אינו זורק (ה-gates בולעים שגיאות). אין לקרוא מתוך [runLocked] — המתנה
+  /// לתור שאתה עצמך חוסם היא דדלוק. מכסה פעולה מרגע כניסתה לתור;
+  /// [cleanupRedundantSettings] סורק את התיקייה לפני כן, ולכן מגן על עצמו
+  /// בבדיקות קיום בתוך הנעילה במקום להסתמך על ה-barrier.
+  static Future<void> settle() async {
+    // כל ערך הוא הפעולה האחרונה בתור של קובץ, והתור סדרתי — ההמתנה לו
+    // מכסה את כולו. הלולאה קולטת פעולות שנוספו בזמן ההמתנה.
+    while (_fileLocks.isNotEmpty) {
+      await Future.wait(_fileLocks.values.toList());
+    }
+  }
+
   /// תאימות לאחור: קבצים ישנים מופתחו לפי שם הספר בלבד. אם אין קובץ למפתח
   /// החדש אך קיים קובץ-מורשת לפי השם — מעתיקים אותו (copy, לא rename) כדי
   /// שגם ספר נוסף בעל אותו שם יוכל לרשת את ההגדרות הישנות. בהעתקה, שדות
@@ -236,16 +252,23 @@ class PerBookSettings {
     }
   }
 
-  /// מחיקת כל קבצי ההגדרות
-  static Future<void> deleteAllSettings() async {
+  /// מחיקת כל קבצי ההגדרות. מחזיר האם המחיקה הושלמה.
+  ///
+  /// ה-[settle] מחייב: בלעדיו שמירה תלויה מכשילה את המחיקה או כותבת את
+  /// הקובץ מחדש אחריה. הנתיב נבנה ישירות ולא דרך [_getSettingsDirectory],
+  /// שיוצר את התיקייה — אין טעם ליצור תיקייה רק כדי למחוק אותה.
+  static Future<bool> deleteAllSettings() async {
+    await settle();
     try {
-      final dir = await _getSettingsDirectory();
+      final dir = Directory(await AppPaths.getPerBookSettingsPath());
       if (await dir.exists()) {
         await dir.delete(recursive: true);
         debugPrint('✅ Deleted all per-book settings');
       }
+      return true;
     } catch (e) {
       debugPrint('❌ Error deleting all per-book settings: $e');
+      return false;
     }
   }
 

--- a/lib/settings/services/per_book_settings_service.dart
+++ b/lib/settings/services/per_book_settings_service.dart
@@ -29,12 +29,16 @@ class PerBookSettings {
   /// שגם הניקוי (שמכיר רק את שם הקובץ) וגם השמירות (שמכירות את המפתח) ינעלו
   /// על אותו ערך.
   static final Map<String, Future<void>> _fileLocks = {};
+  static Completer<void>? _resetGate;
 
   /// מריץ [action] בזו-אחר-זו עם שאר הפעולות על אותו [lockKey] (hash הקובץ).
   static Future<T> runLocked<T>(
     String lockKey,
     Future<T> Function() action,
   ) async {
+    while (_resetGate != null) {
+      await _resetGate!.future;
+    }
     final previous = _fileLocks[lockKey] ?? Future.value();
     // התעלמות מכשל קודם רק לצורך המשכיות התור; כל קורא מקבל את שגיאתו דרך await.
     final current = previous
@@ -66,6 +70,13 @@ class PerBookSettings {
   /// [cleanupRedundantSettings] סורק את התיקייה לפני כן, ולכן מגן על עצמו
   /// בבדיקות קיום בתוך הנעילה במקום להסתמך על ה-barrier.
   static Future<void> settle() async {
+    while (_resetGate != null) {
+      await _resetGate!.future;
+    }
+    await _settleFileLocks();
+  }
+
+  static Future<void> _settleFileLocks() async {
     // כל ערך הוא הפעולה האחרונה בתור של קובץ, והתור סדרתי — ההמתנה לו
     // מכסה את כולו. הלולאה קולטת פעולות שנוספו בזמן ההמתנה.
     while (_fileLocks.isNotEmpty) {
@@ -258,8 +269,13 @@ class PerBookSettings {
   /// הקובץ מחדש אחריה. הנתיב נבנה ישירות ולא דרך [_getSettingsDirectory],
   /// שיוצר את התיקייה — אין טעם ליצור תיקייה רק כדי למחוק אותה.
   static Future<bool> deleteAllSettings() async {
-    await settle();
+    while (_resetGate != null) {
+      await _resetGate!.future;
+    }
+    final resetGate = Completer<void>();
+    _resetGate = resetGate;
     try {
+      await _settleFileLocks();
       final dir = Directory(await AppPaths.getPerBookSettingsPath());
       if (await dir.exists()) {
         await dir.delete(recursive: true);
@@ -269,6 +285,9 @@ class PerBookSettings {
     } catch (e) {
       debugPrint('❌ Error deleting all per-book settings: $e');
       return false;
+    } finally {
+      _resetGate = null;
+      resetGate.complete();
     }
   }
 

--- a/lib/settings/tabs/text_settings_tab.dart
+++ b/lib/settings/tabs/text_settings_tab.dart
@@ -609,8 +609,11 @@ class TextSettingsTab extends StatelessWidget {
     );
 
     if (confirm == true && context.mounted) {
-      await PerBookSettings.deleteAllSettings();
-      UiSnack.show(SettingsMessages.perBookSettingsReset);
+      if (await PerBookSettings.deleteAllSettings()) {
+        UiSnack.show(SettingsMessages.perBookSettingsReset);
+      } else {
+        UiSnack.showError(SettingsMessages.perBookSettingsResetFailed);
+      }
     }
   }
 }

--- a/test/settings/services/per_book_settings_settle_test.dart
+++ b/test/settings/services/per_book_settings_settle_test.dart
@@ -235,6 +235,29 @@ void main() {
       expect(await settingsDir.exists(), isFalse);
     });
 
+    test('פעולה שמתחילה בזמן איפוס ממתינה לו ונשמרת אחריו', () async {
+      final saveStarted = Completer<void>();
+      final releaseSave = Completer<void>();
+      final existingSave = TextBookPerBookSettings.mutate(bookA, (
+        existing,
+      ) async {
+        saveStarted.complete();
+        await releaseSave.future;
+        return (existing ?? TextBookPerBookSettings()).copyWith(fontSize: 18);
+      });
+      await saveStarted.future;
+
+      final reset = PerBookSettings.deleteAllSettings();
+      final laterSave = saveFontSize(bookB, 29);
+      releaseSave.complete();
+
+      expect(await reset, isTrue);
+      await existingSave;
+      await laterSave;
+      expect(await TextBookPerBookSettings.load(bookA), isNull);
+      expect((await TextBookPerBookSettings.load(bookB))?.fontSize, 29);
+    });
+
     test('על תיקייה שאינה קיימת מחזיר true ואינו יוצר אותה', () async {
       expect(await settingsDir.exists(), isFalse);
 

--- a/test/settings/services/per_book_settings_settle_test.dart
+++ b/test/settings/services/per_book_settings_settle_test.dart
@@ -1,0 +1,386 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/app_paths.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/services/per_book_settings_service.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDataRoot;
+  late Directory settingsDir;
+
+  final bookA = TextBook(title: 'ספר א');
+  final bookB = TextBook(title: 'ספר ב');
+
+  setUp(() async {
+    tempDataRoot = await Directory.systemTemp.createTemp('settle_test_');
+    AppPaths.debugOverrideDataRootPath(tempDataRoot.path);
+    settingsDir = Directory(p.join(tempDataRoot.path, 'per_book_settings'));
+  });
+
+  tearDown(() async {
+    await PerBookSettings.settle();
+    AppPaths.debugOverrideDataRootPath(null);
+    if (await tempDataRoot.exists()) {
+      await tempDataRoot.delete(recursive: true);
+    }
+  });
+
+  Future<void> saveFontSize(Book book, double size) =>
+      TextBookPerBookSettings.mutate(
+        book,
+        (existing) =>
+            (existing ?? TextBookPerBookSettings()).copyWith(fontSize: size),
+      );
+
+  group('PerBookSettings.settle — סמנטיקת ה-barrier', () {
+    test('על תור ריק מסתיים בלי להשהות את ה-event loop', () async {
+      final order = <String>[];
+      // משימת event-loop: אם settle משהה ולו סיבוב אחד, ה-timer יקדים אותה.
+      unawaited(
+        Future<void>.delayed(Duration.zero).then((_) => order.add('timer')),
+      );
+
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['settle']);
+    });
+
+    test('ממתין לשמירה שיצאה לדרך בלי await', () async {
+      final order = <String>[];
+      unawaited(saveFontSize(bookA, 18).then((_) => order.add('save')));
+
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['save', 'settle']);
+    });
+
+    test('אחרי ההמתנה הקובץ כבר על הדיסק', () async {
+      unawaited(saveFontSize(bookA, 21));
+
+      await PerBookSettings.settle();
+
+      final files = await settingsDir.list().toList();
+      expect(files.whereType<File>(), hasLength(1));
+      expect((await TextBookPerBookSettings.load(bookA))?.fontSize, 21);
+    });
+
+    test('ממתין לכמה שמירות על אותו ספר (תור נעילה יחיד)', () async {
+      final completed = <double>[];
+      for (final size in [16.0, 17.0, 18.0]) {
+        unawaited(saveFontSize(bookA, size).then((_) => completed.add(size)));
+      }
+
+      await PerBookSettings.settle();
+
+      expect(completed, [16.0, 17.0, 18.0]);
+      expect((await TextBookPerBookSettings.load(bookA))?.fontSize, 18.0);
+    });
+
+    test('ממתין לפעולות על ספרים שונים (תורי נעילה נפרדים)', () async {
+      final completed = <String>{};
+      unawaited(saveFontSize(bookA, 19).then((_) => completed.add('א')));
+      unawaited(saveFontSize(bookB, 23).then((_) => completed.add('ב')));
+
+      await PerBookSettings.settle();
+
+      expect(completed, {'א', 'ב'});
+      expect((await TextBookPerBookSettings.load(bookA))?.fontSize, 19);
+      expect((await TextBookPerBookSettings.load(bookB))?.fontSize, 23);
+    });
+
+    test('ממתין גם לטעינה, לא רק לכתיבה', () async {
+      await saveFontSize(bookA, 20);
+      final order = <String>[];
+      unawaited(
+        TextBookPerBookSettings.load(bookA).then((_) => order.add('load')),
+      );
+
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['load', 'settle']);
+    });
+
+    test('ממתין גם למחיקה', () async {
+      await saveFontSize(bookA, 20);
+      final order = <String>[];
+      unawaited(
+        TextBookPerBookSettings.delete(bookA).then((_) => order.add('delete')),
+      );
+
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['delete', 'settle']);
+      expect(await TextBookPerBookSettings.load(bookA), isNull);
+    });
+
+    test('קולט פעולה שנוספה בזמן ההמתנה', () async {
+      Future<void>? nested;
+      unawaited(
+        TextBookPerBookSettings.mutate(bookA, (existing) {
+          // נכנס לתור של ספר אחר בזמן ש-settle כבר ממתין לתור של ספר א.
+          nested = saveFontSize(bookB, 24);
+          return (existing ?? TextBookPerBookSettings()).copyWith(fontSize: 18);
+        }),
+      );
+
+      await PerBookSettings.settle();
+
+      expect(nested, isNotNull);
+      expect((await TextBookPerBookSettings.load(bookB))?.fontSize, 24);
+    });
+
+    test('אינו זורק כשפעולה תלויה נכשלת', () async {
+      final failing = TextBookPerBookSettings.mutate(
+        bookA,
+        (_) => throw StateError('כשל מכוון'),
+      );
+      unawaited(failing.catchError((_) {}));
+
+      await expectLater(PerBookSettings.settle(), completes);
+    });
+
+    test('כשל בפעולה אחת אינו מונע את ההמתנה לפעולה אחרת', () async {
+      var secondRan = false;
+      unawaited(
+        TextBookPerBookSettings.mutate(
+          bookA,
+          (_) => throw StateError('כשל מכוון'),
+        ).catchError((_) {}),
+      );
+      unawaited(
+        TextBookPerBookSettings.mutate(bookB, (existing) {
+          secondRan = true;
+          return (existing ?? TextBookPerBookSettings()).copyWith(fontSize: 25);
+        }),
+      );
+
+      await PerBookSettings.settle();
+
+      expect(secondRan, isTrue);
+      expect((await TextBookPerBookSettings.load(bookB))?.fontSize, 25);
+    });
+
+    test('קריאה שנייה ברצף מסתיימת מיד — התור התרוקן', () async {
+      unawaited(saveFontSize(bookA, 18));
+      await PerBookSettings.settle();
+
+      final order = <String>[];
+      unawaited(
+        Future<void>.delayed(Duration.zero).then((_) => order.add('timer')),
+      );
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['settle']);
+    });
+
+    test(
+      'רגרסיה: אחרי ההמתנה מחיקת שורש הנתונים מצליחה (PathAccessException)',
+      () async {
+        // בלי ה-barrier הכתיבה מחזיקה את הקובץ פתוח, ומחיקת התיקייה
+        // נכשלת ב-Windows עם errno 32.
+        unawaited(saveFontSize(bookA, 18));
+        unawaited(saveFontSize(bookB, 19));
+
+        await PerBookSettings.settle();
+
+        await expectLater(tempDataRoot.delete(recursive: true), completes);
+        expect(await tempDataRoot.exists(), isFalse);
+      },
+    );
+  });
+
+  group('PerBookSettings.deleteAllSettings', () {
+    test('מוחק את התיקייה ומחזיר true', () async {
+      await saveFontSize(bookA, 18);
+      expect(await settingsDir.exists(), isTrue);
+
+      expect(await PerBookSettings.deleteAllSettings(), isTrue);
+
+      expect(await settingsDir.exists(), isFalse);
+    });
+
+    test('ממתין לשמירה תלויה לפני המחיקה', () async {
+      var saveRan = false;
+      unawaited(
+        TextBookPerBookSettings.mutate(bookA, (existing) {
+          saveRan = true;
+          return (existing ?? TextBookPerBookSettings()).copyWith(fontSize: 18);
+        }),
+      );
+      expect(saveRan, isFalse, reason: 'השמירה עדיין לא רצה');
+
+      expect(await PerBookSettings.deleteAllSettings(), isTrue);
+
+      expect(saveRan, isTrue, reason: 'ה-barrier המתין לשמירה');
+    });
+
+    test('רגרסיה: הגדרה שנשמרה תוך כדי איפוס אינה קמה לתחייה', () async {
+      // בלי ההמתנה הכתיבה מסתיימת אחרי המחיקה, יוצרת מחדש את התיקייה
+      // ומשאירה את ההגדרה שהמשתמש ביקש לאפס.
+      unawaited(saveFontSize(bookA, 18));
+      unawaited(saveFontSize(bookB, 19));
+
+      await PerBookSettings.deleteAllSettings();
+
+      expect(await settingsDir.exists(), isFalse);
+    });
+
+    test('על תיקייה שאינה קיימת מחזיר true ואינו יוצר אותה', () async {
+      expect(await settingsDir.exists(), isFalse);
+
+      expect(await PerBookSettings.deleteAllSettings(), isTrue);
+
+      expect(await settingsDir.exists(), isFalse);
+    });
+
+    test('אחרי איפוס הטעינה מחזירה null', () async {
+      await saveFontSize(bookA, 18);
+      await saveFontSize(bookB, 19);
+
+      await PerBookSettings.deleteAllSettings();
+
+      expect(await TextBookPerBookSettings.load(bookA), isNull);
+      expect(await TextBookPerBookSettings.load(bookB), isNull);
+    });
+
+    test('שמירה חדשה אחרי איפוס יוצרת מחדש את התיקייה', () async {
+      await saveFontSize(bookA, 18);
+      await PerBookSettings.deleteAllSettings();
+
+      await saveFontSize(bookA, 30);
+
+      expect((await TextBookPerBookSettings.load(bookA))?.fontSize, 30);
+    });
+
+    test('אינו משאיר תור נעילה מזוהם', () async {
+      unawaited(saveFontSize(bookA, 18));
+      await PerBookSettings.deleteAllSettings();
+
+      final order = <String>[];
+      unawaited(
+        Future<void>.delayed(Duration.zero).then((_) => order.add('timer')),
+      );
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['settle']);
+    });
+
+    test('מוחק גם קובצי legacy שאינם ממופתחים ב-hash', () async {
+      await settingsDir.create(recursive: true);
+      final legacy = File(p.join(settingsDir.path, 'settings_ספר_א.json'));
+      await legacy.writeAsString('{"fontSize":18.0}');
+
+      await PerBookSettings.deleteAllSettings();
+
+      expect(await legacy.exists(), isFalse);
+    });
+  });
+
+  group('settle מול שאר צרכני תור הנעילה', () {
+    test('ממתין לניקוי התקופתי משנכנס לתור', () async {
+      await saveFontSize(bookA, 18);
+      await saveFontSize(bookB, 19);
+
+      final cleanup = PerBookSettings.cleanupRedundantSettings(
+        defaultFontSize: 18,
+        defaultRemoveNikud: false,
+        defaultShowSplitView: true,
+      );
+      // הסריקה שלפני ה-runLocked הראשון אינה בתור; מחכים שהניקוי ייכנס אליו.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      await PerBookSettings.settle();
+      await cleanup;
+
+      // 18 היה זהה לברירת המחדל ולכן נוקה; 19 שרד.
+      expect(await TextBookPerBookSettings.load(bookA), isNull);
+      expect((await TextBookPerBookSettings.load(bookB))?.fontSize, 19);
+    });
+
+    test('איפוס בזמן ניקוי תקופתי — לא מתנגש ולא מחייה הגדרות', () async {
+      // הניקוי מגן על עצמו בבדיקות קיום בתוך הנעילה, ולכן התוצאה זהה בכל
+      // תזמון: המחיקה מצליחה, והניקוי אינו כותב קובץ אחריה.
+      await saveFontSize(bookA, 18);
+      await saveFontSize(bookB, 19);
+      final cleanup = PerBookSettings.cleanupRedundantSettings(
+        defaultFontSize: 18,
+        defaultRemoveNikud: false,
+        defaultShowSplitView: true,
+      );
+
+      expect(await PerBookSettings.deleteAllSettings(), isTrue);
+      await expectLater(cleanup, completes);
+
+      final leftovers = await settingsDir.exists()
+          ? await settingsDir.list().toList()
+          : const [];
+      expect(leftovers, isEmpty);
+    });
+
+    test('ממתין גם לשמירת הגדרות PDF', () async {
+      final pdf = PdfBook(title: 'ספר PDF', path: r'C:\library\a.pdf');
+      final order = <String>[];
+      unawaited(
+        PdfBookPerBookSettings(zoom: 1.5).save(pdf).then((_) {
+          order.add('pdf');
+        }),
+      );
+
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['pdf', 'settle']);
+      expect((await PdfBookPerBookSettings.load(pdf))?.zoom, 1.5);
+    });
+
+    test('ממתין לשמירות טקסט ו-PDF שיצאו לדרך יחד', () async {
+      final pdf = PdfBook(title: 'ספר PDF', path: r'C:\library\a.pdf');
+      unawaited(saveFontSize(bookA, 18));
+      unawaited(PdfBookPerBookSettings(zoom: 2.0).save(pdf));
+
+      await PerBookSettings.settle();
+
+      expect((await TextBookPerBookSettings.load(bookA))?.fontSize, 18);
+      expect((await PdfBookPerBookSettings.load(pdf))?.zoom, 2.0);
+      await expectLater(tempDataRoot.delete(recursive: true), completes);
+      await tempDataRoot.create(recursive: true);
+    });
+
+    test('שני settle במקביל — שניהם מסתיימים', () async {
+      unawaited(saveFontSize(bookA, 18));
+      unawaited(saveFontSize(bookB, 19));
+
+      await expectLater(
+        Future.wait([PerBookSettings.settle(), PerBookSettings.settle()]),
+        completes,
+      );
+    });
+
+    test('התור אינו דולף אחרי פעולות רבות', () async {
+      for (var i = 0; i < 20; i++) {
+        unawaited(saveFontSize(TextBook(title: 'ספר $i'), 18 + i.toDouble()));
+      }
+      await PerBookSettings.settle();
+
+      final order = <String>[];
+      unawaited(
+        Future<void>.delayed(Duration.zero).then((_) => order.add('timer')),
+      );
+      await PerBookSettings.settle();
+      order.add('settle');
+
+      expect(order, ['settle'], reason: 'התור התרוקן לחלוטין');
+    });
+  });
+}

--- a/test/text_book/bloc/inline_notes_commentator_test.dart
+++ b/test/text_book/bloc/inline_notes_commentator_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/services/per_book_settings_service.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -61,6 +62,9 @@ void main() {
   });
 
   tearDownAll(() async {
+    // חייב לקדום להסרת ה-override: שמירה תלויה עדיין מחזיקה את הקובץ פתוח
+    // (המחיקה נכשלת ב-Windows) ותפתור את הנתיב מחדש אל AppData האמיתי.
+    await PerBookSettings.settle();
     AppPaths.debugOverrideDataRootPath(null);
     if (await tempDataRoot.exists()) {
       await tempDataRoot.delete(recursive: true);

--- a/test/text_book/bloc/per_book_commentators_save_test.dart
+++ b/test/text_book/bloc/per_book_commentators_save_test.dart
@@ -1,0 +1,200 @@
+import 'dart:io';
+
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/app_paths.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/services/per_book_settings_service.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+import '../../test_helpers/memory_cache_provider.dart';
+
+class _FakeTextBookRepository extends TextBookRepository {
+  _FakeTextBookRepository() : super(fileSystem: FileSystemData.instance);
+}
+
+TextBookLoaded _seed(TextBook book, {List<String> active = const []}) {
+  return TextBookLoaded(
+    book: book,
+    content: const ['שורה'],
+    fontSize: 20,
+    showLeftPane: true,
+    showSplitView: false,
+    activeCommentators: active,
+    commentatorGroups: const [],
+    availableCommentators: const ['רש"י', 'רמב"ן'],
+    links: const [],
+    linksByLine: const {},
+    tableOfContents: const [],
+    removeNikud: false,
+    visibleIndices: const [0],
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDataRoot;
+  late TextBook book;
+  late TextBookBloc bloc;
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  setUp(() async {
+    tempDataRoot = await Directory.systemTemp.createTemp('commentators_save_');
+    AppPaths.debugOverrideDataRootPath(tempDataRoot.path);
+    book = TextBook(title: 'ספר בדיקה');
+    bloc = TextBookBloc(
+      repository: _FakeTextBookRepository(),
+      initialState: TextBookInitial.named(book, 0, true, const []),
+      scrollController: ItemScrollController(),
+      positionsListener: ItemPositionsListener.create(),
+    );
+  });
+
+  tearDown(() async {
+    await bloc.close();
+    // חייב לקדום להסרת ה-override: השמירה יוצאת לדרך בלי await, ובלי
+    // ההמתנה היא מחזיקה את הקובץ פתוח והמחיקה נכשלת ב-Windows.
+    await PerBookSettings.settle();
+    AppPaths.debugOverrideDataRootPath(null);
+    if (await tempDataRoot.exists()) {
+      await tempDataRoot.delete(recursive: true);
+    }
+  });
+
+  /// מזין מצב טעון ומחיל אירוע בחירת מפרשים, ואז ממתין לשמירה שיצאה לדרך.
+  Future<void> select(
+    List<String> commentators, {
+    bool isUserAction = true,
+    bool isRestore = false,
+    TextBook? forBook,
+  }) async {
+    bloc.emit(_seed(forBook ?? book));
+    bloc.add(
+      UpdateCommentators(
+        commentators,
+        isUserAction: isUserAction,
+        isRestore: isRestore,
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    await PerBookSettings.settle();
+  }
+
+  group('שמירת בחירת מפרשים פר-ספר', () {
+    test('בחירה ידנית נשמרת ונטענת מהדיסק', () async {
+      await select(const ['רש"י', 'רמב"ן']);
+
+      final saved = await TextBookPerBookSettings.load(book);
+      expect(saved?.activeCommentators, ['רש"י', 'רמב"ן']);
+    });
+
+    test('בחירה ריקה נשמרת — המשתמש ביטל את הכל', () async {
+      await select(const ['רש"י']);
+      await select(const []);
+
+      final saved = await TextBookPerBookSettings.load(book);
+      expect(saved?.activeCommentators, isEmpty);
+    });
+
+    test('בחירה אוטומטית (isUserAction:false) אינה נשמרת', () async {
+      await select(const ['רש"י'], isUserAction: false);
+
+      expect(await TextBookPerBookSettings.load(book), isNull);
+    });
+
+    test('שחזור בחירה שמורה אינו כותב מחדש', () async {
+      await select(const ['רש"י'], isUserAction: false, isRestore: true);
+
+      expect(await TextBookPerBookSettings.load(book), isNull);
+    });
+
+    test('ספר אישי אינו נשמר פר-ספר', () async {
+      final userBook = TextBook(title: 'ספר אישי', isUserBook: true);
+      await select(const ['רש"י'], forBook: userBook);
+
+      expect(await TextBookPerBookSettings.load(userBook), isNull);
+    });
+
+    test('בחירות עוקבות — האחרונה מנצחת', () async {
+      await select(const ['רש"י']);
+      await select(const ['רמב"ן']);
+
+      final saved = await TextBookPerBookSettings.load(book);
+      expect(saved?.activeCommentators, ['רמב"ן']);
+    });
+
+    test('השמירה אינה דורסת הגדרות תצוגה קיימות של אותו ספר', () async {
+      await TextBookPerBookSettings.mutate(
+        book,
+        (existing) =>
+            (existing ?? TextBookPerBookSettings()).copyWith(fontSize: 27),
+      );
+
+      await select(const ['רש"י']);
+
+      final saved = await TextBookPerBookSettings.load(book);
+      expect(saved?.fontSize, 27);
+      expect(saved?.activeCommentators, ['רש"י']);
+    });
+
+    test('שני ספרים שונים נשמרים בנפרד', () async {
+      final other = TextBook(title: 'ספר אחר');
+      await select(const ['רש"י']);
+      await select(const ['רמב"ן'], forBook: other);
+
+      expect(
+        (await TextBookPerBookSettings.load(book))?.activeCommentators,
+        ['רש"י'],
+      );
+      expect(
+        (await TextBookPerBookSettings.load(other))?.activeCommentators,
+        ['רמב"ן'],
+      );
+    });
+  });
+
+  group('רגרסיה: השמירה התלויה מול מחיקת שורש הנתונים', () {
+    test('סגירת ה-bloc לבדה אינה מבטיחה שהשמירה הסתיימה', () async {
+      bloc.emit(_seed(book));
+      bloc.add(const UpdateCommentators(['רש"י']));
+      await Future<void>.delayed(Duration.zero);
+      await bloc.close();
+
+      // ההמתנה כאן היא מה שהופך את המחיקה לבטוחה — בלעדיה היא נכשלה
+      // ב-Windows עם PathAccessException (errno 32).
+      await PerBookSettings.settle();
+
+      await expectLater(tempDataRoot.delete(recursive: true), completes);
+      expect(await tempDataRoot.exists(), isFalse);
+      await tempDataRoot.create(recursive: true);
+    });
+
+    test('כמה בחירות רצופות — ההמתנה מכסה את כל התור', () async {
+      bloc.emit(_seed(book));
+      for (final commentator in ['רש"י', 'רמב"ן', 'ספורנו']) {
+        bloc.add(UpdateCommentators([commentator]));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      await PerBookSettings.settle();
+
+      final saved = await TextBookPerBookSettings.load(book);
+      expect(saved?.activeCommentators, ['ספורנו']);
+      await expectLater(tempDataRoot.delete(recursive: true), completes);
+      await tempDataRoot.create(recursive: true);
+    });
+  });
+}


### PR DESCRIPTION
## מה תוקן

הכשל שהתחיל את זה: `test/text_book/bloc/inline_notes_commentator_test.dart` נכשל ב-`(tearDownAll)`. תיארתי אותו קודם כ-flake — **הוא לא**. הוא נכשל עקבית, והוא תסמין של באג ייצור.

```
00:19 +15: (tearDownAll)          ← tearDownAll מתחיל
📁 Looking for file: ...          ← השמירה התלויה עדיין רצה
✅ Saved per-book settings
00:19 +15 -1: (tearDownAll) [E]
  PathAccessException: Deletion failed (OS Error: The process cannot access
  the file because it is being used by another process, errno = 32)
```

## השורש

`TextBookBloc._onUpdateCommentators` שולח את השמירה הפר-ספרית ב-`unawaited`, ולאף אחד אין דרך לדעת מתי פעולות ההגדרות שקטו. אותו חוסר מייצר באג אמיתי מול המשתמש:

**"איפוס כל ההגדרות המיוחדות"** (`text_settings_tab.dart` → `PerBookSettings.deleteAllSettings`) מתנגש בשמירה שיצאה לדרך, בשני כיוונים:

| תזמון | מה קורה היום |
|---|---|
| השמירה מחזיקה את הקובץ בזמן המחיקה | ב-Windows המחיקה נכשלת ב-errno 32, ה-`catch` בולע, והמשתמש מקבל **"כל ההגדרות המיוחדות אופסו בהצלחה"** בזמן שדבר לא נמחק |
| השמירה מסתיימת אחרי המחיקה | `_getSettingsDirectory` יוצר את התיקייה מחדש והקובץ נכתב שוב — **ההגדרה קמה לתחייה אחרי איפוס** |

התרחיש אינו תיאורטי: שינוי גודל גופן בספר ומעבר מיד להגדרות ולחיצה על "איפוס".

## התיקון

`PerBookSettings.settle()` — barrier על תור הנעילה **הקיים**, בלי מבנה נתונים חדש:

```dart
while (_fileLocks.isNotEmpty) {
  await Future.wait(_fileLocks.values.toList());
}
```

זה עובד כי כל ערך ב-`_fileLocks` הוא כבר הפעולה האחרונה בתור של אותו קובץ, והתור סדרתי — ההמתנה לו מכסה את כולו. הלולאה קולטת פעולות שנוספו בזמן ההמתנה.

- `deleteAllSettings` ממתין ל-`settle()`, מחזיר `bool` במקום `void`, ומפסיק ליצור תיקייה רק כדי למחוק אותה.
- ה-UI מציג שגיאה במקום הודעת הצלחה שקרית (`SettingsMessages.perBookSettingsResetFailed`).
- ה-`tearDownAll` של הטסט קורא ל-`settle()` **לפני** הסרת ה-override — אחרת הפעולה התלויה פותרת את הנתיב מחדש אל `AppData` האמיתי.

## גבול שהטסטים חשפו — מתועד, לא מוסתר

`settle()` מכסה פעולה **מרגע כניסתה לתור**. `cleanupRedundantSettings` סורק את התיקייה לפני ה-`runLocked` הראשון, ולכן חשוף בחלון הזה.

בדקתי אם החלון מסוכן — הוא לא: הניקוי בודק `dir.exists()` בכניסה ו-`file.exists()` **בתוך** הנעילה, כך שהתוצאה זהה בכל תזמון. במקום להעמיד פנים שה-barrier מלא, תיעדתי את הגבול ב-doc של ה-API וכתבתי טסט שמאמת את חוסר-ההתנגשות בפועל.

## חשש לרגרסיה

**הסיכון האמיתי היחיד — דדלוק עתידי.** `settle()` שייקרא מתוך פעולה נעולה ימתין לתור שהוא עצמו חוסם. אין כזה קורא היום (עברתי על כל 5 הקוראים של `runLocked`); המלכודת מתועדת ב-doc.

מה שנבדק ולא מסוכן:
- **חתימה `Future<void>` → `Future<bool>`** — קורא יחיד ב-`lib`, אפס ב-`test`.
- **הפסקת יצירת התיקייה לפני מחיקתה** — תוצאה נטו זהה; `_getSettingsDirectory` יוצר לפי צורך בכל פעולה.
- **דליפת `_fileLocks`** — ה-`identical` ב-`finally` מסיר את המפתח בדיוק פעם אחת, ע"י הפעולה האחרונה בתור. יש טסט ייעודי.
- **עיכוב באיפוס** — התנהגות חדשה, אבל נכונה: היום המחיקה פשוט נכשלת בשקט. כל צרכני התור סופיים, אין סכנת תקיעה.

## 36 טסטים חדשים

`test/settings/services/per_book_settings_settle_test.dart` (26):
סמנטיקת ה-barrier — תור ריק לא משהה את ה-event loop, `mutate`/`load`/`delete`/`PdfBookPerBookSettings.save`, תור יחיד מול תורים נפרדים, פעולה שנוספת תוך כדי המתנה, כשל בפעולה אחת לא מפיל את השאר, שני `settle` במקביל, אי-דליפת תור אחרי 20 פעולות; `deleteAllSettings` — ערך חוזר, המתנה לשמירה תלויה, אי-תחייה של הגדרה, קובצי legacy, תיקייה שאינה קיימת; ושחזור ישיר של ה-`PathAccessException`.

`test/text_book/bloc/per_book_commentators_save_test.dart` (10):
המסלול שהפיל את הטסט המקורי — בחירה ידנית נשמרת, בחירה אוטומטית ושחזור לא, ספר אישי לא, בחירה ריקה כן, אי-דריסת `fontSize` קיים, הפרדה בין ספרים, ושסגירת ה-bloc לבדה אינה מבטיחה שהשמירה הסתיימה.

## אימות

- `flutter analyze` — נקי בקבצים שהשתנו (4 ה-info הנותרים בעץ הם ב-`test/zz_probe_era_test.dart`, קובץ probe זמני שאינו חלק מ-PR זה).
- `flutter test` על `per_book_settings_settle_test` (26), `per_book_commentators_save_test` (10), `inline_notes_commentator_test` (15 — **הכשל המקורי עובר**), `per_book_settings_test` + `settings_bloc_test` (60). הכל ירוק.
- `dart format` על ששת הקבצים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
