### PR TITLE
שיפור: גלילת גלגלת העכבר בקורא הטקסט חלקה ולא בקפיצות

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,6 +649,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Reader side panel shell | `test/widgets/reader_side_panel_shell_test.dart` |
 | Responsive action bar | `test/widgets/responsive_action_bar_test.dart` |
 | Scrollable list scrollbar | `test/widgets/scrollable_positioned_list_scrollbar_test.dart` |
+| Smooth mouse-wheel scrolling | `test/widgets/smooth_wheel_scroll_test.dart` |
 | Smart text render settings | `test/widgets/smart_text/render_settings_test.dart` |
 | Smart text ↔ plugin section sync gate | `test/widgets/smart_text/smart_text_section_sync_gate_test.dart` |
 | Work/indexing status overlays | `test/widgets/work_status_overlay_test.dart`, `…indexing_status_overlay_test.dart` |

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/widgets/misc/direct_link_menu_entries.dart';
 import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
+import 'package:otzaria/widgets/misc/smooth_wheel_scroll.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -1860,7 +1861,9 @@ class _CombinedViewState extends State<CombinedView> {
                                               .add(note);
                                         }
                                       }
-                                      return buildOuterList(state, noteMap);
+                                      return SmoothWheelScroll(
+                                        child: buildOuterList(state, noteMap),
+                                      );
                                     },
                                   ),
                             ),

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -29,6 +29,7 @@ import 'package:otzaria/widgets/misc/commentators_filter_button.dart';
 import 'package:otzaria/widgets/layout/commentators_filter_screen.dart';
 import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
 import 'package:otzaria/widgets/misc/progressive_scrolling.dart';
+import 'package:otzaria/widgets/misc/smooth_wheel_scroll.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/utils/ui/context_menu_utils.dart';
@@ -1803,7 +1804,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                                     itemPositionsListener:
                                         _itemPositionsListener,
                                     itemCount: groups.length,
-                                    child: listView,
+                                    child: SmoothWheelScroll(child: listView),
                                   ),
                                 ),
                               ),

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -50,6 +50,7 @@ import 'package:otzaria/widgets/smart_text/smart_text.dart';
 import 'package:otzaria/text_book/view/error_report_dialog.dart';
 import 'package:otzaria/widgets/misc/direct_link_menu_entries.dart';
 import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
+import 'package:otzaria/widgets/misc/smooth_wheel_scroll.dart';
 import 'package:otzaria/text_book/view/selection/enhanced_gesture_detector.dart';
 import 'package:otzaria/text_book/view/selection/selection_persistence.dart';
 import 'package:otzaria/text_book/view/selection/selection_hit_test.dart';
@@ -2248,23 +2249,27 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
                                     itemPositionsListener: _positionsListener,
                                     itemCount: itemCount,
                                     labelForIndex: widget.labelForIndex,
