### PR TITLE
תיקון: אי אפשר לתפוס את מחוון הגלילה בחלונית המפרשים

### DIFF
--- a/lib/pdf_book/view/pdf_commentary_panel.dart
+++ b/lib/pdf_book/view/pdf_commentary_panel.dart
@@ -1448,6 +1448,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
               maintainSize: true,
               child: ScrollablePositionedListScrollbar(
                 scrollController: _itemScrollController,
+                offsetController: _scrollOffsetController,
                 itemPositionsListener: _itemPositionsListener,
                 itemCount: sortedGroups.length,
                 labelForIndex: (index) =>

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -1801,6 +1801,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                                       ),
                                   child: ScrollablePositionedListScrollbar(
                                     scrollController: _itemScrollController,
+                                    offsetController: scrollController,
                                     itemPositionsListener:
                                         _itemPositionsListener,
                                     itemCount: groups.length,

--- a/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
+++ b/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
@@ -19,6 +19,11 @@ class ScrollablePositionedListScrollbar extends StatefulWidget {
   /// אינדקס→תוכן עניינים).
   final String Function(int index)? labelForIndex;
 
+  /// ה-ScrollOffsetController של אותה רשימה. בלעדיו הסרגל יכול לנחות רק על
+  /// גבולות פריטים; חובה לספקו כשפריט בודד גבוה מה-viewport (חלונית המפרשים —
+  /// פריט = מפרש שלם), אחרת גרירת האגודל אינה מזיזה כלום.
+  final ScrollOffsetController? offsetController;
+
   const ScrollablePositionedListScrollbar({
     super.key,
     required this.scrollController,
@@ -26,6 +31,7 @@ class ScrollablePositionedListScrollbar extends StatefulWidget {
     required this.itemCount,
     required this.child,
     this.labelForIndex,
+    this.offsetController,
   });
 
   @override
@@ -49,13 +55,18 @@ class _ScrollablePositionedListScrollbarState
   // הגיעה לסוף הספר.
   double _maxScrollableIndex = 1;
 
+  // גובה ה-viewport בפיקסלים (= גובה המסילה) — להמרת חלק-פריט לגלילה בפועל.
+  double _viewportHeight = 0;
+
   // להחלקת הקפיצות במיקום
-  int _lastFirstIndex = 0;
+  double _lastJumpTarget = 0.0;
 
   // jumpTo בונה מחדש את החלון הנראה, ולכן קפיצות הגרירה מווסתות.
   static const Duration _dragJumpInterval = Duration(milliseconds: 50);
+  // animateTo טוען ש-duration חייב להיות חיובי, ולכן לא Duration.zero.
+  static const Duration _withinItemJump = Duration(milliseconds: 1);
   final Stopwatch _sinceLastDragJump = Stopwatch();
-  int? _pendingDragTarget;
+  double? _pendingDragTarget;
 
   // גובהי הפריטים שנמדדו (אינדקס → גובה ביחידות מסך). ממוצע גלובלי עליהם נותן
   // אומדן תוכן יציב, במקום ממוצע מקומי מתנודד על הגלויים כרגע.
@@ -150,7 +161,7 @@ class _ScrollablePositionedListScrollbarState
       0.0,
       1.0 - _thumbHeight,
     );
-    return _indexFromThumbPosition(thumbPos);
+    return _targetFromThumbPosition(thumbPos).round();
   }
 
   void _updateScrollPosition() {
@@ -180,11 +191,11 @@ class _ScrollablePositionedListScrollbarState
       }
     }
 
-    // בזמן גרירה, _lastFirstIndex מנוהל בתוך _onDragUpdate על פי היעד שאליו
+    // בזמן גרירה, _lastJumpTarget מנוהל בתוך _onDragUpdate על פי היעד שאליו
     // קפצנו. אסור לדרוס אותו פה לפי הפוזיציה הנוכחית של הרשימה אחרת קפיצות
     // הביניים יפסיקו כי "השינוי קטן מדי".
     if (!_isDragging) {
-      _lastFirstIndex = minIndex;
+      _lastJumpTarget = minIndex.toDouble();
     }
 
     // גובה פריט קבוע תחת גלילה; אם פריט שכבר נמדד מופיע בגובה שונה, ה-layout
@@ -239,15 +250,18 @@ class _ScrollablePositionedListScrollbarState
     final fractionalVisible = localItemHeight > 0
         ? 1.0 / localItemHeight
         : visibleItems.toDouble();
-    final maxScrollableIndex = max(widget.itemCount - fractionalVisible, 1.0);
+    // בלי רצפה של פריט שלם: כשפריט בודד גבוה מהמסך (מפרש ארוך) הטווח הנגלל
+    // קטן מ-1, וכל הגרירה מתרחשת בתוך אותו פריט.
+    final maxScrollableIndex = max(widget.itemCount - fractionalVisible, 0.0);
     // הכפלה ב-(1 - newHeight) שומרת עקביות עם המיפוי ההפוך
