### PR TITLE
תיקון: מעבר בין מהדורת טקסט ל-PDF קפץ לתחילת הספר

### DIFF
--- a/lib/core/messages/text_book_messages.dart
+++ b/lib/core/messages/text_book_messages.dart
@@ -45,6 +45,9 @@ abstract class TextBookMessages {
   static String pdfNotFoundForBook(String bookTitle) =>
       'לא נמצא ספר PDF עבור "$bookTitle"';
 
+  static const String pdfLocationNotFoundOpeningAtStart =
+      'לא נמצא מיקום תואם ב-PDF — הספר נפתח מתחילתו';
+
   // ── תצוגה, העתקה והערות ─────────────────────────────────────────────────
 
   static const String perBookSettingsReset = 'ההגדרות הפר-ספריות אופסו בהצלחה';

--- a/lib/core/messages/text_book_messages.dart
+++ b/lib/core/messages/text_book_messages.dart
@@ -48,10 +48,6 @@ abstract class TextBookMessages {
   static const String pdfLocationNotFoundOpeningAtStart =
       'לא נמצא מיקום תואם ב-PDF — הספר נפתח מתחילתו';
 
-  static String pdfDuplicateEditionsOpeningAtStart(String bookTitle) =>
-      'קיימת יותר ממהדורת PDF אחת בשם "$bookTitle" — הספר נפתח מתחילתו. '
-      'הסרת המהדורה הכפולה תחזיר את המיקום המדויק';
-
   // ── תצוגה, העתקה והערות ─────────────────────────────────────────────────
 
   static const String perBookSettingsReset = 'ההגדרות הפר-ספריות אופסו בהצלחה';

--- a/lib/core/messages/text_book_messages.dart
+++ b/lib/core/messages/text_book_messages.dart
@@ -48,6 +48,10 @@ abstract class TextBookMessages {
   static const String pdfLocationNotFoundOpeningAtStart =
       'לא נמצא מיקום תואם ב-PDF — הספר נפתח מתחילתו';
 
+  static String pdfDuplicateEditionsOpeningAtStart(String bookTitle) =>
+      'קיימת יותר ממהדורת PDF אחת בשם "$bookTitle" — הספר נפתח מתחילתו. '
+      'הסרת המהדורה הכפולה תחזיר את המיקום המדויק';
+
   // ── תצוגה, העתקה והערות ─────────────────────────────────────────────────
 
   static const String perBookSettingsReset = 'ההגדרות הפר-ספריות אופסו בהצלחה';

--- a/lib/library/models/library.dart
+++ b/lib/library/models/library.dart
@@ -193,34 +193,38 @@ class Library extends Category {
     }
 
     // 2. חיפוש גלובלי (מאפשר התאמה לפי נרמול הכותרת כפי שמקובל):
-    final candidates = getAllBooks()
-        .where(
-          (b) =>
-              b.runtimeType == companionType &&
-              _normalizeTitle(b.title) == normalizedTitle,
-        )
-        .toList();
-
-    // סינון התנגשויות ידועות (ירושלמי <-> בבלי)
-    final filtered = candidates.where((candidate) {
-      final bookCat =
-          book.categoryPath ??
-          book.heCategories ??
-          (book is FileBook ? book.path : '');
-      final candCat =
-          candidate.categoryPath ??
-          candidate.heCategories ??
-          (candidate is FileBook ? candidate.path : '');
-
-      if (bookCat.contains('ירושלמי') && candCat.contains('בבלי')) return false;
-      if (bookCat.contains('בבלי') && candCat.contains('ירושלמי')) return false;
-      return true;
-    }).toList();
+    final candidates = getCompanionBooks(book, companionType);
 
     // מהדורה ממקור אחר משמשת רק כשאין אחת מאותו מקור — אחרת מהדורה אישית
     // שנוספה בשם זהה גונבת את הבחירה, ומיפוי העמודים שלה נכשל ופותח בעמוד 1.
-    return filtered.where((c) => _isSameBookSource(book, c)).firstOrNull ??
-        filtered.firstOrNull;
+    return candidates.where((c) => _isSameBookSource(book, c)).firstOrNull ??
+        candidates.firstOrNull;
+  }
+
+  /// כל מהדורות ה-[companionType] בספרייה שכותרתן זהה ל-[book], אחרי סינון
+  /// ההתנגשויות. יותר מאחת = כפילות שם, שבה זהות המלווה אינה חד-משמעית.
+  List<Book> getCompanionBooks(Book book, Type companionType) {
+    final normalizedTitle = _normalizeTitle(book.title);
+    return getAllBooks()
+        .where(
+          (b) =>
+              b.runtimeType == companionType &&
+              _normalizeTitle(b.title) == normalizedTitle &&
+              !_isCrossTraditionConflict(book, b),
+        )
+        .toList();
+  }
+
+  /// מסכתות בבלי וירושלמי חולקות שמות — ואינן מלוות זו את זו.
+  bool _isCrossTraditionConflict(Book book, Book candidate) {
+    String categoryOf(Book b) =>
+        b.categoryPath ?? b.heCategories ?? (b is FileBook ? b.path : '');
+    final bookCat = categoryOf(book);
+    final candCat = categoryOf(candidate);
+
+    if (bookCat.contains('ירושלמי') && candCat.contains('בבלי')) return true;
+    if (bookCat.contains('בבלי') && candCat.contains('ירושלמי')) return true;
+    return false;
   }
 
   /// האם [candidate] בא מאותו מקור ספרים כמו [book] — ספריית אוצריא, הספרים

--- a/lib/library/models/library.dart
+++ b/lib/library/models/library.dart
@@ -180,10 +180,14 @@ class Library extends Category {
                 _normalizeTitle(b.title) == normalizedTitle &&
                 b.runtimeType == companionType,
           )
-          .take(2)
           .toList();
 
-      // שני מועמדים באותה קטגוריה = זהות לא ודאית; מוותרים במקום לנחש.
+      // מועמד יחיד מאותו מקור מכריע; אחרת שני מועמדים = זהות לא ודאית
+      // ומוותרים במקום לנחש.
+      final sameSource = companions
+          .where((c) => _isSameBookSource(book, c))
+          .toList();
+      if (sameSource.length == 1) return sameSource.first;
       if (companions.length > 1) return null;
       if (companions.isNotEmpty) return companions.first;
     }
@@ -213,8 +217,17 @@ class Library extends Category {
       return true;
     }).toList();
 
-    return filtered.firstOrNull;
+    // מהדורה ממקור אחר משמשת רק כשאין אחת מאותו מקור — אחרת מהדורה אישית
+    // שנוספה בשם זהה גונבת את הבחירה, ומיפוי העמודים שלה נכשל ופותח בעמוד 1.
+    return filtered.where((c) => _isSameBookSource(book, c)).firstOrNull ??
+        filtered.firstOrNull;
   }
+
+  /// האם [candidate] בא מאותו מקור ספרים כמו [book] — ספריית אוצריא, הספרים
+  /// האישיים, או אותו קטלוג חיצוני. שם זהה ממקור אחר אינו אותו ספר.
+  bool _isSameBookSource(Book book, Book candidate) =>
+      candidate.isUserBook == book.isUserBook &&
+      candidate.externalLibraryId == book.externalLibraryId;
 
   /// מחפש ספר לפי כותרת עם חיפוש גמיש יותר.
   ///

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -777,12 +777,8 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       final textRange = await pdfTextLineRangeForPageRange(
         startPage: range.startPage,
         endPageExclusive: range.endPageExclusive,
-        resolveTextIndex: (pdfPage) => pdfToTextPage(
-          widget.tab.book,
-          outline,
-          pdfPage,
-          context,
-        ),
+        resolveTextIndex: (pdfPage) =>
+            pdfToTextPage(widget.tab.book, outline, pdfPage),
         isActive: () => mounted,
       );
       if (textRange != null) {
@@ -4574,7 +4570,6 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       widget.tab.book,
       currentOutline,
       currentPage,
-      context,
     );
 
     if (!context.mounted) return;
@@ -4781,7 +4776,6 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                   book,
                   currentOutline,
                   currentPage,
-                  context,
                 );
 
                 if (!context.mounted) return;

--- a/lib/pdf_book/view/pdf_commentators_tab_screen.dart
+++ b/lib/pdf_book/view/pdf_commentators_tab_screen.dart
@@ -435,7 +435,11 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
       int best = 0;
       while (lo <= hi) {
         final mid = (lo + hi) ~/ 2;
-        final page = await textToPdfPage(textBook, headings[mid].value);
+        final page = await textToPdfPage(
+          textBook,
+          headings[mid].value,
+          pdfBook: widget.tab.sourceTab.book,
+        );
         if (page == null) return; // אין מיפוי אמין — נשארים בברירת המחדל
         if (page <= targetPage) {
           best = mid;
@@ -768,6 +772,7 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
           final mapped = await textToPdfPage(
             textBook,
             headings[_selectedHeadingIdx].value,
+            pdfBook: sourceTab.book,
           );
           if (mapped != null) page = mapped;
         }

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -2519,11 +2519,20 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       currentIndex,
       pdfBook: _pdfBook is PdfBook ? _pdfBook as PdfBook : null,
     );
+    // הספרייה נדרשת רק לניסוח הודעת הכשל, ולכן נטענת רק כשהמיפוי נכשל.
+    final library = index == null
+        ? await DataRepository.instance.library
+        : null;
 
     if (!context.mounted) return;
 
