### PR TITLE
תיקון: הודעת שגיאה על כשל בעדכון קפצה בפתיחה גם כשאין אינטרנט

### DIFF
--- a/lib/core/internet_connectivity.dart
+++ b/lib/core/internet_connectivity.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// יעדים ניטרליים בכוונה ולא שרתי העדכון — אחרת תקלה ב-GitHub הייתה נראית
+/// כמו היעדר אינטרנט ואיש לא היה מדווח עליה. היעד הראשון הוא שם מתחם ולא
+/// כתובת IP גולמית: ברשתות מסוננות חיבור ישיר ל-IP ולפורט 53 חסום, ומשתמש
+/// מחובר לגמרי היה מסווג כמנותק.
+const _kProbeTargets = <(String, int)>[
+  ('www.google.com', 443),
+  ('1.1.1.1', 443),
+  ('8.8.8.8', 53),
+];
+
+const _kProbeTimeout = Duration(seconds: 3);
+
+/// דריסת החיבור בטסטים — מונעת גישת רשת אמיתית.
+@visibleForTesting
+Future<bool> Function(String host, int port, Duration timeout)?
+debugSocketConnect;
+
+/// האם קיים חיבור אינטרנט בפועל.
+///
+/// חיבור TCP ליעד קבוע ולא DNS lookup: מטמון ה-DNS של מערכת ההפעלה מחזיר
+/// תשובה מוצלחת גם בלי רשת, ואז "מנותק" נראה כמו "מחובר".
+/// הפונקציה נקראת ממסלולי כשל, ולכן לעולם אינה זורקת בעצמה.
+Future<bool> hasInternetConnection({
+  Duration timeout = _kProbeTimeout,
+}) async {
+  final connect = debugSocketConnect ?? _connect;
+  final results = await Future.wait([
+    for (final (host, port) in _kProbeTargets)
+      _isReachable(connect, host, port, timeout),
+  ]);
+  return results.any((reachable) => reachable);
+}
+
+Future<bool> _isReachable(
+  Future<bool> Function(String, int, Duration) connect,
+  String host,
+  int port,
+  Duration timeout,
+) async {
+  try {
+    // ה-timeout נאכף גם כאן: הקוראים ממתינים לתשובה בתוך מסלול כשל, ותקיעה
+    // כאן משאירה אותם תקועים במצב "בודק".
+    return await connect(host, port, timeout).timeout(timeout);
+  } catch (_) {
+    return false;
+  }
+}
+
+Future<bool> _connect(String host, int port, Duration timeout) async {
+  final socket = await Socket.connect(host, port, timeout: timeout);
+  socket.destroy();
+  return true;
+}

--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+﻿import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -57,6 +57,38 @@ const int _kLibraryTreeFlattenThreshold = 500;
 
 /// מכסת הספרים המוצגים לקטגוריה; מעבר לה מופיעה שורת "הצג עוד".
 const int _kCategoryBooksCap = 500;
+
+/// הסמל בכפתור עדכון הספרייה. מצב מנותק מקבל סמל משלו — כך המשתמש יודע
+/// שהעדכון לא רץ, בלי הודעת שגיאה קופצת שאין לו מה לעשות איתה.
+@visibleForTesting
+IconData libraryUpdateButtonIcon(LibraryUpdateStatus status) =>
+    switch (status) {
+      LibraryUpdateStatus.completed => FluentIcons.checkmark_circle_24_regular,
+      LibraryUpdateStatus.disconnected => FluentIcons.cloud_off_24_regular,
+      _ => FluentIcons.arrow_sync_24_regular,
+    };
+
+/// התיאור (tooltip) של כפתור עדכון הספרייה.
+@visibleForTesting
+String libraryUpdateButtonTooltip(LibraryUpdateState state) =>
+    switch (state.status) {
+      LibraryUpdateStatus.completed =>
+        state.hasUpdate ? 'העדכון הושלם' : 'הספרייה מעודכנת',
+      LibraryUpdateStatus.error => 'שגיאה בעדכון - לחץ לנסות שוב',
+      LibraryUpdateStatus.disconnected => 'אין חיבור לאינטרנט - לחץ לנסות שוב',
+      LibraryUpdateStatus.needsFullConfirmation => state.message,
+      LibraryUpdateStatus.blocked => state.message,
+      _ when state.isBusy => state.message,
+      _ => 'עדכון ספרייה',
+    };
+
+/// האם לחיצה על הכפתור מנקה את המצב הקודם במקום להתחיל עדכון. מצב מנותק
+/// מתחיל ניסיון חדש מיד — אין הודעה שצריך לנקות, ורק הרשת הייתה חסרה.
+@visibleForTesting
+bool libraryUpdateButtonResets(LibraryUpdateStatus status) =>
+    status == LibraryUpdateStatus.completed ||
+    status == LibraryUpdateStatus.error ||
+    status == LibraryUpdateStatus.blocked;
 
 enum FlatLibraryRowKind { categoryHeader, book, rootBook, showMore }
 