-    // ב-_indexFromThumbPosition (שמחלק ב-(1 - _thumbHeight)); בלעדיה האגודל
+    // ב-_targetFromThumbPosition (שמחלק ב-(1 - _thumbHeight)); בלעדיה האגודל
     // "ירד" אחרי קפיצה ליעד, בעוצמה שגדלה ככל שמתקדמים בספר.
-    final newPosition =
-        ((continuousIndex / maxScrollableIndex) * (1.0 - newHeight)).clamp(
-          0.0,
-          1.0 - newHeight,
-        );
+    final newPosition = maxScrollableIndex > 0
+        ? ((continuousIndex / maxScrollableIndex) * (1.0 - newHeight)).clamp(
+            0.0,
+            1.0 - newHeight,
+          )
+        : 0.0;
 
     // כל התוכן נראה אם הפריט הראשון מתחיל בתוך המסך, האחרון מסתיים בתוכו,
     // וכל הפריטים בטווח הזה מיוצגים — במצב כזה אין מה לגלול ואין טעם
@@ -273,16 +287,21 @@ class _ScrollablePositionedListScrollbarState
     });
   }
 
-  // הופך את מיקום האגודל (0.0–(1.0 - _thumbHeight)) לאינדקס יעד בטווח
-  // [0, _maxScrollableIndex]. שימוש ב-_maxScrollableIndex ולא ב-itemCount
-  // מבטיח שגרירה לתחתית באמת מגיעה לסוף הספר גם כש-_thumbHeight מקובל
-  // למינימום (לדוגמה כשמפרש פתוח מתחת ומעט סגמנטים גלויים).
-  int _indexFromThumbPosition(double position) {
+  // הופך את מיקום האגודל (0.0–(1.0 - _thumbHeight)) ליעד רציף בטווח
+  // [0, _maxScrollableIndex] — אינדקס פריט ועוד החלק שנגלל בתוכו. שימוש
+  // ב-_maxScrollableIndex ולא ב-itemCount מבטיח שגרירה לתחתית באמת מגיעה
+  // לסוף הספר גם כש-_thumbHeight מקובל למינימום.
+  double _targetFromThumbPosition(double position) {
     final maxPosition = 1.0 - _thumbHeight;
     if (maxPosition <= 0) return 0;
     final ratio = (position / maxPosition).clamp(0.0, 1.0);
-    return (ratio * _maxScrollableIndex).round();
+    return ratio * _maxScrollableIndex;
   }
+
+  /// גובה פריט ביחידות viewport — המדוד שלו, ואחרת הממוצע הגלובלי.
+  double _itemHeight(int index) =>
+      _itemHeights[index] ??
+      (_itemHeights.isNotEmpty ? _itemHeightSum / _itemHeights.length : 0.0);
 
   /// בודק אם נקודה אנכית על המסילה נמצאת מחוץ לאגודל. רק נקודה כזו מצדיקה
   /// קפיצה מוחלטת; לחיצה/גרירה שמתחילה על האגודל עצמו נועדה לגרירה יחסית
@@ -311,21 +330,43 @@ class _ScrollablePositionedListScrollbarState
     setState(() {
       _thumbPosition = newThumbPos;
     });
-    final int targetIndex = _indexFromThumbPosition(_thumbPosition);
-    _jumpDuringDrag(targetIndex);
+    final double target = _targetFromThumbPosition(_thumbPosition);
+    _jumpDuringDrag(target);
     if (globalPosition != null) {
-      _showLabelForIndex(targetIndex, globalPosition);
+      _showLabelForIndex(target.round(), globalPosition);
     }
   }
 
