### PR TITLE
תצוגת ספר ב-PDF: לחצן היפוך כיוון הזוגות (ללא עמוד ריק בהתחלה)

### DIFF
--- a/lib/pdf_book/bloc/pdf_book_bloc.dart
+++ b/lib/pdf_book/bloc/pdf_book_bloc.dart
@@ -854,7 +854,13 @@ class PdfBookBloc extends Bloc<PdfBookEvent, PdfBookState> {
       }
     }
 
-    layoutModeToApply ??= pdfBookViewByDefault
+    // ללא הגדרה פר-ספרית, מצב שמור בטאב (שחזור טאבים) גובר על ברירת
+    // המחדל הבוליאנית כשהם מסכימים ברמת ספר/רגיל — משמר את כיוון הזוגות.
+    final saved = tab.savedLayoutMode;
+    layoutModeToApply ??=
+        saved != null && saved.isBookView == pdfBookViewByDefault
+        ? saved
+        : pdfBookViewByDefault
         ? PdfLayoutMode.bookView
         : PdfLayoutMode.regularView;
 

--- a/lib/pdf_book/utils/pdf_spread_layout.dart
+++ b/lib/pdf_book/utils/pdf_spread_layout.dart
@@ -18,24 +18,27 @@ int? pdfTopmostVisiblePage(Rect visibleRect, List<Rect> pageRects) {
 }
 
 /// מחזיר את עמוד ההתחלה של הספירייד שמכיל את [pageNumber].