@@ -911,22 +943,10 @@ class _LibraryBrowserState extends State<LibraryBrowser>
       widget: BlocBuilder<LibraryUpdateBloc, LibraryUpdateState>(
         builder: (ctx, state) {
           final isBusy = state.isBusy;
-          final icon = state.status == LibraryUpdateStatus.completed
-              ? FluentIcons.checkmark_circle_24_regular
-              : FluentIcons.arrow_sync_24_regular;
-          final tooltip = switch (state.status) {
-            LibraryUpdateStatus.completed =>
-              state.hasUpdate ? 'העדכון הושלם' : 'הספרייה מעודכנת',
-            LibraryUpdateStatus.error => 'שגיאה בעדכון - לחץ לנסות שוב',
-            LibraryUpdateStatus.needsFullConfirmation => state.message,
-            LibraryUpdateStatus.blocked => state.message,
-            _ when isBusy => state.message,
-            _ => 'עדכון ספרייה',
-          };
           return BarButton.icon(
             compact: compact,
-            tooltip: tooltip,
-            icon: icon,
+            tooltip: libraryUpdateButtonTooltip(state),
+            icon: libraryUpdateButtonIcon(state.status),
             // ספינר מסתובב בזמן עדכון — אינדיקציית פעילות רציפה (ticker עצמאי),
             // כי בשלב ה-apply הארוך אין שינויי state שיבנו מחדש את הכפתור.
             iconWidget: isBusy
@@ -941,9 +961,7 @@ class _LibraryBrowserState extends State<LibraryBrowser>
               final b = ctx.read<LibraryUpdateBloc>();
               if (isBusy) {
                 b.add(const CancelLibraryUpdate());
-              } else if (state.status == LibraryUpdateStatus.completed ||
-                  state.status == LibraryUpdateStatus.error ||
-                  state.status == LibraryUpdateStatus.blocked) {
+              } else if (libraryUpdateButtonResets(state.status)) {
                 b.add(const ResetLibraryUpdate());
               } else {
                 b.add(const StartLibraryUpdate());

--- a/lib/library_update/bloc/library_update_bloc.dart
+++ b/lib/library_update/bloc/library_update_bloc.dart
@@ -1,7 +1,8 @@
-import 'package:bloc/bloc.dart';
+﻿import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:otzaria/core/error_log_file.dart';
+import 'package:otzaria/core/internet_connectivity.dart';
 import 'package:otzaria/library_update/services/companion_assets_service.dart';
 import 'package:seforim_library_updater/seforim_library_updater.dart';
 
@@ -27,6 +28,9 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
   final bool Function() areUpdatesEnabled;
   final bool Function() allowPrerelease;
 
+  /// בדיקת חיבור אמיתי לאינטרנט — ניתנת להזרקה לבדיקות.
+  final Future<bool> Function() hasInternet;
+
   // מזהה הריצה הפעילה. כל התחלה/ביטול/איפוס מגדילים אותו, כך שריצה ישנה
   // (Future שעדיין לא הסתיים) מזוהה כמבוטלת ולא פולטת state או מחליפה DB.
   int _operationId = 0;
@@ -47,6 +51,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     required this.areUpdatesEnabled,
     required this.allowPrerelease,
     this.companionAssets,
+    this.hasInternet = hasInternetConnection,
   }) : super(const LibraryUpdateState()) {
     on<StartLibraryUpdate>(_onStart);
     on<ConfirmFullDownload>(_onConfirmFull);
@@ -137,14 +142,26 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
       // אם בוטל/הוחלף במהלך הבדיקה — לא לדרוס state של ריצה חדשה בשגיאה.
       if (_isStale(opId)) return;
       _logUpdateError('checkForUpdate', e, st);
-      emit(
-        LibraryUpdateState(
-          status: LibraryUpdateStatus.error,
-          message: 'שגיאה בבדיקת עדכונים',
-          errorMessage: e.toString(),
-        ),
+      final failure = await _failureState('שגיאה בבדיקת עדכונים', e);
+      if (isClosed || _isStale(opId)) return;
+      emit(failure);
+    }
+  }
+
+  /// המצב שיש לפלוט אחרי כשל: בלי אינטרנט זו אינה תקלה אלא מצב מנותק — סימון
+  /// שקט בכפתור העדכון במקום כשל שקופץ למשתמש שאין לו מה לתקן.
+  Future<LibraryUpdateState> _failureState(String message, Object error) async {
+    if (await hasInternet()) {
+      return LibraryUpdateState(
+        status: LibraryUpdateStatus.error,
+        message: message,
+        errorMessage: error.toString(),
       );
     }
+    return const LibraryUpdateState(
+      status: LibraryUpdateStatus.disconnected,
+      message: 'אין חיבור לאינטרנט',
+    );
   }
 
   Future<void> _runDelta(
@@ -178,13 +195,9 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     } catch (e, st) {
       if (_isStale(opId)) return;
       _logUpdateError('applyDeltaPlan', e, st);
-      emit(
-        LibraryUpdateState(
-          status: LibraryUpdateStatus.error,
-          message: 'שגיאה בהחלת העדכון',
-          errorMessage: e.toString(),
-        ),
-      );
+      final failure = await _failureState('שגיאה בהחלת העדכון', e);
+      if (isClosed || _isStale(opId)) return;
+      emit(failure);
     }
   }
 
@@ -227,13 +240,9 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     } catch (e, st) {
       if (_isStale(opId)) return;
       _logUpdateError('applyFullDownload', e, st);
-      emit(
-        LibraryUpdateState(
-          status: LibraryUpdateStatus.error,
-          message: 'שגיאה בהורדה המלאה',
-          errorMessage: e.toString(),
-        ),
-      );
+      final failure = await _failureState('שגיאה בהורדה המלאה', e);
+      if (isClosed || _isStale(opId)) return;
+      emit(failure);
     }
   }
 

--- a/lib/library_update/bloc/library_update_bloc.dart
+++ b/lib/library_update/bloc/library_update_bloc.dart
@@ -142,15 +142,17 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
       // אם בוטל/הוחלף במהלך הבדיקה — לא לדרוס state של ריצה חדשה בשגיאה.
       if (_isStale(opId)) return;
       _logUpdateError('checkForUpdate', e, st);
-      final failure = await _failureState('שגיאה בבדיקת עדכונים', e);
+      final failure = await _checkFailureState('שגיאה בבדיקת עדכונים', e);
       if (isClosed || _isStale(opId)) return;
       emit(failure);
     }
   }
 
