### PR TITLE
תיקון: גלילה איטית בתצוגת ספר רציפה

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -586,6 +586,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Background content loading | `test/text_book/bloc/background_full_content_loading_test.dart` |
 | Continuous reading mode | `test/text_book/bloc/continuous_reading_mode_test.dart` |
 | Selected link types persistence | `test/text_book/bloc/selected_link_types_persistence_test.dart` |
+| visibleIndices throttling (scroll perf) | `test/text_book/bloc/visible_indices_throttle_test.dart` |
 
 **Data / Database**
 | Area | Test File |

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -310,9 +310,11 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
   @visibleForTesting
   static bool shouldDispatchVisibleIndicesNow({
     required Duration? sinceLastDispatch,
+    bool continuousReadingMode = true,
     Duration throttleInterval = _visibleIndicesThrottleInterval,
   }) {
-    return sinceLastDispatch == null ||
+    return !continuousReadingMode ||
+        sinceLastDispatch == null ||
         sinceLastDispatch.isNegative ||
         sinceLastDispatch >= throttleInterval;
   }
@@ -876,6 +878,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
 
         final lastDispatchAt = _lastVisibleIndicesDispatchAt;
         if (shouldDispatchVisibleIndicesNow(
+          continuousReadingMode: currentState.continuousReadingMode,
           sinceLastDispatch: lastDispatchAt == null
               ? null
               : DateTime.now().difference(lastDispatchAt),

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -51,6 +51,13 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
   static const Duration _visibleIndicesDebounceDuration = Duration(
     milliseconds: 160,
   );
+
+  /// קצב מרבי לשידור מיידי של visibleIndices בזמן גלילה. במצב קריאה רציף
+  /// השורה הגלויה נגזרת משבר הגלילה בתוך פסקה ממוזגת ולכן משתנה כמעט בכל
+  /// פריים; בלי הגבלה זו כל פריים גורר emit ו-rebuild של הפסקה כולה.
+  static const Duration _visibleIndicesThrottleInterval = Duration(
+    milliseconds: 100,
+  );
   static const String _allTargetBookTitlesSignature =
       '__all_target_book_titles__';
 
@@ -69,6 +76,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
 
   Timer? _debounceTimer;
   Timer? _highlightTimer;
+  DateTime? _lastVisibleIndicesDispatchAt;
   VoidCallback? _positionListenerCallback;
   int? _loadedLinksStart;
   int? _loadedLinksEnd;
@@ -289,6 +297,19 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       return currentState.continuousReadingMode;
     }
     return globalDefault;
+  }
+
+  /// האם לשדר עכשיו עדכון `visibleIndices`, או לדלג ולהשאיר את השידור
+  /// לטיימר הנגרר. [sinceLastDispatch] הוא `null` כשעוד לא שודר דבר.
+  ///
+  /// דילוג בטוח: הטיימר הנגרר נדרך מחדש בכל אירוע גלילה, ולכן המיקום הסופי
+  /// תמיד משודר אחרי שהגלילה נעצרת.
+  @visibleForTesting
+  static bool shouldDispatchVisibleIndicesNow({
+    required Duration? sinceLastDispatch,
+    Duration throttleInterval = _visibleIndicesThrottleInterval,
+  }) {
+    return sinceLastDispatch == null || sinceLastDispatch >= throttleInterval;
   }
 
   @visibleForTesting
@@ -844,11 +865,18 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         }
         if (initialSyncClassification.shouldDispatchImmediately) {
           _debounceTimer?.cancel();
-          add(UpdateVisibleIndecies(visibleIndicesNow));
+          _dispatchVisibleIndices(visibleIndicesNow);
           return;
         }
 
-        add(UpdateVisibleIndecies(visibleIndicesNow));
+        final lastDispatchAt = _lastVisibleIndicesDispatchAt;
+        if (shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: lastDispatchAt == null
+              ? null
+              : DateTime.now().difference(lastDispatchAt),
+        )) {
+          _dispatchVisibleIndices(visibleIndicesNow);
+        }
         _debounceTimer?.cancel();
         _debounceTimer = Timer(_visibleIndicesDebounceDuration, () {
           if (isClosed) {
@@ -869,7 +897,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
                   latestState.visibleIndices,
                   visibleIndicesNow,
                 )) {
-              add(UpdateVisibleIndecies(visibleIndicesNow));
+              _dispatchVisibleIndices(visibleIndicesNow);
             }
           }
         });
@@ -1596,6 +1624,13 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       if (list1[i] != list2[i]) return false;
     }
     return true;
+  }
+
+  /// שידור עדכון `visibleIndices` תוך רישום מועד השידור, שעליו נשענת
+  /// הגבלת הקצב ב-[shouldDispatchVisibleIndicesNow].
+  void _dispatchVisibleIndices(List<int> visibleIndices) {
+    _lastVisibleIndicesDispatchAt = DateTime.now();
+    add(UpdateVisibleIndecies(visibleIndices));
   }
 
   bool _hasMeaningfulVisibleIndicesChange(

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -304,12 +304,17 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
   ///
   /// דילוג בטוח: הטיימר הנגרר נדרך מחדש בכל אירוע גלילה, ולכן המיקום הסופי
   /// תמיד משודר אחרי שהגלילה נעצרת.
+  ///
+  /// משך שלילי נוצר כששעון המערכת הוזז אחורה; בלי המקרה הזה החסימה הייתה
+  /// נמשכת עד שהשעון משלים את הפער.
   @visibleForTesting
   static bool shouldDispatchVisibleIndicesNow({
     required Duration? sinceLastDispatch,
     Duration throttleInterval = _visibleIndicesThrottleInterval,
   }) {
-    return sinceLastDispatch == null || sinceLastDispatch >= throttleInterval;
+    return sinceLastDispatch == null ||
+        sinceLastDispatch.isNegative ||
+        sinceLastDispatch >= throttleInterval;
   }
 
   @visibleForTesting

--- a/lib/text_book/view/widgets/continuous_reading_paragraph.dart
+++ b/lib/text_book/view/widgets/continuous_reading_paragraph.dart
@@ -156,20 +156,11 @@ class _ContinuousReadingParagraphState
     }
 
     final textSpan = TextSpan(style: widget.baseStyle, children: spans);
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final text = Text.rich(
-          textSpan,
-          textAlign: _effectiveTextAlign(
-            textSpan: textSpan,
-            constraints: constraints,
-            textScaler: MediaQuery.textScalerOf(context),
-          ),
-        );
-        if (frameRanges.isEmpty) return text;
-        return PluginHighlightFrameOverlay(ranges: frameRanges, child: text);
-      },
-    );
+    // justify אינו מותח שורה אחרונה, ולכן גם לא פסקה בת שורה חזותית אחת.
+    // מדידה מוקדמת של מספר השורות = layout שני על כל הפסקה, ומייקרת גלילה.
+    final text = Text.rich(textSpan, textAlign: widget.textAlign);
+    if (frameRanges.isEmpty) return text;
+    return PluginHighlightFrameOverlay(ranges: frameRanges, child: text);
   }
 
   List<InlineSpan> _buildLineSpans(ContinuousReadingParagraphLine line) {
@@ -188,28 +179,6 @@ class _ContinuousReadingParagraphState
       anchorActiveBackground: widget.anchorActiveBackground,
       recognizerSink: _linkRecognizers,
     );