-    if (index == null) {
-      UiSnack.show(TextBookMessages.pdfLocationNotFoundOpeningAtStart);
+    if (library != null) {
+      UiSnack.show(
+        pdfLocationFailureMessage(
+          state.book.title,
+          library.getCompanionBooks(state.book, PdfBook).length,
+        ),
+      );
     }
     openBook(
       context,
@@ -3252,6 +3261,14 @@ Future<void> _addNoteFromKeyboard(
 //   context.read<TextBookBloc>().add(const CloseEditor());
 // }
 
+/// ניסוח כשל מיפוי המיקום ל-PDF. כפילות שם היא סיבה שונה מהיעדר מיקום תואם,
+/// והיחידה שהמשתמש יכול לתקן — ולכן היא נאמרת במפורש.
+@visibleForTesting
+String pdfLocationFailureMessage(String bookTitle, int companionEditions) =>
+    companionEditions > 1
+    ? TextBookMessages.pdfDuplicateEditionsOpeningAtStart(bookTitle)
+    : TextBookMessages.pdfLocationNotFoundOpeningAtStart;
+
 void _togglePdfView(
   BuildContext context,
   TextBookLoaded state,
@@ -3280,7 +3297,12 @@ void _togglePdfView(
   if (!context.mounted) return;
 
   if (index == null) {
-    UiSnack.show(TextBookMessages.pdfLocationNotFoundOpeningAtStart);
+    UiSnack.show(
+      pdfLocationFailureMessage(
+        state.book.title,
+        library.getCompanionBooks(state.book, PdfBook).length,
+      ),
+    );
   }
   openBook(
     context,

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -2519,20 +2519,10 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       currentIndex,
       pdfBook: _pdfBook is PdfBook ? _pdfBook as PdfBook : null,
     );
-    // הספרייה נדרשת רק לניסוח הודעת הכשל, ולכן נטענת רק כשהמיפוי נכשל.
-    final library = index == null
-        ? await DataRepository.instance.library
-        : null;
-
     if (!context.mounted) return;
 
-    if (library != null) {
-      UiSnack.show(
-        pdfLocationFailureMessage(
-          state.book.title,
-          library.getCompanionBooks(state.book, PdfBook).length,
-        ),
-      );
+    if (index == null) {
+      UiSnack.show(TextBookMessages.pdfLocationNotFoundOpeningAtStart);
     }
     openBook(
       context,
@@ -3261,14 +3251,6 @@ Future<void> _addNoteFromKeyboard(
 //   context.read<TextBookBloc>().add(const CloseEditor());
 // }
 
-/// ניסוח כשל מיפוי המיקום ל-PDF. כפילות שם היא סיבה שונה מהיעדר מיקום תואם,
-/// והיחידה שהמשתמש יכול לתקן — ולכן היא נאמרת במפורש.
-@visibleForTesting
-String pdfLocationFailureMessage(String bookTitle, int companionEditions) =>
-    companionEditions > 1
-    ? TextBookMessages.pdfDuplicateEditionsOpeningAtStart(bookTitle)
-    : TextBookMessages.pdfLocationNotFoundOpeningAtStart;
-
 void _togglePdfView(
   BuildContext context,
   TextBookLoaded state,
@@ -3297,12 +3279,7 @@ void _togglePdfView(
   if (!context.mounted) return;
 
   if (index == null) {
-    UiSnack.show(
-      pdfLocationFailureMessage(
-        state.book.title,
-        library.getCompanionBooks(state.book, PdfBook).length,
-      ),
-    );
+    UiSnack.show(TextBookMessages.pdfLocationNotFoundOpeningAtStart);
   }
   openBook(
     context,

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -2514,10 +2514,17 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
     final currentIndex = _topmostVisibleSourceLine(state);
     widget.tab.index = currentIndex;
 
-    final index = await textToPdfPage(state.book, currentIndex);
+    final index = await textToPdfPage(
+      state.book,
+      currentIndex,
+      pdfBook: _pdfBook is PdfBook ? _pdfBook as PdfBook : null,
+    );
 
     if (!context.mounted) return;
 
+    if (index == null) {
+      UiSnack.show(TextBookMessages.pdfLocationNotFoundOpeningAtStart);
+    }
     openBook(
       context,
       _pdfBook!,
@@ -3262,13 +3269,19 @@ void _togglePdfView(
     return;
   }
 
+  // אותו מופע שנפתח הוא זה שלפיו מחושב המיפוי — אחרת שני PDF באותה כותרת
+  // היו נותנים מיפוי של האחד ופתיחה של האחר.
   final index = await textToPdfPage(
     state.book,
     currentIndex,
+    pdfBook: book is PdfBook ? book : null,
   );
 
   if (!context.mounted) return;
 
+  if (index == null) {
+    UiSnack.show(TextBookMessages.pdfLocationNotFoundOpeningAtStart);
+  }
   openBook(
     context,
     book,

--- a/lib/utils/file/page_converter.dart
+++ b/lib/utils/file/page_converter.dart
@@ -46,11 +46,13 @@ Future<int?> textToPdfPage(
 
   try {
     final anchorsPdf = await _getPdfAnchors(pdfBook.path);
-    final map = _pageMapCache[key] ??= await _buildPageMap(
-      pdfBook,
-      anchorsPdf,
-      textBook,
-    );
+    final anchorsText = collectTextAnchors(await textBook.tableOfContents);
+    final map = _buildPageMap(pdfBook, anchorsPdf, anchorsText);
+    // גם מפה לא אמינה נשמרת, אחרת דפדוף בונה אותה מחדש בכל עמוד. תוכן עניינים
+    // ריק הוא המצב היחיד שעשוי להיות זמני (ה-DB טרם נטען) ולכן אינו נשמר.
+    if (anchorsText.isNotEmpty) {
+      _pageMapCache[key] = map;
+    }
     if (!map.hasReliableAnchors) {
       return null;
     }
@@ -177,11 +179,11 @@ int _nowMillis() => DateTime.now().millisecondsSinceEpoch;
 /// Converts a PDF page number to the corresponding text book index.
 ///
 /// This function uses a cached, anchor-based map with local interpolation for accuracy and performance.
+/// [outline] - ה-outline של הטאב אם כבר נטען; אחרת הסימניות נקראות מהקובץ.
 Future<int?> pdfToTextPage(
   PdfBook pdfBook,
   List<PdfOutlineNode> outline,
   int pdfPage,
-  BuildContext ctx,
 ) async {
   final textBook =
       (await DataRepository.instance.library).getCompanionBook(
@@ -193,27 +195,44 @@ Future<int?> pdfToTextPage(
     return null;
   }
   final key = '${pdfBook.path}::${textBook.title}';
-  final map = _pageMapCache[key] ??= await _buildPageMap(
-    pdfBook,
-    collectPdfAnchors(outline),
-    textBook,
-  );
-  if (!map.hasReliableAnchors) {
-    return null;
+  final cached = _pageMapCache[key];
+  if (cached != null) {
+    if (!cached.hasReliableAnchors) {
+      return null;
+    }
+    return cached.pdfToText(pdfPage);
   }
 
-  return map.pdfToText(pdfPage);
+  try {
+    // ה-outline של הטאב נטען ברקע; עד שיגיע קוראים את הסימניות מהקובץ.
+    // outline שנטען וריק מעוגנים אינו מצב זמני, ולכן אינו נקרא שוב.
+    final anchorsPdf = outline.isEmpty
+        ? await _getPdfAnchors(pdfBook.path)
+        : collectPdfAnchors(outline);
+    final anchorsText = collectTextAnchors(await textBook.tableOfContents);
+    final map = _buildPageMap(pdfBook, anchorsPdf, anchorsText);
+    if (anchorsText.isNotEmpty) {
+      _pageMapCache[key] = map;
+    }
+    if (!map.hasReliableAnchors) {
+      return null;
+    }
+
+    return map.pdfToText(pdfPage);
+  } catch (e, st) {
+    debugPrint(
+      '[PageConverter] pdfToTextPage failed for "${pdfBook.path}": $e\n$st',
+    );
+    return null;
+  }
 }
 
 /// Builds the synchronized anchor map from PDF anchors and text Table of Contents.
-Future<PageMap> _buildPageMap(
+PageMap _buildPageMap(
   PdfBook pdf,
   List<({int page, String ref})> anchorsPdf,
-  TextBook text,
-) async {
-  final toc = await text.tableOfContents;
-  final anchorsText = collectTextAnchors(toc);
-
+  List<({int index, String ref})> anchorsText,
+) {
   final map = buildPageMapFromAnchors(anchorsPdf, anchorsText);
 
   debugPrint(
@@ -233,11 +252,6 @@ Future<PageMap> _buildPageMap(
     debugPrint(
       '🗺️ [PDF-DEBUG] ⚠️ Text sample refs: ${anchorsText.take(3).map((a) => '"${a.ref}"').join(", ")}',
     );
-  }
-
-  // Fallback: if no anchors matched, anchor to page 1 / index 0.
-  if (map.pdfPages.isEmpty) {
-    return PageMap([1], [0]);
   }
 
   return map;

--- a/lib/utils/file/page_map_builder.dart
+++ b/lib/utils/file/page_map_builder.dart
@@ -56,12 +56,89 @@ class PageMap {
 
 /// Normalizes a ref string for comparison (collapses whitespace, strips
 /// characters that differ only in punctuation style, lowercases).
+///
+/// Dashes are folded to ASCII `-` first: stripping a maqaf or en-dash instead
+/// would glue "דף כב־א" into "דף כבא" and read it as daf 23.
 String normalizeRef(String s) {
   return s
+      .replaceAll(RegExp(r'[־‐-―]'), '-')
       .replaceAll(RegExp(r'\s+'), ' ')
       .replaceAll(RegExp(r'[^\p{L}\p{N}\s/.-]', unicode: true), '')
       .toLowerCase()
       .trim();
+}
+
+/// ערכי אותיות הגימטריה (כולל אותיות סופיות).
+const _hebrewNumeralValues = <String, int>{
+  'א': 1,
+  'ב': 2,
+  'ג': 3,
+  'ד': 4,
+  'ה': 5,
+  'ו': 6,
+  'ז': 7,
+  'ח': 8,
+  'ט': 9,
+  'י': 10,
+  'כ': 20,
+  'ך': 20,
+  'ל': 30,
+  'מ': 40,
+  'ם': 40,
+  'נ': 50,
+  'ן': 50,
+  'ס': 60,
+  'ע': 70,
+  'פ': 80,
+  'ף': 80,
+  'צ': 90,
+  'ץ': 90,
+  'ק': 100,
+  'ר': 200,
+  'ש': 300,
+  'ת': 400,
+};
+
+/// ערך הגימטריה של [letters], או null אם אינו מספר עברי תקין.
+///
+/// תקינות = ערכי האותיות אינם עולים, כמו בכתיב גימטריה ("כב"). זה דוחה את רוב
+/// המילים, אך לא את כולן ("תמיד"=454) — ולכן [canonicalDafKey] דורש בנוסף
+/// קידומת "דף" או סימן עמוד.
+int? hebrewNumeralValue(String letters) {
+  if (letters.isEmpty || letters.length > 4) return null;
+  var sum = 0;
+  var previous = 400;
+  for (final ch in letters.split('')) {
+    final value = _hebrewNumeralValues[ch];
+    if (value == null || value > previous) return null;
+    sum += value;
+    previous = value;
+  }
+  return sum;
+}
+
+/// A "דף" label: the literal prefix, a numeral, and an optional amud marker.
+final _dafLabelPattern = RegExp(
+  r'^דף\s+([א-ת]{1,4})\s*(?:-\s*)?(\.|ע?[אב]|עמוד\s*[אב])?$',
+);
+
+/// Canonical key for a Talmud daf from a **normalized** ([normalizeRef]) label —
+/// "22a"/"22b", or null when the label is not a daf.
+///
+/// Unifies spellings of the same daf: "דף כב.", "דף כב ע\"א", "דף כב - א" → "22a".
+/// [normalizeRef] strips the colon, so a missing marker means amud bet.
+///
+/// The literal "דף" prefix is required: without it, chapter/siman labels
+/// ("א.", "ב.") and words whose gematria is valid ("תמיד.") would be read as
+/// dafim and produce a plausible-looking but wrong map.
+String? canonicalDafKey(String ref) {
+  final match = _dafLabelPattern.firstMatch(ref.trim());
+  if (match == null) return null;
+  final number = hebrewNumeralValue(match.group(1)!);
+  if (number == null) return null;
+  final marker = match.group(2);
+  final isAmudAlef = marker == '.' || (marker != null && marker.endsWith('א'));
+  return '$number${isAmudAlef ? 'a' : 'b'}';
 }
 
 /// Builds a [PageMap] from pre-collected anchor lists.
@@ -76,6 +153,10 @@ String normalizeRef(String s) {
 ///      Text "ברכות/ב."   ← matched via 2-component suffix
 ///    Ambiguous leaves ("הקדמה", "א", "ב" appearing in many tractates) are
 ///    safely skipped because they map to more than one text index.
+/// 3. Canonical daf fallback ([canonicalDafKey]) — bridges editions that spell
+///    the same daf differently ("דף כב." בצד אחד, "דף כב - א" בשני), שאחרת
+///    נותנות אפס התאמות. רץ כמעבר שני ורק כששלבים 1-2 לא הפיקו מיפוי שמיש,
+///    כדי שספר שההתאמה בו כבר עובדת לא ייגע בהיוריסטיקה הזאת.
 PageMap buildPageMapFromAnchors(
   List<({int page, String ref})> anchorsPdf,
   List<({int index, String ref})> anchorsText,
@@ -92,40 +173,68 @@ PageMap buildPageMapFromAnchors(
     }
   }
 
-  final pdfPages = <int>[];
-  final textIndices = <int>[];
-
-  for (final p in anchorsPdf) {
-    int? idx = mapTextByRef[p.ref];
-
-    if (idx == null) {
-      final pdfParts = p.ref.split('/');
-      for (var i = 0; i < pdfParts.length && idx == null; i++) {
-        final suffix = pdfParts.sublist(i).join('/');
-        final matches = mapTextBySuffix[suffix];
-        if (matches != null && matches.length == 1) {
-          idx = matches.first;
-        }
+  int? matchByPath(String ref) {
+    final exact = mapTextByRef[ref];
+    if (exact != null) return exact;
+    final parts = ref.split('/');
+    for (var i = 0; i < parts.length; i++) {
+      final matches = mapTextBySuffix[parts.sublist(i).join('/')];
+      if (matches != null && matches.length == 1) {
+        return matches.first;
       }
     }
-
-    if (idx != null &&
-        !pdfPages.contains(p.page) &&
-        !textIndices.contains(idx)) {
-      pdfPages.add(p.page);
-      textIndices.add(idx);
-    }
+    return null;
   }
 
-  // Sort by PDF page number so interpolation works correctly.
-  final zipped = List.generate(
-    pdfPages.length,
-    (i) => (page: pdfPages[i], idx: textIndices[i]),
-  );
-  zipped.sort((a, b) => a.page.compareTo(b.page));
+  final byPath = _zipAnchors(anchorsPdf, matchByPath);
+  if (byPath.hasReliableAnchors) {
+    return byPath;
+  }
 
+  final mapTextByDaf = <String, List<int>>{};
+  for (final a in anchorsText) {
+    final daf = canonicalDafKey(a.ref.split('/').last);
+    if (daf != null) {
+      (mapTextByDaf[daf] ??= []).add(a.index);
+    }
+  }
+  if (mapTextByDaf.isEmpty) {
+    return byPath;
+  }
+
+  final withDaf = _zipAnchors(anchorsPdf, (ref) {
+    final path = matchByPath(ref);
+    if (path != null) return path;
+    final daf = canonicalDafKey(ref.split('/').last);
+    final matches = daf == null ? null : mapTextByDaf[daf];
+    return matches != null && matches.length == 1 ? matches.first : null;
+  });
+  return withDaf.hasReliableAnchors ? withDaf : byPath;
+}
+
+/// מזווג עוגני PDF לאינדקסי טקסט לפי [resolve], בלי כפילויות בשני הצדדים,
+/// וממוין לפי עמוד ה-PDF כדי שהאינטרפולציה תעבוד.
+PageMap _zipAnchors(
+  List<({int page, String ref})> anchorsPdf,
+  int? Function(String ref) resolve,
+) {
+  final usedPages = <int>{};
+  final usedIndices = <int>{};
+  final matched = <({int page, int idx})>[];
+
+  for (final p in anchorsPdf) {
+    final idx = resolve(p.ref);
+    if (idx == null || !usedPages.add(p.page)) continue;
+    if (!usedIndices.add(idx)) {
+      usedPages.remove(p.page);
+      continue;
+    }
+    matched.add((page: p.page, idx: idx));
+  }
+
+  matched.sort((a, b) => a.page.compareTo(b.page));
   return PageMap(
-    zipped.map((e) => e.page).toList(),
-    zipped.map((e) => e.idx).toList(),
+    matched.map((e) => e.page).toList(),
+    matched.map((e) => e.idx).toList(),
   );
 }

--- a/lib/widgets/commentary/links_list_view.dart
+++ b/lib/widgets/commentary/links_list_view.dart
@@ -68,6 +68,24 @@ String buildSelectedLinkInstanceKey(Link link) {
   return '${link.path2}_${link.index1}_${link.index2}_${link.index2End ?? ''}_${link.heRef}_${link.start}_${link.end}_${link.connectionType}_$target';
 }
 
+/// זהות פריט התצוגה — [buildSelectedLinkInstanceKey] בלי שורת המקור (index1).
+@visibleForTesting
+String buildSelectedLinkTargetKey(Link link) {
+  final target =
+      '${link.targetIsUserBook ? 'u' : 'o'}_${link.targetCategoryId ?? ''}';
+  return '${link.path2}_${link.index2}_${link.index2End ?? ''}_${link.start}_${link.end}_${link.connectionType}_$target';
+}
+
+/// מסיר קישורים כפולים לאותו קטע-יעד. הקטע המוצג פורש כמה שורות מקור, ואותו
+/// קטע-יעד מקושר לעיתים מכמה מהן — בלי המיזוג הוא מופיע ברשימה כמה פעמים.
+@visibleForTesting
+List<Link> dedupeLinksByTarget(List<Link> links) {
+  final seen = <String>{};
+  return links
+      .where((link) => seen.add(buildSelectedLinkTargetKey(link)))
+      .toList();
+}
+
 @visibleForTesting
 String buildSelectedLinksSearchKey({
   required String searchQuery,
@@ -339,7 +357,7 @@ class _LinksListViewState extends State<LinksListView> {
 
   @override
   Widget build(BuildContext context) {
-    final links = widget.links;
+    final links = dedupeLinksByTarget(widget.links);
     final openBookTitle = widget.openBookTitle;
     final chipKeys = _chipKeysFor(widget.chipSourceLinks, openBookTitle);
     final effectiveTypes = effectiveSelectedLinkTypes(
@@ -431,7 +449,9 @@ class _LinksListViewState extends State<LinksListView> {
                   if (chipAxes.eras.isNotEmpty && chipAxes.types.isNotEmpty)
                     const VerticalDivider(
                       key: chipAxesDividerKey,
-                      width: 1,
+                      // width הוא הרוחב הכולל והקו מצויר במרכזו — כך נוצר
+                      // ריווח משני צדיו וצ׳יפ בקצה הציר אינו נצמד אליו.
+                      width: AppTokens.spaceSM * 2 + 1,
                       thickness: 1,
                       indent: AppTokens.spaceXS,
                       endIndent: AppTokens.spaceXS,
@@ -597,26 +617,23 @@ class _LinksListViewState extends State<LinksListView> {
       _filteredLinksFuture = _filterLinksAsync(typeFilteredLinks);
     }
 
-    return Container(
-      color: Theme.of(context).colorScheme.surface,
-      child: AppFutureBuilder<List<Link>>(
-        future: _filteredLinksFuture,
-        builder: (context, data) {
-          final filteredLinks = data;
-          if (filteredLinks.isEmpty) {
-            return _buildEmptyMessage('לא נמצאו קישורים התואמים לחיפוש');
-          }
+    return AppFutureBuilder<List<Link>>(
+      future: _filteredLinksFuture,
+      builder: (context, data) {
+        final filteredLinks = data;
+        if (filteredLinks.isEmpty) {
+          return _buildEmptyMessage('לא נמצאו קישורים התואמים לחיפוש');
+        }
 
-          return ListView.builder(
-            controller: _scrollController,
-            itemCount: filteredLinks.length,
-            itemBuilder: (context, index) {
-              final link = filteredLinks[index];
-              return _buildExpansionTile(link);
-            },
-          );
-        },
-      ),
+        return ListView.builder(
+          controller: _scrollController,
+          itemCount: filteredLinks.length,
+          itemBuilder: (context, index) {
+            final link = filteredLinks[index];
+            return _buildExpansionTile(link);
+          },
+        );
+      },
     );
   }
 
@@ -719,8 +736,6 @@ class _LinksListViewState extends State<LinksListView> {
           color: Theme.of(context).colorScheme.onSurfaceVariant,
         ),
       ),
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      collapsedBackgroundColor: Theme.of(context).colorScheme.surface,
       title: BlocBuilder<SettingsBloc, SettingsState>(
         builder: (context, settingsState) {
           String displayTitle = utils.getTitleFromPath(link.path2);

--- a/test/library/models/get_companion_book_test.dart
+++ b/test/library/models/get_companion_book_test.dart
@@ -105,4 +105,189 @@ void main() {
       expect(library.getCompanionBook(sourceText, PdfBook), same(bavliPdf));
     });
   });
+
+  // תיקיית ספרים אישיים בעלת אותם שמות (למשל "תלמוד בבלי" שהורדה מתוסף
+  // הורדת מאגר) הפכה את הבחירה לתלוית סדר העץ: המהדורה האישית נבחרה,
+  // הסימניות שלה לא התאימו לתוכן העניינים, וה-PDF נפתח בעמוד הראשון.
+  group('Library.getCompanionBook — מקור הספר', () {
+    test('בחיפוש גלובלי — מעדיף מהדורה מובנית על ספר אישי בשם זהה', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+      final userRoot = _category('אישיים');
+      final userBavli = _category('תלמוד בבלי', parent: userRoot);
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final builtInPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\otzaria\תלמוד בבלי\ברכות.pdf',
+        category: bavli,
+      );
+      final userPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\תלמוד בבלי\ברכות.pdf',
+        category: userBavli,
+        isUserBook: true,
+      );
+      seder.books.add(sourceText);
+      bavli.books.add(builtInPdf);
+      userBavli.books.add(userPdf);
+
+      // האישי ראשון בעץ — בלי העדפת המקור הוא היה נבחר.
+      final library = Library(categories: [userRoot, bavli]);
+
+      expect(library.getCompanionBook(sourceText, PdfBook), same(builtInPdf));
+    });
+
+    test('אין מהדורה מובנית — ספר אישי בעל שם זהה כן מוחזר', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+      final userRoot = _category('אישיים');
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final userPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\ברכות.pdf',
+        category: userRoot,
+        isUserBook: true,
+      );
+      seder.books.add(sourceText);
+      userRoot.books.add(userPdf);
+
+      final library = Library(categories: [bavli, userRoot]);
+
+      expect(library.getCompanionBook(sourceText, PdfBook), same(userPdf));
+    });
+
+    test('ספר מקור אישי — מעדיף מלווה אישי על המובנה בקטגוריה אחרת', () {
+      final bavli = _category('תלמוד בבלי');
+      final userRoot = _category('אישיים');
+      final userBavli = _category('תלמוד בבלי', parent: userRoot);
+
+      final sourceText = TextBook(
+        title: 'ברכות',
+        category: userRoot,
+        isUserBook: true,
+      );
+      final builtInPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\otzaria\תלמוד בבלי\ברכות.pdf',
+        category: bavli,
+      );
+      final userPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\תלמוד בבלי\ברכות.pdf',
+        category: userBavli,
+        isUserBook: true,
+      );
+      userRoot.books.add(sourceText);
+      bavli.books.add(builtInPdf);
+      userBavli.books.add(userPdf);
+
+      // המובנה ראשון בעץ — בלי העדפת המקור הוא היה נבחר.
+      final library = Library(categories: [bavli, userRoot]);
+
+      expect(library.getCompanionBook(sourceText, PdfBook), same(userPdf));
+    });
+
+    test('מועמד באותה קטגוריה קודם למועמד מאותו מקור בקטגוריה אחרת', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+      final other = _category('אחר');
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final userPdfSameCategory = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\ברכות.pdf',
+        category: seder,
+        isUserBook: true,
+      );
+      final builtInPdfElsewhere = PdfBook(
+        title: 'ברכות',
+        path: r'C:\otzaria\אחר\ברכות.pdf',
+        category: other,
+      );
+      seder.books.addAll([sourceText, userPdfSameCategory]);
+      other.books.add(builtInPdfElsewhere);
+
+      final library = Library(categories: [bavli, other]);
+
+      expect(
+        library.getCompanionBook(sourceText, PdfBook),
+        same(userPdfSameCategory),
+      );
+    });
+
+    test('שני מועמדים אישיים באותה קטגוריה — מוותר ולא מנחש', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final userPdfA = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\א\ברכות.pdf',
+        category: seder,
+        isUserBook: true,
+      );
+      final userPdfB = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\ב\ברכות.pdf',
+        category: seder,
+        isUserBook: true,
+      );
+      seder.books.addAll([sourceText, userPdfA, userPdfB]);
+
+      final library = Library(categories: [bavli]);
+
+      expect(library.getCompanionBook(sourceText, PdfBook), isNull);
+    });
+
+    test('מובנה ואישי באותה קטגוריה — מחזיר את המובנה ולא מוותר', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final userPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\ברכות.pdf',
+        category: seder,
+        isUserBook: true,
+      );
+      final builtInPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\otzaria\ברכות.pdf',
+        category: seder,
+      );
+      seder.books.addAll([sourceText, userPdf, builtInPdf]);
+
+      final library = Library(categories: [bavli]);
+
+      expect(library.getCompanionBook(sourceText, PdfBook), same(builtInPdf));
+    });
+
+    test('ספר מקטלוג חיצוני — לא נבחר עבור ספר מקומי בשם זהה', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+      final externalRoot = _category('קטלוג חיצוני');
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final externalPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\external\ברכות.pdf',
+        category: externalRoot,
+        externalLibraryId: 'hebrewbooks',
+      );
+      final builtInPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\otzaria\תלמוד בבלי\ברכות.pdf',
+        category: bavli,
+      );
+      seder.books.add(sourceText);
+      externalRoot.books.add(externalPdf);
+      bavli.books.add(builtInPdf);
+
+      final library = Library(categories: [externalRoot, bavli]);
+
+      expect(library.getCompanionBook(sourceText, PdfBook), same(builtInPdf));
+    });
+  });
 }

--- a/test/library/models/get_companion_book_test.dart
+++ b/test/library/models/get_companion_book_test.dart
@@ -264,6 +264,70 @@ void main() {
       expect(library.getCompanionBook(sourceText, PdfBook), same(builtInPdf));
     });
 
+    // הבסיס לאבחון: הודעת הכשל בפתיחת PDF מבחינה בין "אין מיקום תואם" לבין
+    // כפילות שם, לפי מספר המהדורות שמוחזר כאן.
+    test('getCompanionBooks מחזיר את כל המהדורות בעלות אותו שם', () {
+      final bavli = _category('תלמוד בבלי');
+      final seder = _category('סדר זרעים', parent: bavli);
+      final userRoot = _category('אישיים');
+
+      final sourceText = TextBook(title: 'ברכות', category: seder);
+      final builtInPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\otzaria\תלמוד בבלי\ברכות.pdf',
+        category: bavli,
+      );
+      final userPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\אישיים\ברכות.pdf',
+        category: userRoot,
+        isUserBook: true,
+      );
+      seder.books.add(sourceText);
+      bavli.books.add(builtInPdf);
+      userRoot.books.add(userPdf);
+
+      final library = Library(categories: [bavli, userRoot]);
+
+      expect(library.getCompanionBooks(sourceText, PdfBook), [
+        builtInPdf,
+        userPdf,
+      ]);
+      // מהדורה יחידה אינה כפילות.
+      expect(library.getCompanionBooks(builtInPdf, TextBook), [sourceText]);
+    });
+
+    test('getCompanionBooks מסנן התנגשות בבלי/ירושלמי', () {
+      final bavli = _category('תלמוד בבלי');
+      final bavliSeder = _category('סדר זרעים', parent: bavli);
+      final yerushalmi = _category('תלמוד ירושלמי');
+
+      final sourceText = TextBook(
+        title: 'ברכות',
+        category: bavliSeder,
+        categoryPath: 'תלמוד בבלי, סדר זרעים',
+      );
+      final bavliPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\תלמוד בבלי\ברכות.pdf',
+        category: bavli,
+      );
+      final yerushalmiPdf = PdfBook(
+        title: 'ברכות',
+        path: r'C:\תלמוד ירושלמי\ברכות.pdf',
+        category: yerushalmi,
+        categoryPath: 'תלמוד ירושלמי',
+      );
+      bavliSeder.books.add(sourceText);
+      bavli.books.add(bavliPdf);
+      yerushalmi.books.add(yerushalmiPdf);
+
+      final library = Library(categories: [bavli, yerushalmi]);
+
+      // הירושלמי אינו מהדורה נוספת של הבבלי, ולכן אינו כפילות.
+      expect(library.getCompanionBooks(sourceText, PdfBook), [bavliPdf]);
+    });
+
     test('ספר מקטלוג חיצוני — לא נבחר עבור ספר מקומי בשם זהה', () {
       final bavli = _category('תלמוד בבלי');
       final seder = _category('סדר זרעים', parent: bavli);

--- a/test/text_book/view/selected_line_links_view_test.dart
+++ b/test/text_book/view/selected_line_links_view_test.dart
@@ -262,6 +262,74 @@ void main() {
     });
   });
 
+  group('dedupeLinksByTarget', () {
+    Link linkTo({
+      required String title,
+      int index1 = 1,
+      int index2 = 372,
+      String type = 'reference',
+      int? index2End,
+    }) => Link(
+      heRef: 'הפניה',
+      index1: index1,
+      path2: '/books/$title.txt',
+      index2: index2,
+      index2End: index2End,
+      connectionType: type,
+    );
+
+    test('אותו קטע-יעד מכמה שורות מקור ממוזג לפריט אחד', () {
+      final deduped = dedupeLinksByTarget([
+        linkTo(title: 'אוצר מדרשים', index1: 91),
+        linkTo(title: 'אוצר מדרשים', index1: 94),
+        linkTo(title: 'אוצר מדרשים', index1: 98),
+      ]);
+
+      expect(deduped, hasLength(1));
+      expect(deduped.single.index1, 91);
+    });
+
+    test('קטעי יעד שונים באותו ספר נשארים בנפרד', () {
+      final deduped = dedupeLinksByTarget([
+        linkTo(title: 'אוצר מדרשים', index2: 372),
+        linkTo(title: 'אוצר מדרשים', index2: 5473),
+      ]);
+
+      expect(deduped, hasLength(2));
+    });
+
+    test('אותו קטע-יעד בסוגי חיבור שונים אינו ממוזג', () {
+      final deduped = dedupeLinksByTarget([
+        linkTo(title: 'ראשונים א', type: 'QUOTATION'),
+        linkTo(title: 'ראשונים א', type: 'EIN_MISHPAT'),
+      ]);
+
+      expect(deduped, hasLength(2));
+    });
+
+    test('קישור-טווח נפרד מקישור לשורה בודדת באותו קטע', () {
+      final deduped = dedupeLinksByTarget([
+        linkTo(title: 'ראשונים א'),
+        linkTo(title: 'ראשונים א', index2End: 375),
+      ]);
+
+      expect(deduped, hasLength(2));
+    });
+
+    test('הסדר הנתון נשמר', () {
+      final deduped = dedupeLinksByTarget([
+        linkTo(title: 'ב'),
+        linkTo(title: 'א'),
+        linkTo(title: 'ב', index1: 2),
+      ]);
+
+      expect(
+        deduped.map((link) => link.path2),
+        ['/books/ב.txt', '/books/א.txt'],
+      );
+    });
+  });
+
   group('buildLinkChipKeys', () {
     setUp(_seedEras);
     tearDown(CommentaryService.clearEraCache);
@@ -1016,6 +1084,24 @@ void main() {
 
       expect(find.text('ראשונים א'), findsOneWidget);
       expect(find.text('ראשונים ב'), findsOneWidget);
+    });
+
+    testWidgets('אותו קטע-יעד המקושר מכמה שורות מוצג פריט אחד', (tester) async {
+      Link fromLine(int index1) => Link(
+        heRef: 'הפניה ראשונים א',
+        index1: index1,
+        path2: '/books/ראשונים א.txt',
+        index2: 372,
+        connectionType: 'REFERENCE',
+      );
+
+      await _pumpView(
+        tester,
+        links: [fromLine(91), fromLine(94), fromLine(98)],
+      );
+
+      expect(find.text('ראשונים א'), findsOneWidget);
+      expect(find.byType(ExpansionTile), findsOneWidget);
     });
 
     testWidgets('סינון לפי צ׳יפ סוג מציג רק את הסוג הנבחר', (tester) async {

--- a/test/text_book/view/text_book_screen_actions_test.dart
+++ b/test/text_book/view/text_book_screen_actions_test.dart
@@ -8,6 +8,7 @@ import 'package:otzaria/bookmarks/bloc/bookmark_bloc.dart';
 import 'package:otzaria/bookmarks/bloc/bookmark_state.dart';
 import 'package:otzaria/bookmarks/models/bookmark.dart';
 import 'package:otzaria/core/focus_repository.dart';
+import 'package:otzaria/core/messages/text_book_messages.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
@@ -544,6 +545,38 @@ void main() {
         );
       },
     );
+  });
+
+  // כשל המיפוי נראה זהה למשתמש בשני המצבים, אך רק אחד מהם בשליטתו: מהדורת
+  // PDF כפולה בשם זהה. בלי ההבחנה אין לו רמז מה לתקן.
+  group('pdfLocationFailureMessage', () {
+    test('מהדורה אחת — הודעת היעדר מיקום תואם', () {
+      expect(
+        pdfLocationFailureMessage('ברכות', 1),
+        TextBookMessages.pdfLocationNotFoundOpeningAtStart,
+      );
+    });
+
+    test('אין מהדורה — הודעת היעדר מיקום תואם', () {
+      expect(
+        pdfLocationFailureMessage('ברכות', 0),
+        TextBookMessages.pdfLocationNotFoundOpeningAtStart,
+      );
+    });
+
+    test('שתי מהדורות — הודעת כפילות הכוללת את שם הספר', () {
+      final message = pdfLocationFailureMessage('ברכות', 2);
+
+      expect(
+        message,
+        TextBookMessages.pdfDuplicateEditionsOpeningAtStart('ברכות'),
+      );
+      expect(message, contains('ברכות'));
+      expect(
+        message,
+        isNot(TextBookMessages.pdfLocationNotFoundOpeningAtStart),
+      );
+    });
   });
 }
 

--- a/test/text_book/view/text_book_screen_actions_test.dart
+++ b/test/text_book/view/text_book_screen_actions_test.dart
@@ -8,7 +8,6 @@ import 'package:otzaria/bookmarks/bloc/bookmark_bloc.dart';
 import 'package:otzaria/bookmarks/bloc/bookmark_state.dart';
 import 'package:otzaria/bookmarks/models/bookmark.dart';
 import 'package:otzaria/core/focus_repository.dart';
-import 'package:otzaria/core/messages/text_book_messages.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
@@ -545,38 +544,6 @@ void main() {
         );
       },
     );
-  });
-
-  // כשל המיפוי נראה זהה למשתמש בשני המצבים, אך רק אחד מהם בשליטתו: מהדורת
-  // PDF כפולה בשם זהה. בלי ההבחנה אין לו רמז מה לתקן.
-  group('pdfLocationFailureMessage', () {
-    test('מהדורה אחת — הודעת היעדר מיקום תואם', () {
-      expect(
-        pdfLocationFailureMessage('ברכות', 1),
-        TextBookMessages.pdfLocationNotFoundOpeningAtStart,
-      );
-    });
-
-    test('אין מהדורה — הודעת היעדר מיקום תואם', () {
-      expect(
-        pdfLocationFailureMessage('ברכות', 0),
-        TextBookMessages.pdfLocationNotFoundOpeningAtStart,
-      );
-    });
-
-    test('שתי מהדורות — הודעת כפילות הכוללת את שם הספר', () {
-      final message = pdfLocationFailureMessage('ברכות', 2);
-
-      expect(
-        message,
-        TextBookMessages.pdfDuplicateEditionsOpeningAtStart('ברכות'),
-      );
-      expect(message, contains('ברכות'));
-      expect(
-        message,
-        isNot(TextBookMessages.pdfLocationNotFoundOpeningAtStart),
-      );
-    });
   });
 }
 