-  /// המצב שיש לפלוט אחרי כשל: בלי אינטרנט זו אינה תקלה אלא מצב מנותק — סימון
-  /// שקט בכפתור העדכון במקום כשל שקופץ למשתמש שאין לו מה לתקן.
-  Future<LibraryUpdateState> _failureState(String message, Object error) async {
+  /// בכשל בבדיקת הזמינות בלבד, היעדר רשת אינו שגיאה למשתמש.
+  Future<LibraryUpdateState> _checkFailureState(
+    String message,
+    Object error,
+  ) async {
     if (await hasInternet()) {
       return LibraryUpdateState(
         status: LibraryUpdateStatus.error,
@@ -195,9 +197,13 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     } catch (e, st) {
       if (_isStale(opId)) return;
       _logUpdateError('applyDeltaPlan', e, st);
-      final failure = await _failureState('שגיאה בהחלת העדכון', e);
-      if (isClosed || _isStale(opId)) return;
-      emit(failure);
+      emit(
+        LibraryUpdateState(
+          status: LibraryUpdateStatus.error,
+          message: 'שגיאה בהחלת העדכון',
+          errorMessage: e.toString(),
+        ),
+      );
     }
   }
 
@@ -240,9 +246,13 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     } catch (e, st) {
       if (_isStale(opId)) return;
       _logUpdateError('applyFullDownload', e, st);
-      final failure = await _failureState('שגיאה בהורדה המלאה', e);
-      if (isClosed || _isStale(opId)) return;
-      emit(failure);
+      emit(
+        LibraryUpdateState(
+          status: LibraryUpdateStatus.error,
+          message: 'שגיאה בהורדה המלאה',
+          errorMessage: e.toString(),
+        ),
+      );
     }
   }
 