-  }
-
-  TextAlign _effectiveTextAlign({
-    required InlineSpan textSpan,
-    required BoxConstraints constraints,
-    required TextScaler textScaler,
-  }) {
-    if (widget.textAlign != TextAlign.justify || !constraints.hasBoundedWidth) {
-      return widget.textAlign;
-    }
-
-    final textPainter = TextPainter(
-      text: textSpan,
-      textAlign: TextAlign.start,
-      textDirection: TextDirection.rtl,
-      textScaler: textScaler,
-    )..layout(maxWidth: constraints.maxWidth);
-
-    final visualLineCount = textPainter.computeLineMetrics().length;
-    textPainter.dispose();
-
-    return visualLineCount <= 1 ? TextAlign.start : widget.textAlign;
   }
 
   void _rebuildLineRecognizers() {

--- a/lib/text_book/view/widgets/continuous_reading_paragraph.dart
+++ b/lib/text_book/view/widgets/continuous_reading_paragraph.dart
@@ -36,6 +36,44 @@ class ContinuousReadingParagraphLine {
   });
 }
 
+/// תקרת המטמון — גדולה מפסקה ממוזגת טיפוסית, וחסומה כדי שספר שלם לא ייצבר.
+const int _maxCachedFragments = 1024;
+
+/// מטמון DOM מפורק לפי מחרוזת ה-HTML. הפירוק תלוי אך ורק במחרוזת, והמעבר
+/// ב-[_nodesToSpans] הוא קריאה בלבד — ולכן בטוח לחלוק את אותו DOM בין builds.
+final Map<String, dom.DocumentFragment> _fragmentCache =
+    <String, dom.DocumentFragment>{};
+
+int _fragmentParseCount = 0;
+
+/// מספר הפירוקים שבוצעו בפועל — לאימות שהמטמון פוגע.
+@visibleForTesting
+int get inlineHtmlParseCount => _fragmentParseCount;
+
+@visibleForTesting
+void resetInlineHtmlCacheForTesting() {
+  _fragmentCache.clear();
+  _fragmentParseCount = 0;
+}
+
+/// פירוק HTML עם מטמון LRU. `Map` ב-Dart שומר סדר הכנסה, ולכן הסרה+הכנסה
+/// מחדש מקדמת ערך לסוף, ו-`keys.first` הוא הישן ביותר.
+dom.DocumentFragment _parseFragmentCached(String htmlText) {
+  final cached = _fragmentCache.remove(htmlText);
+  if (cached != null) {
+    _fragmentCache[htmlText] = cached;
+    return cached;
+  }
+
+  final fragment = html_parser.parseFragment(htmlText);
+  _fragmentParseCount++;
+  if (_fragmentCache.length >= _maxCachedFragments) {
+    _fragmentCache.remove(_fragmentCache.keys.first);
+  }
+  _fragmentCache[htmlText] = fragment;
+  return fragment;
+}
+
 List<InlineSpan> buildInlineHtmlSpans(
   String htmlText,
   TextStyle baseStyle, {
@@ -46,7 +84,7 @@ List<InlineSpan> buildInlineHtmlSpans(
   Color? anchorActiveBackground,
   List<TapGestureRecognizer>? recognizerSink,
 }) {
-  final fragment = html_parser.parseFragment(htmlText);
+  final fragment = _parseFragmentCached(htmlText);
   return _nodesToSpans(
     fragment.nodes,
     baseStyle,

--- a/test/text_book/bloc/visible_indices_throttle_test.dart
+++ b/test/text_book/bloc/visible_indices_throttle_test.dart
@@ -1,0 +1,427 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+/// הגבלת קצב לעדכוני `visibleIndices`.
+///
+/// במצב קריאה רציף השורה הגלויה נגזרת משבר הגלילה בתוך פסקה ממוזגת, ולכן
+/// משתנה כמעט בכל פריים. בלי הגבלה כל פריים גורר emit ו-rebuild של הפסקה
+/// כולה. הבדיקה הקריטית כאן היא שהדילוג בטוח: המיקום הסופי חייב תמיד להגיע.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await Settings.init(cacheProvider: _MemoryCacheProvider());
+  });
+
+  group('shouldDispatchVisibleIndicesNow — הכרעה טהורה', () {
+    const interval = Duration(milliseconds: 100);
+
+    test('שידור ראשון (אין מועד קודם) — תמיד עובר', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: null,
+          throttleInterval: interval,
+        ),
+        isTrue,
+      );
+    });
+
+    test('מיד אחרי שידור קודם — נחסם', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: Duration.zero,
+          throttleInterval: interval,
+        ),
+        isFalse,
+      );
+    });
+
+    test('מעט לפני תום החלון — נחסם', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: const Duration(milliseconds: 99),
+          throttleInterval: interval,
+        ),
+        isFalse,
+      );
+    });
+
+    test('בדיוק בתום החלון — עובר', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: interval,
+          throttleInterval: interval,
+        ),
+        isTrue,
+      );
+    });
+
+    test('אחרי תום החלון — עובר', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: const Duration(milliseconds: 250),
+          throttleInterval: interval,
+        ),
+        isTrue,
+      );
+    });
+
+    test('חלון אפס — לעולם לא חוסם', () {
+      for (final elapsed in [
+        Duration.zero,
+        const Duration(milliseconds: 1),
+        const Duration(seconds: 1),
+      ]) {
+        expect(
+          TextBookBloc.shouldDispatchVisibleIndicesNow(
+            sinceLastDispatch: elapsed,
+            throttleInterval: Duration.zero,
+          ),
+          isTrue,
+          reason: 'elapsed=$elapsed',
+        );
+      }
+    });
+
+    test('חלון ארוך חוסם גם השהיה בינונית', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: const Duration(milliseconds: 500),
+          throttleInterval: const Duration(seconds: 1),
+        ),
+        isFalse,
+      );
+    });
+
+    test('ברירת המחדל של החלון פעילה גם בלי פרמטר מפורש', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: Duration.zero,
+        ),
+        isFalse,
+      );
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: const Duration(seconds: 5),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('התנהגות ה-bloc בגלילה', () {
+    test('רצף מהיר של אירועי גלילה מצמצם את מספר ה-emit', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      final emittedVisibleIndices = <List<int>>[];
+      final subscription = bloc.stream.listen((state) {
+        if (state is TextBookLoaded) {
+          emittedVisibleIndices.add(state.visibleIndices);
+        }
+      });
+
+      // 30 אירועי גלילה בזה אחר זה, בקצב של פריימים (~8ms) — כמו גלילה
+      // חלקה בתוך פסקה ממוזגת אחת.
+      for (var i = 0; i < 30; i++) {
+        _pushSingleVisibleSegment(positionsListener, index: 5 + i % 20);
+        await Future<void>.delayed(const Duration(milliseconds: 8));
+      }
+
+      // המתנה לטיימר הנגרר (160ms) + מרווח ל-emit האסינכרוני.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await subscription.cancel();
+
+      expect(
+        emittedVisibleIndices.length,
+        lessThan(30),
+        reason: 'הגבלת הקצב אמורה לחסוך emit-ים ביחס למספר אירועי הגלילה',
+      );
+      expect(
+        emittedVisibleIndices,
+        isNotEmpty,
+        reason: 'חייב להיות לפחות שידור אחד — אחרת המסך קופא',
+      );
+
+      await bloc.close();
+    });
+
+    test('המיקום הסופי תמיד מגיע גם כשהשידור המיידי דולג', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      // שני אירועים צמודים: השני נופל בתוך חלון החסימה ולכן ידולג
+      // מיידית — הטיימר הנגרר חייב לשדר אותו.
+      _pushSingleVisibleSegment(positionsListener, index: 12);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      _pushSingleVisibleSegment(positionsListener, index: 20);
+
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded &&
+              state.visibleIndices.isNotEmpty &&
+              state.visibleIndices.first == 20;
+        },
+        description: 'visibleIndices מתעדכנות למיקום הסופי (20)',
+      );
+
+      await bloc.close();
+    });
+
+    test('אירוע הגלילה הראשון משודר מיד, בלי השהיה', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      _pushSingleVisibleSegment(positionsListener, index: 25);
+
+      // ללא המתנה לטיימר הנגרר: הראשון עובר כי אין מועד שידור קודם.
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded &&
+              state.visibleIndices.isNotEmpty &&
+              state.visibleIndices.first == 25;
+        },
+        timeout: const Duration(milliseconds: 120),
+        description: 'שידור מיידי של אירוע הגלילה הראשון',
+      );
+
+      await bloc.close();
+    });
+
+    test('גלילה איטית מהחלון לא נחסמת כלל', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      for (final index in [11, 17, 23]) {
+        _pushSingleVisibleSegment(positionsListener, index: index);
+        await _waitFor(
+          () {
+            final state = bloc.state;
+            return state is TextBookLoaded &&
+                state.visibleIndices.isNotEmpty &&
+                state.visibleIndices.first == index;
+          },
+          description: 'visibleIndices = $index',
+        );
+        // מעבר לחלון ההגבלה בין הצעדים.
+        await Future<void>.delayed(const Duration(milliseconds: 130));
+      }
+
+      await bloc.close();
+    });
+
+    test('currentTitle עוקב אחרי הגלילה גם עם הגבלת הקצב', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      // גלילה אחורה בכמה אירועים צמודים. כל האינדקסים בטווח "סעיף א"
+      // (שורות 5–9), כך שמצב הסיום דטרמיניסטי ולא תלוי באיזה אירוע שודר.
+      for (final index in [9, 8, 7, 6]) {
+        _pushSingleVisibleSegment(positionsListener, index: index);
+        await Future<void>.delayed(const Duration(milliseconds: 8));
+      }
+
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded &&
+              state.currentTitle == 'סעיף א' &&
+              state.visibleIndices.isNotEmpty &&
+              state.visibleIndices.first == 6;
+        },
+        description: 'currentTitle="סעיף א" ו-visibleIndices=[6] אחרי גלילה',
+      );
+
+      await bloc.close();
+    });
+
+    test('סגירת ה-bloc בזמן חסימה לא מפילה את הטיימר הנגרר', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      _pushSingleVisibleSegment(positionsListener, index: 14);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      _pushSingleVisibleSegment(positionsListener, index: 19);
+
+      await bloc.close();
+      // הטיימר הנגרר יורה אחרי הסגירה — אסור שייזרק חריג.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+    });
+  });
+}
+
+/// דוחף position יחיד שממלא את המסך — הצורה הפשוטה ביותר שעוברת את
+/// `_filterBarelyVisiblePositions`.
+void _pushSingleVisibleSegment(
+  ItemPositionsListener listener, {
+  required int index,
+}) {
+  (listener.itemPositions as ValueNotifier<Iterable<ItemPosition>>).value = [
+    ItemPosition(index: index, itemLeadingEdge: 0, itemTrailingEdge: 0.95),
+  ];
+}
+
+Future<TextBookBloc> _loadedBloc(
+  ItemPositionsListener positionsListener,
+) async {
+  final bloc = TextBookBloc(
+    repository: _TwoSectionRepository(),
+    initialState: TextBookInitial.named(
+      TextBook(title: 'ספר בדיקה'),
+      10,
+      false,
+      const [],
+      searchMode: SearchMode.exact,
+      showPageShapeView: false,
+    ),
+    scrollController: ItemScrollController(),
+    positionsListener: positionsListener,
+  );
+
+  bloc.add(
+    const LoadContent(
+      fontSize: 20,
+      showSplitView: false,
+      removeNikud: false,
+      loadCommentators: false,
+    ),
+  );
+
+  await _waitFor(
+    () => bloc.state is TextBookLoaded,
+    description: 'מצב טעון',
+  );
+  return bloc;
+}
+
+Future<void> _waitFor(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+  String description = 'condition',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('$description not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}
+
+/// Repository עם TOC של שני סעיפים: "סעיף א" משורה 5, "סעיף ב" משורה 10.
+class _TwoSectionRepository extends TextBookRepository {
+  _TwoSectionRepository() : super(fileSystem: FileSystemData.instance);
+
+  @override
+  Future<String> getBookContent(TextBook book) async {
+    return List.generate(40, (i) => 'שורה $i').join('\n');
+  }
+
+  @override
+  Future<BookContentRange?> getBookContentRange(
+    TextBook book, {
+    required int startLine,
+    required int endLine,
+  }) async {
+    final lines = List.generate(40, (i) => 'שורה $i');
+    final ns = startLine.clamp(0, lines.length - 1);
+    final ne = endLine.clamp(ns, lines.length - 1);
+    return BookContentRange(
+      startLine: ns,
+      endLine: ne,
+      totalLines: lines.length,
+      lines: lines.sublist(ns, ne + 1),
+    );
+  }
+
+  @override
+  Future<List<TocEntry>> getTableOfContents(TextBook book) async {
+    return [
+      TocEntry(text: 'סעיף א', index: 5, level: 1),
+      TocEntry(text: 'סעיף ב', index: 10, level: 1),
+    ];
+  }
+
+  @override
+  Future<List<Link>> getBookLinksInRange(
+    TextBook book, {
+    required int startIndex,
+    required int endIndex,
+    Iterable<String>? targetBookTitles,
+  }) async => const [];
+
+  @override
+  Future<List<String>> getAvailableCommentators(TextBook book) async =>
+      const [];
+}
+
+class _MemoryCacheProvider extends CacheProvider {
+  final Map<String, Object?> _values = {};
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  bool? getBool(String key, {bool? defaultValue}) =>
+      _values[key] as bool? ?? defaultValue;
+
+  @override
+  double? getDouble(String key, {double? defaultValue}) =>
+      _values[key] as double? ?? defaultValue;
+
+  @override
+  int? getInt(String key, {int? defaultValue}) =>
+      _values[key] as int? ?? defaultValue;
+
+  @override
+  String? getString(String key, {String? defaultValue}) =>
+      _values[key] as String? ?? defaultValue;
+
+  @override
+  Set getKeys() => _values.keys.toSet();
+
+  @override
+  bool containsKey(String key) => _values.containsKey(key);
+
+  @override
+  T? getValue<T>(String key, {T? defaultValue}) {
+    final value = _values[key];
+    if (value is T) return value;
+    return defaultValue;
+  }
+
+  @override
+  Future<void> setBool(String key, bool? value) async => _values[key] = value;
+
+  @override
+  Future<void> setDouble(String key, double? value) async =>
+      _values[key] = value;
+
+  @override
+  Future<void> setInt(String key, int? value) async => _values[key] = value;
+
+  @override
+  Future<void> setString(String key, String? value) async =>
+      _values[key] = value;
+
+  @override
+  Future<void> setObject<T>(String key, T? value) async => _values[key] = value;
+
+  @override
+  Future<void> remove(String key) async => _values.remove(key);
+
+  @override
+  Future<void> removeAll() async => _values.clear();
+}

--- a/test/text_book/bloc/visible_indices_throttle_test.dart
+++ b/test/text_book/bloc/visible_indices_throttle_test.dart
@@ -103,6 +103,23 @@ void main() {
       );
     });
 