-                                    child: ScrollablePositionedList.builder(
-                                      itemScrollController: _scrollController,
-                                      itemPositionsListener: _positionsListener,
-                                      scrollOffsetController: widget.isMainText
-                                          ? state.scrollOffsetController
-                                          : null,
-                                      itemCount: itemCount,
-                                      padding: const EdgeInsets.all(4),
-                                      itemBuilder: (context, index) =>
-                                          _buildLineItem(
-                                            context,
-                                            index,
-                                            state,
-                                            noteMap,
-                                            segments,
-                                            continuous,
-                                          ),
+                                    child: SmoothWheelScroll(
+                                      child: ScrollablePositionedList.builder(
+                                        itemScrollController: _scrollController,
+                                        itemPositionsListener:
+                                            _positionsListener,
+                                        scrollOffsetController:
+                                            widget.isMainText
+                                            ? state.scrollOffsetController
+                                            : null,
+                                        itemCount: itemCount,
+                                        padding: const EdgeInsets.all(4),
+                                        itemBuilder: (context, index) =>
+                                            _buildLineItem(
+                                              context,
+                                              index,
+                                              state,
+                                              noteMap,
+                                              segments,
+                                              continuous,
+                                            ),
+                                      ),
                                     ),
                                   )
                                 : ListView.builder(

--- a/lib/widgets/misc/smooth_wheel_scroll.dart
+++ b/lib/widgets/misc/smooth_wheel_scroll.dart
@@ -1,0 +1,255 @@
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// מחליק את גלילת גלגלת העכבר ברשימה שמתחתיו.
+///
+/// Flutter מיישם נקישת גלגלת כטלפורט: `forcePixels(pixels + delta)` ואז
+/// מהירות אפס — כל התזוזה (100 פיקסלים בהגדרות Windows ברירת המחדל) קורית
+/// בפריים אחד ואין האטה בסוף. כאן חוטפים את האירוע ומזינים את אותו מנוע
+/// עצמו ([ScrollPosition.pointerScroll]) בצעדים קטנים לעבר יעד מצטבר, כך
+/// שהמרחק זהה בדיוק אך פרוס על פריימים.
+class SmoothWheelScroll extends StatefulWidget {
+  const SmoothWheelScroll({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<SmoothWheelScroll> createState() => _SmoothWheelScrollState();
+}
+
+class _SmoothWheelScrollState extends State<SmoothWheelScroll>
+    with SingleTickerProviderStateMixin {
+  /// קבוע הזמן של ההתקרבות ליעד: ~55ms מביאים ל-90% מהדרך בכ-8 פריימים.
+  /// ארוך מזה מרגיש צף ומאחר אחרי היד, קצר מזה חוזר לתחושת הקפיצה.
+  static const double _timeConstantMs = 55.0;
+
+  /// מתחת לזה אין מה להחליק — נוחתים על היעד ועוצרים.
+  static const double _epsilon = 0.5;
+
+  late final Ticker _ticker;
+  Duration? _lastTick;
+
+  ScrollableState? _scrollable;
+
+  double _target = 0.0;
+  int _direction = 1;
+  double? _previousPixels;
+
+  /// ה-minScrollExtent שהיה בתחילת ההחלקה. רשימות ממוקמות מעגנות את מערכת
+  /// הצירים לפריט היעד, ולכן שינוי שלו אומר שהעוגן הוחלף (קפיצת ניווט)
+  /// והיעד השמור מצביע למקום אחר לגמרי.
+  double _anchorMinExtent = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    // חובה ליצור כאן ולא ב-late lazy: אם הגלגלת לא נתפסה אף פעם, dispose היה
+    // יוצר את ה-Ticker על אלמנט שכבר הוסר מהעץ ומפיל assert.
+    _ticker = createTicker(_onTick);
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  ScrollPosition? get _position {
+    final scrollable = _scrollable;
+    if (scrollable == null || !scrollable.mounted) return null;
+    final position = scrollable.position;
+    return position.hasPixels && position.hasContentDimensions
+        ? position
+        : null;
+  }
+
+  /// לוכד את ה-[Scrollable] של הרשימה מתוך ההודעות שהיא שולחת. depth אחר
+  /// מאפס הוא גלילה מקוננת בתוך פריט, שאמורה להישאר של עצמה.
+  bool _capture(BuildContext? notificationContext, int depth) {
+    if (depth == 0 && notificationContext != null) {
+      _scrollable = Scrollable.maybeOf(notificationContext) ?? _scrollable;
+    }
+    return false;
+  }
+
+  bool _shouldClaim(PointerScrollEvent event) {
+    // משטח מגע מגיע כאירועי pan ומקבל אינרציה מהפיזיקה; רק לגלגלת אין.
+    if (event.kind != PointerDeviceKind.mouse) return false;
+
+    final delta = event.scrollDelta.dy;
+    if (delta == 0) return false;
+
+    // Shift מהפך ציר, ושאר הצירופים שמורים לקיצורים — אלה לא גלילה רגילה.
+    final keyboard = HardwareKeyboard.instance;
+    if (keyboard.isShiftPressed ||
+        keyboard.isControlPressed ||
+        keyboard.isAltPressed ||
+        keyboard.isMetaPressed) {
+      return false;
+    }
+
+    final position = _position;
+    if (position == null) return false;
+
+    // בקצה אין מה להחליק, ובלי תפיסה המסלול המקורי גם מעביר לאב אם יש.
+    return delta > 0
+        ? position.pixels < position.maxScrollExtent - _epsilon
+        : position.pixels > position.minScrollExtent + _epsilon;
+  }
+
+  void _onWheel(PointerScrollEvent event) {
+    final position = _position;
+    if (position == null) return;
+
+    // היעד מצטבר. מדידה מהמקום הנוכחי בכל נקישה הייתה מוותרת על המרחק
+    // שההחלקה הקודמת עוד לא הספיקה לספק — נמדד: אובדן של 75% מהגלילה.
+    if (!_ticker.isActive) {
+      _target = position.pixels;
+      _anchorMinExtent = position.minScrollExtent;
+    }
+    _target = (_target + event.scrollDelta.dy).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    _direction = event.scrollDelta.dy > 0 ? 1 : -1;
+    _previousPixels = null;
+
+    // הצעד הראשון מבוצע מיד ולא בפריים הבא: השהיית קלט מורגשת יותר מהקפיצה.
+    _advance(position, 16.0);
+    if (!_ticker.isActive) {
+      _lastTick = null;
+      _ticker.start();
+    }
+  }
+
+  /// מקדם צעד אחד לעבר היעד. מחזיר false כשהמרחק נגמר.
+  bool _advance(ScrollPosition position, double frameMs) {
+    final remaining = _target - position.pixels;
+    if (remaining.abs() <= _epsilon) return false;
+
+    var step = remaining * (1 - math.exp(-frameMs / _timeConstantMs));
+    // ליד היעד המנה שואפת לאפס ומייצרת זחילה — מסיימים בצעד אחד.
+    if (step.abs() < _epsilon) step = remaining;
+
+    // אותו מנוע שבו Flutter מטפל בנקישת גלגלת: מזיז מיד, נחסם בקצוות ומודיע
+    // כמו גלילת משתמש. ההבדל היחיד הוא שכאן מזינים אותו בצעדים קטנים.
+    position.pointerScroll(step);
+    return true;
+  }
+
+  void _onTick(Duration elapsed) {
+    final position = _position;
+    if (position == null ||
+        (position.minScrollExtent - _anchorMinExtent).abs() > _epsilon) {
+      _stop();
+      return;
+    }
+
+    final previousPixels = _previousPixels;
+    _previousPixels = position.pixels;
+    // תזוזה נגד כיוון הגלילה = גורם אחר לקח את ההגה (גרירת אגודל, ניווט).
+    if (previousPixels != null &&
+        (position.pixels - previousPixels) * _direction < -_epsilon) {
+      _stop();
+      return;
+    }
+
+    final previousTick = _lastTick;
+    _lastTick = elapsed;
+    final measuredMs = previousTick == null
+        ? 16.0
+        : (elapsed - previousTick).inMicroseconds / 1000.0;
+    // פריים ראשון או קפיצת זמן (חלון ממוזער/נעילה) — צעד של פריים תקני.
+    final frameMs = measuredMs <= 0 || measuredMs > 100 ? 16.0 : measuredMs;
+
+    if (!_advance(position, frameMs)) {
+      _stop();
+    }
+  }
+
+  void _stop() {
+    _ticker.stop();
+    _previousPixels = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollMetricsNotification>(
+      onNotification: (notification) =>
+          _capture(notification.context, notification.depth),
+      child: NotificationListener<ScrollNotification>(
+        onNotification: (notification) =>
+            _capture(notification.context, notification.depth),
+        child: _WheelSignalInterceptor(
+          shouldClaim: _shouldClaim,
+          onWheel: _onWheel,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+/// תופס אירועי גלגלת לפני ה-[Scrollable] שמתחתיו, דרך רישום ב-
+/// [PointerSignalResolver].
+class _WheelSignalInterceptor extends SingleChildRenderObjectWidget {
+  const _WheelSignalInterceptor({
+    required this.shouldClaim,
+    required this.onWheel,
+    super.child,
+  });
+
+  final bool Function(PointerScrollEvent event) shouldClaim;
+  final void Function(PointerScrollEvent event) onWheel;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderWheelSignalInterceptor(shouldClaim: shouldClaim, onWheel: onWheel);
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderWheelSignalInterceptor renderObject,
+  ) {
+    renderObject
+      ..shouldClaim = shouldClaim
+      ..onWheel = onWheel;
+  }
+}
+
+class _RenderWheelSignalInterceptor extends RenderProxyBox {
+  _RenderWheelSignalInterceptor({
+    required this.shouldClaim,
+    required this.onWheel,
+  });
+
+  bool Function(PointerScrollEvent event) shouldClaim;
+  void Function(PointerScrollEvent event) onWheel;
+
+  /// נרשמים בנתיב ה-hit-test **לפני** הצאצאים. ב-[PointerSignalResolver]
+  /// הרושם הראשון זוכה, והסדר הוא סדר הנתיב — אחרת ה-[Scrollable] שבפנים,
+  /// שעמוק יותר, היה נרשם ראשון וקופץ במקומנו.
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (!size.contains(position)) return false;
+    result.add(BoxHitTestEntry(this, position));
+    return hitTestChildren(result, position: position);
+  }
+
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // ההכרעה חייבת לקרות לפני הרישום: רישום שלא מלווה בטיפול היה בולע את
+    // הגלילה המקורית ומשאיר את הגלגלת מתה.
+    if (event is PointerScrollEvent && shouldClaim(event)) {
+      GestureBinding.instance.pointerSignalResolver.register(
+        event,
+        (claimed) => onWheel(claimed as PointerScrollEvent),
+      );
+    }
+  }
+}

--- a/lib/widgets/misc/smooth_wheel_scroll.dart
+++ b/lib/widgets/misc/smooth_wheel_scroll.dart
@@ -8,11 +8,8 @@ import 'package:flutter/widgets.dart';
 
 /// מחליק את גלילת גלגלת העכבר ברשימה שמתחתיו.
 ///
-/// Flutter מיישם נקישת גלגלת כטלפורט: `forcePixels(pixels + delta)` ואז
-/// מהירות אפס — כל התזוזה (100 פיקסלים בהגדרות Windows ברירת המחדל) קורית
-/// בפריים אחד ואין האטה בסוף. כאן חוטפים את האירוע ומזינים את אותו מנוע
-/// עצמו ([ScrollPosition.pointerScroll]) בצעדים קטנים לעבר יעד מצטבר, כך
-/// שהמרחק זהה בדיוק אך פרוס על פריימים.
+/// מחבר נקישות ליעד מצטבר ומניע אליו [ScrollActivity] אחת, כך שהמרחק
+/// נשמר אך נפרס על פריימים בלי מחזור התחלה וסיום חדש בכל צעד.
 class SmoothWheelScroll extends StatefulWidget {
   const SmoothWheelScroll({super.key, required this.child});
 
@@ -35,26 +32,25 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
   Duration? _lastTick;
 
   ScrollableState? _scrollable;
+  _SmoothWheelActivity? _activity;
+  final Set<ScrollableState> _nestedScrollables = {};
 
   double _target = 0.0;
-  int _direction = 1;
-  double? _previousPixels;
 
-  /// ה-minScrollExtent שהיה בתחילת ההחלקה. רשימות ממוקמות מעגנות את מערכת
-  /// הצירים לפריט היעד, ולכן שינוי שלו אומר שהעוגן הוחלף (קפיצת ניווט)
-  /// והיעד השמור מצביע למקום אחר לגמרי.
+  /// שינוי minScrollExtent ברשימה ממוקמת מעיד שהעוגן הוחלף,
+  /// ולכן היעד השמור כבר שייך למערכת צירים קודמת.
   double _anchorMinExtent = 0.0;
 
   @override
   void initState() {
     super.initState();
-    // חובה ליצור כאן ולא ב-late lazy: אם הגלגלת לא נתפסה אף פעם, dispose היה
-    // יוצר את ה-Ticker על אלמנט שכבר הוסר מהעץ ומפיל assert.
+    // יצירה מראש מונעת ניסיון ליצור Ticker מתוך dispose של State שהוסר.
     _ticker = createTicker(_onTick);
   }
 
   @override
   void dispose() {
+    _finish();
     _ticker.dispose();
     super.dispose();
   }
@@ -71,8 +67,19 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
   /// לוכד את ה-[Scrollable] של הרשימה מתוך ההודעות שהיא שולחת. depth אחר
   /// מאפס הוא גלילה מקוננת בתוך פריט, שאמורה להישאר של עצמה.
   bool _capture(BuildContext? notificationContext, int depth) {
-    if (depth == 0 && notificationContext != null) {
-      _scrollable = Scrollable.maybeOf(notificationContext) ?? _scrollable;
+    if (depth != 0) {
+      final nested = notificationContext == null
+          ? null
+          : Scrollable.maybeOf(notificationContext);
+      if (nested != null) _nestedScrollables.add(nested);
+      return false;
+    }
+    if (notificationContext != null) {
+      final next = Scrollable.maybeOf(notificationContext);
+      if (next != null && !identical(next, _scrollable)) {
+        _finish();
+        _scrollable = next;
+      }
     }
     return false;
   }
@@ -80,6 +87,10 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
   bool _shouldClaim(PointerScrollEvent event) {
     // משטח מגע מגיע כאירועי pan ומקבל אינרציה מהפיזיקה; רק לגלגלת אין.
     if (event.kind != PointerDeviceKind.mouse) return false;
+    if (_isOverNestedScrollable(event.position)) {
+      _finish();
+      return false;
+    }
 
     final delta = event.scrollDelta.dy;
     if (delta == 0) return false;
@@ -102,60 +113,105 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
         : position.pixels > position.minScrollExtent + _epsilon;
   }
 
+  bool _isOverNestedScrollable(Offset globalPosition) {
+    _nestedScrollables.removeWhere((scrollable) => !scrollable.mounted);
+    for (final scrollable in _nestedScrollables) {
+      final renderObject = scrollable.context.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.hasSize) continue;
+      final bounds = MatrixUtils.transformRect(
+        renderObject.getTransformTo(null),
+        Offset.zero & renderObject.size,
+      );
+      if (bounds.contains(globalPosition)) return true;
+    }
+    return false;
+  }
+
   void _onWheel(PointerScrollEvent event) {
     final position = _position;
     if (position == null) return;
 
-    // היעד מצטבר. מדידה מהמקום הנוכחי בכל נקישה הייתה מוותרת על המרחק
-    // שההחלקה הקודמת עוד לא הספיקה לספק — נמדד: אובדן של 75% מהגלילה.
-    if (!_ticker.isActive) {
+    final wasActive = _activity != null;
+    if (!wasActive) {
       _target = position.pixels;
       _anchorMinExtent = position.minScrollExtent;
+      if (!_beginActivity(position)) {
+        position.pointerScroll(event.scrollDelta.dy);
+        event.respond(allowPlatformDefault: false);
+        return;
+      }
     }
     _target = (_target + event.scrollDelta.dy).clamp(
       position.minScrollExtent,
       position.maxScrollExtent,
     );
-    _direction = event.scrollDelta.dy > 0 ? 1 : -1;
-    _previousPixels = null;
+    event.respond(allowPlatformDefault: false);
 
-    // הצעד הראשון מבוצע מיד ולא בפריים הבא: השהיית קלט מורגשת יותר מהקפיצה.
-    _advance(position, 16.0);
-    if (!_ticker.isActive) {
-      _lastTick = null;
-      _ticker.start();
+    // אירועים נוספים רק מעדכנים יעד; התנועה עצמה מתבצעת פעם אחת בכל פריים.
+    if (wasActive) return;
+
+    if (!_advance(position, 16.0)) {
+      _finish();
+      return;
     }
+    _lastTick = null;
+    _ticker.start();
+  }
+
+  bool _beginActivity(ScrollPosition position) {
+    if (position is! ScrollActivityDelegate) return false;
+    final delegate = position as ScrollActivityDelegate;
+
+    late final _SmoothWheelActivity activity;
+    activity = _SmoothWheelActivity(
+      delegate,
+      onDisposed: () => _onActivityDisposed(activity),
+    );
+    _activity = activity;
+    position.beginActivity(activity);
+    return identical(_activity, activity);
   }
 
   /// מקדם צעד אחד לעבר היעד. מחזיר false כשהמרחק נגמר.
   bool _advance(ScrollPosition position, double frameMs) {
+    final activity = _activity;
+    if (activity == null) return false;
+
+    _target = _target.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
     final remaining = _target - position.pixels;
-    if (remaining.abs() <= _epsilon) return false;
+    if (remaining.abs() <= _epsilon) {
+      activity.moveTo(_target, velocity: 0.0);
+      return false;
+    }
 
     var step = remaining * (1 - math.exp(-frameMs / _timeConstantMs));
     // ליד היעד המנה שואפת לאפס ומייצרת זחילה — מסיימים בצעד אחד.
     if (step.abs() < _epsilon) step = remaining;
 
-    // אותו מנוע שבו Flutter מטפל בנקישת גלגלת: מזיז מיד, נחסם בקצוות ומודיע
-    // כמו גלילת משתמש. ההבדל היחיד הוא שכאן מזינים אותו בצעדים קטנים.
-    position.pointerScroll(step);
+    final before = position.pixels;
+    final overscroll = activity.moveTo(
+      before + step,
+      velocity: step * 1000 / frameMs,
+    );
+    final moved = (position.pixels - before).abs() > _epsilon;
+    if (!moved && overscroll.abs() > _epsilon) return false;
+    final remainingAfterStep = _target - position.pixels;
+    if (remainingAfterStep.abs() <= _epsilon) {
+      activity.moveTo(_target, velocity: 0.0);
+      return false;
+    }
     return true;
   }
 
   void _onTick(Duration elapsed) {
     final position = _position;
     if (position == null ||
+        _activity == null ||
         (position.minScrollExtent - _anchorMinExtent).abs() > _epsilon) {
-      _stop();
-      return;
-    }
-
-    final previousPixels = _previousPixels;
-    _previousPixels = position.pixels;
-    // תזוזה נגד כיוון הגלילה = גורם אחר לקח את ההגה (גרירת אגודל, ניווט).
-    if (previousPixels != null &&
-        (position.pixels - previousPixels) * _direction < -_epsilon) {
-      _stop();
+      _finish();
       return;
     }
 
@@ -168,13 +224,22 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
     final frameMs = measuredMs <= 0 || measuredMs > 100 ? 16.0 : measuredMs;
 
     if (!_advance(position, frameMs)) {
-      _stop();
+      _finish();
     }
   }
 
-  void _stop() {
+  void _onActivityDisposed(_SmoothWheelActivity activity) {
+    if (!identical(_activity, activity)) return;
+    _activity = null;
     _ticker.stop();
-    _previousPixels = null;
+  }
+
+  void _finish() {
+    _ticker.stop();
+    final activity = _activity;
+    if (activity == null) return;
+    _activity = null;
+    activity.finish();
   }
 
   @override
@@ -192,6 +257,70 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
         ),
       ),
     );
+  }
+}
+
+class _SmoothWheelActivity extends ScrollActivity {
+  _SmoothWheelActivity(super.delegate, {required this.onDisposed});
+
+  final VoidCallback onDisposed;
+  ScrollDirection _direction = ScrollDirection.idle;
+  double _velocity = 0.0;
+
+  double moveTo(double pixels, {required double velocity}) {
+    _velocity = velocity;
+    return delegate.setPixels(pixels);
+  }
+
+  void finish() => delegate.goBallistic(0.0);
+
+  @override
+  void dispatchScrollUpdateNotification(
+    ScrollMetrics metrics,
+    BuildContext context,
+    double scrollDelta,
+  ) {
+    super.dispatchScrollUpdateNotification(metrics, context, scrollDelta);
+    final direction = scrollDelta > 0
+        ? ScrollDirection.reverse
+        : ScrollDirection.forward;
+    if (direction == _direction) return;
+    _direction = direction;
+    UserScrollNotification(
+      metrics: metrics,
+      context: context,
+      direction: direction,
+    ).dispatch(context);
+  }
+
+  @override
+  void dispatchScrollEndNotification(
+    ScrollMetrics metrics,
+    BuildContext context,
+  ) {
+    super.dispatchScrollEndNotification(metrics, context);
+    if (_direction == ScrollDirection.idle) return;
+    _direction = ScrollDirection.idle;
+    UserScrollNotification(
+      metrics: metrics,
+      context: context,
+      direction: ScrollDirection.idle,
+    ).dispatch(context);
+  }
+
+  @override
+  bool get shouldIgnorePointer => false;
+
+  @override
+  bool get isScrolling => true;
+
+  @override
+  double get velocity => _velocity;
+
+  @override
+  void dispose() {
+    super.dispose();
+    onDisposed();
   }
 }
 
@@ -231,9 +360,8 @@ class _RenderWheelSignalInterceptor extends RenderProxyBox {
   bool Function(PointerScrollEvent event) shouldClaim;
   void Function(PointerScrollEvent event) onWheel;
 
-  /// נרשמים בנתיב ה-hit-test **לפני** הצאצאים. ב-[PointerSignalResolver]
-  /// הרושם הראשון זוכה, והסדר הוא סדר הנתיב — אחרת ה-[Scrollable] שבפנים,
-  /// שעמוק יותר, היה נרשם ראשון וקופץ במקומנו.
+  /// רישום לפני הצאצאים מאפשר להחליף את קפיצת ה-[Scrollable] בהחלקה.
+  /// כשיש Scrollable מקונן, העטיפה אינה נרשמת כלל.
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {
     if (!size.contains(position)) return false;

--- a/test/widgets/smooth_wheel_scroll_test.dart
+++ b/test/widgets/smooth_wheel_scroll_test.dart
@@ -16,7 +16,10 @@ void main() {
   late ItemPositionsListener positions;
   var itemBuilds = 0;
 
-  Widget buildList({bool smooth = true}) {
+  Widget buildList({
+    bool smooth = true,
+    bool Function(ScrollNotification)? onNotification,
+  }) {
     itemController = ItemScrollController();
     offsetController = ScrollOffsetController();
     positions = ItemPositionsListener.create();
@@ -33,12 +36,20 @@ void main() {
       },
     );
 
+    Widget scrollable = smooth ? SmoothWheelScroll(child: list) : list;
+    if (onNotification != null) {
+      scrollable = NotificationListener<ScrollNotification>(
+        onNotification: onNotification,
+        child: scrollable,
+      );
+    }
+
     return MaterialApp(
       home: Scaffold(
         body: SizedBox(
           height: _viewportHeight,
           width: 400,
-          child: smooth ? SmoothWheelScroll(child: list) : list,
+          child: scrollable,
         ),
       ),
     );
@@ -167,6 +178,33 @@ void main() {
 
       expect(smoothBuilds, lessThanOrEqualTo(jumpBuilds));
     });
+
+    testWidgets('אירועים באותו פריים רק מצטברים ליעד', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      for (var n = 0; n < 4; n++) {
+        wheel(tester);
+      }
+      final beforeNextFrame = offset();
+      await tester.pumpAndSettle();
+
+      expect(beforeNextFrame, lessThan(_notch * 0.5));
+      expect(offset(), closeTo(_notch * 4, 0.01));
+    });
+
+    testWidgets('היפוך חלקי שומר את המרחק המצטבר נטו', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      for (var n = 0; n < 4; n++) {
+        wheel(tester);
+      }
+      wheel(tester, dy: -_notch);
+      await tester.pumpAndSettle();
+
+      expect(offset(), closeTo(_notch * 3, 0.01));
+    });
   });
 
   group('קצות הרשימה', () {
@@ -217,6 +255,99 @@ void main() {
 
       expect(offset(), closeTo(_notch, 0.01));
     });
+
+    testWidgets('רשימה מקוננת מקבלת את הגלילה שמתחת לסמן', (tester) async {
+      final outerController = ScrollController();
+      final innerController = ScrollController();
+      const innerKey = ValueKey('inner-list');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            height: _viewportHeight,
+            width: 400,
+            child: SmoothWheelScroll(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  SizedBox(
+                    height: 200,
+                    child: ListView.builder(
+                      key: innerKey,
+                      controller: innerController,
+                      itemExtent: _itemHeight,
+                      itemCount: 20,
+                      itemBuilder: (context, index) => Text('פנימי $index'),
+                    ),
+                  ),
+                  const SizedBox(height: 800),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      tester.binding.handlePointerEvent(
+        PointerScrollEvent(
+          position: tester.getCenter(find.byKey(innerKey)),
+          scrollDelta: const Offset(0, _notch),
+          kind: PointerDeviceKind.mouse,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(innerController.offset, closeTo(_notch, 0.01));
+      expect(outerController.offset, 0.0);
+    });
+
+    testWidgets('רשימה פנימית אינה מבטלת החלקה בשטח הרשימה החיצונית', (
+      tester,
+    ) async {
+      final outerController = ScrollController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            height: _viewportHeight,
+            width: 400,
+            child: SmoothWheelScroll(
+              child: ListView(
+                controller: outerController,
+                children: [
+                  SizedBox(
+                    height: 200,
+                    child: ListView.builder(
+                      itemExtent: _itemHeight,
+                      itemCount: 20,
+                      itemBuilder: (context, index) => Text('פנימי $index'),
+                    ),
+                  ),
+                  const SizedBox(height: 800, key: ValueKey('outer-area')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      tester.binding.handlePointerEvent(
+        PointerScrollEvent(
+          position:
+              tester.getTopLeft(find.byKey(const ValueKey('outer-area'))) +
+              const Offset(200, 100),
+          scrollDelta: const Offset(0, _notch),
+          kind: PointerDeviceKind.mouse,
+        ),
+      );
+      final beforeNextFrame = outerController.offset;
+      await tester.pumpAndSettle();
+
+      expect(beforeNextFrame, lessThan(_notch * 0.5));
+      expect(outerController.offset, closeTo(_notch, 0.01));
+    });
   });
 
   group('שיתוף השליטה', () {
@@ -239,6 +370,51 @@ void main() {
       expect(afterJump, closeTo(300 * _itemHeight, 0.01));
     });
 
+    testWidgets('ביטול אינרציה מפסיק את ההחלקה', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      await tester.pump(const Duration(milliseconds: 16));
+      tester.binding.handlePointerEvent(
+        PointerScrollInertiaCancelEvent(
+          position: tester.getCenter(find.byType(ScrollablePositionedList)),
+          kind: PointerDeviceKind.mouse,
+        ),
+      );
+      final atCancel = offset();
+      await frames(tester, 3);
+
+      expect(offset(), closeTo(atCancel, 0.01));
+    });
+
+    testWidgets('החלקה היא פעילות אחת עם התחלה וסיום יחידים', (tester) async {
+      var starts = 0;
+      var updates = 0;
+      var ends = 0;
+      var directions = 0;
+      await tester.pumpWidget(
+        buildList(
+          onNotification: (notification) {
+            if (notification is ScrollStartNotification) starts++;
+            if (notification is ScrollUpdateNotification) updates++;
+            if (notification is ScrollEndNotification) ends++;
+            if (notification is UserScrollNotification) directions++;
+            return false;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      await frames(tester, 20);
+
+      expect(starts, 1);
+      expect(updates, greaterThan(1));
+      expect(ends, 1);
+      expect(directions, 2);
+    });
+
     // מלכודת: עטיפה ב-render object מרובה-ילדים (Stack) מייצרת את הרשימה
     // החדשה לפני שחרור הקודמת, ואז ItemScrollController נצמד פעמיים וזורק.
     testWidgets('החלפת key של הרשימה אינה מכשילה את חיבור הבקרים', (
@@ -246,6 +422,7 @@ void main() {
     ) async {
       final sharedItemController = ItemScrollController();
       final sharedOffsetController = ScrollOffsetController();
+      positions = ItemPositionsListener.create();
 
       Widget keyed(String tag) => MaterialApp(
         home: Scaffold(
@@ -269,10 +446,13 @@ void main() {
 
       await tester.pumpWidget(keyed('a'));
       await tester.pumpAndSettle();
+      wheel(tester);
+      await tester.pump(const Duration(milliseconds: 16));
       await tester.pumpWidget(keyed('b'));
       await tester.pumpAndSettle();
 
       expect(tester.takeException(), isNull);
+      expect(offset(), closeTo(0.0, 0.01));
     });
 
     testWidgets('פירוק הווידג\'ט באמצע החלקה אינו זורק', (tester) async {

--- a/test/widgets/smooth_wheel_scroll_test.dart
+++ b/test/widgets/smooth_wheel_scroll_test.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/misc/smooth_wheel_scroll.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+const _itemHeight = 40.0;
+const _itemCount = 500;
+const _viewportHeight = 600.0;
+const _notch = 100.0;
+
+void main() {
+  late ItemScrollController itemController;
+  late ScrollOffsetController offsetController;
+  late ItemPositionsListener positions;
+  var itemBuilds = 0;
+
+  Widget buildList({bool smooth = true}) {
+    itemController = ItemScrollController();
+    offsetController = ScrollOffsetController();
+    positions = ItemPositionsListener.create();
+    itemBuilds = 0;
+
+    final list = ScrollablePositionedList.builder(
+      itemScrollController: itemController,
+      scrollOffsetController: offsetController,
+      itemPositionsListener: positions,
+      itemCount: _itemCount,
+      itemBuilder: (context, index) {
+        itemBuilds++;
+        return SizedBox(height: _itemHeight, child: Text('שורה $index'));
+      },
+    );
+
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: _viewportHeight,
+          width: 400,
+          child: smooth ? SmoothWheelScroll(child: list) : list,
+        ),
+      ),
+    );
+  }
+
+  /// האופסט האבסולוטי ביחידות פיקסלים, מחושב ממיקומי הפריטים (שהם היחידים
+  /// שנשארים נכונים גם אחרי החלפת עוגן).
+  double offset() {
+    final first = positions.itemPositions.value.reduce(
+      (a, b) => a.index < b.index ? a : b,
+    );
+    return first.index * _itemHeight - first.itemLeadingEdge * _viewportHeight;
+  }
+
+  void wheel(
+    WidgetTester tester, {
+    double dy = _notch,
+    PointerDeviceKind kind = PointerDeviceKind.mouse,
+  }) {
+    tester.binding.handlePointerEvent(
+      PointerScrollEvent(
+        position: tester.getCenter(find.byType(ScrollablePositionedList)),
+        scrollDelta: Offset(0, dy),
+        kind: kind,
+      ),
+    );
+  }
+
+  Future<void> frames(WidgetTester tester, int count) async {
+    for (var i = 0; i < count; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+  }
+
+  group('נקישה בודדת', () {
+    testWidgets('התזוזה נפרסת על פריימים ואינה קפיצה אחת', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      await tester.pump(const Duration(milliseconds: 16));
+      final afterFirstFrame = offset();
+
+      expect(
+        afterFirstFrame,
+        greaterThan(0.0),
+        reason: 'הפריים הראשון חייב להתחיל לזוז',
+      );
+      expect(
+        afterFirstFrame,
+        lessThan(_notch * 0.5),
+        reason: 'קפיצה של יותר מחצי הדרך בפריים אחד = הגלגלת לא נחטפה',
+      );
+    });
+
+    testWidgets('הנחיתה היא בדיוק על אותו מרחק שהגלגלת ביקשה', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      await tester.pumpAndSettle();
+
+      expect(offset(), closeTo(_notch, 0.01));
+    });
+
+    testWidgets('התנועה מונוטונית — אין ריצוד או חזרה אחורה', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      var previous = offset();
+      var moved = false;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        final current = offset();
+        expect(
+          current,
+          greaterThanOrEqualTo(previous - 0.01),
+          reason: 'תזוזה אחורה בפריים $i',
+        );
+        if (current > previous) moved = true;
+        previous = current;
+      }
+      expect(moved, isTrue);
+    });
+  });
+
+  group('נקישות רצופות', () {
+    // מלכודת: שרשור נאיבי של animateScroll מודד מהמקום הנוכחי שעוד לא הגיע,
+    // ואיבד 75% מהגלילה. היעד המצטבר הוא מה ששומר על המרחק המלא.
+    testWidgets('ארבע נקישות באמצע החלקה = בדיוק ארבעה מרחקים', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      for (var n = 0; n < 4; n++) {
+        wheel(tester);
+        await frames(tester, 3);
+      }
+      await tester.pumpAndSettle();
+
+      expect(offset(), closeTo(_notch * 4, 0.01));
+    });
+
+    testWidgets('החלקה אינה מוסיפה בניות פריטים מעל קפיצה', (tester) async {
+      await tester.pumpWidget(buildList(smooth: false));
+      await tester.pumpAndSettle();
+      final jumpBase = itemBuilds;
+      for (var n = 0; n < 4; n++) {
+        wheel(tester);
+        await frames(tester, 4);
+      }
+      await tester.pumpAndSettle();
+      final jumpBuilds = itemBuilds - jumpBase;
+
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+      final smoothBase = itemBuilds;
+      for (var n = 0; n < 4; n++) {
+        wheel(tester);
+        await frames(tester, 4);
+      }
+      await tester.pumpAndSettle();
+      final smoothBuilds = itemBuilds - smoothBase;
+
+      expect(smoothBuilds, lessThanOrEqualTo(jumpBuilds));
+    });
+  });
+
+  group('קצות הרשימה', () {
+    testWidgets('בראש הרשימה גלילה למעלה אינה מזיזה', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester, dy: -_notch);
+      await tester.pumpAndSettle();
+
+      expect(offset(), 0.0);
+    });
+
+    testWidgets('בסוף הרשימה נעצר בקצה בלי חריגה', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      const maxOffset = _itemCount * _itemHeight - _viewportHeight;
+      for (var n = 0; n < 250; n++) {
+        wheel(tester);
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await tester.pumpAndSettle();
+
+      expect(offset(), closeTo(maxOffset, 1.0));
+    });
+  });
+
+  group('מה לא נחטף', () {
+    testWidgets('משטח מגע נשאר במסלול המקורי — לו יש אינרציה', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester, kind: PointerDeviceKind.trackpad);
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(offset(), closeTo(_notch, 0.01));
+    });
+
+    testWidgets('Ctrl+גלגלת נשאר במסלול המקורי', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      wheel(tester);
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      expect(offset(), closeTo(_notch, 0.01));
+    });
+  });
+
+  group('שיתוף השליטה', () {
+    testWidgets('קפיצה חיצונית באמצע החלקה עוצרת אותה ולא נלחמת בה', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      await tester.pump(const Duration(milliseconds: 16));
+
+      itemController.jumpTo(index: 300);
+      await tester.pumpAndSettle();
+      final afterJump = offset();
+
+      await frames(tester, 10);
+
+      expect(offset(), closeTo(afterJump, 0.01));
+      expect(afterJump, closeTo(300 * _itemHeight, 0.01));
+    });
+
+    // מלכודת: עטיפה ב-render object מרובה-ילדים (Stack) מייצרת את הרשימה
+    // החדשה לפני שחרור הקודמת, ואז ItemScrollController נצמד פעמיים וזורק.
+    testWidgets('החלפת key של הרשימה אינה מכשילה את חיבור הבקרים', (
+      tester,
+    ) async {
+      final sharedItemController = ItemScrollController();
+      final sharedOffsetController = ScrollOffsetController();
+
+      Widget keyed(String tag) => MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: _viewportHeight,
+            width: 400,
+            child: SmoothWheelScroll(
+              child: ScrollablePositionedList.builder(
+                key: ValueKey(tag),
+                itemScrollController: sharedItemController,
+                scrollOffsetController: sharedOffsetController,
+                itemPositionsListener: positions,
+                itemCount: _itemCount,
+                itemBuilder: (context, index) =>
+                    SizedBox(height: _itemHeight, child: Text('שורה $index')),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(keyed('a'));
+      await tester.pumpAndSettle();
+      await tester.pumpWidget(keyed('b'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('פירוק הווידג\'ט באמצע החלקה אינו זורק', (tester) async {
+      await tester.pumpWidget(buildList());
+      await tester.pumpAndSettle();
+
+      wheel(tester);
+      await tester.pump(const Duration(milliseconds: 16));
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## הבעיה

משתמשים מדווחים שהגלילה בגלגלת "מהירה אבל לא חלקה", ושהיא נעצרת בעצירות חדות במקום להאט.

זו התנהגות מובנית של Flutter, לא באג בקוד שלנו. השרשרת, לפי מקורות ה-SDK:

1. Windows מחשב את הצעד: `lines_per_scroll * 100 / 3` (`flutter_window.cc:409`). בהגדרת ברירת המחדל (3 שורות) זה **בדיוק 100 פיקסלים לנקישה**.
2. `ScrollPositionWithSingleContext.pointerScroll` מבצע `forcePixels(pixels + delta)` ואז `goBallistic(0.0)` — טלפורט בפריים אחד, ומהירות אפס אחריו.

מדידה של תזוזת התוכן ב-12 פריימים אחרי נקישה אחת:

```
[100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100]
```

כל התזוזה בפריים הראשון, ואפס ב-11 הבאים. אין אנימציה, אין האטה, אין אינרציה.

זה ספציפי לגלגלת: מסך מגע ומשטח מגע עוברים דרך מזהה-הגרירה (`monodrag`), שמסתיים בזריקה עם מהירות וחיכוך — ולכן חלקים.

## התיקון

`SmoothWheelScroll` חוטף את אירוע הגלגלת ומזין את **אותו מנוע** (`ScrollPosition.pointerScroll`) בצעדים קטנים לעבר יעד מצטבר, בהתקרבות אקספוננציאלית (קבוע זמן 55ms).

המרחק זהה בדיוק, החסימה בקצוות זהה, וההודעות (`UserScroll`/`ScrollUpdate`) זהות — רק פרוסים על פריימים. לא הומצאה פיזיקה חדשה; הצעד של הפלטפורמה מחולק.

**המחיר נמדד** — אותה תזוזה של 400px בשתי הדרכים:

```
קפיצות:  10 בניות פריטים,  4 התראות מיקום,  400px
החלקה:   10 בניות פריטים, 14 התראות מיקום,  400px
```

אותן 10 בניות פריטים בדיוק. החלק הכבד (בניית שורות, ניתוח HTML) לא גדל — שורה נבנית פעם אחת כשהיא נכנסת למסך, לא משנה איך הגעת אליה. התוספת היחידה היא 10 קריאות התראה שכולן יוצאות בתנאי הראשון.

## מה לא נחטף

- **משטח מגע** — כבר מקבל אינרציה מהפיזיקה; החלקה נוספת רק תוסיף השהיה.
- **Ctrl/Shift/Alt/Meta + גלגלת** — Shift מהפך ציר והשאר שמורים לקיצורים.
- **בקצה הרשימה** — בלי תפיסה, המסלול המקורי גם מעביר לאב אם יש גלילה מקוננת.

בכל אלה לא נרשמים ב-`PointerSignalResolver` כלל, ולכן ההתנהגות המקורית נשמרת במלואה.

## שלושה באגים שנתפסו בפיתוח, ולכל אחד יש טסט

**1. `late final Ticker` נוצר ב-`dispose`.** כשהגלגלת לא נתפסה אף פעם (משטח מגע/Ctrl), `dispose` יצר את ה-Ticker על אלמנט שכבר הוסר מהעץ והפיל assert. נוצר עכשיו ב-`initState`.

**2. `animateScroll` לא יכול להזיז סינכרונית.** גם עם `Duration.zero` (שאסור — `DrivenScrollActivity` דורש משך חיובי), האנימציה לא מזיזה בפריים הראשון כי ה-Ticker קובע שם את בסיס הזמן. מימוש שמפעיל אנימציה חדשה בכל פריים ביטל כל צעד לפני שסופק, והתזוזה תלתה בסדר קריאה לא-דטרמיניסטי בין שני Tickers. `pointerScroll` מזיז מיד.

**3. עטיפה ב-`Stack` שברה שתי רשימות קיימות.** ב-render object מרובה-ילדים, ילד עם `key` שהוחלף נוצר מחדש **לפני** ששוחרר הקודם (הילדים המוקלדים משוחררים בסוף `updateChildren`), ואז `ItemScrollController._attach` נזרק על כפילות. במקום Stack, הרנדר-אובג'קט נרשם בנתיב ה-hit-test לפני צאצאיו — פחות קוד ואפס השפעה על layout.

## אימות מוטציות

12 טסטים בקובץ החדש. חמישה מוטנטים, כל אחד נתפס בדיוק בטסט שנועד לו:

| מוטציה | מה נכשל |
|---|---|
| ביטול החטיפה | קפיצה של 100px בפריים אחד |
| מדידה מהמיקום הנוכחי במקום יעד מצטבר | **אובדן 94px מ-400**, ו-8316px מ-25,000 |
| ביטול שמירת השליטה | ההחלקה נלחמת בקפיצת ניווט ומוסיפה 100px מעליה |
| `Ticker` עצל | 3 טסטים |
| החזרת ה-`Stack` | טסט הרגרסיה של החלפת ה-key |

## היקף

מחובר לשלושת משטחי הקריאה: התצוגה המשולבת, צורת הדף, ורשימות המפרשים. שאר הרשימות באפליקציה (ספרייה, תוצאות חיפוש, תצוגה מקדימה להדפסה) לא נכללות — הן מחוץ להיקף הדיווח, וניתן להוסיף אותן בעטיפה של שורה אחת כל אחת.

## בדיקות

`flutter analyze` נקי. **1529 טסטים** ב-`test/widgets/` ו-`test/text_book/` עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