-  /// מבצע קפיצה ומאפס את שעון הוויסות.
-  void _jumpDuringDrag(int targetIndex) {
+  /// מבצע קפיצה ומאפס את שעון הוויסות. [target] רציף: החלק השלם הוא הפריט
+  /// שאליו קופצים, והשארית נגללת בתוכו — בלעדיה פריט הגבוה מהמסך אינו נגלל
+  /// כלל דרך הסרגל (חלונית המפרשים).
+  void _jumpDuringDrag(double target) {
     _pendingDragTarget = null;
-    _lastFirstIndex = targetIndex;
+    _lastJumpTarget = target;
     _sinceLastDragJump
       ..reset()
       ..start();
-    widget.scrollController.jumpTo(index: targetIndex);
+
+    final int maxIndex = max(widget.itemCount - 1, 0);
+    final offsetController = widget.offsetController;
+    if (offsetController == null) {
+      widget.scrollController.jumpTo(index: target.round().clamp(0, maxIndex));
+      return;
+    }
+
+    final int index = target.floor().clamp(0, maxIndex);
+    widget.scrollController.jumpTo(index: index);
+    final double withinItem =
+        (target - index) * _itemHeight(index) * _viewportHeight;
+    if (withinItem <= 0) return;
+    // ה-jumpTo מזמין פריסה מחדש; גלילה בתוך הפריט לפניה נמדדת מול המיקום הישן.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !widget.scrollController.isAttached) return;
+      offsetController.animateScroll(
+        offset: withinItem,
+        duration: _withinItemJump,
+      );
+    });
   }
 
   void _onDragUpdate(
@@ -339,23 +380,23 @@ class _ScrollablePositionedListScrollbarState
       _thumbPosition = _thumbPosition.clamp(0.0, 1.0 - _thumbHeight);
     });
 
-    final int targetIndex = _indexFromThumbPosition(_thumbPosition);
+    final double target = _targetFromThumbPosition(_thumbPosition);
 
-    if (targetIndex != _lastFirstIndex) {
+    if (target != _lastJumpTarget) {
       // התזוזה הראשונה קופצת מיד; אחריה מוותרים על קפיצות הביניים ושומרים את
       // היעד האחרון, כדי שהשחרור ינחת בדיוק במקום שאליו כוונה הגרירה.
       if (!_sinceLastDragJump.isRunning ||
           _sinceLastDragJump.elapsed >= _dragJumpInterval) {
-        _jumpDuringDrag(targetIndex);
+        _jumpDuringDrag(target);
       } else {
-        _pendingDragTarget = targetIndex;
+        _pendingDragTarget = target;
       }
     } else {
       _pendingDragTarget = null;
     }
 
     if (globalPosition != null) {
-      _showLabelForIndex(targetIndex, globalPosition);
+      _showLabelForIndex(target.round(), globalPosition);
     }
   }
 