--- a/lib/library_update/bloc/library_update_state.dart
+++ b/lib/library_update/bloc/library_update_state.dart
@@ -1,4 +1,4 @@
-part of 'library_update_bloc.dart';
+﻿part of 'library_update_bloc.dart';
 
 enum LibraryUpdateStatus {
   /// מצב מנוחה — אין פעולה פעילה.
@@ -24,6 +24,10 @@ enum LibraryUpdateStatus {
 
   /// מצב חסום שדורש פעולה ידנית.
   blocked,
+
+  /// הכשל נבע מהיעדר חיבור לאינטרנט — סימון שקט בכפתור העדכון ולא כשל: אין
+  /// למשתמש מה לתקן. שונה מ-`isOfflineMode` שהוא הגדרת "מצב לא מקוון" יזומה.
+  disconnected,
 
   /// שגיאה.
   error,

--- a/lib/library_update/library_update_work_status.dart
+++ b/lib/library_update/library_update_work_status.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/foundation.dart';
+import 'package:otzaria/library_update/bloc/library_update_bloc.dart';
+import 'package:otzaria/work_status/work_status_item.dart';
+
+/// מזהה פריט חיווי העבודה של עדכון הספרייה.
+const kLibraryUpdateWorkStatusId = 'library_update';
+
+/// פריט חיווי העבודה לעדכון הספרייה, או `null` כשאין מה להציג.
+///
+/// [LibraryUpdateStatus.disconnected] מחזיר `null` בכוונה: היעדר אינטרנט אינו
+/// כשל לדווח עליו, והסימון היחיד עליו הוא הסמל בכפתור עדכון הספרייה.
+WorkStatusItem? libraryUpdateWorkStatusItem(
+  LibraryUpdateState state, {
+  required VoidCallback onRetry,
+}) {
+  if (state.isBusy) {
+    return WorkStatusItem(
+      id: kLibraryUpdateWorkStatusId,
+      title: 'עדכון ספרייה',
+      message: state.message,
+      progress: _busyProgress(state),
+    );
+  }
+
+  if (state.status == LibraryUpdateStatus.error) {
+    return WorkStatusItem(
+      id: kLibraryUpdateWorkStatusId,
+      title: 'עדכון ספרייה',
+      message: state.message,
+      detail: 'לחץ לניסיון חוזר',
+      kind: WorkStatusKind.failed,
+      onTap: onRetry,
+    );
+  }
+
+  return null;
+}
+
+/// מד הבתים תקף רק בזמן ההורדה — בשלבים הבאים הוא שארית דבוקה על 100%.
+/// ב-apply המדד הוא applyProgress (null = אין מדידה).
+double? _busyProgress(LibraryUpdateState state) {
+  switch (state.status) {
+    case LibraryUpdateStatus.downloading:
+      final total = state.bytesTotal ?? 0;
+      return total > 0
+          ? ((state.bytesDownloaded ?? 0) / total).clamp(0.0, 1.0)
+          : null;
+    case LibraryUpdateStatus.applying:
+      return state.applyProgress;
+    default:
+      return null;
+  }
+}

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -66,6 +66,7 @@ import 'package:otzaria/history/view/history_screen.dart';
 import 'package:otzaria/bookmarks/view/bookmark_screen.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/library_update/bloc/library_update_bloc.dart';
+import 'package:otzaria/library_update/library_update_work_status.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
 import 'package:otzaria/utils/ui/fullscreen_helper.dart';
 import 'package:otzaria/widgets/dialogs/app_dialogs.dart';
@@ -2389,44 +2390,16 @@ class MainWindowScreenState extends State<MainWindowScreen>
                 previous.applyProgress != current.applyProgress,
             listener: (context, state) {
               final cubit = context.read<WorkStatusCubit>();
-              if (state.isBusy) {
-                // מד הבתים תקף רק בזמן ההורדה — בשלבים הבאים הוא שארית דבוקה
-                // על 100%. ב-apply המדד הוא applyProgress (null = אין מדידה).
-                final double? progress;
-                switch (state.status) {
-                  case LibraryUpdateStatus.downloading:
-                    final total = state.bytesTotal ?? 0;
-                    progress = total > 0
-                        ? ((state.bytesDownloaded ?? 0) / total).clamp(0.0, 1.0)
-                        : null;
-                  case LibraryUpdateStatus.applying:
-                    progress = state.applyProgress;
-                  default:
-                    progress = null;
-                }
-                cubit.upsert(
-                  WorkStatusItem(
-                    id: 'library_update',
-                    title: 'עדכון ספרייה',
-                    message: state.message,
-                    progress: progress,
-                  ),
-                );
-              } else if (state.status == LibraryUpdateStatus.error) {
-                cubit.upsert(
-                  WorkStatusItem(
-                    id: 'library_update',
-                    title: 'עדכון ספרייה',
-                    message: state.message,
-                    detail: 'לחץ לניסיון חוזר',
-                    kind: WorkStatusKind.failed,
-                    onTap: () => context.read<LibraryUpdateBloc>().add(
-                      const StartLibraryUpdate(),
-                    ),
-                  ),
-                );
+              final item = libraryUpdateWorkStatusItem(
+                state,
+                onRetry: () => context.read<LibraryUpdateBloc>().add(
+                  const StartLibraryUpdate(),
+                ),
+              );
+              if (item == null) {
+                cubit.remove(kLibraryUpdateWorkStatusId);
               } else {
-                cubit.remove('library_update');
+                cubit.upsert(item);
               }
             },
           ),

--- a/lib/update/my_update_widget.dart
+++ b/lib/update/my_update_widget.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/core/internet_connectivity.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/core/app_paths.dart';
@@ -433,6 +434,29 @@ bool updateCheckBlocked({
   required bool updatesEnabled,
 }) => isOfflineMode || !updatesEnabled;
 
+/// הודעת הכשל להצגה אחרי בדיקת עדכון שנכשלה, או `null` כשאין להציג דבר:
+/// בלי אינטרנט זו אינה תקלה של אוצריא ואין למשתמש מה לעשות איתה.
+@visibleForTesting
+String? updateCheckFailureMessage({
+  required bool isNetworkError,
+  required bool hasInternet,
+}) {
+  if (!hasInternet) return null;
+  return isNetworkError
+      ? LibraryMessages.updateCheckNetworkError
+      : LibraryMessages.updateCheckError;
+}
+
+/// השהיה עד הניסיון החוזר ה-[attempt] אחרי בדיקה שנכשלה בהיעדר אינטרנט;
+/// `null` = די בניסיונות.
+@visibleForTesting
+Duration? offlineRecheckDelay(int attempt) => switch (attempt) {
+  0 => const Duration(minutes: 2),
+  1 => const Duration(minutes: 5),
+  2 => const Duration(minutes: 15),
+  _ => null,
+};
+
 /// האם להריץ בדיקת עדכון מחדש לאחר שינוי הגדרות: רק במעבר מחסימה לזמינות,
 /// וכשאין בדיקה/הורדה/התקנה בעיצומן (upToDate הוא גם המצב שנקבע בעת חסימה).
 @visibleForTesting
@@ -492,6 +516,10 @@ class _ManagedUpdatWidgetState extends State<_ManagedUpdatWidget> {
   StreamSubscription<SettingsState>? _settingsSubscription;
   late bool _updateCheckWasBlocked;
 
+  /// ניסיונות חוזרים לבדיקה שנכשלה בהיעדר אינטרנט — ראה [_scheduleOfflineRecheck].
+  Timer? _offlineRecheckTimer;
+  int _offlineRecheckAttempt = 0;
+
   @override
   void initState() {
     super.initState();
@@ -547,6 +575,7 @@ class _ManagedUpdatWidgetState extends State<_ManagedUpdatWidget> {
   void dispose() {
     _tourSubscription?.cancel();
     _settingsSubscription?.cancel();
+    _offlineRecheckTimer?.cancel();
     if (_windowCloseHookInstalled) {
       windowManager.removeListener(_windowListener);
       _windowCloseHookInstalled = false;
@@ -643,6 +672,8 @@ class _ManagedUpdatWidgetState extends State<_ManagedUpdatWidget> {
       final latestVersion = await _getLatestVersion();
 
       if (!mounted) return;
+      // הבדיקה עברה — ניתוק עתידי יקבל שוב מכסת ניסיונות מלאה.
+      _offlineRecheckAttempt = 0;
 
       if (latestVersion == null) {
         setState(() {
@@ -682,12 +713,36 @@ class _ManagedUpdatWidgetState extends State<_ManagedUpdatWidget> {
           e is SocketException ||
           e is TimeoutException ||
           e is http.ClientException;
-      _showUpdateError(
-        isNetwork
-            ? LibraryMessages.updateCheckNetworkError
-            : LibraryMessages.updateCheckError,
+      // גם כשל שאינו רשת נבדק: captive portal מחזיר HTML תקין שנופל ב-parsing,
+      // ובלי הבדיקה הוא היה מוצג כתקלה למי שאין לו אינטרנט בכלל.
+      final message = updateCheckFailureMessage(
+        isNetworkError: isNetwork,
+        hasInternet: await hasInternetConnection(),
       );
+      if (!mounted) return;
+      if (message == null) {
+        setState(() {
+          _status = UpdatStatus.upToDate;
+        });
+        _scheduleOfflineRecheck();
+        return;
+      }
+      _showUpdateError(message);
     }
+  }
+
+  /// מנותק בפתיחה אינו סוף פסוק: בודקים שוב בהשהיות עולות, כדי שמי שהתחבר
+  /// אחרי הפתיחה יקבל את העדכון בלי להפעיל מחדש את אוצריא.
+  void _scheduleOfflineRecheck() {
+    final delay = offlineRecheckDelay(_offlineRecheckAttempt);
+    if (delay == null) return;
+    _offlineRecheckAttempt++;
+    _offlineRecheckTimer?.cancel();
+    _offlineRecheckTimer = Timer(delay, () {
+      // upToDate הוא המצב שנקבע בכשל המנותק — כל מצב אחר מסמן בדיקה/הורדה
+      // חדשה שאין להפריע לה.
+      if (mounted && _status == UpdatStatus.upToDate) _checkForUpdate();
+    });
   }
 
   Future<String?> _getLatestVersion() async {

--- a/test/core/internet_connectivity_test.dart
+++ b/test/core/internet_connectivity_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/internet_connectivity.dart';
+
+void main() {
+  tearDown(() => debugSocketConnect = null);
+
+  group('hasInternetConnection', () {
+    test('יעד אחד שנענה מספיק כדי לקבוע שיש אינטרנט', () async {
+      debugSocketConnect = (host, port, timeout) async => host == '8.8.8.8';
+
+      expect(await hasInternetConnection(), isTrue);
+    });
+
+    test('כשכל היעדים אינם נענים — אין אינטרנט', () async {
+      debugSocketConnect = (host, port, timeout) async => false;
+
+      expect(await hasInternetConnection(), isFalse);
+    });
+
+    test('חריגה ביעד אחד אינה מבטלת יעד אחר שנענה', () async {
+      debugSocketConnect = (host, port, timeout) async {
+        if (host == '1.1.1.1') throw const SocketExceptionStub();
+        return true;
+      };
+
+      expect(await hasInternetConnection(), isTrue);
+    });
+
+    test('חריגה בכל היעדים מחזירה false — הבדיקה עצמה לא זורקת', () async {
+      debugSocketConnect = (host, port, timeout) async =>
+          throw const SocketExceptionStub();
+
+      expect(await hasInternetConnection(), isFalse);
+    });
+
+    test('חריגה סינכרונית (לא Future) גם היא נבלעת', () async {
+      debugSocketConnect = (host, port, timeout) =>
+          throw const SocketExceptionStub();
+
+      expect(await hasInternetConnection(), isFalse);
+    });
+
+    test('נבדקים כמה יעדים במקביל, ולא רק אחד', () async {
+      final probed = <String>[];
+      debugSocketConnect = (host, port, timeout) async {
+        probed.add(host);
+        return false;
+      };
+
+      await hasInternetConnection();
+
+      expect(probed.length, greaterThan(1));
+      expect(probed.toSet().length, probed.length, reason: 'יעדים ייחודיים');
+    });
+
+    test(
+      'היעדים אינם GitHub — תקלה בשרתי העדכון תסווג כתקלה ולא כניתוק',
+      () async {
+        final probed = <String>[];
+        debugSocketConnect = (host, port, timeout) async {
+          probed.add(host);
+          return false;
+        };
+
+        await hasInternetConnection();
+
+        expect(probed.any((host) => host.contains('github')), isFalse);
+      },
+    );
+
+    test('חיבור שנתקע מסתיים ב-timeout ולא מקפיא את הקורא', () async {
+      debugSocketConnect = (host, port, timeout) =>
+          Completer<bool>().future; // לעולם לא מסתיים
+
+      expect(
+        await hasInternetConnection(timeout: const Duration(milliseconds: 20)),
+        isFalse,
+      );
+    });
+
+    test('ה-timeout שהתקבל מועבר לחיבור עצמו', () async {
+      Duration? seen;
+      debugSocketConnect = (host, port, timeout) async {
+        seen = timeout;
+        return false;
+      };
+
+      await hasInternetConnection(timeout: const Duration(milliseconds: 250));
+
+      expect(seen, const Duration(milliseconds: 250));
+    });
+
+    test(
+      'ברירת המחדל היא timeout קצר — הבדיקה לא תתקע את זרימת הכשל',
+      () async {
+        Duration? seen;
+        debugSocketConnect = (host, port, timeout) async {
+          seen = timeout;
+          return false;
+        };
+
+        await hasInternetConnection();
+
+        expect(seen!.inSeconds, lessThanOrEqualTo(5));
+        expect(seen!.inMilliseconds, greaterThan(0));
+      },
+    );
+  });
+}
+
+/// חריגה מדומה — הבדיקה רק מוודאת שכל חריגה נבלעת, לא סוג מסוים.
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+}

--- a/test/library/view/library_update_button_test.dart
+++ b/test/library/view/library_update_button_test.dart
@@ -1,0 +1,122 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/library/view/library_browser.dart';
+import 'package:otzaria/library_update/bloc/library_update_bloc.dart';
+
+void main() {
+  group('libraryUpdateButtonIcon', () {
+    test('מצב מנותק מקבל סמל משלו — סימון שקט שהעדכון לא רץ', () {
+      expect(
+        libraryUpdateButtonIcon(LibraryUpdateStatus.disconnected),
+        FluentIcons.cloud_off_24_regular,
+      );
+    });
+
+    test('סמל המנותק שונה מסמל העדכון הרגיל ומסמל הסיום', () {
+      final offline = libraryUpdateButtonIcon(LibraryUpdateStatus.disconnected);
+
+      expect(offline, isNot(libraryUpdateButtonIcon(LibraryUpdateStatus.idle)));
+      expect(
+        offline,
+        isNot(libraryUpdateButtonIcon(LibraryUpdateStatus.completed)),
+      );
+    });
+
+    test('שאר המצבים שומרים על הסמלים הקיימים', () {
+      expect(
+        libraryUpdateButtonIcon(LibraryUpdateStatus.completed),
+        FluentIcons.checkmark_circle_24_regular,
+      );
+      for (final status in [
+        LibraryUpdateStatus.idle,
+        LibraryUpdateStatus.checking,
+        LibraryUpdateStatus.downloading,
+        LibraryUpdateStatus.applying,
+        LibraryUpdateStatus.refreshing,
+        LibraryUpdateStatus.needsFullConfirmation,
+        LibraryUpdateStatus.blocked,
+        LibraryUpdateStatus.error,
+      ]) {
+        expect(
+          libraryUpdateButtonIcon(status),
+          FluentIcons.arrow_sync_24_regular,
+          reason: '$status',
+        );
+      }
+    });
+  });
+
+  group('libraryUpdateButtonTooltip', () {
+    test('מנותק מסביר את המצב ומזמין ניסיון חוזר', () {
+      const state = LibraryUpdateState(
+        status: LibraryUpdateStatus.disconnected,
+        message: 'אין חיבור לאינטרנט',
+      );
+
+      expect(
+        libraryUpdateButtonTooltip(state),
+        'אין חיבור לאינטרנט - לחץ לנסות שוב',
+      );
+    });
+
+    test('מנותק אינו מוצג כשגיאה', () {
+      const offline = LibraryUpdateState(
+        status: LibraryUpdateStatus.disconnected,
+      );
+      const error = LibraryUpdateState(status: LibraryUpdateStatus.error);
+
+      expect(libraryUpdateButtonTooltip(offline), isNot(contains('שגיאה')));
+      expect(libraryUpdateButtonTooltip(error), contains('שגיאה'));
+    });
+
+    test('מצבי הסיום והעבודה לא השתנו', () {
+      expect(
+        libraryUpdateButtonTooltip(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.completed,
+            hasUpdate: true,
+          ),
+        ),
+        'העדכון הושלם',
+      );
+      expect(
+        libraryUpdateButtonTooltip(
+          const LibraryUpdateState(status: LibraryUpdateStatus.completed),
+        ),
+        'הספרייה מעודכנת',
+      );
+      expect(
+        libraryUpdateButtonTooltip(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.downloading,
+            message: 'מוריד ספרייה מלאה',
+          ),
+        ),
+        'מוריד ספרייה מלאה',
+      );
+      expect(
+        libraryUpdateButtonTooltip(const LibraryUpdateState()),
+        'עדכון ספרייה',
+      );
+    });
+  });
+
+  group('libraryUpdateButtonResets', () {
+    test('לחיצה במצב מנותק מתחילה ניסיון חדש ולא מאפסת', () {
+      expect(
+        libraryUpdateButtonResets(LibraryUpdateStatus.disconnected),
+        isFalse,
+      );
+    });
+
+    test('מצבי סיום/כשל/חסימה עדיין מתאפסים בלחיצה', () {
+      expect(libraryUpdateButtonResets(LibraryUpdateStatus.completed), isTrue);
+      expect(libraryUpdateButtonResets(LibraryUpdateStatus.error), isTrue);
+      expect(libraryUpdateButtonResets(LibraryUpdateStatus.blocked), isTrue);
+    });
+
+    test('מצב מנוחה מתחיל עדכון', () {
+      expect(libraryUpdateButtonResets(LibraryUpdateStatus.idle), isFalse);
+    });
+  });
+}

--- a/test/library_update/library_update_bloc_test.dart
+++ b/test/library_update/library_update_bloc_test.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+﻿import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -242,12 +242,15 @@ LibraryUpdateBloc _bloc(
   bool updatesEnabled = true,
   bool prerelease = false,
   CompanionAssetsService? companionAssets,
+  // ברירת המחדל "מחובר" מונעת גישת רשת אמיתית בבדיקות מסלולי הכשל.
+  bool hasInternet = true,
 }) => LibraryUpdateBloc(
   repository: service,
   isOfflineMode: () => offline,
   areUpdatesEnabled: () => updatesEnabled,
   allowPrerelease: () => prerelease,
   companionAssets: companionAssets,
+  hasInternet: () async => hasInternet,
 );
 
 void main() {
@@ -408,6 +411,147 @@ void main() {
         ),
       ],
     );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'כשל בבדיקה בלי אינטרנט → מנותק ולא שגיאה',
+      build: () =>
+          _bloc(_FakeService(nonePlan, throwOnCheck: true), hasInternet: false),
+      act: (b) => b.add(const StartLibraryUpdate()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.checking,
+        ),
+        isA<LibraryUpdateState>()
+            .having((s) => s.status, 'status', LibraryUpdateStatus.disconnected)
+            .having((s) => s.message, 'message', 'אין חיבור לאינטרנט')
+            .having((s) => s.errorMessage, 'errorMessage', isNull),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'כשל ב-apply בלי אינטרנט → מנותק ולא שגיאה',
+      build: () => _bloc(
+        _FakeService(deltaPlan, throwOnApply: true),
+        hasInternet: false,
+      ),
+      act: (b) => b.add(const StartLibraryUpdate()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.checking,
+        ),
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.disconnected,
+        ),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'כשל בהורדה מלאה בלי אינטרנט → מנותק ולא שגיאה',
+      build: () =>
+          _bloc(_FakeService(fullPlan, throwOnApply: true), hasInternet: false),
+      seed: () => LibraryUpdateState(
+        status: LibraryUpdateStatus.needsFullConfirmation,
+        plan: fullPlan,
+      ),
+      act: (b) => b.add(const ConfirmFullDownload()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.downloading,
+        ),
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.disconnected,
+        ),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'מצב מנותק אינו חוסם ניסיון חוזר — לחיצה מתחילה בדיקה חדשה',
+      build: () => _bloc(_FakeService(nonePlan)),
+      seed: () =>
+          const LibraryUpdateState(status: LibraryUpdateStatus.disconnected),
+      act: (b) => b.add(const StartLibraryUpdate()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.checking,
+        ),
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.completed,
+        ),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'חזרת החיבור אחרי ניתוק → העדכון מתבצע ומצב המנותק נעלם',
+      build: () => _bloc(_FakeService(deltaPlan)),
+      seed: () =>
+          const LibraryUpdateState(status: LibraryUpdateStatus.disconnected),
+      act: (b) => b.add(const StartLibraryUpdate()),
+      verify: (b) {
+        expect((b.repository as _FakeService).applyCalled, isTrue);
+        expect(b.state.status, LibraryUpdateStatus.completed);
+        expect(b.state.hasUpdate, isTrue);
+      },
+    );
+
+    test('מצב מנותק אינו busy — לא מוצג כעבודה פעילה', () {
+      const state = LibraryUpdateState(
+        status: LibraryUpdateStatus.disconnected,
+      );
+      expect(state.isBusy, isFalse);
+    });
+
+    test('בדיקת החיבור נקראת רק אחרי כשל, לא במסלול התקין', () async {
+      var probes = 0;
+      final bloc = LibraryUpdateBloc(
+        repository: _FakeService(nonePlan),
+        isOfflineMode: () => false,
+        areUpdatesEnabled: () => true,
+        allowPrerelease: () => false,
+        hasInternet: () async {
+          probes++;
+          return true;
+        },
+      );
+      bloc.add(const StartLibraryUpdate());
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+
+      expect(bloc.state.status, LibraryUpdateStatus.completed);
+      expect(probes, 0, reason: 'בדיקת רשת עולה זמן — אסור במסלול המוצלח');
+      await bloc.close();
+    });
+
+    test('כשל אחרי סגירת ה-bloc אינו פולט state', () async {
+      final probeGate = Completer<bool>();
+      final bloc = LibraryUpdateBloc(
+        repository: _FakeService(nonePlan, throwOnCheck: true),
+        isOfflineMode: () => false,
+        areUpdatesEnabled: () => true,
+        allowPrerelease: () => false,
+        hasInternet: () => probeGate.future,
+      );
+      bloc.add(const StartLibraryUpdate());
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      await bloc.close();
+      probeGate.complete(false); // הבדיקה חוזרת אחרי הסגירה
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(bloc.state.status, LibraryUpdateStatus.checking);
+    });
 
     blocTest<LibraryUpdateBloc, LibraryUpdateState>(
       'ConfirmFullDownload → מבצע הורדה מלאה ומסיים עם hasUpdate',

--- a/test/library_update/library_update_bloc_test.dart
+++ b/test/library_update/library_update_bloc_test.dart
@@ -431,7 +431,7 @@ void main() {
     );
 
     blocTest<LibraryUpdateBloc, LibraryUpdateState>(
-      'כשל ב-apply בלי אינטרנט → מנותק ולא שגיאה',
+      'כשל ב-apply בלי אינטרנט נשאר שגיאה מקומית',
       build: () => _bloc(
         _FakeService(deltaPlan, throwOnApply: true),
         hasInternet: false,
@@ -446,13 +446,13 @@ void main() {
         isA<LibraryUpdateState>().having(
           (s) => s.status,
           'status',
-          LibraryUpdateStatus.disconnected,
+          LibraryUpdateStatus.error,
         ),
       ],
     );
 
     blocTest<LibraryUpdateBloc, LibraryUpdateState>(
-      'כשל בהורדה מלאה בלי אינטרנט → מנותק ולא שגיאה',
+      'כשל בהורדה מלאה בלי אינטרנט נשאר שגיאה מקומית',
       build: () =>
           _bloc(_FakeService(fullPlan, throwOnApply: true), hasInternet: false),
       seed: () => LibraryUpdateState(
@@ -469,7 +469,7 @@ void main() {
         isA<LibraryUpdateState>().having(
           (s) => s.status,
           'status',
-          LibraryUpdateStatus.disconnected,
+          LibraryUpdateStatus.error,
         ),
       ],
     );

--- a/test/library_update/library_update_work_status_test.dart
+++ b/test/library_update/library_update_work_status_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/library_update/bloc/library_update_bloc.dart';
+import 'package:otzaria/library_update/library_update_work_status.dart';
+import 'package:otzaria/work_status/work_status_item.dart';
+
+void main() {
+  WorkStatusItem? item(LibraryUpdateState state, {VoidCallback? onRetry}) =>
+      libraryUpdateWorkStatusItem(state, onRetry: onRetry ?? () {});
+
+  group('libraryUpdateWorkStatusItem', () {
+    test('מנותק אינו יוצר פריט חיווי כלל — זו הרגרסיה שהתלוננו עליה', () {
+      expect(
+        item(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.disconnected,
+            message: 'אין חיבור לאינטרנט',
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('שגיאה אמיתית עדיין מוצגת ככשל עם ניסיון חוזר', () {
+      final result = item(
+        const LibraryUpdateState(
+          status: LibraryUpdateStatus.error,
+          message: 'שגיאה בבדיקת עדכונים',
+        ),
+      )!;
+
+      expect(result.kind, WorkStatusKind.failed);
+      expect(result.message, 'שגיאה בבדיקת עדכונים');
+      expect(result.detail, 'לחץ לניסיון חוזר');
+      expect(result.onTap, isNotNull);
+    });
+
+    test('הלחיצה על הכשל מפעילה את הניסיון החוזר שהוזרק', () {
+      var retries = 0;
+      final result = item(
+        const LibraryUpdateState(status: LibraryUpdateStatus.error),
+        onRetry: () => retries++,
+      )!;
+
+      result.onTap!();
+
+      expect(retries, 1);
+    });
+
+    test('מצבי עבודה יוצרים פריט רץ עם המזהה הקבוע', () {
+      for (final status in [
+        LibraryUpdateStatus.checking,
+        LibraryUpdateStatus.downloading,
+        LibraryUpdateStatus.applying,
+        LibraryUpdateStatus.refreshing,
+      ]) {
+        final result = item(
+          LibraryUpdateState(status: status, message: 'עובד'),
+        )!;
+
+        expect(result.kind, WorkStatusKind.running, reason: '$status');
+        expect(result.id, kLibraryUpdateWorkStatusId);
+      }
+    });
+
+    test('מצבי מנוחה אינם יוצרים פריט', () {
+      for (final status in [
+        LibraryUpdateStatus.idle,
+        LibraryUpdateStatus.completed,
+        LibraryUpdateStatus.needsFullConfirmation,
+        LibraryUpdateStatus.blocked,
+        LibraryUpdateStatus.disconnected,
+      ]) {
+        expect(
+          item(LibraryUpdateState(status: status)),
+          isNull,
+          reason: '$status',
+        );
+      }
+    });
+
+    test('התקדמות ההורדה מחושבת מהבתים, ונחתכת לטווח חוקי', () {
+      expect(
+        item(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.downloading,
+            bytesDownloaded: 50,
+            bytesTotal: 200,
+          ),
+        )!.progress,
+        0.25,
+      );
+      expect(
+        item(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.downloading,
+            bytesDownloaded: 300,
+            bytesTotal: 200,
+          ),
+        )!.progress,
+        1.0,
+      );
+    });
+
+    test('בלי מדידת בתים אין אחוז — ולא חלוקה באפס', () {
+      expect(
+        item(
+          const LibraryUpdateState(status: LibraryUpdateStatus.downloading),
+        )!.progress,
+        isNull,
+      );
+      expect(
+        item(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.downloading,
+            bytesDownloaded: 10,
+            bytesTotal: 0,
+          ),
+        )!.progress,
+        isNull,
+      );
+    });
+
+    test('בשלב ה-apply המדד הוא applyProgress ולא שארית ההורדה', () {
+      expect(
+        item(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.applying,
+            bytesDownloaded: 200,
+            bytesTotal: 200,
+            applyProgress: 0.4,
+          ),
+        )!.progress,
+        0.4,
+      );
+      expect(
+        item(
+          const LibraryUpdateState(
+            status: LibraryUpdateStatus.applying,
+            bytesDownloaded: 200,
+            bytesTotal: 200,
+          ),
+        )!.progress,
+        isNull,
+      );
+    });
+  });
+}

--- a/test/update/my_update_widget_test.dart
+++ b/test/update/my_update_widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/update/my_update_widget.dart';
 import 'package:updat/updat.dart';
 
@@ -69,6 +70,62 @@ void main() {
       expect(
         updateCheckBlocked(isOfflineMode: false, updatesEnabled: true),
         isFalse,
+      );
+    });
+  });
+
+  group('updateCheckFailureMessage', () {
+    // בלי אינטרנט אין תקלה לדווח עליה — הודעה כזו בפתיחת התוכנה היא רעש
+    // שהמשתמש אינו יכול לעשות איתו דבר.
+    test('בלי אינטרנט אין הודעה כלל — גם לכשל רשת וגם לכשל אחר', () {
+      expect(
+        updateCheckFailureMessage(isNetworkError: true, hasInternet: false),
+        isNull,
+      );
+      expect(
+        updateCheckFailureMessage(isNetworkError: false, hasInternet: false),
+        isNull,
+      );
+    });
+
+    test('עם אינטרנט — כשל רשת מקבל את הודעת הרשת', () {
+      expect(
+        updateCheckFailureMessage(isNetworkError: true, hasInternet: true),
+        LibraryMessages.updateCheckNetworkError,
+      );
+    });
+
+    test('עם אינטרנט — כשל שאינו רשת מקבל את ההודעה הכללית', () {
+      expect(
+        updateCheckFailureMessage(isNetworkError: false, hasInternet: true),
+        LibraryMessages.updateCheckError,
+      );
+    });
+  });
+
+  group('offlineRecheckDelay', () {
+    test('שלושה ניסיונות בהשהיות עולות, ואז די', () {
+      expect(offlineRecheckDelay(0), const Duration(minutes: 2));
+      expect(offlineRecheckDelay(1), const Duration(minutes: 5));
+      expect(offlineRecheckDelay(2), const Duration(minutes: 15));
+      expect(offlineRecheckDelay(3), isNull);
+      expect(offlineRecheckDelay(50), isNull);
+    });
+
+    test('ההשהיה תמיד עולה — אין הצפת בדיקות רשת', () {
+      var previous = Duration.zero;
+      for (var attempt = 0; offlineRecheckDelay(attempt) != null; attempt++) {
+        final delay = offlineRecheckDelay(attempt)!;
+        expect(delay, greaterThan(previous));
+        previous = delay;
+      }
+    });
+
+    test('הניסיון הראשון אינו מיידי — חיבור לא חוזר תוך שניות', () {
+      expect(
+        offlineRecheckDelay(0)!.inMinutes,
+        greaterThanOrEqualTo(1),
+        reason: 'ניסיון מיידי היה מבזבז רשת בלי סיכוי אמיתי להצליח',
       );
     });
   });


### PR DESCRIPTION
## הבעיה

בפתיחת התוכנה ללא אינטרנט קפצה הודעת שגיאה על כשל בבדיקת העדכון, ובנוסף הופיע כשל אדום בחיווי העבודה של עדכון הספרייה. למשתמש בלי אינטרנט אין מה לעשות עם ההודעות האלה — הוא כבר יודע שאין לו חיבור.

## העיקרון

**כשל שנובע מהיעדר אינטרנט אינו תקלה שמדווחים עליה.** שקט, סימון פסיבי, וניסיון חוזר.

| מצב | קודם | עכשיו |
|---|---|---|
| אין אינטרנט, בדיקת תוכנה | הודעה קופצת | שקט + ניסיון חוזר אוטומטי (2/5/15 דק') |
| אין אינטרנט, עדכון ספרייה | כשל אדום בחיווי | סמל ענן־מנותק בכפתור העדכון בעיון; לחיצה = ניסיון מיידי |
| יש אינטרנט והבדיקה נכשלה | הודעת שגיאה | הודעת שגיאה (ללא שינוי) |

## זיהוי הניתוק

`lib/core/internet_connectivity.dart` — חיבור TCP במקביל לשלושה יעדים ניטרליים. שלוש החלטות מהותיות:

- **לא DNS lookup** — מטמון ה-DNS של מערכת ההפעלה מחזיר תשובה מוצלחת גם בלי רשת, ואז מנותק נראה כמחובר.
- **בכוונה לא GitHub** — כך תקלה בשרתי העדכון מסווגת כתקלה ומדווחת, ולא נבלעת כאילו אין רשת.
- **היעד הראשון הוא שם מתחם ולא IP גולמי** — ברשתות מסוננות חיבור ישיר ל-IP ולפורט 53 חסום, ומשתמש מחובר לגמרי היה מסווג כמנותק.

הבדיקה רצה **רק אחרי כשל**, לעולם לא במסלול התקין, והיא לעולם אינה זורקת בעצמה.

## שינויים נוספים

- `LibraryUpdateStatus.disconnected` — מצב חדש שאינו `error` ואינו `isBusy`, ולכן אינו יוצר פריט כשל בחיווי העבודה. השם נבחר להבדילו מ-`isOfflineMode` (הגדרת "מצב לא מקוון" יזומה של המשתמש).
- `libraryUpdateWorkStatusItem` — ההחלטה מה מוצג בחיווי חולצה מתוך ה-`BlocListener` ב-`main_window_screen` לפונקציה טהורה, כדי לכסות אותה בטסטים.
- עוזרי כפתור עדכון הספרייה (`libraryUpdateButtonIcon` / `Tooltip` / `Resets`) חולצו מאותה סיבה.
- `hasInternet` מוזרק ל-`LibraryUpdateBloc` — הטסטים אינם ניגשים לרשת.

## בדיקות

40 טסטים חדשים ב-5 קבצים. `flutter analyze lib test` נקי; 487 טסטים בחבילות המושפעות (`test/core`, `test/update`, `test/library`, `test/library_update`, `test/navigation`) עוברים.

## הערות לסוקר

- מסלול **הורדת** העדכון לא שונה בכוונה: ההורדה נפתחת בלחיצת "עדכן כעת", ולכן כשל בה חייב להישאר גלוי למי שלחץ.
- אין ניסיון חוזר אוטומטי לעדכון הספרייה — שם יש כפתור נראה ללחיצה; בעדכון התוכנה אין שום סימן, ולכן דווקא שם הוא נדרש.

🤖 Generated with [Claude Code](https://claude.com/claude-code)