### PR TITLE
חיבור שכבת החיפוש באוצריא ל־FFI הסמנטי

### DIFF
--- a/cargokit_options.yaml
+++ b/cargokit_options.yaml
@@ -1,1 +1,1 @@
-use_precompiled_binaries: true
+use_precompiled_binaries: false

--- a/cargokit_options.yaml
+++ b/cargokit_options.yaml
@@ -1,1 +1,1 @@
-use_precompiled_binaries: false
+use_precompiled_binaries: true

--- a/lib/search/search_engine_gateway.dart
+++ b/lib/search/search_engine_gateway.dart
@@ -333,6 +333,11 @@ class RustSearchEngineOperations implements SearchEngineOperations {
   }
 
   @override
+  Future<List<SearchResult>> searchHybrid(SearchEngineRequest request) {
+    return searchExact(request);
+  }
+
+  @override
   Future<SearchPageResult> searchAndCountExact(SearchEngineRequest request) {
     final gapped = _exactWithParametersAsAdvanced(request);
     if (gapped != null) return searchAndCountAdvanced(gapped);

--- a/lib/search/search_engine_gateway.dart
+++ b/lib/search/search_engine_gateway.dart
@@ -140,12 +140,75 @@ class SearchEngineRequest {
   }
 }
 
+/// בקשת חיפוש בציר האחזור הסמנטי.
+///
+/// [lexicalMode] קובע כיצד Tantivy מפרש את השאילתה הלקסיקלית, ואילו
+/// [retrievalMode] קובע אם המועמדים מגיעים מ-Tantivy, מהמודל, או משניהם.
+/// ההפרדה מ-[SearchEngineRequest] מכוונת: לחיפוש המתקדם אין כרגע ייצוג
+/// בחוזה הסמנטי של המנוע.
+class SemanticSearchRequest {
+  final String query;
+  final List<String> facets;
+  final int limit;
+  final int offset;
+  final SemanticLexicalMode lexicalMode;
+  final int fuzzyMaxDistance;
+  final SemanticRetrievalMode retrievalMode;
+  final SemanticGroupingMode? grouping;
+  final bool matchNikud;
+  final bool matchTaamim;
+
+  const SemanticSearchRequest({
+    required this.query,
+    required this.facets,
+    this.limit = 0,
+    this.offset = 0,
+    this.lexicalMode = SemanticLexicalMode.exact,
+    this.fuzzyMaxDistance = 0,
+    this.retrievalMode = SemanticRetrievalMode.hybrid,
+    this.grouping,
+    this.matchNikud = false,
+    this.matchTaamim = false,
+  });
+
+  /// מנוע החיפוש תומך במרחק עריכה 0–2 בלבד.
+  int get effectiveFuzzyMaxDistance => fuzzyMaxDistance.clamp(0, 2);
+}
+
+/// חוזה נפרד לפעולות הסמנטיות שמנועי בדיקה לקסיקליים אינם חייבים לממש.
+abstract interface class SemanticSearchEngineOperations {
+  /// מבצע חיפוש לפי ציר האחזור וציר הפירוש הלקסיקלי שבבקשה.
+  Future<SemanticSearchResponse> searchSemantic(SemanticSearchRequest request);
+
+  /// מגדיר את נתיבי המודל והאינדקס עבור ה-session הסמנטי.
+  Future<SemanticStatus> configureSemantic(SemanticConfigInput config);
+
+  /// סוגר את ה-session הסמנטי הפעיל.
+  Future<void> disableSemantic();
+
+  /// מחזיר תמונת מצב של ה-backend והאינדקס הסמנטיים.
+  Future<SemanticStatus> semanticStatus();
+
+  /// משווה בין ספרי האינדקס הסמנטי לבין manifest המקורות שלו.
+  Future<SemanticIndexDiff> semanticIndexDiff();
+
+  /// מוסיף או מעדכן ספרים באינדקס הסמנטי.
+  Future<SemanticIndexingSummary> semanticIndexBooks(
+    List<SemanticBookInput> books,
+  );
+
+  /// מסיר מהאינדקס הסמנטי את הספרים המזוהים במפתחות המקור.
+  Future<SemanticRemoveResult> removeSemanticBooks(List<String> sourceBookKeys);
+
+  /// מאפס את כל תוכן האינדקס הסמנטי.
+  Future<SemanticResetResult> resetSemanticIndex();
+}
+
 /// ממשק קטן וניתן לבדיקה מעל ה-API של `search_engine`.
 abstract class SearchEngineOperations {
   Future<List<SearchResult>> searchExact(SearchEngineRequest request);
   Future<List<SearchResult>> searchAdvanced(SearchEngineRequest request);
   Future<List<SearchResult>> searchFuzzy(SearchEngineRequest request);
-  Future<List<SearchResult>> searchHybrid(SearchEngineRequest request) async => searchExact(request);
 
   Future<SearchPageResult> searchAndCountExact(SearchEngineRequest request);
   Future<SearchPageResult> searchAndCountAdvanced(SearchEngineRequest request);
@@ -230,7 +293,8 @@ abstract class SearchEngineOperations {
   }
 }
 
