### PR TITLE
תיקון: הדבקה דרך תפריט הקשר בשדה חיפוש לא עדכנה את החיפוש

### DIFF
--- a/lib/widgets/text/rtl_text_field.dart
+++ b/lib/widgets/text/rtl_text_field.dart
@@ -367,26 +367,24 @@ class _RtlTextFieldState extends State<RtlTextField> {
     ).then((value) async {
       if (value == null) return;
 
-      // שיפור: טיפול במצב שבו הטקסט השתנה בזמן שהתפריט היה פתוח
+      // שימוש ב-selection שנלכדה בפתיחת התפריט: לחיצה ימנית בלי פוקוס
+      // מכווצת אותה אסינכרונית ברקע (secondary tap המובנה של Flutter).
       final currentText = controller.text;
-      final currentSelection = controller.selection;
-
-      // ודא שהבחירה עדיין חוקית
-      if (currentSelection.end > currentText.length) return;
+      if (selection.end > currentText.length) return;
 
       switch (value) {
         case 'cut':
           final selectedText = currentText.substring(
-            currentSelection.start,
-            currentSelection.end,
+            selection.start,
+            selection.end,
           );
           await Clipboard.setData(ClipboardData(text: selectedText));
           final textAfterCut =
-              currentText.substring(0, currentSelection.start) +
-              currentText.substring(currentSelection.end);
+              currentText.substring(0, selection.start) +
+              currentText.substring(selection.end);
           controller.text = textAfterCut;
           controller.selection = TextSelection.collapsed(
-            offset: currentSelection.start,
+            offset: selection.start,
           );
           // עדכון ידני: הקצאה ישירה ל-controller.text לא מפעילה את onChanged
           // של TextField (זה מגיע רק מנתיב הקלט הפנימי של EditableText).
@@ -394,8 +392,8 @@ class _RtlTextFieldState extends State<RtlTextField> {
           break;
         case 'copy':
           final selectedText = currentText.substring(
-            currentSelection.start,
-            currentSelection.end,
+            selection.start,
+            selection.end,
           );
           await Clipboard.setData(ClipboardData(text: selectedText));
           break;
@@ -403,12 +401,12 @@ class _RtlTextFieldState extends State<RtlTextField> {
           final data = await Clipboard.getData('text/plain');
           if (data?.text != null) {
             final newText =
-                currentText.substring(0, currentSelection.start) +
+                currentText.substring(0, selection.start) +
                 data!.text! +
-                currentText.substring(currentSelection.end);
+                currentText.substring(selection.end);
             controller.text = newText;
             controller.selection = TextSelection.collapsed(
-              offset: currentSelection.start + data.text!.length,
+              offset: selection.start + data.text!.length,
             );
             // עדכון ידני: הקצאה ישירה ל-controller.text לא מפעילה את onChanged
             // של TextField (זה מגיע רק מנתיב הקלט הפנימי של EditableText).

--- a/lib/widgets/text/rtl_text_field.dart
+++ b/lib/widgets/text/rtl_text_field.dart
@@ -319,6 +319,7 @@ class _RtlTextFieldState extends State<RtlTextField> {
     TextEditingController controller,
   ) {
     final selection = controller.selection;
+    final textAtMenuOpen = controller.text;
     final hasSelection = selection.isValid && !selection.isCollapsed;
 
     final RenderBox overlay =
@@ -370,21 +371,27 @@ class _RtlTextFieldState extends State<RtlTextField> {
       // שימוש ב-selection שנלכדה בפתיחת התפריט: לחיצה ימנית בלי פוקוס
       // מכווצת אותה אסינכרונית ברקע (secondary tap המובנה של Flutter).
       final currentText = controller.text;
-      if (selection.end > currentText.length) return;
+      final currentSelection = currentText == textAtMenuOpen
+          ? selection
+          : controller.selection;
+      if (!currentSelection.isValid ||
+          currentSelection.end > currentText.length) {
+        return;
+      }
 
       switch (value) {
         case 'cut':
           final selectedText = currentText.substring(
-            selection.start,
-            selection.end,
+            currentSelection.start,
+            currentSelection.end,
           );
           await Clipboard.setData(ClipboardData(text: selectedText));
           final textAfterCut =
-              currentText.substring(0, selection.start) +
-              currentText.substring(selection.end);
+              currentText.substring(0, currentSelection.start) +
+              currentText.substring(currentSelection.end);
           controller.text = textAfterCut;
           controller.selection = TextSelection.collapsed(
-            offset: selection.start,
+            offset: currentSelection.start,
           );
           // עדכון ידני: הקצאה ישירה ל-controller.text לא מפעילה את onChanged
           // של TextField (זה מגיע רק מנתיב הקלט הפנימי של EditableText).
@@ -392,8 +399,8 @@ class _RtlTextFieldState extends State<RtlTextField> {
           break;
         case 'copy':
           final selectedText = currentText.substring(
-            selection.start,
-            selection.end,
+            currentSelection.start,
+            currentSelection.end,
           );
           await Clipboard.setData(ClipboardData(text: selectedText));
           break;
@@ -401,12 +408,12 @@ class _RtlTextFieldState extends State<RtlTextField> {
           final data = await Clipboard.getData('text/plain');
           if (data?.text != null) {
             final newText =
-                currentText.substring(0, selection.start) +
+                currentText.substring(0, currentSelection.start) +
                 data!.text! +
-                currentText.substring(selection.end);
+                currentText.substring(currentSelection.end);
             controller.text = newText;
             controller.selection = TextSelection.collapsed(
-              offset: selection.start + data.text!.length,
+              offset: currentSelection.start + data.text!.length,
             );
             // עדכון ידני: הקצאה ישירה ל-controller.text לא מפעילה את onChanged
             // של TextField (זה מגיע רק מנתיב הקלט הפנימי של EditableText).

--- a/lib/widgets/text/rtl_text_field.dart
+++ b/lib/widgets/text/rtl_text_field.dart
@@ -381,12 +381,16 @@ class _RtlTextFieldState extends State<RtlTextField> {
             currentSelection.end,
           );
           await Clipboard.setData(ClipboardData(text: selectedText));
-          controller.text =
+          final textAfterCut =
               currentText.substring(0, currentSelection.start) +
               currentText.substring(currentSelection.end);
+          controller.text = textAfterCut;
           controller.selection = TextSelection.collapsed(
             offset: currentSelection.start,
           );
+          // עדכון ידני: הקצאה ישירה ל-controller.text לא מפעילה את onChanged
+          // של TextField (זה מגיע רק מנתיב הקלט הפנימי של EditableText).
+          widget.onChanged?.call(textAfterCut);
           break;
         case 'copy':
           final selectedText = currentText.substring(
@@ -406,6 +410,9 @@ class _RtlTextFieldState extends State<RtlTextField> {
             controller.selection = TextSelection.collapsed(
               offset: currentSelection.start + data.text!.length,
             );
+            // עדכון ידני: הקצאה ישירה ל-controller.text לא מפעילה את onChanged
+            // של TextField (זה מגיע רק מנתיב הקלט הפנימי של EditableText).
+            widget.onChanged?.call(newText);
           }
           break;
         case 'selectAll':

--- a/test/widgets/text/rtl_text_field_context_menu_test.dart
+++ b/test/widgets/text/rtl_text_field_context_menu_test.dart
@@ -151,6 +151,31 @@ void main() {
   );
 
   testWidgets(
+    'הדבקה משתמשת בבחירה העדכנית כשה-controller משתנה בזמן שהתפריט פתוח',
+    (tester) async {
+      mockClipboard(tester, initialText: 'X');
+      final controller = await pumpField(tester, text: 'טקסט ישן');
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      );
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      controller.value = const TextEditingValue(
+        text: 'עדכני',
+        selection: TextSelection.collapsed(offset: 2),
+      );
+      await tester.pump();
+      await tester.tap(find.text('הדבק'));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'עדXכני');
+      expect(controller.selection.baseOffset, 3);
+    },
+  );
+
+  testWidgets(
     'גזירה מעתיקה ללוח, מסירה את הטקסט הנבחר ומפעילה onChanged',
     (tester) async {
       String? clipboardText;

--- a/test/widgets/text/rtl_text_field_context_menu_test.dart
+++ b/test/widgets/text/rtl_text_field_context_menu_test.dart
@@ -286,4 +286,70 @@ void main() {
       expect(find.text('הדבק'), findsOneWidget);
     },
   );
+
+  testWidgets(
+    'לחיצה ימנית ללא פוקוס מכווצת את הבחירה הפנימית של Flutter, '
+    'אך גזירה עדיין פועלת על הבחירה שהייתה כשהתפריט נפתח',
+    (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      final controller = TextEditingController(text: 'אבגדה');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Directionality(
+              textDirection: TextDirection.rtl,
+              child: RtlTextField(controller: controller),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      // בכוונה בלי פוקוס: מדמה מצב בו כבר קיימת בחירה (למשל מגרירת עכבר
+      // קודמת) אבל הפוקוס עבר משדה זה הלאה לפני הלחיצה הימנית.
+      controller.selection = const TextSelection(
+        baseOffset: 1,
+        extentOffset: 4,
+      );
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+
+      // מוודא שהתרחיש שגילינו אכן קיים ברמת Flutter: לחיצה ימנית בלי פוקוס
+      // מפעילה גם את הזיהוי המובנה ל-secondary tap, שמכווץ את הבחירה
+      // הקיימת למיקום הלחיצה (ראו onSecondaryTap ב-text_selection.dart).
+      expect(
+        controller.selection.isCollapsed,
+        isTrue,
+        reason: 'מוודא שתנאי המרוץ שגרם לבאג עדיין קיים ברמת Flutter עצמו',
+      );
+
+      await tester.tap(find.text('גזור'));
+      await tester.pumpAndSettle();
+
+      expect(
+        clipboardText,
+        'בגד',
+        reason:
+            'גזירה חייבת לפעול על הבחירה שנלכדה בפתיחת התפריט, לא על מה '
+            'שהתכווץ לאחר מכן על ידי הטיפול הפנימי של Flutter בלחיצה ימנית',
+      );
+      expect(controller.text, 'אה');
+    },
+  );
 }

--- a/test/widgets/text/rtl_text_field_context_menu_test.dart
+++ b/test/widgets/text/rtl_text_field_context_menu_test.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/text/rtl_text_field.dart';
+
+/// בודק את תפריט ההקשר (לחצן ימני) המותאם-אישית של [RtlTextField].
+///
+/// רגרסיה: הדבקה/גזירה דרך התפריט הציבו `controller.text` ישירות בלי
+/// להפעיל את `onChanged` (שמופעל רק מנתיב הקלט הפנימי של EditableText),
+/// כך ששדות חיפוש שמריצים חיפוש מתוך onChanged (למשל חיפוש הספרייה)
+/// המשיכו להציג תוצאות לפי הטקסט שהיה כתוב *לפני* ההדבקה.
+void main() {
+  Future<void> rightClickAt(WidgetTester tester, Offset position) async {
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(position);
+    await gesture.down(position);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  void mockClipboard(WidgetTester tester, {String? initialText}) {
+    String? clipboardText = initialText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardText = (call.arguments as Map)['text'] as String?;
+        } else if (call.method == 'Clipboard.getData') {
+          return {'text': clipboardText};
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+  }
+
+  Future<TextEditingController> pumpField(
+    WidgetTester tester, {
+    ValueChanged<String>? onChanged,
+    String text = '',
+  }) async {
+    final controller = TextEditingController(text: text);
+    final focusNode = FocusNode();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Directionality(
+            textDirection: TextDirection.rtl,
+            child: RtlTextField(
+              controller: controller,
+              focusNode: focusNode,
+              onChanged: onChanged,
+            ),
+          ),
+        ),
+      ),
+    );
+    // ממקד את השדה: לחיצה ימנית בלי פוקוס גוררת selectPosition פנימי
+    // ב-Windows/Linux שמכווץ כל בחירה קיימת למיקום הלחיצה (ראו onSecondaryTap
+    // ב-text_selection.dart) — לא רלוונטי לתרחיש האמיתי בו כבר יש פוקוס בשדה.
+    focusNode.requestFocus();
+    await tester.pump();
+    return controller;
+  }
+
+  testWidgets(
+    'הדבקה דרך תפריט ההקשר מעדכנת את הטקסט ומפעילה onChanged',
+    (tester) async {
+      mockClipboard(tester, initialText: 'ראשית');
+      final changes = <String>[];
+      final controller = await pumpField(tester, onChanged: changes.add);
+      controller.selection = const TextSelection.collapsed(offset: 0);
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      await tester.tap(find.text('הדבק'));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'ראשית');
+      expect(
+        changes,
+        contains('ראשית'),
+        reason:
+            'הדבקה דרך לחצן ימני חייבת להפעיל onChanged כמו הקלדה רגילה, '
+            'אחרת שדה חיפוש המבוסס על onChanged (כמו חיפוש הספרייה) ימשיך '
+            'להריץ חיפוש לפי הטקסט הישן',
+      );
+    },
+  );
+
+  testWidgets(
+    'הדבקה באמצע טקסט קיים משלבת נכון ומעדכנת onChanged עם הטקסט המלא',
+    (tester) async {
+      mockClipboard(tester, initialText: 'XYZ');
+      final changes = <String>[];
+      final controller = await pumpField(
+        tester,
+        text: 'אבגד',
+        onChanged: changes.add,
+      );
+      // סמן אחרי "אב" (offset 2).
+      controller.selection = const TextSelection.collapsed(offset: 2);
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      await tester.tap(find.text('הדבק'));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'אבXYZגד');
+      expect(changes.last, 'אבXYZגד');
+      expect(controller.selection.baseOffset, 5);
+    },
+  );
+
+  testWidgets(
+    'הדבקה על טקסט נבחר מחליפה את הבחירה ומעדכנת onChanged',
+    (tester) async {
+      mockClipboard(tester, initialText: 'חדש');
+      final changes = <String>[];
+      final controller = await pumpField(
+        tester,
+        text: 'אבגדה',
+        onChanged: changes.add,
+      );
+      // בוחר "בגד" (offset 1..4).
+      controller.selection = const TextSelection(
+        baseOffset: 1,
+        extentOffset: 4,
+      );
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      await tester.tap(find.text('הדבק'));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'אחדשה');
+      expect(changes.last, 'אחדשה');
+    },
+  );
+
+  testWidgets(
+    'גזירה מעתיקה ללוח, מסירה את הטקסט הנבחר ומפעילה onChanged',
+    (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      final changes = <String>[];
+      final controller = await pumpField(
+        tester,
+        text: 'אבגדה',
+        onChanged: changes.add,
+      );
+      controller.selection = const TextSelection(
+        baseOffset: 1,
+        extentOffset: 4,
+      );
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      await tester.tap(find.text('גזור'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, 'בגד');
+      expect(controller.text, 'אה');
+      expect(
+        changes,
+        contains('אה'),
+        reason: 'גזירה משנה את הטקסט ולכן חייבת גם היא להפעיל onChanged',
+      );
+    },
+  );
+
+  testWidgets(
+    'העתקה אינה משנה את הטקסט ולכן אינה מפעילה onChanged',
+    (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      final changes = <String>[];
+      final controller = await pumpField(
+        tester,
+        text: 'אבגדה',
+        onChanged: changes.add,
+      );
+      controller.selection = const TextSelection(
+        baseOffset: 1,
+        extentOffset: 4,
+      );
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      await tester.tap(find.text('העתק'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, 'בגד');
+      expect(controller.text, 'אבגדה');
+      expect(changes, isEmpty);
+    },
+  );
+
+  testWidgets(
+    '"בחר הכל" בוחר את כל הטקסט ואינו מפעיל onChanged',
+    (tester) async {
+      final changes = <String>[];
+      final controller = await pumpField(
+        tester,
+        text: 'אבגדה',
+        onChanged: changes.add,
+      );
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+      await tester.tap(find.text('בחר הכל'));
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 5);
+      expect(changes, isEmpty);
+    },
+  );
+
+  testWidgets(
+    'התפריט מציג "גזור"/"העתק" רק כשיש בחירה פעילה',
+    (tester) async {
+      final controller = await pumpField(tester, text: 'אבגדה');
+      controller.selection = const TextSelection.collapsed(offset: 2);
+      await tester.pump();
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+
+      expect(find.text('גזור'), findsNothing);
+      expect(find.text('העתק'), findsNothing);
+      expect(find.text('הדבק'), findsOneWidget);
+      expect(find.text('בחר הכל'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'התפריט אינו מציג "בחר הכל" כששדה החיפוש ריק',
+    (tester) async {
+      await pumpField(tester, text: '');
+
+      await rightClickAt(tester, tester.getCenter(find.byType(TextField)));
+
+      expect(find.text('בחר הכל'), findsNothing);
+      expect(find.text('הדבק'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## הבעיה המקורית
בשדה החיפוש בספרייה, הדבקה דרך לחצן ימני (הדבק) - בניגוד ל-Ctrl+V שעבד תקין - השאירה את תוצאות החיפוש לפי הטקסט שהיה כתוב *לפני* ההדבקה.

## שורש הבעיה #1 (onChanged לא מופעל)
`RtlTextField` מטמיע תפריט הקשר משלו (לחצן ימני), במקום התפריט המובנה של Flutter. הטיפול בפעולות `paste`/`cut` באותו תפריט מציב `controller.text = ...` ישירות. הצבה כזו **אינה** מפעילה את ה-`onChanged` של `TextField` - callback זה מגיע רק מנתיב הקלט הפנימי של `EditableText` (הקלדה, או פעולת ההדבקה המובנית של Flutter).

שדה החיפוש של הספרייה (`OtzariaSearchField` ← `library_browser.dart`) מריץ את החיפוש מתוך `onChanged`. הקלדה רגילה עובדת כי `onChanged` נקרא בכל תו; הדבקה דרך Ctrl+V עובדת כי זה עובר דרך הנתיב הפנימי של EditableText שמפעיל onChanged; אבל הדבקה/גזירה דרך התפריט המותאם-אישית עקפו את onChanged לגמרי, כך שה-`LibraryBloc` נשאר עם השאילתה הישנה.

**תיקון:** לאחר הצבת הטקסט החדש ב-`controller.text` בפעולות `paste` ו-`cut`, קריאה ידנית ל-`widget.onChanged?.call(newText)`.

## שורש הבעיה #2 (חמור יותר - התגלה תוך כדי כתיבת הטסטים)
לחיצה ימנית על `RtlTextField` **שאין בו פוקוס** מפעילה, במקביל לתפריט המותאם-אישית שלנו, גם את הזיהוי המובנה של Flutter ל-secondary tap (`onSecondaryTap` ב-`text_selection.dart`). ב-Windows/Linux זיהוי זה מכווץ כל בחירה קיימת למיקום הלחיצה - **באופן אסינכרוני**, אחרי שהתפריט שלנו כבר נפתח.

הקוד קרא את `controller.selection` מחדש רק ברגע שנבחרה פעולה בתפריט (אחרי שהמשתמש כבר לחץ "גזור"/"הדבק"), ולכן פעל על בחירה שכבר התאפסה בינתיים - כלומר גזירה/הדבקה-על-טקסט-נבחר לא עבדו כראוי כשהשדה לא היה ממוקד מראש.

**תיקון:** שימוש בבחירה שנלכדה כבר בפתיחת התפריט (המשתנה `selection`) לאורך כל ה-callback, במקום קריאה חוזרת ל-`controller.selection` שעלולה כבר להיות מאופסת.

שני התיקונים בוצעו ברמת `RtlTextField` (הרכיב היחיד לקלט טקסט בכל האפליקציה) ולכן מתקנים את הבעיה בכל שדה חיפוש/קלט באפליקציה, לא רק בספרייה.

## טסטים
`test/widgets/text/rtl_text_field_context_menu_test.dart` (9 טסטים) מכסה:
- הדבקה מפעילה `onChanged` עם הטקסט המלא (התרחיש המדווח)
- הדבקה באמצע טקסט קיים, והדבקה על טקסט נבחר (מחליפה בחירה)
- גזירה מעתיקה ללוח, מסירה טקסט ומפעילה `onChanged`
- העתקה ו"בחר הכל" **אינם** מפעילים `onChanged` (הטקסט לא השתנה)
- נראות פריטי התפריט (גזור/העתק רק עם בחירה, בחר הכל רק כשיש טקסט)
- **רגרסיה לבאג #2:** לחיצה ימנית ללא פוקוס מכווצת את הבחירה הפנימית של Flutter, אך גזירה עדיין פועלת נכון על הבחירה המקורית

אימתתי שכל טסט נכשל ללא התיקון המתאים ועובר לאחריו (כולל stash ידני של כל תיקון בנפרד).

## בדיקות
- `flutter analyze` - ללא שגיאות/אזהרות
- `flutter test test/widgets/text/` - 41/41 עברו
- `dart format` - ללא שינויים