-/// עמוד 1 עומד לבדו (כריכה ימנית בעברית); שאר העמודים מצומדים בזוגות —
-/// (2,3), (4,5), וכן הלאה.
-int pdfSpreadStartPage(int pageNumber) {
+/// עם [coverPage] — עמוד 1 עומד לבדו והזוגות הם (2,3), (4,5);
+/// בלעדיו הזוגות מתחילים מהעמוד הראשון — (1,2), (3,4).
+int pdfSpreadStartPage(int pageNumber, {bool coverPage = true}) {
   if (pageNumber <= 1) return 1;
-  return pageNumber.isEven ? pageNumber : pageNumber - 1;
+  if (coverPage) return pageNumber.isEven ? pageNumber : pageNumber - 1;
+  return pageNumber.isOdd ? pageNumber : pageNumber - 1;
 }
 
 /// מחזיר את טווח עמודי הספירייד עבור עמוד נתון:
 /// [startPage] (כולל) ו-[endPageExclusive] (לא כולל).
 ///
 /// בתצוגה רגילה ([bookView] = false) — תמיד עמוד אחד.
-/// בתצוגת ספר ([bookView] = true) — שני עמודים, למעט עמוד 1 העומד לבדו.
+/// בתצוגת ספר ([bookView] = true) — שני עמודים, למעט עמוד 1 העומד לבדו
+/// כש-[coverPage] פעיל.
 ///
 /// כש-[totalPages] מסופק, [endPageExclusive] מוגבל ל-[totalPages] + 1 —
 /// כך שספירייד אחרון במסמך עם מספר עמודים זוגי לא יפנה לעמוד שאינו קיים.
 ({int startPage, int endPageExclusive}) pdfSpreadPageRange(
   int pageNumber, {
   required bool bookView,
+  bool coverPage = true,
   int? totalPages,
 }) {
   final int startPage;
@@ -44,8 +47,8 @@ int pdfSpreadStartPage(int pageNumber) {
     startPage = pageNumber;
     rawEnd = pageNumber + 1;
   } else {
-    startPage = pdfSpreadStartPage(pageNumber);
-    rawEnd = startPage == 1 ? 2 : startPage + 2;
+    startPage = pdfSpreadStartPage(pageNumber, coverPage: coverPage);
+    rawEnd = coverPage && startPage == 1 ? 2 : startPage + 2;
   }
   if (totalPages == null) {
     return (startPage: startPage, endPageExclusive: rawEnd);
@@ -74,16 +77,20 @@ Future<({int start, int? end})?> pdfTextLineRangeForPageRange({
 
 /// עמוד היעד של דפדוף קדימה בתצוגת ספר: העמוד הראשון (הימני) של הזוג הבא.
 /// אחרי הכריכה (עמוד 1) הזוג הבא מתחיל בעמוד 2. מחזיר null כשאין זוג הבא.
-int? pdfNextSpreadFocusPage(int currentPage, int totalPages) {
-  final spreadStart = pdfSpreadStartPage(currentPage);
-  final next = spreadStart == 1 ? 2 : spreadStart + 2;
+int? pdfNextSpreadFocusPage(
+  int currentPage,
+  int totalPages, {
+  bool coverPage = true,
+}) {
+  final spreadStart = pdfSpreadStartPage(currentPage, coverPage: coverPage);
+  final next = coverPage && spreadStart == 1 ? 2 : spreadStart + 2;
   return next > totalPages ? null : next;
 }
 
 /// עמוד היעד של דפדוף אחורה בתצוגת ספר: העמוד השני (השמאלי) של הזוג הקודם —
 /// העמוד האחרון שנקרא לפני הזוג הנוכחי. מחזיר null כשאין זוג קודם.
-int? pdfPreviousSpreadFocusPage(int currentPage) {
-  final spreadStart = pdfSpreadStartPage(currentPage);
+int? pdfPreviousSpreadFocusPage(int currentPage, {bool coverPage = true}) {
+  final spreadStart = pdfSpreadStartPage(currentPage, coverPage: coverPage);
   return spreadStart <= 1 ? null : spreadStart - 1;
 }
 

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -539,12 +539,18 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     final initialGlobalLayoutMode = settingsBloc.state.pdfBookViewByDefault
         ? PdfLayoutMode.bookView
         : PdfLayoutMode.regularView;
+    final savedMode = widget.tab.savedLayoutMode;
+    // גם ללא הגדרות פר-ספר, מצב שמור בטאב שמסכים עם ברירת המחדל ברמת
+    // ספר/רגיל נשמר — כך כיוון הזוגות שורד שחזור טאבים.
     final initialLayoutMode = settingsBloc.state.enablePerBookSettings
-        ? (widget.tab.savedLayoutMode ?? initialGlobalLayoutMode)
-        : initialGlobalLayoutMode;
+        ? (savedMode ?? initialGlobalLayoutMode)
+        : (savedMode != null &&
+                  savedMode.isBookView == initialGlobalLayoutMode.isBookView
+              ? savedMode
+              : initialGlobalLayoutMode);
 
     if (!settingsBloc.state.enablePerBookSettings) {
-      widget.tab.savedLayoutMode = initialGlobalLayoutMode;
+      widget.tab.savedLayoutMode = initialLayoutMode;
     }
 
     _bloc = PdfBookBloc(
@@ -569,18 +575,24 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       _bloc.add(pdf_events.UpdateRightPaneWidth(state.commentaryPaneWidth));
 
       if (!state.enablePerBookSettings) {
-        final desiredLayoutMode = state.pdfBookViewByDefault
-            ? PdfLayoutMode.bookView
-            : PdfLayoutMode.regularView;
         final currentLayoutMode = switch (_bloc.state) {
           PdfBookInitial initial => initial.layoutMode,
           PdfBookLoaded loaded => loaded.layoutMode,
           _ => null,
         };
 
-        if (currentLayoutMode != desiredLayoutMode) {
+        // ההשוואה ברמת ספר/רגיל בלבד — ברירת המחדל הגלובלית היא בוליאנית,
+        // והשוואה מדויקת הייתה דורסת את כיוון הזוגות (bookViewNoCover) שנבחר.
+        if (currentLayoutMode != null &&
+            currentLayoutMode.isBookView != state.pdfBookViewByDefault) {
           _lockedSpreadStartPage = null;
-          _bloc.add(pdf_events.SetLayoutMode(desiredLayoutMode));
+          _bloc.add(
+            pdf_events.SetLayoutMode(
+              state.pdfBookViewByDefault
+                  ? PdfLayoutMode.bookView
+                  : PdfLayoutMode.regularView,
+            ),
+          );
         }
       }
     });
@@ -709,8 +721,12 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     PdfLayoutMode layoutMode = pdfBookViewByDefault
         ? PdfLayoutMode.bookView
         : PdfLayoutMode.regularView;
+    final saved = widget.tab.savedLayoutMode;
+    if (saved != null && saved.isBookView == layoutMode.isBookView) {
+      layoutMode = saved;
+    }
 
-    if (enablePerBookSettings && widget.tab.savedLayoutMode == null) {
+    if (enablePerBookSettings && saved == null) {
       final settings = await _loadPerBookSettings();
       if (settings?.layoutMode != null) {
         layoutMode = settings!.layoutMode!;
@@ -745,6 +761,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     return pdfSpreadPageRange(
       pageNumber,
       bookView: _isBookViewModeActive(),
+      coverPage: _hasCoverPage(),
       totalPages: totalPages,
     );
   }
@@ -1158,13 +1175,17 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   }
 
   PdfViewerParams _buildPdfViewerParams(PdfLayoutMode layoutMode) {
-    if (layoutMode == PdfLayoutMode.bookView) {
-      _lockedSpreadStartPage ??= _spreadStartPageFor(widget.tab.pageNumber);
+    if (layoutMode.isBookView) {
+      _lockedSpreadStartPage ??= pdfSpreadStartPage(
+        widget.tab.pageNumber,
+        coverPage: layoutMode.hasCoverPage,
+      );
     }
 
     return PdfViewerParams(
-      layoutPages: layoutMode == PdfLayoutMode.bookView
+      layoutPages: layoutMode.isBookView
           ? (pages, params) {
+              final hasCover = layoutMode.hasCoverPage;
               final pageLayouts = <Rect>[];
               const gap = _bookViewGap;
               const scale = _bookViewScale;
@@ -1180,14 +1201,14 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                 final scaledWidth = currentPage.width * scale;
                 final scaledHeight = currentPage.height * scale;
 
-                if (i == 0) {
+                if (hasCover && i == 0) {
                   // עמוד 0 (שער) - לבדו
                   pageLayouts.add(
                     Rect.fromLTWH(0, totalHeight, scaledWidth, scaledHeight),
                   );
                   totalHeight += scaledHeight + params.margin;
                 } else {
-                  final pageIndex = i - 1;
+                  final pageIndex = hasCover ? i - 1 : i;
                   final isRightPage = pageIndex % 2 == 0;
 
                   if (isRightPage) {
@@ -1230,11 +1251,11 @@ class _PdfBookScreenState extends State<PdfBookScreen>
               );
             }
           : null,
-      calculateCurrentPageNumber: layoutMode == PdfLayoutMode.bookView
+      calculateCurrentPageNumber: layoutMode.isBookView
           ? null
           : (visibleRect, pageRects, controller) =>
                 pdfTopmostVisiblePage(visibleRect, pageRects),
-      normalizeMatrix: layoutMode == PdfLayoutMode.bookView
+      normalizeMatrix: layoutMode.isBookView
           ? (matrix, viewSize, layout, controller) {
               if (_isPageTurnInProgress) {
                 return matrix;
@@ -1284,7 +1305,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       // הרגיל (2 בספר, 1 רגיל).
       verticalCacheExtent: _waitingForStableLayout
           ? 0
-          : (layoutMode == PdfLayoutMode.bookView ? 2 : 1),
+          : (layoutMode.isBookView ? 2 : 1),
       pageAnchor: PdfPageAnchor.top, // עיגון לראש הדף
       onInteractionStart: (_) {
         if (!(widget.tab.pinLeftPane.value ||
@@ -1434,8 +1455,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
         final savedZoom = widget.tab.savedZoom;
         final hasSavedZoom = savedZoom != null && savedZoom != 1.0;
-        bool shouldFitToWidth =
-            layoutMode != PdfLayoutMode.bookView && !hasSavedZoom;
+        bool shouldFitToWidth = !layoutMode.isBookView && !hasSavedZoom;
 
         // בחירת המפרשים נטענת תמיד (לא תלוי ב-enablePerBookSettings); זום ופריסה
         // נשארים כפופים להגדרה.
@@ -1685,10 +1705,19 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
   bool _isBookViewModeActive() {
     final state = _bloc.state;
-    return state is PdfBookLoaded && state.layoutMode == PdfLayoutMode.bookView;
+    return state is PdfBookLoaded && state.layoutMode.isBookView;
   }
 
-  int _spreadStartPageFor(int pageNumber) => pdfSpreadStartPage(pageNumber);
+  /// האם העמוד הראשון עומד לבדו בתצוגת הספר הפעילה.
+  bool _hasCoverPage() => switch (_bloc.state) {
+    PdfBookInitial s => s.layoutMode.hasCoverPage,
+    PdfBookLoading s => s.layoutMode.hasCoverPage,
+    PdfBookLoaded s => s.layoutMode.hasCoverPage,
+    _ => true,
+  };
+
+  int _spreadStartPageFor(int pageNumber) =>
+      pdfSpreadStartPage(pageNumber, coverPage: _hasCoverPage());
 
   Rect? _spreadRectForPageLayout(PdfPageLayout layout, int spreadStartPage) {
     final pageLayouts = layout.pageLayouts;
@@ -1697,7 +1726,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     }
     final rightPageRect = pageLayouts[spreadStartPage - 1];
 
-    if (spreadStartPage == 1) {
+    if (_hasCoverPage() && spreadStartPage == 1) {
       return Rect.fromLTWH(
         0,
         rightPageRect.top,
@@ -1783,9 +1812,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     final spreadStartPage =
         _lockedSpreadStartPage ?? _spreadStartPageFor(currentPage);
     final totalPages = controller.pageCount;
+    final hasCover = _hasCoverPage();
     final pageNumbers = <int>[
       spreadStartPage,
-      if (spreadStartPage > 1 && spreadStartPage < totalPages)
+      if ((!hasCover || spreadStartPage > 1) && spreadStartPage < totalPages)
         spreadStartPage + 1,
     ];
 
@@ -1800,7 +1830,8 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       if (!pageRect.overlaps(viewportBounds)) continue;
 
       final isLeftPage =
-          spreadStartPage == 1 || pageNumber == spreadStartPage + 1;
+          (hasCover && spreadStartPage == 1) ||
+          pageNumber == spreadStartPage + 1;
       final outerStackPages = isLeftPage
           ? totalPages - pageNumber
           : pageNumber - 1;
@@ -1853,11 +1884,12 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
     final currentPage = widget.tab.pdfViewerController.pageNumber ?? 1;
     final totalPages = widget.tab.pdfViewerController.pageCount;
-    final canGoPrevious = pdfSpreadStartPage(currentPage) > 1;
+    final canGoPrevious = _spreadStartPageFor(currentPage) > 1;
     final canGoNext =
         pdfSpreadPageRange(
           currentPage,
           bookView: true,
+          coverPage: _hasCoverPage(),
           totalPages: totalPages,
         ).endPageExclusive <=
         totalPages;
@@ -2326,7 +2358,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     if (!controller.isReady) return const [];
     final totalPages = controller.pageCount;
     if (spreadStartPage < 1 || spreadStartPage > totalPages) return const [];
-    if (spreadStartPage == 1) return const [1];
+    if (_hasCoverPage() && spreadStartPage == 1) return const [1];
     return spreadStartPage + 1 <= totalPages
         ? [spreadStartPage, spreadStartPage + 1]
         : [spreadStartPage];
@@ -2933,7 +2965,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
         ? (controller.pageNumber ?? widget.tab.pageNumber)
         : widget.tab.pageNumber;
     if (_isBookViewModeActive()) {
-      return pdfSpreadStartPage(page) == pdfSpreadStartPage(viewerPage);
+      return _spreadStartPageFor(page) == _spreadStartPageFor(viewerPage);
     }
     return page == viewerPage;
   }
@@ -2991,9 +3023,9 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       // ללולאת ייצוב אינסופית. ההשוואה ברמת ה-spread.
       final currentPage = controller.pageNumber ?? target;
       final inBookView = _isBookViewModeActive();
-      final targetKey = inBookView ? pdfSpreadStartPage(target) : target;
+      final targetKey = inBookView ? _spreadStartPageFor(target) : target;
       final currentKey = inBookView
-          ? pdfSpreadStartPage(currentPage)
+          ? _spreadStartPageFor(currentPage)
           : currentPage;
       if (currentKey != targetKey) {
         // הגנה מפני לולאה אינסופית: אם controller.goToPage לא מצליח
@@ -3371,6 +3403,8 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     final previous = _lastObservedLayoutMode;
     _lastObservedLayoutMode = mode;
     if (shouldRecomputeLineRangeOnLayoutModeChange(previous, mode)) {
+      // ההיפוך משנה את הרכב הזוגות — ספריידים שרונדרו מראש כבר לא תקפים.
+      _disposeAllSpreadCache();
       _recomputeTextLineRangeForCurrentPage();
     }
   }
@@ -3757,9 +3791,76 @@ class _PdfBookScreenState extends State<PdfBookScreen>
               );
             },
           ),
+          BlocBuilder<PdfBookBloc, PdfBookState>(
+            buildWhen: (prev, curr) {
+              (PdfLayoutMode, bool)? keyOf(PdfBookState s) => switch (s) {
+                PdfBookLoaded v => (v.layoutMode, v.showZoomBar),
+                _ => null,
+              };
+              return keyOf(prev) != keyOf(curr);
+            },
+            builder: (context, state) {
+              // מוסתר בזמן שסרגל הזום מוצג — שניהם ממורכזים מתחת לסרגל העליון.
+              if (state is! PdfBookLoaded ||
+                  !state.layoutMode.isBookView ||
+                  state.showZoomBar) {
+                return const SizedBox.shrink();
+              }
+              return Positioned(
+                top: 4,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: _buildBookViewDirectionToggle(
+                    context,
+                    state.layoutMode,
+                  ),
+                ),
+              );
+            },
+          ),
         ],
       ),
     );
+  }
+
+  /// לחצן צף (מתחת לסרגל העליון) להיפוך כיוון הזוגות בתצוגת ספר:
+  /// עמוד ראשון בודד משמאל, או מזווג ומתחיל מימין (ללא עמוד ריק).
+  Widget _buildBookViewDirectionToggle(
+    BuildContext context,
+    PdfLayoutMode layoutMode,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      elevation: 2,
+      borderRadius: AppTokens.borderRadiusAll,
+      color: colorScheme.surface,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: AppTokens.borderRadiusAll,
+          border: Border.all(color: colorScheme.outlineVariant, width: 1),
+        ),
+        child: IconButton(
+          icon: const Icon(FluentIcons.arrow_swap_24_regular, size: 16),
+          tooltip: layoutMode.hasCoverPage
+              ? 'היפוך כיוון: התחלת הספר מימין (ללא עמוד ריק)'
+              : 'היפוך כיוון: התחלת הספר משמאל (עם עמוד ריק)',
+          onPressed: _toggleBookViewDirection,
+          padding: const EdgeInsets.all(4),
+          constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+        ),
+      ),
+    );
+  }
+
+  void _toggleBookViewDirection() {
+    final state = _bloc.state;
+    if (state is! PdfBookLoaded || !state.layoutMode.isBookView) return;
+    _lockedSpreadStartPage = null;
+    final target = state.layoutMode == PdfLayoutMode.bookView
+        ? PdfLayoutMode.bookViewNoCover
+        : PdfLayoutMode.bookView;
+    _bloc.add(pdf_events.SetLayoutMode(target));
   }
 
   Widget _buildLeftPaneContent(bool showLeftPane) {
@@ -3931,7 +4032,11 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     final totalPages = widget.tab.pdfViewerController.pageCount;
     final int nextPage;
     if (isBookViewMode) {
-      final focus = pdfNextSpreadFocusPage(basePage, totalPages);
+      final focus = pdfNextSpreadFocusPage(
+        basePage,
+        totalPages,
+        coverPage: _hasCoverPage(),
+      );
       if (focus == null) return;
       nextPage = focus;
     } else {
@@ -3965,7 +4070,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     final basePage = _effectiveCurrentPageForNavigation();
     final int prevPage;
     if (isBookViewMode) {
-      final focus = pdfPreviousSpreadFocusPage(basePage);
+      final focus = pdfPreviousSpreadFocusPage(
+        basePage,
+        coverPage: _hasCoverPage(),
+      );
       if (focus == null) return;
       prevPage = focus;
     } else {
@@ -4617,7 +4725,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
         bookId: widget.tab.book.title,
         createPdfOverride: (_) => file.readAsBytes(),
         initialPage: initialPrintPage,
-        isBookView: currentLayoutMode == PdfLayoutMode.bookView,
+        isBookView: currentLayoutMode.isBookView,
         pdfOutline: widget.tab.outline.value ?? [],
       ),
     );
@@ -4693,7 +4801,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   }
 
   Widget _buildLayoutModeDropdown(BuildContext context, PdfBookLoaded state) {
-    final isBookViewMode = state.layoutMode == PdfLayoutMode.bookView;
+    final isBookViewMode = state.layoutMode.isBookView;
     final iconData = isBookViewMode
         ? FluentIcons.book_open_24_regular
         : FluentIcons.book_24_regular;
@@ -4706,14 +4814,19 @@ class _PdfBookScreenState extends State<PdfBookScreen>
         child: Icon(iconData),
       ),
       position: PopupMenuPosition.under,
-      onSelected: (layoutMode) {
+      onSelected: (selectedMode) {
+        // בחירת "תצוגת ספר" כשכבר בתצוגת ספר משמרת את כיוון הזוגות
+        // שנבחר בלחצן ההיפוך.
+        final layoutMode =
+            selectedMode == PdfLayoutMode.bookView &&
+                state.layoutMode.isBookView
+            ? state.layoutMode
+            : selectedMode;
         _lockedSpreadStartPage = null;
 
         final settingsBloc = context.read<SettingsBloc>();
         if (!settingsBloc.state.enablePerBookSettings) {
-          settingsBloc.add(
-            UpdatePdfBookViewByDefault(layoutMode == PdfLayoutMode.bookView),
-          );
+          settingsBloc.add(UpdatePdfBookViewByDefault(layoutMode.isBookView));
         }
 
         _bloc.add(pdf_events.SetLayoutMode(layoutMode));

--- a/lib/printing/printing_helpers.dart
+++ b/lib/printing/printing_helpers.dart
@@ -1,4 +1,5 @@
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/pdf_book/utils/pdf_spread_layout.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart';
 import 'package:pdfrx/pdfrx.dart';
 
@@ -52,16 +53,15 @@ bool hasPdfPageRange({required int startPage, required int? endPage}) {
 /// מחזיר את עמוד-ההתחלה לטווח ההדפסה כברירת מחדל.
 ///
 /// בתצוגה רגילה (או על העמוד הראשון) — מחזיר את העמוד הנוכחי כפי שהוא.
-/// בתצוגת ספר (שני עמודים זה לצד זה), נדרש לסנכרן לתחילת ה-spread:
-/// אם currentPage זוגי — זו התחלת ה-spread, אחרת מקדימים בעמוד אחד.
+/// בתצוגת ספר (שני עמודים זה לצד זה), נדרש לסנכרן לתחילת ה-spread.
 int resolveInitialPdfPrintPage({
   required int currentPage,
   required PdfLayoutMode layoutMode,
 }) {
-  if (layoutMode != PdfLayoutMode.bookView || currentPage <= 1) {
+  if (!layoutMode.isBookView || currentPage <= 1) {
     return currentPage;
   }
-  return currentPage.isEven ? currentPage : currentPage - 1;
+  return pdfSpreadStartPage(currentPage, coverPage: layoutMode.hasCoverPage);
 }
 
 /// מחזיר את האינדקס של הכותרת האחרונה ברשימה ששורת ההתחלה שלה <= [lineIndex].

--- a/lib/settings/services/per_book_settings_service.dart
+++ b/lib/settings/services/per_book_settings_service.dart
@@ -531,7 +531,15 @@ class TextBookPerBookSettings {
 /// מצב תצוגת PDF
 enum PdfLayoutMode {
   regularView, // תצוגה רגילה
-  bookView, // תצוגת ספר
+  bookView, // תצוגת ספר — עמוד ראשון בודד (עם "עמוד ריק" לצדו)
+  bookViewNoCover, // תצוגת ספר — זוגות מהעמוד הראשון: (1,2), (3,4)
+}
+
+extension PdfLayoutModeX on PdfLayoutMode {
+  bool get isBookView => this != PdfLayoutMode.regularView;
+
+  /// האם העמוד הראשון עומד לבדו בתצוגת ספר (כמו עמוד שער).
+  bool get hasCoverPage => this == PdfLayoutMode.bookView;
 }
 
 /// הגדרות פר-ספר לספרי PDF

--- a/test/pdf_book/pdf_book_screen_test.dart
+++ b/test/pdf_book/pdf_book_screen_test.dart
@@ -45,6 +45,23 @@ void main() {
         1,
       );
     });
+
+    test('במצב ספר ללא עמוד שער — מנרמלת לתחילת זוג אי-זוגי', () {
+      expect(
+        resolveInitialPdfPrintPage(
+          currentPage: 4,
+          layoutMode: PdfLayoutMode.bookViewNoCover,
+        ),
+        3,
+      );
+      expect(
+        resolveInitialPdfPrintPage(
+          currentPage: 5,
+          layoutMode: PdfLayoutMode.bookViewNoCover,
+        ),
+        5,
+      );
+    });
   });
 
   group('shouldShowOpenPdfCommentaryPaneEntry', () {

--- a/test/pdf_book/pdf_book_tab_test.dart
+++ b/test/pdf_book/pdf_book_tab_test.dart
@@ -172,6 +172,13 @@ void main() {
       expect(restored.savedLayoutMode, PdfLayoutMode.bookView);
     });
 
+    test('fromJson roundtrip שומר bookViewNoCover', () {
+      final tab = _tab();
+      tab.savedLayoutMode = PdfLayoutMode.bookViewNoCover;
+      final restored = PdfBookTab.fromJson(tab.toJson());
+      expect(restored.savedLayoutMode, PdfLayoutMode.bookViewNoCover);
+    });
+
     test('fromJson ללא savedLayoutMode → savedLayoutMode=null', () {
       final tab = _tab();
       final restored = PdfBookTab.fromJson(tab.toJson());

--- a/test/pdf_book/pdf_spread_layout_test.dart
+++ b/test/pdf_book/pdf_spread_layout_test.dart
@@ -25,6 +25,15 @@ void main() {
       expect(pdfSpreadStartPage(5), 4);
       expect(pdfSpreadStartPage(11), 10);
     });
+
+    test('ללא עמוד שער — הזוגות הם (1,2), (3,4)', () {
+      expect(pdfSpreadStartPage(1, coverPage: false), 1);
+      expect(pdfSpreadStartPage(2, coverPage: false), 1);
+      expect(pdfSpreadStartPage(3, coverPage: false), 3);
+      expect(pdfSpreadStartPage(4, coverPage: false), 3);
+      expect(pdfSpreadStartPage(10, coverPage: false), 9);
+      expect(pdfSpreadStartPage(0, coverPage: false), 1);
+    });
   });
 
   group('pdfNextSpreadFocusPage', () {
@@ -47,6 +56,13 @@ void main() {
     test('זוג אחרון בעל עמוד יחיד עדיין נגיש', () {
       expect(pdfNextSpreadFocusPage(8, 10), 10);
     });
+
+    test('ללא עמוד שער — מהזוג (1,2) לעמוד 3', () {
+      expect(pdfNextSpreadFocusPage(1, 10, coverPage: false), 3);
+      expect(pdfNextSpreadFocusPage(2, 10, coverPage: false), 3);
+      expect(pdfNextSpreadFocusPage(4, 10, coverPage: false), 5);
+      expect(pdfNextSpreadFocusPage(9, 10, coverPage: false), isNull);
+    });
   });
 
   group('pdfPreviousSpreadFocusPage', () {
@@ -64,6 +80,13 @@ void main() {
     test('מהכריכה — null', () {
       expect(pdfPreviousSpreadFocusPage(1), isNull);
       expect(pdfPreviousSpreadFocusPage(0), isNull);
+    });
+
+    test('ללא עמוד שער — מהזוג הראשון null, מזוג פנימי לעמוד השמאלי הקודם', () {
+      expect(pdfPreviousSpreadFocusPage(1, coverPage: false), isNull);
+      expect(pdfPreviousSpreadFocusPage(2, coverPage: false), isNull);
+      expect(pdfPreviousSpreadFocusPage(3, coverPage: false), 2);
+      expect(pdfPreviousSpreadFocusPage(6, coverPage: false), 4);
     });
   });
 
@@ -123,6 +146,29 @@ void main() {
           reason: 'spread for page $page should span 2 pages',
         );
       }
+    });
+
+    test('ללא עמוד שער — עמודים 1 ו-2 הם ספירייד אחד', () {
+      for (final page in [1, 2]) {
+        expect(pdfSpreadPageRange(page, bookView: true, coverPage: false), (
+          startPage: 1,
+          endPageExclusive: 3,
+        ));
+      }
+      expect(pdfSpreadPageRange(4, bookView: true, coverPage: false), (
+        startPage: 3,
+        endPageExclusive: 5,
+      ));
+    });
+
+    test('ללא עמוד שער — עמוד אחרון אי-זוגי נחתך לגבול המסמך', () {
+      final range = pdfSpreadPageRange(
+        9,
+        bookView: true,
+        coverPage: false,
+        totalPages: 9,
+      );
+      expect(range, (startPage: 9, endPageExclusive: 10));
     });
   });
 


### PR DESCRIPTION
מצב חדש bookViewNoCover שבו העמוד הראשון מזווג ומופיע מימין — (1,2), (3,4) — במקום לעמוד לבדו משמאל. לחצן צף ממורכז מתחת לסרגל העליון מחליף בין הכיוונים בתצוגת ספר, והבחירה נשמרת פר-ספר וגם בשחזור טאבים.