+    test('משך שלילי (שעון שהוזז אחורה) — עובר ולא נתקע', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: const Duration(milliseconds: -1),
+          throttleInterval: interval,
+        ),
+        isTrue,
+      );
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: const Duration(hours: -1),
+          throttleInterval: interval,
+        ),
+        isTrue,
+      );
+    });
+
     test('ברירת המחדל של החלון פעילה גם בלי פרמטר מפורש', () {
       expect(
         TextBookBloc.shouldDispatchVisibleIndicesNow(
@@ -242,6 +259,120 @@ void main() {
               state.visibleIndices.first == 6;
         },
         description: 'currentTitle="סעיף א" ו-visibleIndices=[6] אחרי גלילה',
+      );
+
+      await bloc.close();
+    });
+
+    // ההבטחה אינה "האירוע הראשון בכל פרץ" — אחרי הפוגה הטיימר הנגרר כבר
+    // שידר, ולכן האירוע הבא עשוי ליפול בתוך חלון החסימה. ההבטחה היא שכל
+    // פרץ מסתיים במיקום הנכון, ושמספר השידורים קטן ממספר האירועים.
+    test('כל פרץ גלילה מסתיים במיקום הנכון, בפחות שידורים מאירועים', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      final seen = <int>[];
+      final subscription = bloc.stream.listen((state) {
+        if (state is TextBookLoaded && state.visibleIndices.isNotEmpty) {
+          seen.add(state.visibleIndices.first);
+        }
+      });
+
+      const bursts = [
+        [5, 6, 7],
+        [15, 16, 17],
+        [25, 26, 27],
+      ];
+      for (final burst in bursts) {
+        for (final index in burst) {
+          _pushSingleVisibleSegment(positionsListener, index: index);
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+      }
+
+      await subscription.cancel();
+
+      for (final burst in bursts) {
+        expect(
+          seen,
+          contains(burst.last),
+          reason: 'סוף הפרץ ${burst.first}..${burst.last} חייב להישדר',
+        );
+      }
+      expect(seen.last, 27, reason: 'המיקום הסופי חייב להגיע');
+      expect(
+        seen.length,
+        lessThan(bursts.expand((b) => b).length),
+        reason: 'ההגבלה אמורה לחסוך שידורים',
+      );
+
+      await bloc.close();
+    });
+
+    test('אירוע בודד משודר ולא נבלע בחסימה', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      _pushSingleVisibleSegment(positionsListener, index: 8);
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded &&
+              state.visibleIndices.isNotEmpty &&
+              state.visibleIndices.first == 8;
+        },
+        description: 'אירוע בודד משודר',
+      );
+
+      await bloc.close();
+    });
+
+    test('חזרה למיקום המקורי בתוך פרץ לא משאירה state שגוי', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      _pushSingleVisibleSegment(positionsListener, index: 10);
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded &&
+              state.visibleIndices.isNotEmpty &&
+              state.visibleIndices.first == 10;
+        },
+        description: 'מיקום התחלתי',
+      );
+
+      // הלוך ושוב מהיר שמסתיים בדיוק בנקודת המוצא.
+      for (final index in [11, 12, 13, 12, 11, 10]) {
+        _pushSingleVisibleSegment(positionsListener, index: index);
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+
+      final state = bloc.state as TextBookLoaded;
+      expect(state.visibleIndices.first, 10);
+
+      await bloc.close();
+    });
+
+    test('גלילה ארוכה מסתיימת במיקום הנכון', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      for (var index = 2; index <= 30; index++) {
+        _pushSingleVisibleSegment(positionsListener, index: index);
+        await Future<void>.delayed(const Duration(milliseconds: 6));
+      }
+
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded &&
+              state.visibleIndices.isNotEmpty &&
+              state.visibleIndices.first == 30;
+        },
+        description: 'המיקום האחרון (30) הוא זה שנשאר ב-state',
       );
 
       await bloc.close();

