### PR TITLE
תוספים: חסימת פתיחת קבצים שנגררים לתוך WebView של תוסף

### DIFF
--- a/lib/plugins/view/plugin_background_host.dart
+++ b/lib/plugins/view/plugin_background_host.dart
@@ -27,6 +27,7 @@ import 'package:otzaria/plugins/services/plugin_network_access_resolver.dart';
 import 'package:otzaria/plugins/services/plugin_ref_line_resolver.dart';
 import 'package:otzaria/plugins/services/plugin_runtime_dispatcher.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
+import 'package:otzaria/plugins/view/plugin_drop_guard_script.dart';
 import 'package:otzaria/plugins/view/webview_environment_holder.dart';
 import 'package:otzaria/search/search_repository.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
@@ -541,6 +542,7 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
           source: _sdkStub,
           injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
         ),
+        buildPluginDropGuardScript(),
       ]),
       onWebViewCreated: (controller) {
         try {

--- a/lib/plugins/view/plugin_drop_guard_script.dart
+++ b/lib/plugins/view/plugin_drop_guard_script.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+// גרירת קובץ מה-OS לאזור בלי מאזין drop מנווטת את הדף לקובץ עצמו (ברירת
+// המחדל של Chromium) ועוקפת את מדיניות ה-file:// של התוסף. preventDefault
+// ברמת window מבטל את הניווט בלי לשבור אזורי גרירה שהתוסף מגדיר בעצמו —
+// המאזינים שלו עדיין מקבלים את האירוע.
+const String _dropGuardJs = r'''
+(function () {
+  // capture=true כדי ש-stopPropagation באלמנט פנימי לא יעקוף את החסימה.
+  function isFileDrag(e) {
+    var types = e.dataTransfer && e.dataTransfer.types;
+    return !!types && Array.prototype.indexOf.call(types, 'Files') !== -1;
+  }
+  window.addEventListener('dragover', function (e) {
+    if (isFileDrag(e)) e.preventDefault();
+  }, true);
+  window.addEventListener('drop', function (e) {
+    if (isFileDrag(e)) e.preventDefault();
+  }, true);
+})();
+''';
+
+/// סקריפט שחוסם את פתיחת קובץ שנגרר לתוך WebView של תוסף.
+///
+/// מוזרק לכל frame (גם iframes) — הגרירה נוחתת על ה-frame שמתחת לסמן.
+UserScript buildPluginDropGuardScript() {
+  return UserScript(
+    source: _dropGuardJs,
+    injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+    forMainFrameOnly: false,
+  );
+}

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -39,6 +39,7 @@ import 'package:otzaria/plugins/services/plugin_store_link_parser.dart';
 import 'package:otzaria/plugins/view/plugin_crashed_view.dart';
 import 'package:otzaria/plugins/view/plugin_webview2_missing_view.dart';
 import 'package:otzaria/plugins/models/plugin_network_allowlist.dart';
+import 'package:otzaria/plugins/view/plugin_drop_guard_script.dart';
 import 'package:otzaria/plugins/services/plugin_network_access_resolver.dart';
 import 'package:otzaria/plugins/services/plugin_file_server.dart';
 import 'package:otzaria/settings/settings_exports.dart';
@@ -476,6 +477,7 @@ class _PluginTabPageState extends State<PluginTabPage> {
           source: _sdkStub,
           injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
         ),
+        buildPluginDropGuardScript(),
       ]),
       onWebViewCreated: (controller) {
         // מסמנים שמתחיל ניסיון טעינה. שימוש בגרסה הסינכרונית מבטיח שהקובץ

--- a/test/plugins/plugin_drop_guard_script_test.dart
+++ b/test/plugins/plugin_drop_guard_script_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/plugins/view/plugin_drop_guard_script.dart';
+
+void main() {
+  group('buildPluginDropGuardScript', () {
+    test('מוזרק לפני קוד הדף וגם ל-iframes', () {
+      final script = buildPluginDropGuardScript();
+      expect(
+        script.injectionTime,
+        UserScriptInjectionTime.AT_DOCUMENT_START,
+      );
+      expect(script.forMainFrameOnly, isFalse);
+    });
+
+    test('חוסם את ברירת המחדל של גרירת קובץ (dragover + drop)', () {
+      final source = buildPluginDropGuardScript().source;
+      expect(source, contains("addEventListener('dragover'"));
+      expect(source, contains("addEventListener('drop'"));
+      expect(source, contains('preventDefault'));
+    });
+
+    test('חוסם רק גרירת קבצים, בשלב capture', () {
+      final source = buildPluginDropGuardScript().source;
+      expect(source, contains("'Files'"));
+      expect(source, contains('}, true);'));
+    });
+  });
+}


### PR DESCRIPTION
## הבעיה
גרירת קובץ (סרטון, תמונה וכו') לתוך חלון של תוסף פתחה את הקובץ — ברירת המחדל של Chromium מנווטת את הדף ל-\`file://\` של הקובץ שנגרר. זה עוקף את מדיניות ה-\`file://\` של התוספים (מותר רק מתוך תיקיית ההתקנה), ובסביבות מנוהלות מאפשר לפתוח קבצים שכל דרך אחרת לפתיחתם נחסמה.

## הפתרון
סקריפט guard חדש (\`plugin_drop_guard_script.dart\`) שמוזרק לשני מארחי ה-WebView של תוספים (טאב + רקע):
- חוסם רק גרירות שמכילות קבצים (\`dataTransfer.types\` כולל \`Files\`) — גרירת טקסט/קישורים לשדות קלט לא נפגעת.
- נרשם בשלב capture כך ש-\`stopPropagation\` באלמנט פנימי לא עוקף אותו.
- מוזרק לכל frame (\`forMainFrameOnly: false\`) — מכסה גם iframes.
- אזורי גרירה שהתוסף מממש בעצמו ממשיכים לקבל את האירוע (\`preventDefault\` בלבד, בלי לעצור הפצה).

## הערה
זו שכבת ההגנה בצד הדף. גרירה על UI פנימי של הדפדפן (למשל תצוגת הדפסה מקדימה) נחסמת בשכבת ה-native — PR נפרד ב-flutter_inappwebview.

## בדיקות
- \`test/plugins/plugin_drop_guard_script_test.dart\` — 3 בדיקות.
- \`flutter analyze\` נקי.