@@ -391,6 +432,8 @@ class _ScrollablePositionedListScrollbarState
             child: LayoutBuilder(
               builder: (context, constraints) {
                 final trackHeight = constraints.maxHeight;
+                // המסילה והרשימה חולקות שורה, ולכן זהו גם גובה ה-viewport.
+                _viewportHeight = trackHeight;
                 final thumbPixelHeight = trackHeight * _thumbHeight;
                 final thumbPixelTop = trackHeight * _thumbPosition;
                 final colorScheme = Theme.of(context).colorScheme;

--- a/lib/widgets/layout/adaptive_side_pane.dart
+++ b/lib/widgets/layout/adaptive_side_pane.dart
@@ -243,6 +243,7 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
     return ResizableDragHandle(
       isVertical: true,
       showDivider: false,
+      gripOffset: paneHandleGripOffset(context, paneOnRight: paneOnRight),
       onDragStart: () => _onDragStart(currentlyWide),
       onDragDelta: (delta) => _onDragDelta(delta, paneOnRight),
       onDragEnd: _onDragEnd,
@@ -314,15 +315,17 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
         widget.isResizable &&
         widget.onPaneWidthChanged != null;
 
-    final overhang = showHandle ? handleHitOverhang(context) : 0.0;
+    // כאן ה-Positioned נמדד מהקצה שמעבר לדופן הפנימית של הפאנל (בשונה מהפריסה
+    // הצרה), ולכן המרחק הוא הגלישה החוצה ולא הכניסה פנימה.
+    final outreach = showHandle ? handleHitOutreach(context) : 0.0;
 
     // ה-handle לא תלוי ברוחב — מוגדר מחוץ ל-ValueListenableBuilder
     final handleWidget = showHandle
         ? Positioned(
             top: _kWideTopGap,
             bottom: _kWideBottomGap,
-            left: paneOnRight ? _kWideOuterSideGap - overhang : null,
-            right: paneOnRight ? null : _kWideOuterSideGap - overhang,
+            left: paneOnRight ? _kWideOuterSideGap - outreach : null,
+            right: paneOnRight ? null : _kWideOuterSideGap - outreach,
             child: _buildResizeHandle(paneOnRight, true),
           )
         : null;
@@ -460,9 +463,7 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
                   final currentWidth = liveWidth > maxPaneWidth
                       ? maxPaneWidth
                       : liveWidth;
-                  final overhang = showHandle
-                      ? handleHitOverhang(context)
-                      : 0.0;
+                  final overhang = showHandle ? kPaneHandleInnerReach : 0.0;
 
                   return Stack(
                     children: [

--- a/lib/widgets/layout/context_overlay_panel.dart
+++ b/lib/widgets/layout/context_overlay_panel.dart
@@ -278,7 +278,7 @@ class _ContextOverlayPanelState extends State<ContextOverlayPanel> {
     // centerEnd = שמאל פיזי ב-RTL, centerStart = ימין פיזי
     final isLeft = widget.alignment == AlignmentDirectional.centerEnd;
     final showHandle = widget.isOpen;
-    final overhang = showHandle ? handleHitOverhang(context) : 0.0;
+    final overhang = showHandle ? kPaneHandleInnerReach : 0.0;
     // בחלון צר מצמצמים את הרוחב כדי להשאיר שוליים משני הצדדים
     const sideMargin = 10.0;
     final maxPanelWidth = (constraints.maxWidth - sideMargin * 2).clamp(
@@ -363,6 +363,7 @@ class _ContextOverlayPanelState extends State<ContextOverlayPanel> {
               child: ResizableDragHandle(
                 isVertical: true,
                 showDivider: false,
+                gripOffset: paneHandleGripOffset(context, paneOnRight: !isLeft),
                 onDragDelta: (delta) {
                   final d = isLeft ? delta : -delta;
                   setState(() {

--- a/lib/widgets/layout/resizable_drag_handle.dart
+++ b/lib/widgets/layout/resizable_drag_handle.dart
@@ -5,15 +5,30 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 
-/// מחזיר את החצי של hitSize שגולש מחוץ לפאנל (overhang).
-/// 12px במצב רחב, 9px במצב קומפקט.
-double handleHitOverhang(BuildContext context) {
+/// כמה משטח המגע של הידית נכנס פנימה לתוך הפאנל. בקצה הפנימי יושב גם פס
+/// הגלילה, והידית מצוירת מעליו ב-Stack — כניסה גדולה קוברת אותו. 4px היה
+/// הערך בפועל עד שהגדלת שטח המגע מיקמה חצי ממנו בתוך הפאנל; היתרה גולשת
+/// החוצה, אל הרווח שבין הפאנל לתוכן.
+const double kPaneHandleInnerReach = 4;
+
+/// שטח המגע המלא של הידית: 24px רגיל, 18px במצב קומפקטי.
+double handleHitSize(BuildContext context) {
   final isCompact =
       context.read<SettingsBloc?>()?.state.compactMenuMode ?? false;
-  final hitSize = isCompact
+  return isCompact
       ? AppTokens.dragHandleCompactHitSize
       : AppTokens.dragHandleRegularHitSize;
-  return hitSize / 2;
+}
+
+/// היתרה שגולשת החוצה מהפאנל, אל הרווח שבינו לתוכן.
+double handleHitOutreach(BuildContext context) =>
+    handleHitSize(context) - kPaneHandleInnerReach;
+
+/// בכמה להזיז את הקו הנראה כדי שיישב על דופן הפאנל: שטח המגע אינו ממורכז
+/// עליה אלא גולש החוצה, ובלי ההזזה הקו מרחף מנותק ממנה.
+double paneHandleGripOffset(BuildContext context, {required bool paneOnRight}) {
+  final shift = handleHitSize(context) / 2 - kPaneHandleInnerReach;
+  return paneOnRight ? shift : -shift;
 }
 
 class ResizableDragHandle extends StatefulWidget {
@@ -26,6 +41,7 @@ class ResizableDragHandle extends StatefulWidget {
     this.onDragStart,
     this.onDragEnd,
     this.showDivider = true,
+    this.gripOffset = 0,
   });
 
   /// True for a vertical handle (between left/right panes), false for horizontal.
@@ -46,6 +62,9 @@ class ResizableDragHandle extends StatefulWidget {
 
   /// Whether to show the divider line in idle state. If false, the line only appears on hover/drag.
   final bool showDivider;
+
+  /// הזזת הקו הנראה בפיקסלים לאורך ציר השינוי. ראה [paneHandleGripOffset].
+  final double gripOffset;
 
   @override
   State<ResizableDragHandle> createState() => _ResizableDragHandleState();
@@ -154,7 +173,7 @@ class _ResizableDragHandleState extends State<ResizableDragHandle> {
                             ? constraints.maxWidth
                             : gripLength);
 
-                  return Stack(
+                  final grip = Stack(
                     alignment: Alignment.center,
                     children: [
                       if (widget.showDivider)
@@ -196,6 +215,16 @@ class _ResizableDragHandleState extends State<ResizableDragHandle> {
                         ),
                       ),
                     ],
+                  );
+
+                  if (widget.gripOffset == 0) return grip;
+                  // שטח המגע גולש החוצה ואינו ממורכז על דופן הפאנל; ההזזה
+                  // מחזירה את הקו הנראה אל הדופן עצמה.
+                  return Transform.translate(
+                    offset: widget.isVertical
+                        ? Offset(widget.gripOffset, 0)
+                        : Offset(0, widget.gripOffset),
+                    child: grip,
                   );
                 },
               ),

--- a/test/widgets/adaptive_side_pane_test.dart
+++ b/test/widgets/adaptive_side_pane_test.dart
@@ -339,9 +339,10 @@ void main() {
       ),
     );
 
-    // handle ממוקם בקצה הפנימי של הפאנל, שמוזז _kNarrowSideGap (10) מהדופן
-    // → right = 10 + 300 - 12 = 298 → dx = 500 - 298 = 202
-    expect(tester.getTopRight(find.byType(ResizableDragHandle)).dx, 202.0);
+    // handle ממוקם בקצה הפנימי של הפאנל, שמוזז _kNarrowSideGap (10) מהדופן,
+    // וחודר פנימה רק kPaneHandleInnerReach (4) כדי לא לכסות את פס הגלילה
+    // → right = 10 + 300 - 4 = 306 → dx = 500 - 306 = 194
+    expect(tester.getTopRight(find.byType(ResizableDragHandle)).dx, 194.0);
   });
 
   // אזורי רגרסיה לאופטימיזציה של commit 4996fff (דחיית בנייה ראשונה של הפאנל)

--- a/test/widgets/resizable_drag_handle_test.dart
+++ b/test/widgets/resizable_drag_handle_test.dart
@@ -1,7 +1,8 @@
 // בדיקת רגרסיה לבאג מפורום https://otzaria.org/forum/topic/1488:
 // פס גלילה בהגדרות/TOC לא הגיב ללחיצה כי ידית הגרירה (ResizableDragHandle)
-// חפפה אותו. תוקן בקומיט c8950aa81 ע"י צמצום שטח הלחיצה של הידית
-// (48/36 -> 24/18), שממנו נגזר ה-overhang החודר לתוך הפאנל.
+// חפפה אותו. הצמצום ב-c8950aa81 (48/36 -> 24/18) רק חצה את החדירה פנימה,
+// ובחלונית המפרשים היא עדיין כיסתה את המסילה במלואה. כעת החדירה מנותקת
+// משטח המגע וקבועה ב-kPaneHandleInnerReach.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -47,44 +48,56 @@ void main() {
     expect(AppTokens.dragHandleCompactHitSize, lessThan(36));
   });
 
-  testWidgets(
-    'handleHitOverhang במצב רגיל שווה למחצית dragHandleRegularHitSize',
-    (tester) async {
-      late double overhang;
-      await tester.pumpWidget(
-        _wrap(
-          Builder(
-            builder: (context) {
-              overhang = handleHitOverhang(context);
-              return const SizedBox();
-            },
-          ),
+  test('החדירה לתוך הפאנל משאירה את אגודל פס הגלילה תפיס', () {
+    // המסילה 12px והאגודל מרוּוח 2px מכל צד, כלומר תופס [2, 10] מהקצה.
+    // חדירה של 6px ומעלה בולעת את מרכזו — שם המשתמש מכוון.
+    expect(kPaneHandleInnerReach, lessThan(6));
+  });
+
+  testWidgets('הכניסה פנימה והגלישה החוצה מרכיבות יחד את שטח המגע המלא', (
+    tester,
+  ) async {
+    late double outreach;
+    late double hitSize;
+    await tester.pumpWidget(
+      _wrap(
+        Builder(
+          builder: (context) {
+            outreach = handleHitOutreach(context);
+            hitSize = handleHitSize(context);
+            return const SizedBox();
+          },
         ),
-      );
+      ),
+    );
 
-      expect(overhang, AppTokens.dragHandleRegularHitSize / 2);
-    },
-  );
+    // החדירה קבועה ואינה נגזרת מ-hitSize; הגדלת שטח המגע מוסיפה רק החוצה.
+    expect(hitSize, AppTokens.dragHandleRegularHitSize);
+    expect(kPaneHandleInnerReach + outreach, hitSize);
+  });
 
-  testWidgets(
-    'handleHitOverhang במצב קומפקטי שווה למחצית dragHandleCompactHitSize',
-    (tester) async {
-      late double overhang;
-      await tester.pumpWidget(
-        _wrap(
-          Builder(
-            builder: (context) {
-              overhang = handleHitOverhang(context);
-              return const SizedBox();
-            },
-          ),
-          compactMenuMode: true,
+  testWidgets('הקו הנראה מוזז אל דופן הפאנל ולא נשאר במרכז שטח המגע', (
+    tester,
+  ) async {
+    late double offsetLeftPane;
+    late double offsetRightPane;
+    await tester.pumpWidget(
+      _wrap(
+        Builder(
+          builder: (context) {
+            offsetLeftPane = paneHandleGripOffset(context, paneOnRight: false);
+            offsetRightPane = paneHandleGripOffset(context, paneOnRight: true);
+            return const SizedBox();
+          },
         ),
-      );
+      ),
+    );
 
-      expect(overhang, AppTokens.dragHandleCompactHitSize / 2);
-    },
-  );
+    final expected =
+        AppTokens.dragHandleRegularHitSize / 2 - kPaneHandleInnerReach;
+    expect(offsetLeftPane, -expected);
+    expect(offsetRightPane, expected);
+  });
 
   testWidgets(
     'שטח הלחיצה בפועל של ResizableDragHandle תואם לטוקן dragHandleRegularHitSize',

--- a/test/widgets/scrollable_positioned_list_scrollbar_test.dart
+++ b/test/widgets/scrollable_positioned_list_scrollbar_test.dart
@@ -1119,6 +1119,90 @@ void main() {
     });
   });
 
+  group('פריט גבוה מהמסך (חלונית המפרשים)', () {
+    /// רשימה של [itemCount] פריטים בגובה 4000px בתוך מסך 600px, עם סרגל
+    /// שמקבל offsetController — בדיוק צורת חלונית המפרשים (פריט = מפרש שלם).
+    Future<ItemPositionsListener> dragThumbToBottom(
+      WidgetTester tester, {
+      required int itemCount,
+    }) async {
+      tester.view.physicalSize = const Size(400, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final listener = ItemPositionsListener.create();
+      final controller = ItemScrollController();
+      final offsetController = ScrollOffsetController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScrollablePositionedListScrollbar(
+              scrollController: controller,
+              offsetController: offsetController,
+              itemPositionsListener: listener,
+              itemCount: itemCount,
+              child: ScrollablePositionedList.builder(
+                itemScrollController: controller,
+                itemPositionsListener: listener,
+                scrollOffsetController: offsetController,
+                itemCount: itemCount,
+                itemBuilder: (context, i) =>
+                    SizedBox(height: 4000, child: Text('פריט $i')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final thumb = find.descendant(
+        of: find.byType(ScrollablePositionedListScrollbar),
+        matching: find.byWidgetPredicate(
+          (w) => w is Container && w.decoration is BoxDecoration,
+        ),
+      );
+      final gesture = await tester.startGesture(tester.getRect(thumb).center);
+      await tester.pump();
+      for (var i = 0; i < 20; i++) {
+        await gesture.moveBy(const Offset(0, 30));
+        await tester.pump(const Duration(milliseconds: 60));
+      }
+      await gesture.up();
+      await tester.pumpAndSettle();
+      return listener;
+    }
+
+    /// הקצה העליון של הפריט הראשון הגלוי, ביחידות viewport.
+    ItemPosition firstVisible(ItemPositionsListener listener) =>
+        listener.itemPositions.value.reduce(
+          (a, b) => a.index <= b.index ? a : b,
+        );
+
+    testWidgets('מפרש בודד ארוך — גרירת האגודל גוללת עד סוף התוכן', (
+      tester,
+    ) async {
+      // רגרסיה: הסרגל קפץ לאינדקס פריט שלם בלבד. עם מפרש אחד היעד היחיד היה
+      // 0, ולכן גרירת האגודל לא הזיזה כלום והוא חזר לראש המסילה.
+      final listener = await dragThumbToBottom(tester, itemCount: 1);
+
+      // 4000px תוכן במסך 600px → גלילה מרבית 3400px = 5.667 viewports.
+      expect(firstVisible(listener).index, 0);
+      expect(firstVisible(listener).itemLeadingEdge, closeTo(-5.667, 0.1));
+    });
+
+    testWidgets('כמה מפרשים ארוכים — הגרירה מגיעה לסוף האחרון, לא לתחילתו', (
+      tester,
+    ) async {
+      // רגרסיה: קפיצה לאינדקס נחתה בתחילת הפריט האחרון, ו-3400px האחרונים
+      // (28% מהתוכן) היו בלתי-נגישים דרך הסרגל.
+      final listener = await dragThumbToBottom(tester, itemCount: 3);
+
+      expect(firstVisible(listener).index, 2);
+      expect(firstVisible(listener).itemLeadingEdge, closeTo(-5.667, 0.1));
+    });
+  });
+
   testWidgets('האגודל אינו זז אחרי שהתוכן נוחת ביעד הגרירה', (tester) async {
     // רגרסיה: מיפוי המיקום והמיפוי ההפוך חייבים לחלוק מכנה. כשהופרדו, שחרור
     // הגרירה נחת עד 4.3% מהמסילה מתחת למקום שהמשתמש עזב — האגודל "ברח"

--- a/test/widgets/scrollable_positioned_list_scrollbar_test.dart
+++ b/test/widgets/scrollable_positioned_list_scrollbar_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
+import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
+import 'package:otzaria/widgets/layout/resizable_drag_handle.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class _RecordingItemScrollController extends ItemScrollController {
@@ -999,6 +1002,121 @@ void main() {
       closeTo(tester.getRect(track).bottom, 1.0),
       reason: 'בסוף הרשימה האגודל חייב להיות צמוד לתחתית המסילה',
     );
+  });
+
+  group('בתוך פאנל צד — המסילה לא מתחת לידית שינוי הגודל', () {
+    /// פאנל צד פתוח וניתן לשינוי גודל (כמו חלונית המפרשים), עם רשימה גלילה
+    /// שיש לה [ScrollablePositionedListScrollbar].
+    Future<void> pumpPane(
+      WidgetTester tester, {
+      required AlignmentDirectional alignment,
+    }) async {
+      tester.view.physicalSize = const Size(500, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final listener = ItemPositionsListener.create();
+      final controller = ItemScrollController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('he', 'IL'),
+          localizationsDelegates: GlobalMaterialLocalizations.delegates,
+          supportedLocales: const [Locale('he', 'IL')],
+          home: Scaffold(
+            body: AdaptiveSidePane(
+              isOpen: true,
+              alignment: alignment,
+              isResizable: true,
+              onPaneWidthChanged: (_) {},
+              onClose: () {},
+              mainContent: const SizedBox.expand(),
+              paneContent: ScrollablePositionedListScrollbar(
+                scrollController: controller,
+                itemPositionsListener: listener,
+                itemCount: 100,
+                child: ScrollablePositionedList.builder(
+                  itemScrollController: controller,
+                  itemPositionsListener: listener,
+                  itemCount: 100,
+                  itemBuilder: (context, i) =>
+                      SizedBox(height: 80, child: Text('שורה $i')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    void expectThumbGrabbable(WidgetTester tester) {
+      final scrollbar = find.byType(ScrollablePositionedListScrollbar);
+      final thumb = find.descendant(
+        of: scrollbar,
+        matching: find.byWidgetPredicate(
+          (w) => w is Container && w.decoration is BoxDecoration,
+        ),
+      );
+      expect(thumb, findsOneWidget, reason: 'האגודל חייב להיות מוצג');
+      final handle = find.byType(ResizableDragHandle);
+      expect(handle, findsOneWidget, reason: 'ידית שינוי הגודל חייבת להיות שם');
+
+      final thumbRect = tester.getRect(thumb);
+      final handleRect = tester.getRect(handle);
+      // המשתמש מכוון למרכז האגודל; אם גם הוא בשטח המגע של הידית, הסמן הופך
+      // לחץ שינוי גודל והגרירה משנה את רוחב החלונית במקום לגלול.
+      expect(
+        handleRect.contains(thumbRect.center),
+        isFalse,
+        reason:
+            'שטח המגע של הידית ($handleRect) בולע את מרכז האגודל ($thumbRect)',
+      );
+
+      // המסילה נשארת בכיוון הקריאה, כמו כל שאר מחווני הגלילה בעברית.
+      expect(
+        thumbRect.center.dx,
+        greaterThan(tester.getRect(scrollbar).center.dx),
+        reason: 'המסילה עברה לשמאל — כיוון הפוך לשאר המחוונים באפליקציה',
+      );
+    }
+
+    /// הקו הנראה של הידית חייב לשבת על דופן הפאנל. שטח המגע גולש החוצה ואינו
+    /// ממורכז עליה, ולכן בלי הזזה מפורשת הקו מרחף לידה ונראה מנותק.
+    void expectGripOnPaneEdge(
+      WidgetTester tester, {
+      required bool paneOnRight,
+    }) {
+      final paneRect = tester.getRect(
+        find.byType(ScrollablePositionedListScrollbar),
+      );
+      final paneEdge = paneOnRight ? paneRect.left : paneRect.right;
+      final grip = tester.getRect(
+        find.descendant(
+          of: find.byType(ResizableDragHandle),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(
+        grip.center.dx,
+        closeTo(paneEdge, 0.5),
+        reason: 'הקו הנראה של הידית מרחף במרחק מדופן הפאנל ($paneEdge)',
+      );
+    }
+
+    testWidgets('פאנל בצד שמאל (חלונית המפרשים)', (tester) async {
+      // רגרסיה: הגדלת שטח המגע של הידית (8px→24px, cc5ee27ae) הכפילה את
+      // כניסתה לתוך הפאנל מ-4px ל-12px — בדיוק רוחב מסילת הגלילה שיושבת שם.
+      await pumpPane(tester, alignment: AlignmentDirectional.centerStart);
+      expectThumbGrabbable(tester);
+      expectGripOnPaneEdge(tester, paneOnRight: false);
+    });
+
+    testWidgets('פאנל בצד ימין', (tester) async {
+      await pumpPane(tester, alignment: AlignmentDirectional.centerEnd);
+      expectThumbGrabbable(tester);
+      expectGripOnPaneEdge(tester, paneOnRight: true);
+    });
   });
 
   testWidgets('האגודל אינו זז אחרי שהתוכן נוחת ביעד הגרירה', (tester) async {


### PR DESCRIPTION
## התקלה

בחלונית המפרשים אי אפשר לתפוס את מחוון הגלילה ולגרור אותו. בהתקרבות אליו הסמן הופך לחץ שינוי גודל, והגרירה משנה את רוחב החלונית במקום לגלול.

## הסיבה

שטח המגע של `ResizableDragHandle` ממורכז על דופן הפאנל, כלומר חציו נכנס פנימה — בדיוק על מסילת הגלילה (12px). הידית מצוירת מעל הפאנל ב-`Stack` ולכן גוברת עליו ב-hit-test.

השרשרת:

| קומיט | מה השתנה | חדירה לתוך הפאנל |
|---|---|---|
| (מקור) | `hitSize = 8` | **4px** — המסילה עבדה |
| `cc5ee27ae` | "וו גרירה: הגדלת שטח לחיצה": 8 → 48/36 | **24px** |
| `c8950aa81` | תיקון לפורום 1488 (פס גלילה בהגדרות/TOC): צמצום ל-24/18 | **12px** = רוחב המסילה |

הבאג הזה כבר תוקן פעם אחת חלקית. התיקון ההוא נגע ב-`hitSize` במקום בקשר `overhang = hitSize / 2`, ולכן החדירה נחתה על 12px — בהגדרות/TOC זה הספיק כי שם פס Material שממילא מועבר לדופן החיצונית, בחלונית המפרשים לא.

## התיקון

`kPaneHandleInnerReach = 4` קבוע ומנותק מ-`hitSize` — הערך שהיה לפני הרגרסיה. שטח המגע נשאר 24px אך גולש החוצה בלבד, כך שהגדלה עתידית שלו לא תוכל להחזיר את הבאג. `gripOffset` מחזיר את הקו הנראה אל הדופן, שאחרת היה מרחף מנותק ממנה.

הפריסה הרחבה מדדה את ה-`Positioned` מהקצה הנגדי ולכן שם הועבר לגלישה החוצה, כדי ששתי הפריסות יתנהגו זהה.

**מדידות (חלונית ברוחב ברירת מחדל, דופן ב-350):**

| | לפני | אחרי |
|---|---|---|
| שטח מגע של הידית | `338 → 362` | `346 → 370` |
| אגודל | `340 → 348` (כולו מתחת לידית) | `340 → 348` (חופשי) |
| קו נראה (מרכז) | 350 | 350 |

האגודל לא זז ממקומו והקו נשאר על הדופן — התיקון לא משנה את המראה.

## קומיט שני (נפרד וניתן להסרה)

`653c5ddf5` מתקן באג אחר שהתגלה תוך כדי: הסרגל מיפה את מיקום האגודל לאינדקס פריט שלם. בחלונית המפרשים פריט = מפרש שלם, ולכן כשמפרש בודד גבוה מהמסך היעד היחיד היה 0 והגרירה לא הזיזה כלום; עם כמה מפרשים ארוכים היא נחתה בתחילת האחרון והשארית נותרה בלתי-נגישה. היעד הפך רציף, והשארית נגללת דרך ה-`ScrollOffsetController` שכבר היה מחובר לרשימה. בלי `offsetController` ההתנהגות זהה לקודם, ולכן שאר הסרגלים לא הושפעו.

זהו באג נפרד מזה שדווח — אם עדיף בשינוי משלו, אפשר להסיר את הקומיט הזה בלבד.

## בדיקות

- `flutter analyze lib test` — נקי.
- שלוש בדיקות קיימות עודכנו: הן קיבעו את החוזה השבור `overhang == hitSize/2`. במקומן — החדירה קטנה מהסף שמעליו מרכז האגודל נבלע, כניסה + גלישה = שטח המגע, והקו יושב על הדופן.
- בדיקות רגרסיה חדשות ל-2 הבאגים, שנכשלות על הקוד הישן.
- 123 בדיקות בכל 11 הקבצים שנוגעים ב-`AdaptiveSidePane`/`ContextOverlayPanel`/`ResizableDragHandle`; 892 ב-`test/widgets/` + `test/settings/` + `test/library/view/`; `test/text_book/view/` + `test/pdf_book/` + `test/tools/calendar/` עוברות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
