### PR TITLE
תיקון: טסטי תפריט היקף החיפוש נכשלו בריצות CI ללא מנוע החיפוש

### DIFF
--- a/test/search/search_dialog_scope_lazy_test.dart
+++ b/test/search/search_dialog_scope_lazy_test.dart
@@ -95,7 +95,10 @@ Library _buildLibrary(int total) {
 }
 
 Future<void> main() async {
-  await tryInitSearchEngine();
+  // פתיחת התפריט מגיעה ל-normalizeFindQuery → sanitizeQuery, שמאציל למנוע
+  // הנייטיבי. בריצות CI שאינן נוגעות בקבצי חיפוש המנוע אינו נבנה, ולכן
+  // הטסטים שפותחים את התפריט מדולגים במקום להיכשל.
+  final engineReady = await tryInitSearchEngine();
 
   setUpAll(() async {
     await Settings.init(cacheProvider: MemoryCacheProvider());
@@ -390,7 +393,7 @@ Future<void> main() async {
       final small = await measureMenuOpen(200);
       final large = await measureMenuOpen(20000);
       expectScanFree(small, large, 'פתיחת תפריט ההיקף');
-    });
+    }, skip: !engineReady);
 
     testWidgets('התפריט והחיפוש בו עובדים על העץ שנבנה בעצלתיים', (
       tester,
@@ -419,7 +422,7 @@ Future<void> main() async {
         ),
         findsWidgets,
       );
-    });
+    }, skip: !engineReady);
 
     testWidgets('כניסה לספרי יסוד מסווגת בעצלתיים ומציגה את הספרים', (
       tester,
@@ -467,7 +470,7 @@ Future<void> main() async {
 
       expect(find.text('בראשית'), findsOneWidget);
       expect(tester.takeException(), isNull);
-    });
+    }, skip: !engineReady);
 
     testWidgets('rebuild עם ספרייה חדשה אינו בונה את העץ מחדש', (tester) async {
       // שני טסטי התזמון שלמעלה עובדים על אותו אובייקט ספרייה, ולכן מטמון
@@ -586,7 +589,7 @@ Future<void> main() async {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
       expect(inMenu('ספרייה חדשה'), findsWidgets);
-    });
+    }, skip: !engineReady);
   });
 }
 


### PR DESCRIPTION
## הבאג

מאז שהטסט `test/search/search_dialog_scope_lazy_test.dart` נכנס ל-dev (PR #647), **כל ענף שנבנה על dev נכשל** באותם 4 טסטים — כולל ענפים שאינם נוגעים בחיפוש:

| ענף | קומיט | תוצאה |
|---|---|---|
| `perf/search-dialog-scope-tree` (הענף שהכניס את הטסט) | `dc5469f87` | ✅ success |
| `fix/shortcut-non-latin-recording` | `7097aba5c` | ❌ failure |
| `perf/commentary-group-era-cache` | `5f70fabb2` | ❌ failure |
| `fix/per-book-settings-settle` | `84c69877f` | ❌ failure |

בשלושת הכשלים — בדיוק אותם 4 טסטים.

## שורש הבעיה

```
Bad state: flutter_rust_bridge has not been initialized
#2  sanitizeQuery (otzaria_search_engine/.../search_engine.dart:65)
#3  SearchQueryBuilder.sanitizeQuery (lib/search/search_query_builder.dart:373)
#4  normalizeFindQuery (lib/search/utils/find_match_utils.dart:6)
#5  _ScopeMenuPanelState._normalizedQuery (lib/search/view/search_scope_menu.dart:665)
#8  _ScopeMenuPanelState.build (lib/search/view/search_scope_menu.dart:999)
```

פתיחת התפריט מגיעה ל-`normalizeFindQuery` → `sanitizeQuery`, שמאציל למנוע ה-Rust. לפי `.github/workflows/flutter_tests.yml:35-36`:

> מנוע החיפוש נבנה רק כשה-PR נוגע בקבצי חיפוש — בשאר הריצות הטסטים התלויים בו מדולגים (`skip: searchEngineSkipReason`) במקום להיכשל.

הטסט קורא `await tryInitSearchEngine()` אבל **זורק את התוצאה** ואינו מדלג. לכן הוא עבר ב-CI של הענף שלו (הענף נגע ב-`lib/search/` → המנוע נבנה) ונכשל בכל ענף אחר.

## התיקון

שמירת התוצאה ב-`engineReady` והוספת `skip: !engineReady` לארבעת הטסטים שפותחים את התפריט — בהתאם לתקדים בפרויקט (`test/history/view/history_screen_test.dart:373`, `test/pdf_book/pdf_search_screen_visual_index_test.dart:141`).

ששת הטסטים שאינם פותחים את התפריט (מדידות התזמון ובדיקות התווית) ממשיכים לרוץ בכל ריצה — הם לא נוגעים במנוע.

## אימות — שוחזר מקומית ע"י הסתרת הספרייה הנייטיבית

| מצב | תוצאה |
|---|---|
| בלי המנוע, **לפני** התיקון | `+6 -4` — שחזור מדויק של כשל ה-CI |
| בלי המנוע, **אחרי** התיקון | `+6 ~4` — 4 מדולגים, השאר עוברים |
| עם המנוע, אחרי התיקון | `+10` — כל הטסטים רצים, אף אחד לא מדולג |

`flutter analyze test/search` נקי.

הערה: ה-PR הזה נוגע בקובץ עם `search` בשמו, ולכן ה-CI שלו **יבנה** את המנוע ויריץ את כל 10 הטסטים — הירוק כאן אינו מוכיח את התיקון. ההוכחה היא טבלת האימות שלמעלה; הראיה בפועל תהיה שהענף הבא שאינו נוגע בחיפוש יעבור.

🤖 Generated with [Claude Code](https://claude.com/claude-code)