-class RustSearchEngineOperations implements SearchEngineOperations {
+class RustSearchEngineOperations
+    implements SearchEngineOperations, SemanticSearchEngineOperations {
   final SearchEngine _engine;
 
   const RustSearchEngineOperations(this._engine);
@@ -333,8 +397,52 @@ class RustSearchEngineOperations implements SearchEngineOperations {
   }
 
   @override
-  Future<List<SearchResult>> searchHybrid(SearchEngineRequest request) {
-    return searchExact(request);
+  Future<SemanticSearchResponse> searchSemantic(SemanticSearchRequest request) {
+    return _engine.searchSemantic(
+      query: request.query,
+      facets: request.facets,
+      limit: request.limit,
+      offset: request.offset,
+      lexicalMode: request.lexicalMode,
+      fuzzyMaxDistance: request.effectiveFuzzyMaxDistance,
+      retrievalMode: request.retrievalMode,
+      grouping: request.grouping,
+      matchNikud: request.matchNikud,
+      matchTaamim: request.matchTaamim,
+    );
+  }
+
+  @override
+  Future<SemanticStatus> configureSemantic(SemanticConfigInput config) {
+    return _engine.configureSemantic(config: config);
+  }
+
+  @override
+  Future<void> disableSemantic() => _engine.disableSemantic();
+
+  @override
+  Future<SemanticStatus> semanticStatus() => _engine.semanticStatus();
+
+  @override
+  Future<SemanticIndexDiff> semanticIndexDiff() => _engine.semanticIndexDiff();
+
+  @override
+  Future<SemanticIndexingSummary> semanticIndexBooks(
+    List<SemanticBookInput> books,
+  ) {
+    return _engine.semanticIndexBooks(books: books);
+  }
+
+  @override
+  Future<SemanticRemoveResult> removeSemanticBooks(
+    List<String> sourceBookKeys,
+  ) {
+    return _engine.removeSemanticBooks(sourceBookKeys: sourceBookKeys);
+  }
+
+  @override
+  Future<SemanticResetResult> resetSemanticIndex() {
+    return _engine.resetSemanticIndex();
   }
 
   @override
@@ -735,6 +843,54 @@ class RustSearchEngineOperations implements SearchEngineOperations {
 
 class SearchEngineGateway {
   const SearchEngineGateway();
+
+  Future<SemanticSearchResponse> searchSemantic(
+    SemanticSearchEngineOperations engine,
+    SemanticSearchRequest request,
+  ) {
+    return engine.searchSemantic(request);
+  }
+
+  Future<SemanticStatus> configureSemantic(
+    SemanticSearchEngineOperations engine,
+    SemanticConfigInput config,
+  ) {
+    return engine.configureSemantic(config);
+  }
+
+  Future<void> disableSemantic(SemanticSearchEngineOperations engine) {
+    return engine.disableSemantic();
+  }
+
+  Future<SemanticStatus> semanticStatus(SemanticSearchEngineOperations engine) {
+    return engine.semanticStatus();
+  }
+
+  Future<SemanticIndexDiff> semanticIndexDiff(
+    SemanticSearchEngineOperations engine,
+  ) {
+    return engine.semanticIndexDiff();
+  }
+
+  Future<SemanticIndexingSummary> semanticIndexBooks(
+    SemanticSearchEngineOperations engine,
+    List<SemanticBookInput> books,
+  ) {
+    return engine.semanticIndexBooks(books);
+  }
+
+  Future<SemanticRemoveResult> removeSemanticBooks(
+    SemanticSearchEngineOperations engine,
+    List<String> sourceBookKeys,
+  ) {
+    return engine.removeSemanticBooks(sourceBookKeys);
+  }
+
+  Future<SemanticResetResult> resetSemanticIndex(
+    SemanticSearchEngineOperations engine,
+  ) {
+    return engine.resetSemanticIndex();
+  }
 
   Future<List<SearchResult>> search(
     SearchEngineOperations engine,

--- a/lib/search/search_engine_gateway.dart
+++ b/lib/search/search_engine_gateway.dart
@@ -145,6 +145,7 @@ abstract class SearchEngineOperations {
   Future<List<SearchResult>> searchExact(SearchEngineRequest request);
   Future<List<SearchResult>> searchAdvanced(SearchEngineRequest request);
   Future<List<SearchResult>> searchFuzzy(SearchEngineRequest request);
+  Future<List<SearchResult>> searchHybrid(SearchEngineRequest request) async => searchExact(request);
 
   Future<SearchPageResult> searchAndCountExact(SearchEngineRequest request);
   Future<SearchPageResult> searchAndCountAdvanced(SearchEngineRequest request);

--- a/lib/search/search_repository.dart
+++ b/lib/search/search_repository.dart
@@ -35,6 +35,63 @@ class SearchRepository {
     );
   }
 
+  Future<SemanticSearchEngineOperations> _semanticEngine() async {
+    final engine = await _engine();
+    if (engine case final SemanticSearchEngineOperations semanticEngine) {
+      return semanticEngine;
+    }
+    throw StateError('מנוע החיפוש שסופק אינו תומך בפעולות סמנטיות');
+  }
+
+  /// מבצע חיפוש לקסיקלי, היברידי או סמנטי דרך חוזה המנוע המאוחד.
+  Future<SemanticSearchResponse> searchSemantic(
+    SemanticSearchRequest request,
+  ) async {
+    return _gateway.searchSemantic(await _semanticEngine(), request);
+  }
+
+  /// פותח session סמנטי. המודל נטען עצלנית בתחילת האינדוקס.
+  Future<SemanticStatus> configureSemantic(SemanticConfigInput config) async {
+    return _gateway.configureSemantic(await _semanticEngine(), config);
+  }
+
+  /// סוגר את ה-session הסמנטי ומאפשר להגדיר מודל או שורש אחרים.
+  Future<void> disableSemantic() async {
+    return _gateway.disableSemantic(await _semanticEngine());
+  }
+
+  /// מחזיר את זמינות ה-backend, מצב המודל ונתוני האינדקס הסמנטי.
+  Future<SemanticStatus> semanticStatus() async {
+    return _gateway.semanticStatus(await _semanticEngine());
+  }
+
+  /// מחשב אילו ספרים נוספו, השתנו או הוסרו מאז האינדוקס האחרון.
+  Future<SemanticIndexDiff> semanticIndexDiff() async {
+    return _gateway.semanticIndexDiff(await _semanticEngine());
+  }
+
+  /// מוסיף או מעדכן ספרים באינדקס הסמנטי.
+  Future<SemanticIndexingSummary> semanticIndexBooks(
+    List<SemanticBookInput> books,
+  ) async {
+    return _gateway.semanticIndexBooks(await _semanticEngine(), books);
+  }
+
+  /// מסיר ספרים מהאינדקס הסמנטי לפי מפתחות המקור שלהם.
+  Future<SemanticRemoveResult> removeSemanticBooks(
+    List<String> sourceBookKeys,
+  ) async {
+    return _gateway.removeSemanticBooks(
+      await _semanticEngine(),
+      sourceBookKeys,
+    );
+  }
+
+  /// מוחק את כל הווקטורים וה-manifest של האינדקס הסמנטי.
+  Future<SemanticResetResult> resetSemanticIndex() async {
+    return _gateway.resetSemanticIndex(await _semanticEngine());
+  }
+
   Future<List<SearchResult>> searchTexts(
     String query,
     List<String> facets,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dependencies:
   googleapis_auth: ^2.3.3
   characters: ^1.4.1
   collection: ^1.19.1
-  otzaria_search_engine: ^0.6.9
+  otzaria_search_engine: ^0.7.0
   seforim_library_updater:
     git:
       url: https://github.com/Otzaria/otzaria_library_updater
@@ -95,10 +95,6 @@ dependencies:
       path: flutter_inappwebview
 
 dependency_overrides:
-  otzaria_search_engine:
-    git:
-      url: https://github.com/Amlaach/otzaria_search_engine.git
-      ref: refactor
   matcher: ^0.12.20
   analyzer: any
   device_info_plus: ^13.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -95,6 +95,10 @@ dependencies:
       path: flutter_inappwebview
 
 dependency_overrides:
+  otzaria_search_engine:
+    git:
+      url: https://github.com/Amlaach/otzaria_search_engine.git
+      ref: refactor
   matcher: ^0.12.20
   analyzer: any
   device_info_plus: ^13.2.0

--- a/test/search/semantic_search_gateway_test.dart
+++ b/test/search/semantic_search_gateway_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/search_engine_gateway.dart';
+import 'package:otzaria/search/search_repository.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart';
+
+import '../support/recording_search_engine.dart';
+
+void main() {
+  group('SemanticSearchRequest', () {
+    test('מרחק החיפוש המקורב נחתך לטווח שהמנוע תומך בו', () {
+      expect(
+        const SemanticSearchRequest(
+          query: 'א',
+          facets: ['/'],
+          fuzzyMaxDistance: -1,
+        ).effectiveFuzzyMaxDistance,
+        0,
+      );
+      expect(
+        const SemanticSearchRequest(
+          query: 'א',
+          facets: ['/'],
+          fuzzyMaxDistance: 7,
+        ).effectiveFuzzyMaxDistance,
+        2,
+      );
+    });
+  });
+
+  group('SearchRepository semantic bridge', () {
+    test('מעביר חיפוש סמנטי בלי לערבב את ציר החיפוש הלקסיקלי', () async {
+      final engine = _RecordingSemanticEngine();
+      final repository = SearchRepository(engineProvider: () async => engine);
+      const request = SemanticSearchRequest(
+        query: 'בריאת העולם',
+        facets: ['/תנ״ך'],
+        limit: 25,
+        offset: 5,
+        lexicalMode: SemanticLexicalMode.fuzzy,
+        fuzzyMaxDistance: 2,
+        retrievalMode: SemanticRetrievalMode.semanticOnly,
+        grouping: SemanticGroupingMode.sameSection,
+        matchNikud: true,
+        matchTaamim: true,
+      );
+
+      final response = await repository.searchSemantic(request);
+
+      expect(engine.lastSearchRequest, same(request));
+      expect(response.executedMode, SemanticExecutedMode.semanticOnly);
+      expect(response.semanticAvailable, isTrue);
+    });
+
+    test('מעביר את כל פעולות מחזור החיים הסמנטי', () async {
+      final engine = _RecordingSemanticEngine();
+      final repository = SearchRepository(engineProvider: () async => engine);
+      const config = SemanticConfigInput(
+        rootDir: '/semantic',
+        modelPath: '/model.gguf',
+        modelId: 'otzaria-v1',
+        embeddingDim: 1024,
+      );
+      final book = SemanticBookInput(
+        sourceBookKey: 'id:1',
+        title: 'בראשית',
+        contentFingerprint: BigInt.one,
+        isPdf: false,
+        topics: '/תנ״ך',
+        extraFacets: const [],
+        lines: const [],
+      );
+
+      await repository.configureSemantic(config);
+      await repository.semanticStatus();
+      await repository.semanticIndexDiff();
+      await repository.semanticIndexBooks([book]);
+      await repository.removeSemanticBooks(const ['id:1']);
+      await repository.resetSemanticIndex();
+      await repository.disableSemantic();
+
+      expect(engine.lastConfig, same(config));
+      expect(engine.lastBooks, [book]);
+      expect(engine.lastRemovedBookKeys, ['id:1']);
+      expect(engine.calls, [
+        'configure',
+        'status',
+        'diff',
+        'index',
+        'remove',
+        'reset',
+        'disable',
+      ]);
+    });
+
+    test('נכשל במפורש כשמוזרק מנוע לקסיקלי בלבד', () async {
+      final repository = SearchRepository(
+        engineProvider: () async => RecordingSearchEngine(),
+      );
+
+      await expectLater(repository.semanticStatus(), throwsStateError);
+    });
+  });
+}
+
+class _RecordingSemanticEngine extends RecordingSearchEngine
+    implements SemanticSearchEngineOperations {
+  final List<String> calls = [];
+  SemanticSearchRequest? lastSearchRequest;
+  SemanticConfigInput? lastConfig;
+  List<SemanticBookInput>? lastBooks;
+  List<String>? lastRemovedBookKeys;
+
+  @override
+  Future<SemanticSearchResponse> searchSemantic(
+    SemanticSearchRequest request,
+  ) async {
+    lastSearchRequest = request;
+    return SemanticSearchResponse(
+      results: const [],
+      totalCount: 0,
+      lexicalTotalCount: 0,
+      countsAreExact: false,
+      requestedMode: request.retrievalMode,
+      executedMode: SemanticExecutedMode.semanticOnly,
+      semanticAvailable: true,
+      latencyMs: BigInt.zero,
+      candidateWindowTruncated: false,
+      truncated: false,
+    );
+  }
+
+  @override
+  Future<SemanticStatus> configureSemantic(SemanticConfigInput config) async {
+    calls.add('configure');
+    lastConfig = config;
+    return _status;
+  }
+
+  @override
+  Future<void> disableSemantic() async {
+    calls.add('disable');
+  }
+
+  @override
+  Future<SemanticIndexDiff> semanticIndexDiff() async {
+    calls.add('diff');
+    return const SemanticIndexDiff(
+      enabled: true,
+      newBooks: [],
+      changedBooks: [],
+      unverifiableBooks: [],
+      removedBooks: [],
+      modelMismatch: false,
+      chunkingMismatch: false,
+      normalizationMismatch: false,
+    );
+  }
+
+  @override
+  Future<SemanticIndexingSummary> semanticIndexBooks(
+    List<SemanticBookInput> books,
+  ) async {
+    calls.add('index');
+    lastBooks = books;
+    return const SemanticIndexingSummary(
+      enabled: true,
+      booksIndexed: 1,
+      booksSkipped: 0,
+      booksEmpty: 0,
+      chunksWritten: 1,
+    );
+  }
+
+  @override
+  Future<SemanticRemoveResult> removeSemanticBooks(
+    List<String> sourceBookKeys,
+  ) async {
+    calls.add('remove');
+    lastRemovedBookKeys = sourceBookKeys;
+    return const SemanticRemoveResult(enabled: true, vectorsRemoved: 1);
+  }
+
+  @override
+  Future<SemanticResetResult> resetSemanticIndex() async {
+    calls.add('reset');
+    return const SemanticResetResult(enabled: true, vectorsRemoved: 1);
+  }
+
+  @override
+  Future<SemanticStatus> semanticStatus() async {
+    calls.add('status');
+    return _status;
+  }
+}
+
+const _status = SemanticStatus(
+  enabled: true,
+  available: true,
+  modelLoaded: true,
+  indexedBookCount: 1,
+  vectorCount: 1,
+  modelId: 'otzaria-v1',
+  embeddingDim: 1024,
+  embeddingBackend: 'llama.cpp',
+  vectorBackend: 'memory',
+  vectorsPersisted: false,
+);


### PR DESCRIPTION
## מה השתנה

- שודרגה התלות הרשמית `otzaria_search_engine` לגרסה `^0.7.0`; הוסר ה־override הזמני ל־fork והוחזר השימוש בבינאריים החתומים.
- נוסף חוזה נפרד `SemanticSearchEngineOperations`, כדי לא לערבב בין ציר הפירוש הלקסיקלי (exact/fuzzy) לבין ציר האחזור (lexical/hybrid/semantic).
- `RustSearchEngineOperations` מעביר בפועל ל־FFI את החיפוש הסמנטי ואת כל פעולות מחזור החיים: configure, status, diff, index, remove, reset ו־disable.
- `SearchRepository` חושף את הפעולות לאפליקציה ונכשל במפורש אם מוזרק מנוע שאינו תומך בסמנטיקה — אין fallback שקט לחיפוש exact.
- נוספו בדיקות שמכסות את מיפוי הבקשה, כל פעולות מחזור החיים ומסלול הכשל המפורש.

## אימות

- `flutter analyze`
- כל בדיקות `test/search/`
- בדיקות Tantivy ו־indexing הרלוונטיות
- בדיקה נוספת מול build מקומי של מנוע Rust הנוכחי, שבה כל 253 בדיקות החיפוש הפעילות עברו

## גבול ה־PR

זהו חיבור תשתיתי אמיתי של שכבת Dart ל־FFI, אך הוא עדיין לא מפעיל חיפוש סמנטי ב־UI.

לפני חיבור ה־BLoC והמסכים צריך להשלים במנוע API יעיל שמאנדקס ספר ישירות ממקור Tantivy/קובץ. ה־API הנוכחי דורש מ־Dart לשלוח כל שורה עם מזהים ומטא־דאטה; בנייה מחדש של מיליוני השורות באפליקציה תהיה יקרה ועלולה לסטות מהאינדקס הלקסיקלי. בנוסף נדרשת החלטה נפרדת על הפצת המודל ועל אחסון וקטורים מתמיד.