--- a/test/utils/page_converter_cache_test.dart
+++ b/test/utils/page_converter_cache_test.dart
@@ -1,0 +1,441 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/app_paths.dart';
+import 'package:otzaria/data/data_providers/book_composite_key.dart';
+import 'package:otzaria/data/data_providers/cache_database_holder.dart';
+import 'package:otzaria/data/data_providers/library_provider.dart';
+import 'package:otzaria/data/data_providers/library_provider_manager.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/migration/models/pdf_anchor_cache_entry.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/settings/engine/settings_repository.dart';
+import 'package:otzaria/utils/file/page_converter.dart';
+import 'package:path/path.dart' as p;
+import 'package:pdfrx/pdfrx.dart';
+
+import '../helpers/memory_settings_cache.dart';
+
+/// מחרוזת PDF הקסדצימלית ב-UTF-16BE עם BOM — הכתיב היחיד לכותרות עבריות.
+String _pdfHexString(String value) {
+  final buffer = StringBuffer('<FEFF');
+  for (final unit in value.codeUnits) {
+    buffer.write(unit.toRadixString(16).padLeft(4, '0').toUpperCase());
+  }
+  buffer.write('>');
+  return buffer.toString();
+}
+
+/// בונה קובץ PDF תקין מינימלי עם [pageCount] עמודים ורשימת סימניות שטוחה.
+/// [bookmarks] ריק = PDF ללא outline.
+Uint8List buildMinimalPdf({
+  required int pageCount,
+  List<({String title, int page})> bookmarks = const [],
+}) {
+  final pageObjNums = List.generate(pageCount, (i) => 3 + i);
+  final outlinesObjNum = 3 + pageCount;
+  final itemObjNums = List.generate(
+    bookmarks.length,
+    (i) => outlinesObjNum + 1 + i,
+  );
+
+  final objects = <String>[
+    bookmarks.isEmpty
+        ? '<< /Type /Catalog /Pages 2 0 R >>'
+        : '<< /Type /Catalog /Pages 2 0 R /Outlines $outlinesObjNum 0 R >>',
+    '<< /Type /Pages /Kids [${pageObjNums.map((n) => '$n 0 R').join(' ')}] '
+        '/Count $pageCount >>',
+    for (var i = 0; i < pageCount; i++)
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>',
+  ];
+
+  if (bookmarks.isNotEmpty) {
+    objects.add(
+      '<< /Type /Outlines /First ${itemObjNums.first} 0 R '
+      '/Last ${itemObjNums.last} 0 R /Count ${bookmarks.length} >>',
+    );
+    for (var i = 0; i < bookmarks.length; i++) {
+      objects.add(
+        '<< ${[
+          '/Title ${_pdfHexString(bookmarks[i].title)}',
+          '/Parent $outlinesObjNum 0 R',
+          if (i > 0) '/Prev ${itemObjNums[i - 1]} 0 R',
+          if (i < bookmarks.length - 1) '/Next ${itemObjNums[i + 1]} 0 R',
+          '/Dest [${pageObjNums[bookmarks[i].page - 1]} 0 R /Fit]',
+        ].join(' ')} >>',
+      );
+    }
+  }
+
+  final bytes = <int>[];
+  void write(String s) => bytes.addAll(s.codeUnits);
+
+  write('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(bytes.length);
+    write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+
+  final xrefOffset = bytes.length;
+  write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final offset in offsets) {
+    write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n');
+  write('startxref\n$xrefOffset\n%%EOF\n');
+
+  return Uint8List.fromList(bytes);
+}
+
+PdfOutlineNode _outlineNode(String title, int page) => PdfOutlineNode(
+  title: title,
+  dest: PdfDest(page, PdfDestCommand.fit, null),
+  children: const [],
+);
+
+/// ה-outline של מהדורת ה-PDF: שלושה עמודי דף בכתיב המקוצר.
+List<PdfOutlineNode> _matchingOutline() => [
+  _outlineNode('דף ב.', 1),
+  _outlineNode('דף ב:', 2),
+  _outlineNode('דף ג.', 3),
+];
+
+const _pdfBookmarks = <({String title, int page})>[
+  (title: 'דף ב.', page: 1),
+  (title: 'דף ב:', page: 2),
+  (title: 'דף ג.', page: 3),
+];
+
+/// ספק תוכן-עניינים שניתן להחליף בזמן ריצה — כך אפשר לדמות DB שטרם נטען.
+class _FakeTocProvider implements LibraryProvider {
+  List<TocEntry> toc = const [];
+
+  @override
+  Future<List<TocEntry>?> getBookToc(
+    String title,
+    int categoryId,
+    String fileType, {
+    bool preferUserBooks = false,
+  }) async => toc;
+
+  @override
+  String get displayName => 'Fake';
+  @override
+  bool get isInitialized => true;
+  @override
+  int get priority => 0;
+  @override
+  String get providerId => 'fake';
+  @override
+  String get sourceIndicator => 'T';
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<Set<String>> getAvailableBookTitles() async => const {};
+  @override
+  Future<bool> hasBook(String title, int categoryId, String fileType) async =>
+      true;
+  @override
+  Future<String?> getBookText(
+    String title,
+    int categoryId,
+    String fileType, {
+    bool preferUserBooks = false,
+  }) async => '';
+  @override
+  Future<Library> buildLibraryCatalog(
+    Map<String, Map<String, dynamic>> metadata,
+    String rootPath,
+  ) => throw UnimplementedError();
+  @override
+  Future<List<Link>> getAllLinksForBook(
+    String title,
+    int categoryId,
+    String fileType,
+  ) async => const [];
+  @override
+  Future<String> getLinkContent(Link link) => throw UnimplementedError();
+  @override
+  Future<Map<String, List<Book>>> loadBooks(
+    Map<String, Map<String, dynamic>> metadata,
+  ) async => const {};
+}
+
+/// תוכן עניינים של מסכת: שורש ותחתיו שלושה דפים באותו כתיב כמו ה-PDF.
+List<TocEntry> _tractateToc(String tractate) {
+  final root = TocEntry(text: tractate, index: 0);
+  root.children = [
+    TocEntry(text: 'דף ב.', index: 10, level: 2, parent: root),
+    TocEntry(text: 'דף ב:', index: 20, level: 2, parent: root),
+    TocEntry(text: 'דף ג.', index: 30, level: 2, parent: root),
+  ];
+  return [root];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+    tempDir = await Directory.systemTemp.createTemp('page_converter_cache');
+    final dbDir = Directory(p.join(tempDir.path, 'databases'));
+    await dbDir.create(recursive: true);
+
+    final previousDataRoot = AppPaths.cachedDataRootPath;
+    AppPaths.debugOverrideDataRootPath(tempDir.path);
+    await Settings.setValue<String>(
+      SettingsRepository.keyDatabasesPath,
+      dbDir.path,
+    );
+
+    // addTearDown רץ ב-LIFO: קודם סגירת ה-DB, ואחר כך מחיקת התיקייה.
+    addTearDown(() async {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {
+        // ב-Windows ייתכן שידית לקובץ עוד לא שוחררה ברגע הסיום.
+      }
+    });
+    addTearDown(() => AppPaths.debugOverrideDataRootPath(previousDataRoot));
+    addTearDown(() => CacheDatabaseHolder.instance.close());
+    addTearDown(() => LibraryProviderManager.instance.resetForTesting());
+  });
+
+  /// ספרייה עם מהדורת PDF אחת ומהדורות טקסט לפי [textTitles], וספק
+  /// תוכן-עניינים רשום — בלעדיו `TextBook.tableOfContents` מחזיר רשימה ריקה.
+  ({List<TextBook> texts, PdfBook pdf, _FakeTocProvider provider}) seedLibrary({
+    required List<String> textTitles,
+    required String pdfPath,
+    bool withToc = true,
+  }) {
+    final category = Category(
+      title: 'תלמוד בבלי',
+      description: '',
+      shortDescription: '',
+      order: 0,
+      subCategories: [],
+      books: [],
+      parent: null,
+    );
+    final texts = [
+      for (final title in textTitles)
+        TextBook(
+          title: title,
+          category: category,
+          categoryId: 1,
+          fileType: 'txt',
+        ),
+    ];
+    final pdf = PdfBook(
+      title: textTitles.first,
+      path: pdfPath,
+      category: category,
+    );
+    category.books
+      ..addAll(texts)
+      ..add(pdf);
+
+    DataRepository.instance.library = Future.value(
+      Library(categories: [category]),
+    );
+
+    final provider = _FakeTocProvider();
+    if (withToc) provider.toc = _tractateToc(textTitles.first);
+    LibraryProviderManager.instance.seedMappingsForTesting(
+      mapping: {
+        for (final title in textTitles)
+          BookCompositeKey.create(
+            title: title,
+            categoryId: 1,
+            fileType: 'txt',
+          ): provider,
+      },
+      providers: [provider],
+    );
+
+    return (texts: texts, pdf: pdf, provider: provider);
+  }
+
+  /// מריץ [probe] עד שהוא מחזיר ערך שאינו null — הכתיבות למטמון המתמיד
+  /// יוצאות ב-`unawaited` ולכן אינן מסונכרנות עם החזרת ההמרה.
+  Future<T?> waitFor<T>(Future<T?> Function() probe, {int attempts = 40}) async {
+    for (var i = 0; i < attempts; i++) {
+      final value = await probe();
+      if (value != null) return value;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    return null;
+  }
+
+  Future<PdfAnchorCacheEntry?> anchorRow(String pdfPath) async =>
+      (await CacheDatabaseHolder.instance.repository).getPdfAnchorCacheEntry(
+        pdfPath,
+      );
+
+  // ---------------------------------------------------------------------------
+  // מטמון מפת העמודים בזיכרון — נבדק דרך pdfToTextPage, שמקבל outline מוכן
+  // ולכן אינו נוגע בקובץ כלל.
+  // ---------------------------------------------------------------------------
+  group('מטמון מפת העמודים בזיכרון', () {
+    test('מפה אמינה נשמרת ומשרתת את שני הכיוונים ללא גישה לקובץ', () async {
+      // הקובץ אינו קיים: אילו הכיוון ההפוך לא היה נהנה מהמטמון, פתיחת ה-PDF
+      // הייתה זורקת וההמרה הייתה מחזירה null.
+      final books = seedLibrary(
+        textTitles: const ['ברכות-מטמון'],
+        pdfPath: p.join(tempDir.path, 'never-opened.pdf'),
+      );
+
+      expect(await pdfToTextPage(books.pdf, _matchingOutline(), 3), 30);
+      expect(await textToPdfPage(books.texts.first, 20, pdfBook: books.pdf), 2);
+    });
+
+    test('תוכן עניינים ריק אינו נשמר — הקריאה אחרי טעינת ה-DB מצליחה', () async {
+      // רגרסיה: תוכן עניינים ריק הוא מצב זמני (ה-DB טרם נטען). אם הוא נשמר
+      // במטמון, כל מעבר טקסט↔PDF נופל לתחילת הספר עד להפעלה מחדש.
+      final books = seedLibrary(
+        textTitles: const ['שבת-מטמון'],
+        pdfPath: p.join(tempDir.path, 'toc-later.pdf'),
+        withToc: false,
+      );
+
+      expect(await pdfToTextPage(books.pdf, _matchingOutline(), 3), isNull);
+
+      books.provider.toc = _tractateToc('שבת-מטמון');
+      expect(await pdfToTextPage(books.pdf, _matchingOutline(), 3), 30);
+    });
+
+    test('מפה לא אמינה נשמרת בכוונה כשתוכן העניינים כבר נטען', () async {
+      // מיפוי שנכשל מול תוכן עניינים קיים הוא עובדה על המהדורות, ולא מצב
+      // זמני — הוא נשמר כדי שדפדוף לא יבנה את המפה מחדש בכל עמוד.
+      final books = seedLibrary(
+        textTitles: const ['עירובין-מטמון'],
+        pdfPath: p.join(tempDir.path, 'mismatched.pdf'),
+      );
+
+      expect(
+        await pdfToTextPage(books.pdf, [_outlineNode('כותרת זרה', 1)], 2),
+        isNull,
+      );
+      expect(await pdfToTextPage(books.pdf, _matchingOutline(), 3), isNull);
+    });
+
+    test('כשל בפתיחת הקובץ אינו נשמר במטמון', () async {
+      final books = seedLibrary(
+        textTitles: const ['פסחים-מטמון'],
+        pdfPath: p.join(tempDir.path, 'does-not-exist.pdf'),
+      );
+
+      expect(
+        await textToPdfPage(books.texts.first, 10, pdfBook: books.pdf),
+        isNull,
+      );
+      expect(await pdfToTextPage(books.pdf, _matchingOutline(), 3), 30);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // מטמון העוגנים המתמיד (cache.db) — קורא ופותח קובצי PDF אמיתיים
+  // ---------------------------------------------------------------------------
+  group('מטמון העוגנים המתמיד (cache.db)', () {
+    test('PDF עם סימניות — הרשומה נשמרת וההמרה מצליחה', () async {
+      final pdfPath = p.join(tempDir.path, 'with-outline.pdf');
+      await File(pdfPath).writeAsBytes(
+        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
+      );
+      final books = seedLibrary(
+        textTitles: const ['סוכה-מלא'],
+        pdfPath: pdfPath,
+      );
+
+      expect(await textToPdfPage(books.texts.first, 20, pdfBook: books.pdf), 2);
+
+      final entry = await waitFor(() => anchorRow(pdfPath));
+      expect(entry, isNotNull);
+      expect(entry!.decodeAnchors(), hasLength(3));
+      expect(entry.fileSize, await File(pdfPath).length());
+    });
+
+    test('רשומה תקפה משמשת מחדש — createdAt נשמר ו-accessedAt מתעדכן', () async {
+      // שתי כותרות טקסט מול אותו PDF: מפתח מפת-העמודים שונה, ולכן הקריאה
+      // השנייה חוזרת למטמון המתמיד במקום להתקצר במטמון שבזיכרון.
+      final pdfPath = p.join(tempDir.path, 'reused.pdf');
+      await File(pdfPath).writeAsBytes(
+        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
+      );
+      final books = seedLibrary(
+        textTitles: const ['יומא-א', 'יומא-ב'],
+        pdfPath: pdfPath,
+      );
+
+      expect(await textToPdfPage(books.texts[0], 20, pdfBook: books.pdf), 2);
+      final first = await waitFor(() => anchorRow(pdfPath));
+      expect(first, isNotNull);
+
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      expect(await textToPdfPage(books.texts[1], 20, pdfBook: books.pdf), 2);
+
+      final touched = await waitFor(() async {
+        final row = await anchorRow(pdfPath);
+        return row != null && row.accessedAt > first!.accessedAt ? row : null;
+      });
+      expect(touched, isNotNull, reason: 'accessedAt אמור להתעדכן בקריאה חוזרת');
+      expect(
+        touched!.createdAt,
+        first!.createdAt,
+        reason: 'הרשומה שוחזרה מהמטמון ולא נבנתה מחדש',
+      );
+    });
+
+    test('החלפת הקובץ פוסלת את הרשומה ומרעננת את העוגנים', () async {
+      final pdfPath = p.join(tempDir.path, 'replaced.pdf');
+      final file = File(pdfPath);
+      await file.writeAsBytes(
+        buildMinimalPdf(
+          pageCount: 3,
+          bookmarks: const [(title: 'דף ב.', page: 1)],
+        ),
+      );
+      final books = seedLibrary(
+        textTitles: const ['נדרים-א', 'נדרים-ב'],
+        pdfPath: pdfPath,
+      );
+
+      await textToPdfPage(books.texts[0], 10, pdfBook: books.pdf);
+      final before = await waitFor(() => anchorRow(pdfPath));
+      expect(before!.decodeAnchors(), hasLength(1));
+
+      await file.writeAsBytes(
+        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
+      );
+
+      expect(await textToPdfPage(books.texts[1], 20, pdfBook: books.pdf), 2);
+      final after = await waitFor(() async {
+        final row = await anchorRow(pdfPath);
+        return row != null && row.decodeAnchors().length == 3 ? row : null;
+      });
+      expect(after, isNotNull, reason: 'הרשומה אמורה להיבנות מחדש מהקובץ החדש');
+      expect(after!.fileSize, await file.length());
+    });
+
+    test('outline ריק מהטאב — הסימניות נקראות מהקובץ', () async {
+      // ה-outline של הטאב נטען ברקע; לחיצה לפני שהגיע חייבת ליפול לקובץ.
+      final pdfPath = p.join(tempDir.path, 'tab-outline-empty.pdf');
+      await File(pdfPath).writeAsBytes(
+        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
+      );
+      final books = seedLibrary(
+        textTitles: const ['גיטין-רקע'],
+        pdfPath: pdfPath,
+      );
+
+      expect(await pdfToTextPage(books.pdf, const [], 3), 30);
+    });
+  });
+}

--- a/test/utils/page_converter_test.dart
+++ b/test/utils/page_converter_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/utils/file/page_converter.dart';
+import 'package:otzaria/utils/file/page_map_builder.dart';
 import 'package:pdfrx/pdfrx.dart';
 
 PdfOutlineNode node(
@@ -92,6 +93,87 @@ void main() {
 
     test('רשימה ריקה מחזירה רשימה ריקה', () {
       expect(collectTextAnchors(const []), isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // השרשרת המלאה שהאפליקציה מריצה: outline → TOC → מפת עמודים.
+  // ---------------------------------------------------------------------------
+  group('שרשרת מלאה — מסכת גמרא', () {
+    /// עץ ה-outline של מסכת בבלי: צומת שורש ותחתיו כל הדפים.
+    List<PdfOutlineNode> talmudOutline() => [
+      node(
+        'ברכות',
+        1,
+        children: [
+          node('דף ב.', 1),
+          node('דף ב:', 2),
+          node('דף ג.', 3),
+        ],
+      ),
+    ];
+
+    test('מהדורות תואמות — מפה אמינה מלאה', () {
+      final root = TocEntry(text: 'ברכות', index: 0);
+      root.children = [
+        TocEntry(text: 'דף ב.', index: 1, level: 2, parent: root),
+        TocEntry(text: 'דף ב:', index: 16, level: 2, parent: root),
+        TocEntry(text: 'דף ג.', index: 36, level: 2, parent: root),
+      ];
+
+      final map = buildPageMapFromAnchors(
+        collectPdfAnchors(talmudOutline()),
+        collectTextAnchors([root]),
+      );
+
+      expect(map.hasReliableAnchors, isTrue);
+      expect(map.pdfPages, [1, 2, 3]);
+      expect(map.textIndices, [0, 16, 36]);
+      expect(map.textToPdf(16), 2);
+      expect(map.pdfToText(3), 36);
+    });
+
+    test('מהדורת טקסט בכתיב שונה — נגשרת ואינה נופלת לתחילת הספר', () {
+      // "תלמוד בבלי - ברכות" / "פרק ראשון - מאימתי" / "דף ב - א"
+      final root = TocEntry(text: 'תלמוד בבלי - ברכות', index: 0);
+      final chapter = TocEntry(
+        text: 'פרק ראשון - מאימתי',
+        index: 1,
+        level: 2,
+        parent: root,
+      );
+      chapter.children = [
+        TocEntry(text: 'דף ב - א', index: 2, level: 3, parent: chapter),
+        TocEntry(text: 'דף ב - ב', index: 13, level: 3, parent: chapter),
+        TocEntry(text: 'דף ג - א', index: 19, level: 3, parent: chapter),
+      ];
+      root.children = [chapter];
+
+      final map = buildPageMapFromAnchors(
+        collectPdfAnchors(talmudOutline()),
+        collectTextAnchors([root]),
+      );
+
+      expect(map.hasReliableAnchors, isTrue);
+      expect(map.pdfPages, [1, 2, 3]);
+      expect(map.textIndices, [2, 13, 19]);
+    });
+
+    test('PDF ללא סימניות — מפה לא אמינה, ואינה נשמרת כמצב תקין', () {
+      final root = TocEntry(text: 'ברכות', index: 0);
+      root.children = [
+        TocEntry(text: 'דף ב.', index: 1, level: 2, parent: root),
+      ];
+
+      final map = buildPageMapFromAnchors(
+        collectPdfAnchors(const []),
+        collectTextAnchors([root]),
+      );
+
+      expect(map.pdfPages, isEmpty);
+      expect(map.hasReliableAnchors, isFalse);
+      expect(map.textToPdf(0), isNull);
+      expect(map.pdfToText(1), isNull);
     });
   });
 }

--- a/test/utils/page_map_builder_test.dart
+++ b/test/utils/page_map_builder_test.dart
@@ -28,6 +28,145 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // hebrewNumeralValue – השומר שמונע ממילים להתחזות למספרי דף
+  // ---------------------------------------------------------------------------
+  group('hebrewNumeralValue', () {
+    test('אות בודדת', () {
+      expect(hebrewNumeralValue('א'), 1);
+      expect(hebrewNumeralValue('ב'), 2);
+      expect(hebrewNumeralValue('י'), 10);
+      expect(hebrewNumeralValue('ת'), 400);
+    });
+
+    test('מספרים מורכבים בסדר יורד', () {
+      expect(hebrewNumeralValue('כב'), 22);
+      expect(hebrewNumeralValue('יא'), 11);
+      expect(hebrewNumeralValue('טו'), 15);
+      expect(hebrewNumeralValue('טז'), 16);
+      expect(hebrewNumeralValue('קיז'), 117);
+      expect(hebrewNumeralValue('תתקא'), 901);
+    });
+
+    test('אותיות סופיות מקבלות את אותו ערך', () {
+      expect(hebrewNumeralValue('ך'), 20);
+      expect(hebrewNumeralValue('ם'), 40);
+      expect(hebrewNumeralValue('ן'), 50);
+      expect(hebrewNumeralValue('ף'), 80);
+      expect(hebrewNumeralValue('ץ'), 90);
+    });
+
+    test('ערכים עולים נדחים — אינם כתיב גימטריה', () {
+      expect(hebrewNumeralValue('בכ'), isNull);
+      expect(hebrewNumeralValue('אי'), isNull);
+    });
+
+    test('שמות מסכתות נדחים ואינם מתחזים למספרי דף', () {
+      for (final name in ['שבת', 'נדה', 'סוכה', 'ביצה', 'יומא', 'סוטה']) {
+        expect(hebrewNumeralValue(name), isNull, reason: name);
+      }
+    });
+
+    test('מעל ארבע אותיות נדחה', () {
+      expect(hebrewNumeralValue('הקדמה'), isNull);
+      expect(hebrewNumeralValue('מאימתי'), isNull);
+    });
+
+    test('מחרוזת ריקה ותווים שאינם עבריים נדחים', () {
+      expect(hebrewNumeralValue(''), isNull);
+      expect(hebrewNumeralValue('ab'), isNull);
+      expect(hebrewNumeralValue('כ2'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canonicalDafKey – גישור בין כתיבי דף שונים
+  // ---------------------------------------------------------------------------
+  group('canonicalDafKey', () {
+    test('נקודה = עמוד א, היעדר סימן = עמוד ב (הקולון הוסר בנרמול)', () {
+      expect(canonicalDafKey('דף ב.'), '2a');
+      expect(canonicalDafKey('דף ב'), '2b');
+      expect(canonicalDafKey(normalizeRef('דף ב:')), '2b');
+    });
+
+    test('בלי הקידומת "דף" אין מפתח — כך סימנים ופרקים אינם דפים', () {
+      for (final label in ['כב.', 'א.', 'ב.', 'כב-ב', 'כב', 'ב']) {
+        expect(canonicalDafKey(label), isNull, reason: label);
+      }
+    });
+
+    test('מילים שהגימטריה שלהן תקינה אינן מתחזות לדף', () {
+      // כולן ערכי גימטריה חוקיים: תמיד=454, שם=340, תשא=701, ריטבא=221.
+      for (final label in [
+        'תמיד',
+        'תמיד.',
+        'שם',
+        'שם.',
+        'תשא.',
+        'ריטבא',
+        'פסח',
+        'עמ א',
+      ]) {
+        expect(canonicalDafKey(label), isNull, reason: label);
+      }
+    });
+
+    test('"דף" ו"עמוד" אינם נחשבים מספר הדף', () {
+      expect(canonicalDafKey('עמוד א'), isNull);
+      expect(canonicalDafKey('דף דף א'), isNull);
+      expect(canonicalDafKey('דף'), isNull);
+      expect(canonicalDafKey('דף.'), isNull);
+    });
+
+    test('מקפים שאינם ASCII מתקפלים ואינם נדבקים למספר', () {
+      // בלי קיפול המקף "דף כב־א" היה נקרא "דף כבא" = דף 23.
+      expect(canonicalDafKey(normalizeRef('דף כב־א')), '22a');
+      expect(canonicalDafKey(normalizeRef('דף כב–א')), '22a');
+      expect(canonicalDafKey(normalizeRef('דף כב—ב')), '22b');
+    });
+
+    test('כתיב מקף ("דף כב - א")', () {
+      expect(canonicalDafKey('דף כב - א'), '22a');
+      expect(canonicalDafKey('דף כב - ב'), '22b');
+      expect(canonicalDafKey('דף כב-א'), '22a');
+    });
+
+    test('כתיב ע"א / ע"ב אחרי נרמול', () {
+      expect(canonicalDafKey(normalizeRef('דף כב ע"א')), '22a');
+      expect(canonicalDafKey(normalizeRef('דף כב ע"ב')), '22b');
+    });
+
+    test('כתיב "עמוד א" מלא', () {
+      expect(canonicalDafKey('דף כב עמוד א'), '22a');
+      expect(canonicalDafKey('דף כב עמוד ב'), '22b');
+    });
+
+    test('כל הכתיבים של אותו דף מתלכדים למפתח אחד', () {
+      final keys = [
+        'דף כב.',
+        'דף כב - א',
+        'דף כב ע"א',
+        'דף כב עמוד א',
+      ].map((s) => canonicalDafKey(normalizeRef(s))).toSet();
+      expect(keys, {'22a'});
+    });
+
+    test('כותרות שאינן דף מוחזרות null', () {
+      for (final label in [
+        'הקדמה',
+        'פרק ראשון - מאימתי',
+        'סימן כב',
+        'ברכות',
+        'שבת',
+        'סוכה',
+        'תוכן העניינים',
+        '',
+      ]) {
+        expect(canonicalDafKey(label), isNull, reason: '"$label"');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // PageMap interpolation
   // ---------------------------------------------------------------------------
   group('PageMap', () {
@@ -207,6 +346,155 @@ void main() {
       final m = buildPageMapFromAnchors(pdf, text);
       expect(m.pdfPages, [3]);
       expect(m.textIndices, [0]); // exact match wins, not 999
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildPageMapFromAnchors – שלב 3: התאמת דף קנונית
+  // כל טסט כאן מגן על אי-רגרסיה: השלב פועל רק כשההתאמה לפי כותרות נכשלה.
+  // ---------------------------------------------------------------------------
+  group('buildPageMapFromAnchors – canonical daf fallback', () {
+    test('מגשר בין מהדורות שכותבות את אותו דף אחרת', () {
+      // PDF: "דף ב." / "דף ב" (קולון הוסר) — טקסט: "דף ב - א" / "דף ב - ב".
+      // אף כותרת אינה זהה, ואף סיומת אינה משותפת → בלי שלב 3 אפס התאמות.
+      final pdf = [
+        (page: 1, ref: 'ברכות/דף ב.'),
+        (page: 2, ref: 'ברכות/דף ב'),
+        (page: 3, ref: 'ברכות/דף ג.'),
+      ];
+      final text = [
+        (index: 2, ref: 'תלמוד בבלי - ברכות/פרק ראשון/דף ב - א'),
+        (index: 13, ref: 'תלמוד בבלי - ברכות/פרק ראשון/דף ב - ב'),
+        (index: 19, ref: 'תלמוד בבלי - ברכות/פרק ראשון/דף ג - א'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, [1, 2, 3]);
+      expect(m.textIndices, [2, 13, 19]);
+      expect(m.hasReliableAnchors, isTrue);
+    });
+
+    test('גם בתוך שלב 3 התאמת הנתיב גוברת על מפתח הדף', () {
+      // עוגן א מותאם לפי נתיב מלא (→0) ויש לו מתחרה עם אותו מפתח דף (→999);
+      // עוגן ב מותאם רק לפי מפתח דף. שלב 3 רץ כי הנתיב לבדו נתן עוגן אחד.
+      final pdf = [
+        (page: 3, ref: 'ברכות/דף כב.'),
+        (page: 8, ref: 'ברכות/דף כג.'),
+      ];
+      final text = [
+        (index: 0, ref: 'ברכות/דף כב.'),
+        (index: 999, ref: 'שבת/דף כב - א'),
+        (index: 500, ref: 'אחר/דף כג - א'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, [3, 8]);
+      expect(m.textIndices, [0, 500]);
+    });
+
+    test('גם בתוך שלב 3 התאמת הסיומת גוברת על מפתח הדף', () {
+      final pdf = [
+        (page: 3, ref: 'תלמוד בבלי/ברכות/דף כב.'),
+        (page: 8, ref: 'תלמוד בבלי/ברכות/דף כג.'),
+      ];
+      final text = [
+        (index: 40, ref: 'ברכות/דף כב.'), // סיומת חד-משמעית
+        (index: 999, ref: 'אחר/דף כב - א'), // אותו מפתח דף
+        (index: 500, ref: 'אחר/דף כג - א'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, [3, 8]);
+      expect(m.textIndices, [40, 500]);
+    });
+
+    test('מפתח דף שאינו חד-משמעי נדחה', () {
+      // אותו דף מופיע בשני מקומות בטקסט → אין ודאות → מדלגים.
+      final pdf = [(page: 3, ref: 'דף כב.')];
+      final text = [
+        (index: 10, ref: 'א/דף כב - א'),
+        (index: 20, ref: 'ב/דף כב - א'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, isEmpty);
+    });
+
+    test('ספר שאינו גמרא — השלב הוא no-op ואינו ממציא התאמות', () {
+      final pdf = [
+        (page: 2, ref: 'שולחן ערוך/הקדמה'),
+        (page: 9, ref: 'שולחן ערוך/דיני נטילת ידיים'),
+      ];
+      final text = [
+        (index: 5, ref: 'אורח חיים/פתיחה'),
+        (index: 80, ref: 'אורח חיים/סדר היום'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, isEmpty);
+    });
+
+    test('ספר ממוספר בסימנים מול PDF ממוספר בדפים — אין מיפוי מדומה', () {
+      // "א." בטקסט הוא מספר סימן. ללא דרישת הקידומת "דף" הוא היה נקשר ל"דף א."
+      // ומייצר מפה "אמינה" ושגויה לגמרי, בלי שהמשתמש יקבל הודעה.
+      final pdf = [
+        (page: 5, ref: 'ספר/דף א.'),
+        (page: 9, ref: 'ספר/דף ב.'),
+        (page: 14, ref: 'ספר/דף ג.'),
+      ];
+      final text = [
+        (index: 10, ref: 'אגרא דפרקא/א.'),
+        (index: 90, ref: 'אגרא דפרקא/ב.'),
+        (index: 160, ref: 'אגרא דפרקא/ג.'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, isEmpty);
+    });
+
+    test('שלב 3 אינו משנה מפה שכבר הותאמה במלואה לפי כותרות', () {
+      // אותו קלט שמותאם 1:1 בשלב 1 — התוצאה חייבת להישאר זהה.
+      final pdf = [
+        (page: 1, ref: 'ברכות/דף ב.'),
+        (page: 2, ref: 'ברכות/דף ב'),
+        (page: 3, ref: 'ברכות/דף ג.'),
+      ];
+      final text = [
+        (index: 1, ref: 'ברכות/דף ב.'),
+        (index: 16, ref: 'ברכות/דף ב'),
+        (index: 36, ref: 'ברכות/דף ג.'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, [1, 2, 3]);
+      expect(m.textIndices, [1, 16, 36]);
+    });
+
+    test('מיפוי חלקי-אך-שמיש אינו נפתח למפתחות דף — אפס רגרסיה', () {
+      // שני עוגנים הותאמו לפי כותרות. השלישי אינו מותאם לפי נתיב (כתיב שונה)
+      // אך מפתח הדף היה קושר אותו לאינדקס 5 ומעוות מפה שכבר עובדת.
+      final pdf = [
+        (page: 1, ref: 'ספר/פרק א'),
+        (page: 20, ref: 'ספר/פרק ב'),
+        (page: 30, ref: 'ספר/דף פו.'),
+      ];
+      final text = [
+        (index: 0, ref: 'ספר/פרק א'),
+        (index: 400, ref: 'ספר/פרק ב'),
+        (index: 5, ref: 'נספח/דף פו - א'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, [1, 20]);
+      expect(m.textIndices, [0, 400]);
+    });
+
+    test('כשמפתחות הדף אינם מספיקים חוזרים למפת הכותרות ולא מרעים', () {
+      // עוגן אחד לפי כותרת, ומפתח דף שאינו חד-משמעי → התוצאה נשארת העוגן הבודד.
+      final pdf = [
+        (page: 3, ref: 'ספר/פתיחה'),
+        (page: 8, ref: 'ספר/דף ה.'),
+      ];
+      final text = [
+        (index: 2, ref: 'ספר/פתיחה'),
+        (index: 60, ref: 'א/דף ה.'),
+        (index: 90, ref: 'ב/דף ה.'),
+      ];
+      final m = buildPageMapFromAnchors(pdf, text);
+      expect(m.pdfPages, [3]);
+      expect(m.textIndices, [2]);
     });
   });
 


### PR DESCRIPTION
## הבעיה

המיפוי בין מהדורת הטקסט ל-PDF נבנה מסימניות ה-PDF מוצלבות בתוכן העניינים של הספר. כשהבנייה נכשלה, שני הכפתורים נפלו לעמוד 1 / שורה 0 — ובכיוון טקסט→PDF גם בלי שום הודעה למשתמש.

## מה תוקן

- **מפה ריקה נדבקה לכל ההרצה.** `pdfToTextPage` קיבל את ה-outline מהטאב, שנטען ברקע אחרי פתיחת המסמך. לחיצה לפני שהגיע בנתה מפה ריקה, שנשמרה במטמון המשותף לשני הכיוונים. כשה-outline עדיין ריק, הסימניות נקראות עכשיו ישירות מהקובץ.
- **מפה לא אמינה נשמרת בכוונה**, אחרת דפדוף היה בונה אותה מחדש בכל עמוד. תוכן עניינים ריק — המצב היחיד שעשוי להיות זמני — אינו נשמר.
- **שכבת התאמה שלישית** מגשרת בין מהדורות שכותבות את אותו דף אחרת ("דף כב." מול "דף כב - א"). היא רצה כמעבר שני ורק כשהתאמת הכותרות לא הפיקה מיפוי שמיש, כדי שספר שההתאמה בו עובדת לא ייגע בהיוריסטיקה. נדרשת קידומת "דף" מפורשת — אחרת מספרי סימן ("א.", "ב.") ומילים שהגימטריה שלהן תקינה ("תמיד.") נקראים כדפים.
- **הכיוון טקסט→PDF מציג הודעה כשההמרה נכשלה**, כמו הכיוון ההפוך.

## בדיקות

`flutter analyze` נקי, והסוויטה המלאה עוברת. נוספו טסטים ל-`page_converter`, ל-`page_map_builder` ולמטמון העוגנים המתמיד.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
