### PR TITLE
תיקון: מפרשים מעטים הוצגו ממורכזים לגובה במקום בראש החלונית

### DIFF
--- a/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
+++ b/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
@@ -425,6 +425,9 @@ class _ScrollablePositionedListScrollbarState
   @override
   Widget build(BuildContext context) {
     return Row(
+      // המסילה תופסת את מלוא הגובה; תוכן נמוך ממנה (מפרשים מכווצים) היה
+      // מתמרכז אנכית תחת ברירת המחדל center.
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (widget.itemCount > 0 && _canScroll)
           SizedBox(

--- a/test/widgets/scrollable_positioned_list_scrollbar_test.dart
+++ b/test/widgets/scrollable_positioned_list_scrollbar_test.dart
@@ -75,6 +75,42 @@ void main() {
     expect(tester.getTopLeft(find.byKey(contentKey)).dx, 0.0);
   });
 
+  testWidgets('תוכן נמוך מהמסילה נשאר בראש ולא מתמרכז לגובה', (tester) async {
+    final listener = ItemPositionsListener.create();
+    final controller = ItemScrollController();
+    const contentKey = Key('scroll-content');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              height: 600,
+              width: 400,
+              child: ScrollablePositionedListScrollbar(
+                scrollController: controller,
+                itemPositionsListener: listener,
+                itemCount: 10,
+                child: const SizedBox(key: contentKey, height: 100),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // המסילה מוצגת (יש מה לגלול) אך התוכן נמוך ממנה — מפרשים מכווצים.
+    (listener.itemPositions as ValueNotifier<Iterable<ItemPosition>>).value =
+        const [
+          ItemPosition(index: 0, itemLeadingEdge: 0, itemTrailingEdge: 0.5),
+          ItemPosition(index: 1, itemLeadingEdge: 0.5, itemTrailingEdge: 1.0),
+        ];
+    await tester.pump();
+
+    expect(tester.getTopLeft(find.byKey(contentKey)).dy, 0.0);
+  });
+
   testWidgets('הקלקה על תחתית המסילה מגיעה לסוף הספר גם כשמעט פריטים גלויים '
       '(מפרש פתוח מתחת)', (tester) async {
     // רגרסיה: כשמפרש פתוח מתחת ושני סגמנטים גלויים מתוך 100, חישוב היעד


### PR DESCRIPTION
## הבעיה

כשיש מעט מפרשים והם לא ממלאים את גובה החלונית, הם מוצגים "ממורכזים" לגובה — רווח גדול מעליהם ומתחתיהם. קורה גם אחרי כיווץ כל המפרשים.

## שורש הבעיה

`ScrollablePositionedListScrollbar` בונה `Row` של שני ילדים: מסילת הגלילה והרשימה ב-`Expanded`. הציר הרוחבי של `Row` הוא **האנכי**, וברירת המחדל שלו היא `CrossAxisAlignment.center`:

- המסילה בנויה מ-`Stack(fit: StackFit.expand)` ולכן תמיד תופסת את מלוא גובה החלונית.
- הרשימה נבנית עם `shrinkWrap: true`, ולכן כשהמפרשים קצרים או מכווצים היא מתכווצת לגובה התוכן.
- `Expanded` שולט רק בציר הראשי (האופקי); בציר האנכי הרשימה הנמוכה קיבלה אילוצים רופפים ומורכזה מול המסילה הגבוהה.

לכן זה מופיע רק כשהמסילה מוצגת **וגם** התוכן נמוך ממנה — כשהתוכן ארוך הרשימה ממלאת את הגובה ואין מה למרכז.

## התיקון

`crossAxisAlignment: CrossAxisAlignment.start` על ה-`Row`. שורה אחת במקום המשותף, ולכן חלה על כל התצוגות בבת אחת: חלונית המפרשים בצד, מפרשים מתחת לטקסט, כרטסיית המפרשים, צורת הדף, חלונית המפרשים ב-PDF ותצוגה מקדימה בהדפסה.

לא `stretch` — הוא היה כופה גובה מלא על הרשימה ושובר את קופסאות המפרשים ה-inline בתצוגה המשולבת, שמסתמכות על `shrinkWrap` כדי להיצמד לגובה התוכן.

## בדיקות

נוסף טסט רגרסיה ב-`test/widgets/scrollable_positioned_list_scrollbar_test.dart`: תוכן בגובה 100 בתוך חלונית 600 כשהמסילה מוצגת.

- לפני התיקון נכשל: `Expected: <0.0>, Actual: <250.0>` — בדיוק `(600-100)/2`.
- אחרי התיקון עובר, וכל 23 הטסטים בקובץ עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