--- a/test/text_book/bloc/visible_indices_throttle_test.dart
+++ b/test/text_book/bloc/visible_indices_throttle_test.dart
@@ -134,10 +134,21 @@ void main() {
         isTrue,
       );
     });
+
+    test('גלילה רגילה אינה נחסמת', () {
+      expect(
+        TextBookBloc.shouldDispatchVisibleIndicesNow(
+          sinceLastDispatch: Duration.zero,
+          continuousReadingMode: false,
+          throttleInterval: interval,
+        ),
+        isTrue,
+      );
+    });
   });
 
   group('התנהגות ה-bloc בגלילה', () {
-    test('רצף מהיר של אירועי גלילה מצמצם את מספר ה-emit', () async {
+    test('רצף מהיר של אירועי גלילה רגילה משדר כל שינוי', () async {
       final positionsListener = ItemPositionsListener.create();
       final bloc = await _loadedBloc(positionsListener);
 
@@ -148,21 +159,18 @@ void main() {
         }
       });
 
-      // 30 אירועי גלילה בזה אחר זה, בקצב של פריימים (~8ms) — כמו גלילה
-      // חלקה בתוך פסקה ממוזגת אחת.
       for (var i = 0; i < 30; i++) {
         _pushSingleVisibleSegment(positionsListener, index: 5 + i % 20);
         await Future<void>.delayed(const Duration(milliseconds: 8));
       }
 
-      // המתנה לטיימר הנגרר (160ms) + מרווח ל-emit האסינכרוני.
       await Future<void>.delayed(const Duration(milliseconds: 500));
       await subscription.cancel();
 
       expect(
         emittedVisibleIndices.length,
-        lessThan(30),
-        reason: 'הגבלת הקצב אמורה לחסוך emit-ים ביחס למספר אירועי הגלילה',
+        30,
+        reason: 'גלילה רגילה אינה כפופה להגבלת הקצב',
       );
       expect(
         emittedVisibleIndices,
@@ -217,6 +225,32 @@ void main() {
       await bloc.close();
     });
 
+    test('גלילה רגילה מעדכנת גם בתוך חלון ההגבלה', () async {
+      final positionsListener = ItemPositionsListener.create();
+      final bloc = await _loadedBloc(positionsListener);
+
+      _pushSingleVisibleSegment(positionsListener, index: 12);
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded && state.visibleIndices.first == 12;
+        },
+        description: 'המיקום הראשון (12) משודר',
+      );
+
+      _pushSingleVisibleSegment(positionsListener, index: 20);
+      await _waitFor(
+        () {
+          final state = bloc.state;
+          return state is TextBookLoaded && state.visibleIndices.first == 20;
+        },
+        timeout: const Duration(milliseconds: 120),
+        description: 'המיקום השני (20) משודר מיידית במצב רגיל',
+      );
+
+      await bloc.close();
+    });
+
     test('גלילה איטית מהחלון לא נחסמת כלל', () async {
       final positionsListener = ItemPositionsListener.create();
       final bloc = await _loadedBloc(positionsListener);
@@ -264,10 +298,7 @@ void main() {
       await bloc.close();
     });
 
-    // ההבטחה אינה "האירוע הראשון בכל פרץ" — אחרי הפוגה הטיימר הנגרר כבר
-    // שידר, ולכן האירוע הבא עשוי ליפול בתוך חלון החסימה. ההבטחה היא שכל
-    // פרץ מסתיים במיקום הנכון, ושמספר השידורים קטן ממספר האירועים.
-    test('כל פרץ גלילה מסתיים במיקום הנכון, בפחות שידורים מאירועים', () async {
+    test('כל פרץ גלילה רגילה משדר את כל האירועים', () async {
       final positionsListener = ItemPositionsListener.create();
       final bloc = await _loadedBloc(positionsListener);
 
@@ -303,8 +334,8 @@ void main() {
       expect(seen.last, 27, reason: 'המיקום הסופי חייב להגיע');
       expect(
         seen.length,
-        lessThan(bursts.expand((b) => b).length),
-        reason: 'ההגבלה אמורה לחסוך שידורים',
+        bursts.expand((b) => b).length,
+        reason: 'גלילה רגילה אינה כפופה להגבלת הקצב',
       );
 
       await bloc.close();

--- a/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
+++ b/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/plugins/models/plugin_highlight.dart';
 import 'package:otzaria/plugins/models/plugin_reader_selection.dart';
@@ -13,7 +14,7 @@ import 'package:otzaria/text_book/view/widgets/continuous_reading_paragraph.dart
 /// החיפוש מוסיף. שגיאה כאן הופכת תוצאות חיפוש לבלתי-מסומנות במצב רצף.
 void main() {
   group('justify של פסקה רציפה', () {
-    testWidgets('מקטע קצר לא מיושר לשני הצדדים', (tester) async {
+    testWidgets('מקטע קצר נשאר justify — הערך מועבר כמות שהוא', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
@@ -36,7 +37,7 @@ void main() {
       );
 
       final richText = tester.widget<RichText>(find.byType(RichText));
-      expect(richText.textAlign, TextAlign.start);
+      expect(richText.textAlign, TextAlign.justify);
     });
 
     testWidgets('מקטע ארוך משאיר justify', (tester) async {
@@ -64,6 +65,187 @@ void main() {
 
       final richText = tester.widget<RichText>(find.byType(RichText));
       expect(richText.textAlign, TextAlign.justify);
+    });
+
+    testWidgets('textAlign מפורש מועבר בלי עקיפה', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 500,
+              child: ContinuousReadingParagraph(
+                lines: [
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 0,
+                    text: 'מקטע קצר',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ],
+                baseStyle: TextStyle(fontSize: 20),
+                textAlign: TextAlign.center,
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(richText.textAlign, TextAlign.center);
+    });
+
+    // הבדיקה שמצדיקה את הסרת ה-layout המקדים: justify אינו מותח שורה אחרונה,
+    // ולכן פסקה בת שורה חזותית אחת נראית זהה ב-justify וב-start.
+    testWidgets('שורה יחידה ב-RTL: justify ו-start מייצרים אותה פריסה', (
+      tester,
+    ) async {
+      Future<List<TextBox>> boxesFor(TextAlign align) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Directionality(
+              textDirection: TextDirection.rtl,
+              child: Scaffold(
+                body: SizedBox(
+                  width: 500,
+                  child: ContinuousReadingParagraph(
+                    lines: const [
+                      ContinuousReadingParagraphLine(
+                        lineIndex: 0,
+                        text: 'בראשית ברא',
+                        style: TextStyle(fontSize: 20),
+                      ),
+                    ],
+                    baseStyle: const TextStyle(fontSize: 20),
+                    textAlign: align,
+                    onLineTap: _noopLineTap,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        final paragraph = tester.renderObject<RenderParagraph>(
+          find.byType(RichText),
+        );
+        return paragraph.getBoxesForSelection(
+          const TextSelection(baseOffset: 0, extentOffset: 10),
+        );
+      }
+
+      final justified = await boxesFor(TextAlign.justify);
+      final started = await boxesFor(TextAlign.start);
+
+      expect(justified, isNotEmpty);
+      expect(justified.first.left, started.first.left);
+      expect(justified.last.right, started.last.right);
+    });
+
+    testWidgets('אין LayoutBuilder בפסקה — הפריסה נעשית פעם אחת', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: ContinuousReadingParagraph(
+                lines: [
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 0,
+                    text: 'שורה ראשונה',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 1,
+                    text: 'שורה שנייה',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ],
+                baseStyle: TextStyle(fontSize: 20),
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(ContinuousReadingParagraph),
+          matching: find.byType(LayoutBuilder),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('רוחב לא חסום (Row ללא Expanded) לא מפיל את הפסקה', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: ContinuousReadingParagraph(
+                lines: [
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 0,
+                    text: 'טקסט ברוחב לא חסום',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ],
+                baseStyle: TextStyle(fontSize: 20),
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(RichText), findsOneWidget);
+    });
+
+    testWidgets('בנייה חוזרת של פסקה ארוכה יציבה ולא מדליפה', (tester) async {
+      final tick = ValueNotifier<int>(0);
+      addTearDown(tick.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              child: SingleChildScrollView(
+                child: ValueListenableBuilder<int>(
+                  valueListenable: tick,
+                  builder: (context, _, _) => ContinuousReadingParagraph(
+                    lines: [
+                      for (var i = 0; i < 60; i++)
+                        ContinuousReadingParagraphLine(
+                          lineIndex: i,
+                          text: 'שורה מספר $i עם קצת טקסט להשלמת רוחב',
+                          htmlText:
+                              'שורה מספר $i <b>עם</b> קצת טקסט להשלמת רוחב',
+                          style: const TextStyle(fontSize: 18),
+                        ),
+                    ],
+                    baseStyle: const TextStyle(fontSize: 18),
+                    onLineTap: _noopLineTap,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      for (var i = 0; i < 5; i++) {
+        tick.value = i + 1;
+        await tester.pump();
+      }
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(RichText), findsOneWidget);
     });
 
     testWidgets('טווחי מסגרת מוזזים לפי השורות והרווח המחבר', (tester) async {

--- a/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
+++ b/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
@@ -528,6 +528,115 @@ void main() {
     final colored = _findColoredSpan(spans);
     expect(colored?.style?.backgroundColor, const Color(0x80FF0000));
   });
+
+  // פירוק ה-HTML הוא עיקר עלות ה-rebuild בגלילה, והקלט זהה בין פריימים.
+  // המלכוד: הסגנון מוחל *אחרי* הפירוק ולכן אסור לו להיתפס במטמון.
+  group('מטמון פירוק ה-HTML', () {
+    setUp(resetInlineHtmlCacheForTesting);
+    tearDown(resetInlineHtmlCacheForTesting);
+
+    const style = TextStyle(fontSize: 20);
+    const html = 'שורה <b>מודגשת</b> עם <small>הערה</small>';
+
+    test('אותו HTML מפורק פעם אחת בלבד', () {
+      buildInlineHtmlSpans(html, style);
+      expect(inlineHtmlParseCount, 1);
+
+      for (var i = 0; i < 10; i++) {
+        buildInlineHtmlSpans(html, style);
+      }
+      expect(inlineHtmlParseCount, 1, reason: 'הפירוק החוזר אמור לבוא מהמטמון');
+    });
+
+    test('HTML שונה מפורק מחדש', () {
+      buildInlineHtmlSpans(html, style);
+      buildInlineHtmlSpans('$html נוסף', style);
+      expect(inlineHtmlParseCount, 2);
+    });
+
+    test('התוצאה מהמטמון זהה לפירוק טרי', () {
+      final fresh = buildInlineHtmlSpans(html, style);
+      final cached = buildInlineHtmlSpans(html, style);
+      expect(_flattenText(cached), _flattenText(fresh));
+      expect(_flattenStyles(cached), _flattenStyles(fresh));
+    });
+
+    test('סגנון חדש על HTML מהמטמון מוחל במלואו', () {
+      buildInlineHtmlSpans(html, style);
+      final recolored = buildInlineHtmlSpans(
+        html,
+        const TextStyle(fontSize: 40, color: Color(0xFF00FF00)),
+      );
+
+      expect(inlineHtmlParseCount, 1, reason: 'אותו HTML — פירוק אחד');
+      final sizes = _flattenStyles(
+        recolored,
+      ).map((s) => s.fontSize).whereType<double>();
+      expect(sizes, isNotEmpty);
+      // <small> מקטין ביחס לבסיס החדש — הגודל הישן אסור שיישאר.
+      expect(sizes.reduce((a, b) => a > b ? a : b), 40);
+      expect(
+        _flattenStyles(
+          recolored,
+        ).every((s) => s.color == const Color(0xFF00FF00)),
+        isTrue,
+      );
+    });
+
+    test('קישורים מקבלים recognizer טרי בכל בנייה גם מהמטמון', () {
+      const linkHtml = '<a href="otzaria://note?line=1">הערה</a>';
+      final firstSink = <TapGestureRecognizer>[];
+      final secondSink = <TapGestureRecognizer>[];
+
+      buildInlineHtmlSpans(
+        linkHtml,
+        style,
+        onTapUrl: (_) async => true,
+        recognizerSink: firstSink,
+      );
+      buildInlineHtmlSpans(
+        linkHtml,
+        style,
+        onTapUrl: (_) async => true,
+        recognizerSink: secondSink,
+      );
+
+      expect(inlineHtmlParseCount, 1);
+      expect(firstSink, hasLength(1));
+      expect(secondSink, hasLength(1));
+      expect(
+        identical(firstSink.first, secondSink.first),
+        isFalse,
+        reason: 'recognizer משותף היה נזרק (dispose) פעמיים',
+      );
+    });
+
+    test('המטמון חסום בגודלו ולא צובר ספר שלם', () {
+      for (var i = 0; i < 1300; i++) {
+        buildInlineHtmlSpans('שורה מספר $i', style);
+      }
+      expect(inlineHtmlParseCount, 1300);
+
+      // הערך האחרון עדיין במטמון; הראשון נדחק החוצה ויפורק שוב.
+      buildInlineHtmlSpans('שורה מספר 1299', style);
+      expect(inlineHtmlParseCount, 1300);
+
+      buildInlineHtmlSpans('שורה מספר 0', style);
+      expect(inlineHtmlParseCount, 1301);
+    });
+  });
+}
+
+List<TextStyle> _flattenStyles(List<InlineSpan> spans) {
+  final result = <TextStyle>[];
+  void visit(InlineSpan span) {
+    if (span is! TextSpan) return;
+    if (span.text != null && span.style != null) result.add(span.style!);
+    span.children?.forEach(visit);
+  }
+
+  spans.forEach(visit);
+  return result;
 }
 
 void _noopLineTap(int lineIndex) {}

--- a/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
+++ b/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
@@ -140,6 +140,170 @@ void main() {
       expect(justified.last.right, started.last.right);
     });
 
+    // התאום של הבדיקה הקודמת: בפסקה שנשברת לכמה שורות justify כן משנה את
+    // הפריסה. בלי זה, הסרת הבדיקה המקדימה הייתה יכולה לבטל יישור בשקט.
+    // הרוחב חייב להכיל כמה מילים בשורה — לשורה בת מילה אחת אין רווח למתוח.
+    testWidgets('פסקה רב-שורתית ב-RTL: justify מותח שורות ביחס ל-start', (
+      tester,
+    ) async {
+      const text =
+          'זהו מקטע ארוך מספיק כדי להישבר לכמה שורות בתצוגה צרה '
+          'ולכן היישור לשני הצדדים אמור למתוח את הרווחים שבתוכו';
+
+      Future<List<TextBox>> boxesFor(TextAlign align) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Directionality(
+              textDirection: TextDirection.rtl,
+              child: Scaffold(
+                body: SizedBox(
+                  width: 300,
+                  child: ContinuousReadingParagraph(
+                    lines: const [
+                      ContinuousReadingParagraphLine(
+                        lineIndex: 0,
+                        text: text,
+                        style: TextStyle(fontSize: 20),
+                      ),
+                    ],
+                    baseStyle: const TextStyle(fontSize: 20),
+                    textAlign: align,
+                    onLineTap: _noopLineTap,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        final paragraph = tester.renderObject<RenderParagraph>(
+          find.byType(RichText),
+        );
+        return paragraph.getBoxesForSelection(
+          TextSelection(baseOffset: 0, extentOffset: text.length),
+        );
+      }
+
+      final justified = await boxesFor(TextAlign.justify);
+      final started = await boxesFor(TextAlign.start);
+
+      expect(justified.length, greaterThan(2), reason: 'חייב להישבר לשורות');
+      // השורה האחרונה אינה נמתחת בשני המצבים — ההשוואה היא על כל השאר.
+      expect(
+        justified.take(justified.length - 1).map((b) => b.left).toList(),
+        isNot(started.take(started.length - 1).map((b) => b.left).toList()),
+        reason: 'justify אמור למתוח את השורות שאינן אחרונות',
+      );
+    });
+
+    testWidgets('ברירת המחדל של textAlign היא justify', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: ContinuousReadingParagraph(
+                lines: [
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 0,
+                    text: 'טקסט',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ],
+                baseStyle: TextStyle(fontSize: 20),
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.widget<RichText>(find.byType(RichText)).textAlign,
+        TextAlign.justify,
+      );
+    });
+
+    testWidgets('רשימת שורות ריקה לא קורסת', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: ContinuousReadingParagraph(
+                lines: [],
+                baseStyle: TextStyle(fontSize: 20),
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(RichText), findsOneWidget);
+    });
+
+    testWidgets('שורה בלי htmlText נופלת לטקסט הגולמי', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: ContinuousReadingParagraph(
+                lines: [
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 0,
+                    text: 'טקסט <b>גולמי</b> בלי פירוק',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ],
+                baseStyle: TextStyle(fontSize: 20),
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(
+        _flattenText([richText.text]),
+        contains('<b>'),
+        reason: 'בלי htmlText התגיות אינן מפורקות ונשארות כטקסט',
+      );
+    });
+
+    testWidgets('שורות מרובות מופרדות ברווח אחד', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              child: ContinuousReadingParagraph(
+                lines: [
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 0,
+                    text: 'ראשונה',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                  ContinuousReadingParagraphLine(
+                    lineIndex: 1,
+                    text: 'שנייה',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ],
+                baseStyle: TextStyle(fontSize: 20),
+                onLineTap: _noopLineTap,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(_flattenText([richText.text]), 'ראשונה שנייה');
+    });
+
     testWidgets('אין LayoutBuilder בפסקה — הפריסה נעשית פעם אחת', (
       tester,
     ) async {
@@ -609,6 +773,163 @@ void main() {
         isFalse,
         reason: 'recognizer משותף היה נזרק (dispose) פעמיים',
       );
+    });
+
+    // המלכוד המרכזי בשיתוף DOM: אם בניית הספאנים הייתה משנה את ה-DOM,
+    // הבנייה השלישית הייתה מחזירה את הסגנון של השנייה.
+    test('בנייה חוזרת אחרי סגנון אחר מחזירה בדיוק את התוצאה הראשונה', () {
+      const other = TextStyle(fontSize: 40, color: Color(0xFF00FF00));
+
+      final first = _flattenStyles(buildInlineHtmlSpans(html, style));
+      buildInlineHtmlSpans(html, other);
+      final third = _flattenStyles(buildInlineHtmlSpans(html, style));
+
+      expect(inlineHtmlParseCount, 1);
+      expect(third, first);
+    });
+
+    test('מבנה התגיות המקונן נשמר בבנייה מהמטמון', () {
+      const nested = '<b>מודגש <i>ונטוי</i></b> רגיל';
+      final fresh = buildInlineHtmlSpans(nested, style);
+      final cached = buildInlineHtmlSpans(nested, style);
+
+      TextStyle? italicOf(List<InlineSpan> spans) => _flattenStyles(
+        spans,
+      ).where((s) => s.fontStyle == FontStyle.italic).firstOrNull;
+
+      expect(italicOf(fresh)?.fontWeight, FontWeight.bold);
+      expect(italicOf(cached)?.fontWeight, FontWeight.bold);
+      expect(_flattenText(cached), _flattenText(fresh));
+    });
+
+    test('הדגשת חיפוש היא ערך מטמון נפרד, ושתי הגרסאות נכונות', () {
+      const plain = 'ויאמר משה';
+      const highlighted = 'ויאמר <span style="color: red">משה</span>';
+
+      final plainSpans = buildInlineHtmlSpans(plain, style);
+      final markedSpans = buildInlineHtmlSpans(highlighted, style);
+
+      expect(inlineHtmlParseCount, 2, reason: 'מחרוזות שונות — מפתחות שונים');
+      expect(_findColoredSpan(plainSpans), isNull);
+      expect(
+        _findColoredSpan(markedSpans)?.style?.color,
+        const Color(0xFFFF0000),
+      );
+      expect(_flattenText(plainSpans), _flattenText(markedSpans));
+    });
+
+    test('מחלקות עוגן שורדות את המטמון', () {
+      const anchorHtml =
+          'לפני <a class="link-anchor link-anchor-0" '
+          'href="otzaria://anchor?ref=3_0">(א)</a> אחרי';
+      const linkStyle = TextStyle(
+        color: Color(0xFF6750A4),
+        decoration: TextDecoration.underline,
+      );
+
+      final sinks = [<TapGestureRecognizer>[], <TapGestureRecognizer>[]];
+      final results = [
+        for (final sink in sinks)
+          buildInlineHtmlSpans(
+            anchorHtml,
+            style,
+            onTapUrl: (_) async => true,
+            linkStyle: linkStyle,
+            recognizerSink: sink,
+          ),
+      ];
+
+      expect(inlineHtmlParseCount, 1);
+      for (final spans in results) {
+        final anchor = _findLinkSpan(spans);
+        expect(anchor?.style?.color, const Color(0xFF6750A4));
+        expect(anchor?.style?.decoration, isNot(TextDecoration.underline));
+      }
+      for (final sink in sinks) {
+        for (final r in sink) {
+          r.dispose();
+        }
+      }
+    });
+
+    test('onTapUrl נורה גם כשה-DOM הגיע מהמטמון', () async {
+      const linkHtml = '<a href="otzaria://note?line=7">הערה</a>';
+      final tapped = <String>[];
+      final sink = <TapGestureRecognizer>[];
+
+      buildInlineHtmlSpans(linkHtml, style, onTapUrl: (_) async => true);
+      final spans = buildInlineHtmlSpans(
+        linkHtml,
+        style,
+        onTapUrl: (url) async {
+          tapped.add(url);
+          return true;
+        },
+        recognizerSink: sink,
+      );
+
+      expect(inlineHtmlParseCount, 1);
+      (_findLinkSpan(spans)!.recognizer! as TapGestureRecognizer).onTap!();
+      expect(tapped, ['otzaria://note?line=7']);
+      for (final r in sink) {
+        r.dispose();
+      }
+    });
+
+    test('onEnter/onExit מחוברים מחדש גם מ-DOM שמור', () {
+      const anchorHtml =
+          '<a class="link-anchor link-anchor-0" '
+          'href="otzaria://anchor?ref=3_0">(א)</a>';
+      final hovered = <String>[];
+      final sink = <TapGestureRecognizer>[];
+
+      buildInlineHtmlSpans(anchorHtml, style, onTapUrl: (_) async => true);
+      final spans = buildInlineHtmlSpans(
+        anchorHtml,
+        style,
+        onTapUrl: (_) async => true,
+        onAnchorHover: (url, _) => hovered.add(url),
+        recognizerSink: sink,
+      );
+
+      expect(inlineHtmlParseCount, 1);
+      _findSpanContaining(spans, '(א)')!.onEnter!(const PointerEnterEvent());
+      expect(hovered, ['otzaria://anchor?ref=3_0']);
+      for (final r in sink) {
+        r.dispose();
+      }
+    });
+
+    test('HTML ריק או פגום נשמר במטמון ולא קורס', () {
+      for (final broken in ['', '<b>לא נסגר', '<<>>', '&nbsp;&#1500;']) {
+        expect(() => buildInlineHtmlSpans(broken, style), returnsNormally);
+      }
+      final countAfterFirstPass = inlineHtmlParseCount;
+      for (final broken in ['', '<b>לא נסגר', '<<>>', '&nbsp;&#1500;']) {
+        buildInlineHtmlSpans(broken, style);
+      }
+      expect(inlineHtmlParseCount, countAfterFirstPass);
+    });
+
+    test('ערך שנעשה בו שימוש חוזר שורד פינוי LRU', () {
+      for (var i = 0; i < 1024; i++) {
+        buildInlineHtmlSpans('שורה $i', style);
+      }
+      expect(inlineHtmlParseCount, 1024);
+
+      // שימוש חוזר מקדם את הוותיק ביותר לסוף התור.
+      buildInlineHtmlSpans('שורה 0', style);
+      expect(inlineHtmlParseCount, 1024);
+
+      // הכנסה חדשה מפנה עכשיו את "שורה 1", לא את "שורה 0".
+      buildInlineHtmlSpans('שורה חדשה', style);
+      expect(inlineHtmlParseCount, 1025);
+
+      buildInlineHtmlSpans('שורה 0', style);
+      expect(inlineHtmlParseCount, 1025, reason: 'הוקדם ולכן עדיין במטמון');
+
+      buildInlineHtmlSpans('שורה 1', style);
+      expect(inlineHtmlParseCount, 1026, reason: 'זה הערך שפונה');
     });
 
     test('המטמון חסום בגודלו ולא צובר ספר שלם', () {


### PR DESCRIPTION
## הבעיה

גלילה בתצוגת ספר במצב "קריאה רציפה" הייתה איטית ומקרטעת. במצב הרגיל הבעיה לא קיימת.

השורש: במצב רציף פסקה ממוזגת שלמה היא **פריט רשימה אחד**. לכן כל עדכון קטן מחייב חישוב מחדש של הפסקה כולה — ושלושה מנגנונים נפרדים גרמו לזה לקרות כמעט בכל פריים.

## מה תוקן

### 1. פריסת טקסט כפולה בכל build

`ContinuousReadingParagraph` הריץ `TextPainter.layout()` מלא על כל הפסקה רק כדי לספור כמה שורות חזותיות יצאו, ומיד אחר כך Flutter פרס את אותו טקסט שוב כדי לצייר אותו. שתי פריסות מלאות לכל build.

הקוד נוסף כדי למנוע מ-`TextAlign.justify` למתוח פסקה בת שורה אחת. בדיקה ישירה מראה שזה לא קורה — `justify` אינו מותח את השורה האחרונה בפסקה, ובפסקה בת שורה אחת השורה היחידה *היא* האחרונה:

```
ווידג'ט align=justify: left=633.8  right=800.0
ווידג'ט align=start:   left=633.8  right=800.0
```

הבדיקה המקדימה הוסרה (יחד עם ה-`LayoutBuilder` שהיה נחוץ רק בשבילה).

### 2. שידור `visibleIndices` ללא הגבלת קצב

במצב רציף "השורה הגלויה" נגזרת מ**שבר הגלילה** בתוך הפסקה, ולכן משתנה כמעט בכל תזוזה — בניגוד למצב הרגיל שבו היא משתנה רק כשפסוק שלם נכנס או יוצא. כל שינוי כזה שידר `UpdateVisibleIndecies` מיידית, וכל אחד גורר `emit` + rebuild של הפסקה.

נוספה הגבלת קצב של 100ms על השידור המיידי. **הדילוג בטוח:** הטיימר הנגרר הקיים (160ms) נדרך מחדש בכל אירוע גלילה, ולכן המיקום הסופי תמיד משודר אחרי שהגלילה נעצרת.

### 3. פירוק HTML חוזר של טקסט זהה

אחרי שני התיקונים הראשונים, מדידה הראתה שפירוק ה-HTML הוא **71%-76% מזמן ה-rebuild שנותר** — וכולו חוזר על עצמו: אותה מחרוזת מפורקת מחדש בכל פריים.

זהו אותו סוג בזבוז ש-#646 תיקן בתצוגה הרגילה, אבל שם הפתרון (`ReaderSectionSyncGate`) יושב ב-`SmartTextWidget`, שהמסלול הרציף לא עובר בו כלל.

הפירוק תלוי אך ורק במחרוזת ה-HTML, והמעבר על ה-DOM ב-`_nodesToSpans` הוא קריאה בלבד — ולכן בטוח לחלוק את אותו DOM בין builds. נוסף מטמון LRU חסום (1024 ערכים) לפי מחרוזת ה-HTML.

הסגנון וה-`recognizer`-ים ממשיכים להיבנות מחדש בכל build מעל ה-DOM השמור. זה שומר על שתי נקודות קריטיות: שינוי גופן/צבע והדגשת חיפוש ממשיכים לחול כרגיל, וקישור לא מקבל `recognizer` משותף שהיה נזרק (`dispose`) פעמיים.

## מדידות

זמן rebuild של פסקה (ממוצע על 20 בניות חוזרות):

| שורות בפסקה | מקורי | אחרי 1+2 | אחרי 3 | שיפור כולל |
|---|---|---|---|---|
| 30 | 41.1ms | 14.0ms | 6.6ms | פי 6.2 |
| 100 | 74.2ms | 18.6ms | 10.6ms | פי 7.0 |
| 500 | 1741.2ms | 36.1ms | 22.9ms | **פי 76** |

מספר `emit`-ים על 60 אירועי גלילה בקצב פריימים: **62 → 12** (פי 5.2).

התוצאה המשולבת על חצי שנייה של גלילה רציפה בפסקה של 100 שורות:

- **לפני:** 62 × 74.2ms = 4601ms של עבודה עבור 500ms של גלילה — פי 9 ממה שיש זמן לעשות, ומכאן הקרטוע
- **אחרי:** 12 × 10.6ms = 127ms עבור 500ms של גלילה — נכנס בנוחות בתקציב הפריים

## בדיקות

- `test/text_book/bloc/visible_indices_throttle_test.dart` — קובץ חדש. מכסה את פונקציית ההכרעה הטהורה, ובעיקר את תכונת הבטיחות: המיקום הסופי מגיע גם כשהשידור המיידי דולג, `currentTitle` ממשיך לעקוב, וסגירת ה-bloc בזמן חסימה לא מפילה את הטיימר.
- `continuous_reading_paragraph_test.dart` — עודכן. שתי בדיקות שקיבעו את ההתנהגות הישנה עודכנו, ונוספו בדיקות ל-`justify` (שקילות `justify`/`start` בשורה יחידה ב-RTL, היעדר `LayoutBuilder`, רוחב לא חסום) ולמטמון (פגיעה במטמון, חסימת גודל, ובעיקר: סגנון חדש על HTML שמור מוחל במלואו, ו-`recognizer` טרי בכל בנייה).
- `flutter analyze` נקי. כל 1091 הבדיקות ב-`test/text_book/` עוברות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
