### PR TITLE
feat(context-menu): מפרשים וקישורים של קטע היעד בלחיצה ימנית על מפרש

### DIFF
--- a/lib/core/app_runtime_reset.dart
+++ b/lib/core/app_runtime_reset.dart
@@ -14,6 +14,7 @@ import 'package:otzaria/personal_notes/storage/personal_notes_database.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
 import 'package:otzaria/plugins/services/plugin_runtime_dispatcher.dart';
 import 'package:otzaria/services/commentary_service.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
 import 'package:otzaria/tools/tools_screen.dart';
 
 /// מאפס מצב runtime מקומי כדי שהאפליקציה תוכל להיבנות מחדש בלי סגירת תהליך.
@@ -42,6 +43,7 @@ Future<void> resetRuntimeStateForAppRestart() async {
   // ניזונים מהקאשים שלמעלה. בלי איפוס יזום הם ישרדו עד restart מלא.
   FindRefRepository.clearAllCaches();
   CommentaryService.clearEraCache();
+  TargetLineLinksService.instance.clearCache();
 }
 
 /// תאימות לשם הישן במסלול איפוס הגדרות.

--- a/lib/navigation/navigation_repository.dart
+++ b/lib/navigation/navigation_repository.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 import 'package:otzaria/find_ref/repository/find_ref_repository.dart';
 import 'package:otzaria/services/commentary_service.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
 import 'package:otzaria/find_ref/repository/reference_books_cache.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 
@@ -79,6 +80,7 @@ class NavigationRepository {
       // ניזונים מהקאשים שלמעלה. בלי איפוס יזום הם ישרדו עד restart מלא.
       FindRefRepository.clearAllCaches();
       CommentaryService.clearEraCache();
+      TargetLineLinksService.instance.clearCache();
 
       // עדכון נתיב הספרייה
       FileSystemData.instance.libraryPath = libraryPath;

--- a/lib/pdf_book/view/pdf_commentary_panel.dart
+++ b/lib/pdf_book/view/pdf_commentary_panel.dart
@@ -32,6 +32,8 @@ import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
 import 'package:otzaria/personal_notes/widgets/personal_notes_sidebar.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
+import 'package:otzaria/utils/navigation/talmud_bavli_open_format.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/utils/ui/context_menu_utils.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
@@ -911,6 +913,13 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
     );
   }
 
+  /// פותח את יעד הקישור בכרטיסייה חדשה (טקסט או PDF, לפי תבנית הפתיחה).
+  Future<void> _navigateToLink(Link link) async {
+    final tab = await buildLinkTargetTab(link);
+    if (!mounted) return;
+    widget.openBookCallback(tab);
+  }
+
   /// בניית תפריט הקשר למפרש ספציפי
   List<AppContextMenuEntry> _buildCommentaryContextMenuEntries(
     BuildContext menuCtx,
@@ -924,6 +933,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       removeNikud: widget.removeNikud,
       removePunctuation: widget.removePunctuation,
       savedSelectedText: _savedSelectedText,
+      onNavigateToLink: _navigateToLink,
       onCopySelected: () => ContextMenuUtils.copyFormattedText(
         context: menuCtx,
         savedSelectedText: _restoreLineBreaks(_savedSelectedText),
@@ -2102,6 +2112,12 @@ class _CollapsibleCommentaryGroupState
                     ),
                     const SizedBox(height: 4),
                     AppContextMenuRegion(
+                      // ריחוף מקדים את טעינת קישורי קטע היעד, כדי שהתפריט
+                      // ייבנה עם נתונים מוכנים. הלחיצה מכסה מגע/עט (אין ריחוף).
+                      onHoverEnter: () =>
+                          TargetLineLinksService.instance.prefetchOnHover(link),
+                      onSecondaryTapDown: (_) =>
+                          TargetLineLinksService.instance.prefetch(link),
                       // לחיצה ימנית על הטקסט המסומן בפועל לא תשחרר את הבחירה
                       // (התנהגות ברירת המחדל של SelectableRegion ב-Windows); לחיצה
                       // על חלק לא-מסומן מבטלת כרגיל. הבחירה מנוהלת ע"י SelectionArea

--- a/lib/services/commentary_service.dart
+++ b/lib/services/commentary_service.dart
@@ -326,6 +326,19 @@ class CommentaryService {
     return (base != null && present.contains(base)) ? base : null;
   }
 
+  /// הדור שלפיו [sortLinksByEraSync] מציב את [link] בתוך [presentTitles].
+  ///
+  /// ספר "הערות על XX" מעוגן לדור של XX, ולכן מי שמקבץ את הרשימה הממוינת
+  /// (למשל פס מבדיל בין דורות) חייב את אותה נוסחה — [getCachedBookEra] על
+  /// כותרת הפריט עצמו היה מחזיר "שאר מפרשים" ושובר את הקיבוץ.
+  static CommentaryEra sortingEraForLink(
+    Link link,
+    Set<String> presentTitles,
+  ) {
+    final title = utils.getTitleFromPath(link.path2);
+    return getCachedBookEra(_notesBaseInSet(title, presentTitles) ?? title);
+  }
+
   /// ממיין רשימת קישורים שטוחה לפי סדר הדורות
   ///
   /// [links] - רשימת הקישורים למיון

--- a/lib/services/target_line_links_service.dart
+++ b/lib/services/target_line_links_service.dart
@@ -1,0 +1,396 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/widgets.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/services/commentary_service.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
+import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
+import 'package:otzaria/widgets/misc/app_popup_menu.dart';
+import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
+
+/// קישורי שורת היעד, מופרדים לשתי הרשימות שמוצגות כתתי-תפריט נפרדים.
+@immutable
+class TargetLineLinks {
+  /// קישורים תלויי-טקסט — מפרשים על אותו קטע.
+  final List<Link> commentaries;
+
+  /// קישורי הפניה/עיון היוצאים מאותו קטע.
+  final List<Link> references;
+
+  const TargetLineLinks({
+    required this.commentaries,
+    required this.references,
+  });
+
+  /// קטע שנטען ואין בו לא מפרשים ולא קישורים.
+  static const empty = TargetLineLinks(commentaries: [], references: []);
+}
+
+/// חתימת פונקציית הטעינה, מוזרקת כדי לאפשר החלפת מימוש ובדיקות.
+typedef TargetLineLinksLoader =
+    Future<List<Link>> Function(TextBook book, int startIndex, int endIndex);
+
+/// טוען את הקישורים היוצאים מקטע היעד של [Link] — הבסיס לתתי-התפריטים
+/// "מפרשים" ו"קישורים" בתפריט ההקשר של מפרש או של קישור.
+///
+/// כשלוחצים לחיצה ימנית על רש"י בפאנל המפרשים, [Link.path2] הוא ספר רש"י
+/// ו-[Link.index2] השורה בו; מכאן נטענים המפרשים והקישורים *על אותה שורה*.
+/// שאילתה אחת מספיקה לשתי הרשימות — ההפרדה היא לפי [LinkTypes].
+///
+/// המטמון גלובלי ומוגבל, ונשמר בין מסכים. הטעינה עצלה ומתרעננת דרך
+/// [refreshStream]; [clearCache] נדרש כשהמסד עצמו משתנה.
+class TargetLineLinksService {
+  /// מספר הקטעים במטמון לפני פינוי הישן ביותר.
+  static const int _maxCacheEntries = 256;
+
+  /// תקרת שורות לקישור-טווח, שלא ייטען קטע ענק בגלל מפרש ארוך.
+  static const int _maxRangeLines = 10;
+
+  /// השהיית הטעינה בריחוף. תואמת את ההשהיות האחרות בתפריט ההקשר.
+  static const Duration hoverPrefetchDelay = Duration(milliseconds: 150);
+
+  final TargetLineLinksLoader _loader;
+
+  /// [loader] מוזרק בבדיקות; בייצור נטען דרך [TextBookRepository].
+  TargetLineLinksService({TargetLineLinksLoader? loader})
+    : _loader = loader ?? _defaultLoader;
+
+  /// המופע המשותף לכל המסכים — כך המטמון נשמר במעבר בין פאנל, כרטיסייה ו-PDF.
+  static TargetLineLinksService instance = TargetLineLinksService();
+
+  @visibleForTesting
+  static void resetInstanceForTesting({TargetLineLinksLoader? loader}) {
+    instance._dispose();
+    instance = TargetLineLinksService(loader: loader);
+  }
+
+  void _dispose() {
+    _hoverPrefetchTimer?.cancel();
+    _refresh.close();
+  }
+
+  static Future<List<Link>> _defaultLoader(
+    TextBook book,
+    int startIndex,
+    int endIndex,
+  ) {
+    return TextBookRepository(
+      fileSystem: FileSystemData.instance,
+    ).getBookLinksInRange(book, startIndex: startIndex, endIndex: endIndex);
+  }
+
+  // ערך null = בטעינה. LinkedHashMap שומר סדר הכנסה, ולכן המפתח הראשון הוא
+  // הוותיק ביותר ומפונה כשהמטמון מתמלא.
+  final LinkedHashMap<String, TargetLineLinks?> _cache = LinkedHashMap();
+  final StreamController<void> _refresh = StreamController<void>.broadcast();
+
+  // ריחוף אחד פעיל בכל רגע, ולכן טיימר יחיד מספיק.
+  Timer? _hoverPrefetchTimer;
+
+  // עולה בכל [clearCache]. טעינה שהתחילה לפני הניקוי לא תיגע במטמון שכבר שייך
+  // לספרייה אחרת — לא תדרוס ערך חדש ולא תמחק placeholder של טעינה שאחריה.
+  int _generation = 0;
+
+  // קטעים שטעינתם נכשלה. הכשל אינו נשמר במטמון (הוא עשוי להיות זמני), אבל
+  // בלי הסימון הזה תת-התפריט היה מציג "טוען…" לנצח ויורה שאילתה בכל בנייה.
+  final Set<String> _failed = {};
+
+  /// נפלט בכל פעם שטעינה הסתיימה — תתי-התפריטים נבנים מחדש מהמטמון.
+  Stream<void> get refreshStream => _refresh.stream;
+
+  @visibleForTesting
+  int get cacheSize => _cache.length;
+
+  /// ספר היעד של הקישור — הספר שעליו נפתח תפריט ההקשר.
+  static TextBook targetBookOf(Link link) => TextBook(
+    title: utils.getTitleFromPath(link.path2),
+    categoryId: link.targetCategoryId,
+    fileType: link.targetFileType,
+    isUserBook: link.targetIsUserBook,
+  );
+
+  /// זהות היעד כוללת אישי/רשמי וסוג קובץ: מזהי הקטגוריה של user_books.db הם
+  /// מרחב נפרד, ובלעדיהם שני ספרים שונים באותה כותרת היו חולקים ערך במטמון.
+  static String _cacheKey(Link link) {
+    final title = utils.getTitleFromPath(link.path2);
+    final target =
+        '${link.targetIsUserBook ? 'u' : 'o'}_${link.targetCategoryId ?? ''}'
+        '_${link.targetFileType ?? ''}';
+    return '$title|$target|${link.index2}|${link.index2End}';
+  }
+
+  static (int start, int end) _rangeOf(Link link) {
+    final start = (link.index2 - 1).clamp(0, 1 << 30);
+    final rawEnd = ((link.index2End ?? link.index2) - 1).clamp(start, 1 << 30);
+    return (start, rawEnd.clamp(start, start + _maxRangeLines));
+  }
+
+  /// מחזיר את מה שכבר במטמון, או null כשהקטע עדיין לא נטען.
+  TargetLineLinks? cached(Link link) {
+    final key = _cacheKey(link);
+    if (!_cache.containsKey(key)) return null;
+    // remove+reinsert מזיז את המפתח לסוף — בלעדיו הפינוי היה FIFO, והקטע
+    // שחוזרים אליו הכי הרבה היה מפונה לפני קטע שנטען פעם אחת ונשכח.
+    final value = _cache.remove(key);
+    _cache[key] = value;
+    return value;
+  }
+
+  /// האם לקישור יש קטע יעד שאפשר לטעון עליו. קישור בלי יעד תקין לא ייטען
+  /// לעולם, ולכן תת-התפריט שלו חייב להיות אפור ולא תקוע ב"טוען…".
+  static bool _hasLoadableTarget(Link link) =>
+      link.path2.isNotEmpty && link.index2 > 0;
+
+  /// מתחיל טעינה אם טרם התחילה. בטוח לקריאה חוזרת.
+  void prefetch(Link link) {
+    if (!_hasLoadableTarget(link)) return;
+    final key = _cacheKey(link);
+    if (_cache.containsKey(key)) return;
+    // ריחוף או לחיצה ימנית חדשים = ניסיון חוזר מפורש אחרי כשל.
+    _failed.remove(key);
+    _cache[key] = null;
+    _evictIfNeeded();
+    unawaited(_load(key, link));
+  }
+
+  /// טעינה מקדימה בריחוף, בהשהיה קצרה — בלעדיה סמן שחולף מעל רשימת מפרשים
+  /// היה פותח שאילתה (ו-Isolate) לכל פריט בדרך. ריחוף חדש מבטל את הקודם.
+  void prefetchOnHover(Link link) {
+    _hoverPrefetchTimer?.cancel();
+    if (_cache.containsKey(_cacheKey(link))) return;
+    _hoverPrefetchTimer = Timer(hoverPrefetchDelay, () => prefetch(link));
+  }
+
+  /// מפנה את הוותיק ביותר, ולעולם לא קטע שנמצא כרגע בטעינה — פינוי כזה היה
+  /// מבטל את אירוע הרענון שלו ומשאיר תת-תפריט פתוח תקוע ב"טוען…".
+  void _evictIfNeeded() {
+    if (_cache.length <= _maxCacheEntries) return;
+    for (final key in _cache.keys.toList()) {
+      if (_cache.length <= _maxCacheEntries) return;
+      if (_cache[key] == null) continue;
+      _cache.remove(key);
+    }
+  }
+
+  /// מנקה את המטמון — בהחלפת ספרייה או אחרי ייבוא קישורי-משתמש, שבהם המיפוי
+  /// (ספר, שורה) ← קישורים משתנה במסד.
+  void clearCache() {
+    _generation++;
+    _hoverPrefetchTimer?.cancel();
+    _cache.clear();
+    _failed.clear();
+    if (!_refresh.isClosed) _refresh.add(null);
+  }
+
+  Future<void> _load(String key, Link link) async {
+    final generation = _generation;
+    TargetLineLinks result;
+    try {
+      final (start, end) = _rangeOf(link);
+      final links = await _loader(targetBookOf(link), start, end);
+      result = _partition(links);
+    } catch (_) {
+      // כשל זמני (DB נעול, החלפת ספרייה) — מסירים את המפתח כדי שפתיחה הבאה של
+      // התפריט תנסה שוב, במקום לקבע רשימה ריקה עד הפעלה מחדש. במכוון בלי
+      // פליטה לזרם: היא הייתה בונה מחדש את תת-התפריט, שקורא ל-prefetch, ותחת
+      // כשל קבוע נוצרת לולאת שאילתות. תת-תפריט פתוח נשאר ב"טוען…" עד שייסגר.
+      if (generation == _generation) {
+        _cache.remove(key);
+        _failed.add(key);
+      }
+      return;
+    }
+    _failed.remove(key);
+    await _preloadEras(result);
+    if (generation != _generation) return;
+    // המפתח פונה מהמטמון בזמן הטעינה — אין טעם להחזירו ולפנות ערך חי אחר.
+    if (!_cache.containsKey(key)) return;
+    // remove+reinsert: הצבה על מפתח קיים אינה מזיזה אותו לסוף, והקטע שהרגע
+    // נטען היה נחשב הוותיק ביותר ומפונה מיד בגל טעינות מקבילות.
+    _cache.remove(key);
+    _cache[key] = result;
+    _evictIfNeeded();
+    if (!_refresh.isClosed) _refresh.add(null);
+  }
+
+  /// טוען את דורות ספרי היעד למטמון של [CommentaryService], שממנו קורא המיון
+  /// הסינכרוני בזמן ההצגה. נעשה *לפני* הפליטה לזרם, אחרת הרשימה הייתה מוצגת
+  /// אלפביתית ואז מסתדרת מחדש מול העיניים. כישלון אינו פוסל את הקישורים.
+  static Future<void> _preloadEras(TargetLineLinks data) async {
+    try {
+      await CommentaryService.preloadEras([
+        for (final link in [...data.commentaries, ...data.references])
+          utils.getTitleFromPath(link.path2),
+      ]);
+    } catch (_) {
+      return;
+    }
+  }
+
+  /// מפצל לשתי הרשימות ומסיר כפילויות. הדדופ נעשה בתוך כל רשימה בנפרד ואחרי
+  /// הסיווג — אחרת קישור שנזרק (למשל הפניה inline) היה תופס את המשבצת של
+  /// קישור לגיטימי לאותו יעד. המיון לפי דורות נעשה בזמן ההצגה, כדי שלא ייקבע
+  /// סדר שגוי אם טבלת הדורות עדיין לא נטענה.
+  static TargetLineLinks _partition(List<Link> links) {
+    final commentaries = <Link>[];
+    final references = <Link>[];
+    final seenCommentaries = <String>{};
+    final seenReferences = <String>{};
+
+    for (final link in links) {
+      if (link.path2.isEmpty || link.index2 <= 0) continue;
+      if (LinkTypes.isVirtualSource(link.connectionType)) continue;
+      final targetKey =
+          '${link.path2}|${link.index2}|${link.targetIsUserBook ? 'u' : 'o'}';
+
+      if (LinkTypes.isDependentTextLink(link.connectionType)) {
+        if (seenCommentaries.add(targetKey)) commentaries.add(link);
+      } else if (link.start == null && link.end == null) {
+        // קישורי-טווח inline מסומנים בטקסט עצמו ואינם פריט תפריט.
+        if (seenReferences.add(targetKey)) references.add(link);
+      }
+    }
+
+    if (commentaries.isEmpty && references.isEmpty) {
+      return TargetLineLinks.empty;
+    }
+    return TargetLineLinks(
+      commentaries: commentaries,
+      references: references,
+    );
+  }
+
+  /// פריט "מפרשים" — המפרשים על קטע היעד של [link].
+  AppContextMenuEntry buildCommentariesEntry({
+    required Link link,
+    required void Function(Link link) onNavigate,
+    bool? removeNikud,
+    bool? removePunctuation,
+  }) {
+    return _buildEntry(
+      link: link,
+      onNavigate: onNavigate,
+      removeNikud: removeNikud,
+      removePunctuation: removePunctuation,
+      label: 'מפרשים',
+      icon: FluentIcons.book_24_regular,
+      emptyLabel: 'אין מפרשים על קטע זה',
+      select: (data) => data.commentaries,
+      groupByEra: true,
+    );
+  }
+
+  /// פריט "קישורים" — ההפניות היוצאות מקטע היעד של [link].
+  AppContextMenuEntry buildLinksEntry({
+    required Link link,
+    required void Function(Link link) onNavigate,
+    bool? removeNikud,
+    bool? removePunctuation,
+  }) {
+    return _buildEntry(
+      link: link,
+      onNavigate: onNavigate,
+      removeNikud: removeNikud,
+      removePunctuation: removePunctuation,
+      label: 'קישורים',
+      icon: FluentIcons.link_24_regular,
+      emptyLabel: 'אין קישורים על קטע זה',
+      select: (data) => data.references,
+      groupByEra: false,
+    );
+  }
+
+  AppContextMenuEntry _buildEntry({
+    required Link link,
+    required void Function(Link link) onNavigate,
+    required bool? removeNikud,
+    required bool? removePunctuation,
+    required String label,
+    required IconData icon,
+    required String emptyLabel,
+    required List<Link> Function(TargetLineLinks) select,
+    required bool groupByEra,
+  }) {
+    // ה-enabled נקבע פעם אחת בבניית התפריט ואינו מתרענן עם הזרם. כשהמטמון כבר
+    // מלא (ריחוף מקדים) הוא מדויק; אחרת אופטימי, כדי שלא ייצבע אפור בטעות.
+    final data = cached(link);
+    return AppContextMenuEntry(
+      label: label,
+      icon: icon,
+      enabled:
+          _hasLoadableTarget(link) && (data == null || select(data).isNotEmpty),
+      childrenBuilder: () => _buildChildren(
+        link: link,
+        onNavigate: onNavigate,
+        removeNikud: removeNikud,
+        removePunctuation: removePunctuation,
+        emptyLabel: emptyLabel,
+        select: select,
+        groupByEra: groupByEra,
+      ),
+      childrenRefreshStream: refreshStream,
+    );
+  }
+
+  List<AppContextMenuEntry> _buildChildren({
+    required Link link,
+    required void Function(Link link) onNavigate,
+    required bool? removeNikud,
+    required bool? removePunctuation,
+    required String emptyLabel,
+    required List<Link> Function(TargetLineLinks) select,
+    required bool groupByEra,
+  }) {
+    if (!_hasLoadableTarget(link)) {
+      return [AppContextMenuEntry(label: emptyLabel, enabled: false)];
+    }
+    // לא קוראים ל-prefetch על קטע שנכשל: כל בנייה מחדש הייתה יורה שאילתה
+    // כושלת נוספת. ריחוף או לחיצה ימנית חדשים ינסו שוב.
+    if (_failed.contains(_cacheKey(link))) {
+      return const [
+        AppContextMenuEntry(label: 'שגיאה בטעינה', enabled: false),
+      ];
+    }
+    prefetch(link);
+    final data = cached(link);
+    if (data == null) {
+      return const [AppContextMenuEntry(label: 'טוען…', enabled: false)];
+    }
+
+    // המיון כאן ולא בטעינה: מטמון הדורות מתמלא אסינכרונית, ומיון מוקדם היה
+    // מקבע סדר אלפביתי שגוי שגם המפרידים שנגזרים ממנו לא היו תואמים לו.
+    final items = CommentaryService.sortLinksByEraSync(select(data));
+    if (items.isEmpty) {
+      return [AppContextMenuEntry(label: emptyLabel, enabled: false)];
+    }
+
+    final presentTitles = {
+      for (final item in items) utils.getTitleFromPath(item.path2),
+    };
+    final entries = <AppContextMenuEntry>[];
+    CommentaryEra? lastEra;
+    for (final item in items) {
+      if (groupByEra) {
+        final era = CommentaryService.sortingEraForLink(item, presentTitles);
+        if (lastEra != null && era != lastEra) {
+          entries.add(const AppContextMenuEntry.divider());
+        }
+        lastEra = era;
+      }
+      entries.add(
+        buildLinkContextMenuEntry(
+          link: item,
+          removeNikud: removeNikud,
+          removePunctuation: removePunctuation,
+          onTap: () => onNavigate(item),
+        ),
+      );
+    }
+    return entries;
+  }
+}

--- a/lib/services/target_line_links_service.dart
+++ b/lib/services/target_line_links_service.dart
@@ -151,10 +151,10 @@ class TargetLineLinksService {
     if (!_hasLoadableTarget(link)) return;
     final key = _cacheKey(link);
     if (_cache.containsKey(key)) return;
+    if (!_makeRoomForNewEntry()) return;
     // ריחוף או לחיצה ימנית חדשים = ניסיון חוזר מפורש אחרי כשל.
     _failed.remove(key);
     _cache[key] = null;
-    _evictIfNeeded();
     unawaited(_load(key, link));
   }
 
@@ -168,7 +168,18 @@ class TargetLineLinksService {
 
   /// מפנה את הוותיק ביותר, ולעולם לא קטע שנמצא כרגע בטעינה — פינוי כזה היה
   /// מבטל את אירוע הרענון שלו ומשאיר תת-תפריט פתוח תקוע ב"טוען…".
-  void _evictIfNeeded() {
+  bool _makeRoomForNewEntry() {
+    if (_cache.length < _maxCacheEntries) return true;
+    for (final key in _cache.keys.toList()) {
+      if (_cache[key] != null) {
+        _cache.remove(key);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _evictOverflow() {
     if (_cache.length <= _maxCacheEntries) return;
     for (final key in _cache.keys.toList()) {
       if (_cache.length <= _maxCacheEntries) return;
@@ -214,7 +225,7 @@ class TargetLineLinksService {
     // נטען היה נחשב הוותיק ביותר ומפונה מיד בגל טעינות מקבילות.
     _cache.remove(key);
     _cache[key] = result;
-    _evictIfNeeded();
+    _evictOverflow();
     if (!_refresh.isClosed) _refresh.add(null);
   }
 

--- a/lib/settings/services/custom_folders/bloc/custom_folders_bloc.dart
+++ b/lib/settings/services/custom_folders/bloc/custom_folders_bloc.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/migration/sync/background_sync_initializer.dart';
 import 'package:otzaria/migration/sync/file_sync_service.dart'
     show FileSyncResult;
 import 'package:otzaria/services/commentary_service.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/services/custom_folders/custom_folder.dart';
 import 'package:otzaria/user_content_import/repository/user_content_repository.dart';
@@ -308,6 +309,7 @@ class CustomFoldersBloc extends Bloc<CustomFoldersEvent, CustomFoldersState> {
       if (r.generationsApplied > 0 || r.linksApplied > 0) {
         GenerationCache.instance.clear();
         CommentaryService.clearEraCache();
+        TargetLineLinksService.instance.clearCache();
         _addLibraryEvent(RefreshLibrary());
       }
       final imp = (

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -10,7 +10,10 @@ import 'package:otzaria/text_book/view/selection/selected_text_restore.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
+import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/utils/navigation/talmud_bavli_open_format.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/widgets/text_book_state_builder.dart';
@@ -85,7 +88,7 @@ Set<String> effectiveCommentaryTypes({
 );
 
 class CommentaryListBase extends StatefulWidget {
-  final Function(TextBookTab) openBookCallback;
+  final Function(OpenedTab) openBookCallback;
   final double fontSize;
   final List<int>? indexes;
   final bool showSearch;
@@ -2045,7 +2048,7 @@ class _CollapsibleCommentaryGroup extends StatefulWidget {
   final CommentaryGroup group;
   final bool isExpanded;
   final double fontSize;
-  final Function(TextBookTab) openBookCallback;
+  final Function(OpenedTab) openBookCallback;
   final bool removeNikud;
   final bool removePunctuation;
   final bool showSearch;
@@ -2116,6 +2119,13 @@ class _CollapsibleCommentaryGroupState
   void initState() {
     super.initState();
     _isExpanded = widget.isExpanded;
+  }
+
+  /// פותח את יעד הקישור בכרטיסייה חדשה (טקסט או PDF, לפי תבנית הפתיחה).
+  Future<void> _navigateToLink(Link link) async {
+    final tab = await buildLinkTargetTab(link);
+    if (!mounted) return;
+    widget.openBookCallback(tab);
   }
 
   @override
@@ -2268,6 +2278,12 @@ class _CollapsibleCommentaryGroupState
                             ? widget.getItemSearchIndex(link)
                             : 0;
                         return AppContextMenuRegion(
+                          // ריחוף מקדים את טעינת קישורי קטע היעד, כדי שהתפריט
+                          // ייבנה מוכן. הלחיצה מכסה מגע/עט, שאין בהם ריחוף.
+                          onHoverEnter: () => TargetLineLinksService.instance
+                              .prefetchOnHover(link),
+                          onSecondaryTapDown: (_) =>
+                              TargetLineLinksService.instance.prefetch(link),
                           // לחיצה ימנית על הטקסט המסומן בפועל לא תשחרר את הבחירה
                           // (התנהגות ברירת המחדל של SelectableRegion ב-Windows);
                           // לחיצה על חלק לא-מסומן מבטלת כרגיל. אין כאן מעקב
@@ -2301,6 +2317,7 @@ class _CollapsibleCommentaryGroupState
                               removeNikud: widget.removeNikud,
                               removePunctuation: widget.removePunctuation,
                               savedSelectedText: savedTextAtBuild,
+                              onNavigateToLink: _navigateToLink,
                               onCopySelected: () => ContextMenuUtils.copyFormattedText(
                                 context: menuCtx,
                                 savedSelectedText:
@@ -2382,7 +2399,7 @@ class _NotesCommentaryWidget extends StatefulWidget {
   final List<String> notes;
   final double fontSize;
   final bool removeNikud;
-  final Function(TextBookTab) openBookCallback;
+  final Function(OpenedTab) openBookCallback;
 
   /// מצב הספר הראשי — דרוש לדיווח על טעות (ההערות inline בתוכו).
   final TextBookLoaded state;

--- a/lib/utils/ui/context_menu_utils.dart
+++ b/lib/utils/ui/context_menu_utils.dart
@@ -8,6 +8,7 @@ import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/personal_notes/personal_notes_system.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -35,6 +36,10 @@ class ContextMenuUtils {
   ///
   /// מחזיר [List<AppContextMenuEntry>] לשימוש עם [AppContextMenuRegion].
   ///
+  /// [onNavigateToLink] — ניווט אל יעד קישור. כשהוא מסופק נוספים תתי-התפריטים
+  /// "מפרשים" ו"קישורים" של קטע היעד ([TargetLineLinksService]); בלעדיו התפריט
+  /// מכיל רק את פעולות ההעתקה, הפתיחה והדיווח.
+  ///
   /// דוגמה:
   /// ```dart
   /// AppContextMenuRegion(
@@ -47,6 +52,7 @@ class ContextMenuUtils {
   ///     removePunctuation: removePunctuation,
   ///     savedSelectedText: _savedText,
   ///     onCopySelected: _copy,
+  ///     onNavigateToLink: _navigateToLink,
   ///   ),
   ///   child: myCommentaryWidget,
   /// )
@@ -60,7 +66,9 @@ class ContextMenuUtils {
     required bool removePunctuation,
     String? savedSelectedText,
     required VoidCallback onCopySelected,
+    void Function(Link link)? onNavigateToLink,
   }) {
+    final linksService = TargetLineLinksService.instance;
     final entries = <AppContextMenuEntry>[
       AppContextMenuEntry(
         label: 'הוסף הערה אישית',
@@ -101,6 +109,21 @@ class ContextMenuUtils {
           removePunctuation: removePunctuation,
         ),
       ),
+      if (onNavigateToLink != null) ...[
+        const AppContextMenuEntry.divider(),
+        linksService.buildCommentariesEntry(
+          link: link,
+          onNavigate: onNavigateToLink,
+          removeNikud: removeNikud,
+          removePunctuation: removePunctuation,
+        ),
+        linksService.buildLinksEntry(
+          link: link,
+          onNavigate: onNavigateToLink,
+          removeNikud: removeNikud,
+          removePunctuation: removePunctuation,
+        ),
+      ],
       const AppContextMenuEntry.divider(),
       AppContextMenuEntry(
         label: 'פתח ספר זה בחלון נפרד',

--- a/lib/widgets/commentary/links_list_view.dart
+++ b/lib/widgets/commentary/links_list_view.dart
@@ -7,6 +7,7 @@ import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/services/commentary_service.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
@@ -576,6 +577,13 @@ class _LinksListViewState extends State<LinksListView> {
     });
   }
 
+  /// פותח את יעד הקישור בכרטיסייה חדשה (טקסט או PDF, לפי תבנית הפתיחה).
+  Future<void> _navigateToLink(Link link) async {
+    final tab = await buildLinkTargetTab(link);
+    if (!mounted) return;
+    widget.openBookCallback(tab);
+  }
+
   Widget _buildLinksList(
     List<Link> links,
     Set<String> selectedTypes,
@@ -895,6 +903,12 @@ class _LinksListViewState extends State<LinksListView> {
             }
           },
           child: AppContextMenuRegion(
+            // ריחוף מקדים את טעינת קישורי קטע היעד, כדי שהתפריט ייבנה עם
+            // נתונים מוכנים. הלחיצה הימנית מכסה מגע/עט, שאין בהם ריחוף.
+            onHoverEnter: () =>
+                TargetLineLinksService.instance.prefetchOnHover(link),
+            onSecondaryTapDown: (_) =>
+                TargetLineLinksService.instance.prefetch(link),
             // לחיצה ימנית על הטקסט המסומן בפועל לא תשחרר את הבחירה (התנהגות ברירת
             // המחדל של SelectableRegion ב-Windows); לחיצה על חלק לא-מסומן מבטלת
             // כרגיל. הבחירה מנוהלת ע"י SelectionArea פר-קישור, לכן מחשבים את קטע
@@ -920,6 +934,7 @@ class _LinksListViewState extends State<LinksListView> {
                   removeNikud: widget.removeNikud,
                   removePunctuation: widget.removePunctuation,
                   savedSelectedText: _savedSelectedText,
+                  onNavigateToLink: _navigateToLink,
                   onCopySelected: () => ContextMenuUtils.copyFormattedText(
                     context: menuCtx,
                     savedSelectedText: _savedSelectedText,
@@ -928,11 +943,7 @@ class _LinksListViewState extends State<LinksListView> {
                   ),
                 ),
             child: GestureDetector(
-              onTap: () async {
-                final tab = await buildLinkTargetTab(link);
-                if (!mounted) return;
-                widget.openBookCallback(tab);
-              },
+              onTap: () => _navigateToLink(link),
               child: Container(
                 width: double.infinity,
                 padding: const EdgeInsets.all(12.0),

--- a/lib/widgets/misc/app_context_menu.dart
+++ b/lib/widgets/misc/app_context_menu.dart
@@ -37,6 +37,10 @@ class AppContextMenuRegion extends StatefulWidget {
   /// משמש לשמירת ההקשר (למשל אינדקס השורה) עבור פעולות התפריט.
   final GestureTapDownCallback? onSecondaryTapDown;
 
+  /// נקרא כשהסמן נכנס לאזור. משמש לטעינה מקדימה של תוכן שהתפריט יצטרך —
+  /// כך הוא נבנה עם נתונים מוכנים במקום להציג "טוען…".
+  final VoidCallback? onHoverEnter;
+
   /// האם לחיצה ארוכה במגע או בעט פותחת את תפריט ההקשר.
   final bool openOnLongPress;
 
@@ -54,6 +58,7 @@ class AppContextMenuRegion extends StatefulWidget {
     required this.menuBuilder,
     this.menuItemKeysByLabel,
     this.onSecondaryTapDown,
+    this.onHoverEnter,
     this.shouldPreserveSelectionOnSecondaryTap,
     this.openOnLongPress = true,
   });
@@ -408,9 +413,19 @@ class AppContextMenuRegionState extends State<AppContextMenuRegion> {
               _openContextMenu(event.position);
             }
           },
-          child: widget.child,
+          child: _wrapWithHoverEnter(widget.child),
         ),
       ),
+    );
+  }
+
+  Widget _wrapWithHoverEnter(Widget child) {
+    final onHoverEnter = widget.onHoverEnter;
+    if (onHoverEnter == null) return child;
+    return MouseRegion(
+      opaque: false,
+      onEnter: (_) => onHoverEnter(),
+      child: child,
     );
   }
 

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -225,7 +225,7 @@ class AppContextMenuEntry {
 }
 
 bool hasEnabledAppContextMenuEntries(List<AppContextMenuEntry> entries) {
-  return entries.any((entry) => !entry.isDivider);
+  return entries.any((entry) => !entry.isDivider && entry.enabled);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/test/services/target_line_links_service_test.dart
+++ b/test/services/target_line_links_service_test.dart
@@ -1,0 +1,1177 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/services/commentary_service.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
+import 'package:otzaria/widgets/misc/app_popup_menu.dart';
+
+Link _link({
+  required String path2,
+  int index2 = 1,
+  String connectionType = LinkTypes.commentary,
+  int index1 = 1,
+  int? categoryId = 7,
+  int? start,
+  int? end,
+  int? index2End,
+}) {
+  return Link(
+    heRef: path2,
+    index1: index1,
+    path2: path2,
+    index2: index2,
+    connectionType: connectionType,
+    targetCategoryId: categoryId,
+    start: start,
+    end: end,
+    index2End: index2End,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(TargetLineLinksService.resetInstanceForTesting);
+
+  group('פיצול לקישורים ולמפרשים', () {
+    test('קישור תלוי-טקסט נכנס למפרשים, הפניה נכנסת לקישורים', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: 'מהרש"א', connectionType: LinkTypes.commentary),
+          _link(path2: 'תרגום', connectionType: LinkTypes.targum),
+          _link(path2: 'עין משפט', connectionType: LinkTypes.einMishpat),
+          _link(path2: 'רמב"ם', connectionType: LinkTypes.reference),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      final data = service.cached(_link(path2: 'רש"י'))!;
+      expect(
+        data.commentaries.map((l) => l.path2),
+        containsAll(<String>['מהרש"א', 'תרגום']),
+      );
+      expect(
+        data.references.map((l) => l.path2),
+        containsAll(<String>['עין משפט', 'רמב"ם']),
+      );
+      expect(data.commentaries, hasLength(2));
+      expect(data.references, hasLength(2));
+    });
+
+    test('סוג באותיות קטנות מזוהה כמפרש (נרמול)', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: 'מהרש"א', connectionType: 'commentary'),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(service.cached(_link(path2: 'רש"י'))!.commentaries, hasLength(1));
+    });
+
+    test('SOURCE הווירטואלי אינו מוצג באף אחת מהרשימות', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: 'ברכות', connectionType: LinkTypes.source),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      final data = service.cached(_link(path2: 'רש"י'))!;
+      expect(data.commentaries, isEmpty);
+      expect(data.references, isEmpty);
+    });
+
+    test('קישור-טווח inline (start/end) אינו מוצג בקישורים', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(
+            path2: 'הפניה inline',
+            connectionType: LinkTypes.reference,
+            start: 3,
+            end: 9,
+          ),
+          _link(path2: 'הפניה רגילה', connectionType: LinkTypes.reference),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      final data = service.cached(_link(path2: 'רש"י'))!;
+      expect(data.references.map((l) => l.path2), ['הפניה רגילה']);
+    });
+
+    test('אותו יעד באותה שורה מוצג פעם אחת', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: 'מהרש"א', index2: 4),
+          _link(path2: 'מהרש"א', index2: 4),
+          _link(path2: 'מהרש"א', index2: 9),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(service.cached(_link(path2: 'רש"י'))!.commentaries, hasLength(2));
+    });
+
+    test('הפניה inline אינה בולעת הפניה רגילה לאותו יעד', () async {
+      // הדדופ חייב לרוץ אחרי הסיווג: קישור שנזרק תפס את המשבצת ומחק את
+      // ההפניה הלגיטימית, והפריט "קישורים" יצא אפור.
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(
+            path2: 'רמב"ם',
+            index2: 12,
+            connectionType: LinkTypes.reference,
+            start: 3,
+            end: 9,
+          ),
+          _link(
+            path2: 'רמב"ם',
+            index2: 12,
+            connectionType: LinkTypes.reference,
+          ),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(service.cached(_link(path2: 'רש"י'))!.references, hasLength(1));
+    });
+
+    test('מפרש והפניה לאותו יעד מופיעים כל אחד ברשימה שלו', () async {
+      // דדופ משותף לשתי הרשימות היה מותיר רק את הראשון בסדר השאילתה.
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(
+            path2: 'יעד',
+            index2: 4,
+            connectionType: LinkTypes.commentary,
+          ),
+          _link(
+            path2: 'יעד',
+            index2: 4,
+            connectionType: LinkTypes.mesoratHashas,
+          ),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      final data = service.cached(_link(path2: 'רש"י'))!;
+      expect(data.commentaries, hasLength(1));
+      expect(data.references, hasLength(1));
+    });
+
+    test('קישור בלי יעד תקין מסונן', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: '', index2: 3),
+          _link(path2: 'תקין', index2: 0),
+          _link(path2: 'תקין', index2: 3),
+        ],
+      );
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(service.cached(_link(path2: 'רש"י'))!.commentaries, hasLength(1));
+    });
+  });
+
+  group('מטמון וטעינה', () {
+    test('cached מחזיר null עד שהטעינה מסתיימת', () async {
+      // שער מפורש ולא השהיית שעון-קיר, שלא ייווצר טסט תלוי-עומס.
+      final gate = Completer<void>();
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          await gate.future;
+          return [_link(path2: 'מהרש"א')];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      expect(service.cached(link), isNull);
+
+      gate.complete();
+      await pumpEventQueue();
+      expect(service.cached(link), isNotNull);
+    });
+
+    test('clearCache בזמן טעינה — התוצאה אינה חוזרת למטמון', () async {
+      final gate = Completer<void>();
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          await gate.future;
+          return [_link(path2: 'מהרש"א')];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      service.clearCache();
+
+      gate.complete();
+      await pumpEventQueue();
+      expect(service.cached(link), isNull);
+      expect(service.cacheSize, 0);
+    });
+
+    test(
+      'כשל של טעינה ישנה אינו מוחק placeholder של טעינה שאחרי clearCache',
+      () async {
+        // החלפת ספרייה בזמן טעינה: בלי מזהה-דור, ה-catch של הטעינה הישנה היה
+        // מוחק את ה-placeholder של החדשה, והתת-תפריט נשאר "טוען…" לצמיתות.
+        final gates = <Completer<void>>[];
+        final service = TargetLineLinksService(
+          loader: (_, _, _) async {
+            final gate = Completer<void>();
+            gates.add(gate);
+            await gate.future;
+            if (gates.length == 1) throw StateError('DB נעול');
+            return [_link(path2: 'מהרש"א')];
+          },
+        );
+        final link = _link(path2: 'רש"י');
+
+        service.prefetch(link);
+        await pumpEventQueue();
+        service.clearCache();
+        service.prefetch(link);
+        await pumpEventQueue();
+        expect(gates, hasLength(2));
+
+        gates[0].complete(); // הישנה נכשלת
+        await pumpEventQueue();
+        gates[1].complete(); // החדשה מצליחה
+        await pumpEventQueue();
+
+        expect(service.cached(link)!.commentaries, hasLength(1));
+      },
+    );
+
+    test('תוצאה מלפני clearCache אינה נכתבת למטמון', () async {
+      final gate = Completer<void>();
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          await gate.future;
+          return [_link(path2: 'מהמסד הישן')];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      service.clearCache();
+
+      gate.complete();
+      await pumpEventQueue();
+
+      expect(service.cached(link), isNull);
+      expect(service.cacheSize, 0);
+    });
+
+    test('clearCache פולט לזרם ומבטל ריחוף ממתין', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+      final emissions = <void>[];
+      final sub = service.refreshStream.listen(emissions.add);
+
+      service.prefetchOnHover(_link(path2: 'רש"י'));
+      service.clearCache();
+      await Future<void>.delayed(
+        TargetLineLinksService.hoverPrefetchDelay * 2,
+      );
+
+      expect(emissions, hasLength(1));
+      expect(loads, 0, reason: 'הריחוף הממתין בוטל');
+      await sub.cancel();
+    });
+
+    test('טעינה שמסתיימת אחרי איפוס המופע אינה זורקת', () async {
+      final gate = Completer<void>();
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async {
+          await gate.future;
+          return const [];
+        },
+      );
+      final service = TargetLineLinksService.instance;
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+      // סוגר את ה-StreamController שהטעינה התלויה עומדת לפלוט אליו.
+      TargetLineLinksService.resetInstanceForTesting();
+
+      gate.complete();
+      await expectLater(pumpEventQueue(), completes);
+    });
+
+    test('prefetch חוזר על אותו קטע אינו טוען פעמיים', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+      final link = _link(path2: 'רש"י', index2: 5);
+
+      service.prefetch(link);
+      service.prefetch(link);
+      await pumpEventQueue();
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      expect(loads, 1);
+    });
+
+    test('ספר אישי וספר רשמי באותה כותרת אינם חולקים ערך במטמון', () async {
+      // מזהי הקטגוריה של user_books.db הם מרחב נפרד, ולכן שתי הכותרות יכולות
+      // להתנגש (כולל null == null) ולהחזיר זו את הקישורים של זו.
+      final service = TargetLineLinksService(
+        loader: (book, _, _) async => [
+          _link(path2: book.isUserBook ? 'יעד אישי' : 'יעד רשמי'),
+        ],
+      );
+      final official = Link(
+        heRef: 'x',
+        index1: 1,
+        path2: 'רש"י',
+        index2: 5,
+        connectionType: LinkTypes.commentary,
+      );
+      final personal = Link(
+        heRef: 'x',
+        index1: 1,
+        path2: 'רש"י',
+        index2: 5,
+        connectionType: LinkTypes.commentary,
+        targetIsUserBook: true,
+      );
+
+      service.prefetch(official);
+      service.prefetch(personal);
+      await pumpEventQueue();
+
+      expect(service.cached(official)!.commentaries.single.path2, 'יעד רשמי');
+      expect(service.cached(personal)!.commentaries.single.path2, 'יעד אישי');
+    });
+
+    test('שורות שונות באותו ספר נטענות בנפרד', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: 'רש"י', index2: 5));
+      service.prefetch(_link(path2: 'רש"י', index2: 6));
+      await pumpEventQueue();
+
+      expect(loads, 2);
+    });
+
+    test('כישלון זמני אינו מקובע — ניסיון חוזר טוען שוב', () async {
+      // DB נעול בסנכרון רקע: קיבוע רשימה ריקה היה מותיר את הפריט אפור עד
+      // הפעלה מחדש, למרות שיש מפרשים.
+      var attempts = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          attempts++;
+          if (attempts == 1) throw StateError('DB נעול');
+          return [_link(path2: 'מהרש"א')];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      expect(service.cached(link), isNull, reason: 'הכישלון לא נשמר במטמון');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      expect(service.cached(link)!.commentaries, hasLength(1));
+    });
+
+    test('כישלון אינו פולט לזרם — אחרת נוצרת לולאת שאילתות', () async {
+      // הזרם בונה מחדש את תת-התפריט, שקורא ל-prefetch. פליטה בכשל הייתה
+      // סוגרת מעגל: כשל → פליטה → בנייה → prefetch → כשל, בלי הפוגה.
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => throw StateError('DB לא זמין'),
+      );
+      final emissions = <void>[];
+      final sub = service.refreshStream.listen(emissions.add);
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(emissions, isEmpty);
+      await sub.cancel();
+    });
+
+    test('clearCache מנקה ומאפשר טעינה מחדש', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      service.clearCache();
+
+      expect(service.cached(link), isNull);
+      expect(service.cacheSize, 0);
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      expect(loads, 2);
+    });
+
+    test('פינוי אינו נוגע בקטע שנמצא בטעינה', () async {
+      final gate = Completer<void>();
+      final service = TargetLineLinksService(
+        loader: (book, _, _) async {
+          if (book.title == 'איטי') await gate.future;
+          return const [];
+        },
+      );
+      final slow = _link(path2: 'איטי');
+
+      service.prefetch(slow);
+      for (var i = 1; i <= 300; i++) {
+        service.prefetch(_link(path2: 'ספר', index2: i));
+      }
+      await pumpEventQueue();
+
+      gate.complete();
+      await pumpEventQueue();
+      expect(
+        service.cached(slow),
+        isNotNull,
+        reason: 'פינוי מפתח בטעינה היה משאיר תת-תפריט פתוח תקוע ב"טוען…"',
+      );
+    });
+
+    test('המטמון מפנה לפי שימוש אחרון ולא לפי סדר הכנסה', () async {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+
+      for (var i = 1; i <= 256; i++) {
+        service.prefetch(_link(path2: 'ספר', index2: i));
+      }
+      await pumpEventQueue();
+
+      // נגיעה בוותיק ביותר מחדשת אותו; הבא בתור הוא שאמור לפנות.
+      final oldest = _link(path2: 'ספר', index2: 1);
+      expect(service.cached(oldest), isNotNull);
+
+      service.prefetch(_link(path2: 'ספר', index2: 999));
+      await pumpEventQueue();
+
+      expect(service.cached(oldest), isNotNull);
+      expect(service.cached(_link(path2: 'ספר', index2: 2)), isNull);
+    });
+
+    test('טעינה פולטת לזרם פעם אחת בלבד', () async {
+      // פליטה שנייה הייתה מסדרת את הרשימה מחדש מול עיני המשתמש.
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [_link(path2: 'מהרש"א')],
+      );
+      final emissions = <void>[];
+      final sub = service.refreshStream.listen(emissions.add);
+
+      service.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(emissions, hasLength(1));
+      await sub.cancel();
+    });
+
+    test('קישור בלי יעד תקין אינו מפעיל טעינה כלל', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: '', index2: 1));
+      service.prefetch(_link(path2: 'רש"י', index2: 0));
+      await pumpEventQueue();
+
+      expect(loads, 0);
+      expect(service.cacheSize, 0);
+    });
+
+    test('המטמון חסום ומפנה את הוותיק ביותר', () async {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+
+      for (var i = 1; i <= 300; i++) {
+        service.prefetch(_link(path2: 'ספר', index2: i));
+      }
+      await pumpEventQueue();
+
+      expect(service.cacheSize, lessThanOrEqualTo(256));
+      expect(service.cached(_link(path2: 'ספר', index2: 1)), isNull);
+      expect(service.cached(_link(path2: 'ספר', index2: 300)), isNotNull);
+    });
+  });
+
+  group('כשל טעינה', () {
+    Link failing() => _link(path2: 'רש"י');
+
+    TargetLineLinksService failingService(int failuresBeforeSuccess) {
+      var attempts = 0;
+      return TargetLineLinksService(
+        loader: (_, _, _) async {
+          attempts++;
+          if (attempts <= failuresBeforeSuccess) {
+            throw StateError('ספר היעד חסר');
+          }
+          return [_link(path2: 'מהרש"א')];
+        },
+      );
+    }
+
+    test('קטע שנכשל מציג "שגיאה בטעינה" ולא "טוען…"', () async {
+      final service = failingService(99);
+      final entry = service.buildCommentariesEntry(
+        link: failing(),
+        onNavigate: (_) {},
+      );
+
+      entry.childrenBuilder!();
+      await pumpEventQueue();
+
+      expect(entry.childrenBuilder!().single.label, 'שגיאה בטעינה');
+    });
+
+    test('בנייה חוזרת אחרי כשל אינה יורה שאילתה נוספת', () async {
+      // בלי הסימון, כל פליטה לזרם הייתה מפעילה שאילתה כושלת נוספת.
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          throw StateError('ספר היעד חסר');
+        },
+      );
+      final entry = service.buildCommentariesEntry(
+        link: failing(),
+        onNavigate: (_) {},
+      );
+
+      entry.childrenBuilder!();
+      await pumpEventQueue();
+      for (var i = 0; i < 5; i++) {
+        entry.childrenBuilder!();
+        await pumpEventQueue();
+      }
+
+      expect(loads, 1);
+    });
+
+    test('ריחוף חדש אחרי כשל מנסה שוב ומצליח', () async {
+      final service = failingService(1);
+      final link = failing();
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      expect(service.cached(link), isNull);
+
+      service.prefetchOnHover(link);
+      await Future<void>.delayed(
+        TargetLineLinksService.hoverPrefetchDelay * 2,
+      );
+      await pumpEventQueue();
+
+      expect(service.cached(link)!.commentaries, hasLength(1));
+    });
+
+    test('לחיצה ימנית אחרי כשל מנסה שוב', () async {
+      final service = failingService(1);
+      final link = failing();
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      expect(service.cached(link)!.commentaries, hasLength(1));
+    });
+
+    test('הצלחה אחרי כשל מנקה את סימון הכשל', () async {
+      final service = failingService(1);
+      final link = failing();
+      final entry = service.buildCommentariesEntry(
+        link: link,
+        onNavigate: (_) {},
+      );
+
+      entry.childrenBuilder!();
+      await pumpEventQueue();
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      expect(entry.childrenBuilder!().single.label, contains('מהרש"א'));
+    });
+
+    test('clearCache מנקה סימוני כשל', () async {
+      final service = failingService(1);
+      final link = failing();
+      final entry = service.buildCommentariesEntry(
+        link: link,
+        onNavigate: (_) {},
+      );
+
+      entry.childrenBuilder!();
+      await pumpEventQueue();
+      service.clearCache();
+
+      // אחרי הניקוי הבנייה חוזרת לנסות, והפעם ה-loader מצליח.
+      entry.childrenBuilder!();
+      await pumpEventQueue();
+      expect(service.cached(link)!.commentaries, hasLength(1));
+    });
+
+    test('כשל בקטע אחד אינו משפיע על קטע אחר', () async {
+      final service = TargetLineLinksService(
+        loader: (book, _, _) async {
+          if (book.title == 'שבור') throw StateError('חסר');
+          return [_link(path2: 'מהרש"א')];
+        },
+      );
+      final broken = _link(path2: 'שבור');
+      final healthy = _link(path2: 'תקין');
+
+      service.prefetch(broken);
+      service.prefetch(healthy);
+      await pumpEventQueue();
+
+      expect(service.cached(broken), isNull);
+      expect(service.cached(healthy)!.commentaries, hasLength(1));
+    });
+  });
+
+  group('טעינה מקדימה בריחוף', () {
+    test('סמן שנעצר על פריט טוען אותו', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+
+      service.prefetchOnHover(_link(path2: 'רש"י'));
+      expect(loads, 0, reason: 'הטעינה נדחית עד שהסמן נעצר');
+
+      await Future<void>.delayed(
+        TargetLineLinksService.hoverPrefetchDelay * 2,
+      );
+      expect(loads, 1);
+    });
+
+    test('סמן שחולף מעל רשימה טוען רק את הפריט שעליו נעצר', () async {
+      final loaded = <String>[];
+      final service = TargetLineLinksService(
+        loader: (book, _, _) async {
+          loaded.add(book.title);
+          return const [];
+        },
+      );
+
+      for (var i = 1; i <= 20; i++) {
+        service.prefetchOnHover(_link(path2: 'מפרש $i'));
+      }
+      await Future<void>.delayed(
+        TargetLineLinksService.hoverPrefetchDelay * 2,
+      );
+
+      expect(loaded, ['מפרש 20']);
+    });
+
+    test('ריחוף על קטע שכבר במטמון אינו קובע טיימר מיותר', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+      service.prefetchOnHover(link);
+      await Future<void>.delayed(
+        TargetLineLinksService.hoverPrefetchDelay * 2,
+      );
+
+      expect(loads, 1);
+    });
+
+    test('ריחוף אחרי לחיצה ימנית אינו טוען שוב', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetchOnHover(link);
+      service.prefetch(link);
+      await Future<void>.delayed(
+        TargetLineLinksService.hoverPrefetchDelay * 2,
+      );
+
+      expect(loads, 1);
+    });
+  });
+
+  group('טווח הטעינה', () {
+    test('קישור לשורה בודדת טוען את אותה שורה בלבד', () async {
+      int? start;
+      int? end;
+      final service = TargetLineLinksService(
+        loader: (_, s, e) async {
+          start = s;
+          end = e;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: 'רש"י', index2: 12));
+      await pumpEventQueue();
+
+      expect(start, 11);
+      expect(end, 11);
+    });
+
+    test('קישור-טווח טוען את הטווח, חסום בתקרה', () async {
+      int? start;
+      int? end;
+      final service = TargetLineLinksService(
+        loader: (_, s, e) async {
+          start = s;
+          end = e;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: 'רש"י', index2: 5, index2End: 100));
+      await pumpEventQueue();
+
+      expect(start, 4);
+      expect(end, 14);
+    });
+
+    test('index2End קטן מ-index2 נטען כשורה בודדת', () async {
+      int? start;
+      int? end;
+      final service = TargetLineLinksService(
+        loader: (_, s, e) async {
+          start = s;
+          end = e;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: 'רש"י', index2: 10, index2End: 3));
+      await pumpEventQueue();
+
+      expect(start, 9);
+      expect(end, 9);
+    });
+
+    test('טווח קצר מהתקרה אינו נחתך', () async {
+      int? start;
+      int? end;
+      final service = TargetLineLinksService(
+        loader: (_, s, e) async {
+          start = s;
+          end = e;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: 'רש"י', index2: 5, index2End: 8));
+      await pumpEventQueue();
+
+      expect(start, 4);
+      expect(end, 7);
+    });
+
+    test('השורה הראשונה בספר נטענת מאינדקס 0', () async {
+      int? start;
+      final service = TargetLineLinksService(
+        loader: (_, s, _) async {
+          start = s;
+          return const [];
+        },
+      );
+
+      service.prefetch(_link(path2: 'רש"י', index2: 1));
+      await pumpEventQueue();
+
+      expect(start, 0);
+    });
+
+    test('ספר היעד נגזר מהקישור על כל שדותיו', () async {
+      TextBook? loadedBook;
+      final service = TargetLineLinksService(
+        loader: (book, _, _) async {
+          loadedBook = book;
+          return const [];
+        },
+      );
+
+      service.prefetch(
+        Link(
+          heRef: 'x',
+          index1: 1,
+          path2: 'רש"י על ברכות',
+          index2: 5,
+          connectionType: LinkTypes.commentary,
+          targetCategoryId: 42,
+          targetFileType: 'docx',
+          targetIsUserBook: true,
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(loadedBook!.title, 'רש"י על ברכות');
+      expect(loadedBook!.categoryId, 42);
+      expect(loadedBook!.fileType, 'docx');
+      expect(loadedBook!.isUserBook, isTrue);
+    });
+  });
+
+  group('פריטי התפריט', () {
+    AppContextMenuEntry commentariesEntry(
+      TargetLineLinksService service,
+      Link link,
+    ) => service.buildCommentariesEntry(link: link, onNavigate: (_) {});
+
+    AppContextMenuEntry linksEntry(
+      TargetLineLinksService service,
+      Link link,
+    ) => service.buildLinksEntry(link: link, onNavigate: (_) {});
+
+    test('לפני טעינה הפריט פעיל ומציג "טוען…"', () {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+      final entry = commentariesEntry(service, _link(path2: 'רש"י'));
+
+      expect(entry.label, 'מפרשים');
+      expect(entry.enabled, isTrue);
+      expect(entry.childrenBuilder!().single.label, 'טוען…');
+    });
+
+    test('אחרי טעינה ריקה הפריט אפור', () async {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      expect(commentariesEntry(service, link).enabled, isFalse);
+      expect(linksEntry(service, link).enabled, isFalse);
+    });
+
+    test('פריט אפור רק בצד שריק', () async {
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: 'מהרש"א', connectionType: LinkTypes.commentary),
+        ],
+      );
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      expect(commentariesEntry(service, link).enabled, isTrue);
+      expect(linksEntry(service, link).enabled, isFalse);
+    });
+
+    test('קישור בלי יעד תקין אפור ואינו נתקע ב"טוען…"', () {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+
+      for (final broken in [
+        _link(path2: '', index2: 3),
+        _link(path2: 'רש"י', index2: 0),
+      ]) {
+        final entry = commentariesEntry(service, broken);
+        expect(entry.enabled, isFalse);
+        expect(entry.childrenBuilder!().single.label, isNot('טוען…'));
+      }
+    });
+
+    test('רשימה ריקה מציגה הודעה מושבתת ולא פריט לחיץ', () async {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+      final link = _link(path2: 'רש"י');
+
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      final child = commentariesEntry(service, link).childrenBuilder!().single;
+      expect(child.label, 'אין מפרשים על קטע זה');
+      expect(child.enabled, isFalse);
+    });
+
+    test('לחיצה על פריט מנווטת אל אותו קישור', () async {
+      final target = _link(path2: 'מהרש"א', index2: 8);
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [target],
+      );
+      final link = _link(path2: 'רש"י');
+      Link? navigated;
+
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      final entry = service.buildCommentariesEntry(
+        link: link,
+        onNavigate: (l) => navigated = l,
+      );
+      entry.childrenBuilder!().single.onTap!();
+
+      expect(navigated, same(target));
+    });
+
+    test('בניית הפריט לבדה מפעילה טעינה (בלי ריחוף מקדים)', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+
+      commentariesEntry(service, _link(path2: 'רש"י')).childrenBuilder!();
+      await pumpEventQueue();
+
+      expect(loads, 1);
+    });
+
+    test('זרם הרענון של הפריט פולט כשהטעינה מסתיימת', () async {
+      // ה-getter של broadcast stream מחזיר עטיפה חדשה בכל קריאה, ולכן בודקים
+      // שהזרם *פועל* ולא שהוא אותו מופע.
+      final gate = Completer<void>();
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          await gate.future;
+          return [_link(path2: 'מהרש"א')];
+        },
+      );
+      final entry = commentariesEntry(service, _link(path2: 'רש"י'));
+      final emissions = <void>[];
+      final sub = entry.childrenRefreshStream!.listen(emissions.add);
+
+      entry.childrenBuilder!();
+      await pumpEventQueue();
+      expect(emissions, isEmpty);
+
+      gate.complete();
+      await pumpEventQueue();
+      expect(emissions, hasLength(1));
+      expect(entry.childrenBuilder!().single.label, contains('מהרש"א'));
+      await sub.cancel();
+    });
+
+    test('לשני הפריטים אייקונים נבדלים ותוויות נכונות', () {
+      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+      final link = _link(path2: 'רש"י');
+
+      final commentaries = commentariesEntry(service, link);
+      final links = linksEntry(service, link);
+
+      expect(commentaries.label, 'מפרשים');
+      expect(links.label, 'קישורים');
+      expect(commentaries.icon, isNot(links.icon));
+    });
+  });
+
+  group('מפרידי דורות', () {
+    setUp(CommentaryService.clearEraCache);
+    tearDown(CommentaryService.clearEraCache);
+
+    Future<List<AppContextMenuEntry>> childrenFor(List<Link> loaded) async {
+      final service = TargetLineLinksService(loader: (_, _, _) async => loaded);
+      final link = _link(path2: 'רש"י');
+      service.prefetch(link);
+      await pumpEventQueue();
+      return service
+          .buildCommentariesEntry(link: link, onNavigate: (_) {})
+          .childrenBuilder!();
+    }
+
+    test('מעבר בין דורות מוסיף פס מבדיל', () async {
+      CommentaryService.seedEraCache({
+        'רשב"ם': CommentaryEra.rishonim,
+        'מהרש"א': CommentaryEra.acharonim,
+      });
+
+      final children = await childrenFor([
+        _link(path2: 'רשב"ם'),
+        _link(path2: 'מהרש"א'),
+      ]);
+
+      expect(children.where((e) => e.isDivider), hasLength(1));
+    });
+
+    test('אותו דור אינו מקבל פס מבדיל', () async {
+      CommentaryService.seedEraCache({
+        'רשב"ם': CommentaryEra.rishonim,
+        'רמב"ן': CommentaryEra.rishonim,
+      });
+
+      final children = await childrenFor([
+        _link(path2: 'רשב"ם'),
+        _link(path2: 'רמב"ן'),
+      ]);
+
+      expect(children.where((e) => e.isDivider), isEmpty);
+    });
+
+    test('"הערות על XX" אינו שובר את קבוצת הדור של XX', () async {
+      // המיון מעגן "הערות על רש״י" לדור של רש״י. אם המפריד נגזר מהכותרת
+      // עצמה (=שאר מפרשים) נוצרים שני מפרידים מזויפים בתוך אותו דור.
+      CommentaryService.seedEraCache({
+        'רש"י': CommentaryEra.rishonim,
+        'רשב"ם': CommentaryEra.rishonim,
+      });
+
+      final children = await childrenFor([
+        _link(path2: 'רש"י'),
+        _link(path2: 'הערות על רש"י'),
+        _link(path2: 'רשב"ם'),
+      ]);
+
+      expect(children.where((e) => e.isDivider), isEmpty);
+    });
+
+    test('רשימת הקישורים אינה מקבלת מפרידי דורות', () async {
+      CommentaryService.seedEraCache({
+        'עין משפט': CommentaryEra.rishonim,
+        'מסורת הש"ס': CommentaryEra.acharonim,
+      });
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async => [
+          _link(path2: 'עין משפט', connectionType: LinkTypes.einMishpat),
+          _link(path2: 'מסורת הש"ס', connectionType: LinkTypes.mesoratHashas),
+        ],
+      );
+      final link = _link(path2: 'רש"י');
+      service.prefetch(link);
+      await pumpEventQueue();
+
+      final children = service
+          .buildLinksEntry(link: link, onNavigate: (_) {})
+          .childrenBuilder!();
+
+      expect(children.where((e) => e.isDivider), isEmpty);
+      expect(children, hasLength(2));
+    });
+
+    test('הרשימה ממוינת לפי סדר הדורות ולא לפי סדר השאילתה', () async {
+      CommentaryService.seedEraCache({
+        'מהרש"א': CommentaryEra.acharonim,
+        'רשב"ם': CommentaryEra.rishonim,
+      });
+
+      final children = await childrenFor([
+        _link(path2: 'מהרש"א'),
+        _link(path2: 'רשב"ם'),
+      ]);
+
+      final labels = children
+          .where((e) => !e.isDivider)
+          .map((e) => e.label)
+          .toList();
+      expect(labels.first, contains('רשב"ם'));
+      expect(labels.last, contains('מהרש"א'));
+    });
+
+    test('sortingEraForLink מעגן "הערות על XX" לדור של XX', () {
+      CommentaryService.seedEraCache({'רש"י': CommentaryEra.rishonim});
+      final notes = _link(path2: 'הערות על רש"י');
+
+      expect(
+        CommentaryService.sortingEraForLink(notes, {'רש"י', 'הערות על רש"י'}),
+        CommentaryEra.rishonim,
+      );
+    });
+
+    test('sortingEraForLink נופל ל"שאר מפרשים" כשהבסיס אינו ברשימה', () {
+      CommentaryService.seedEraCache({'רש"י': CommentaryEra.rishonim});
+      final notes = _link(path2: 'הערות על רש"י');
+
+      expect(
+        CommentaryService.sortingEraForLink(notes, {'הערות על רש"י'}),
+        CommentaryEra.other,
+      );
+    });
+  });
+
+  group('singleton', () {
+    test('resetInstanceForTesting מחליף את המימוש', () async {
+      var loads = 0;
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async {
+          loads++;
+          return const [];
+        },
+      );
+
+      TargetLineLinksService.instance.prefetch(_link(path2: 'רש"י'));
+      await pumpEventQueue();
+
+      expect(loads, 1);
+    });
+
+    test('איפוס מנקה את המטמון של המופע הקודם', () async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [],
+      );
+      final link = _link(path2: 'רש"י');
+      TargetLineLinksService.instance.prefetch(link);
+      await pumpEventQueue();
+      expect(TargetLineLinksService.instance.cached(link), isNotNull);
+
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [],
+      );
+      expect(TargetLineLinksService.instance.cached(link), isNull);
+    });
+  });
+}

--- a/test/services/target_line_links_service_test.dart
+++ b/test/services/target_line_links_service_test.dart
@@ -481,6 +481,28 @@ void main() {
       );
     });
 
+    test('טעינות תלויות אינן חורגות מתקרת המטמון', () async {
+      final gate = Completer<void>();
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          await gate.future;
+          return const [];
+        },
+      );
+
+      for (var i = 1; i <= 300; i++) {
+        service.prefetch(_link(path2: 'ספר', index2: i));
+      }
+
+      expect(service.cacheSize, 256);
+      expect(loads, 256);
+
+      gate.complete();
+      await pumpEventQueue();
+    });
+
     test('המטמון מפנה לפי שימוש אחרון ולא לפי סדר הכנסה', () async {
       final service = TargetLineLinksService(loader: (_, _, _) async => []);
 
@@ -532,17 +554,24 @@ void main() {
       expect(service.cacheSize, 0);
     });
 
-    test('המטמון חסום ומפנה את הוותיק ביותר', () async {
-      final service = TargetLineLinksService(loader: (_, _, _) async => []);
+    test('המטמון חסום כשכל הערכים מתחילים להיטען יחד', () async {
+      var loads = 0;
+      final service = TargetLineLinksService(
+        loader: (_, _, _) async {
+          loads++;
+          return [];
+        },
+      );
 
       for (var i = 1; i <= 300; i++) {
         service.prefetch(_link(path2: 'ספר', index2: i));
       }
       await pumpEventQueue();
 
-      expect(service.cacheSize, lessThanOrEqualTo(256));
-      expect(service.cached(_link(path2: 'ספר', index2: 1)), isNull);
-      expect(service.cached(_link(path2: 'ספר', index2: 300)), isNotNull);
+      expect(service.cacheSize, 256);
+      expect(loads, 256);
+      expect(service.cached(_link(path2: 'ספר', index2: 1)), isNotNull);
+      expect(service.cached(_link(path2: 'ספר', index2: 300)), isNull);
     });
   });
 

--- a/test/utils/context_menu_target_line_links_test.dart
+++ b/test/utils/context_menu_target_line_links_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/link_types.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/services/target_line_links_service.dart';
+import 'package:otzaria/utils/ui/context_menu_utils.dart';
+import 'package:otzaria/widgets/misc/app_menu_exports.dart';
+
+/// תפריט ההקשר של מפרש/קישור מציג "מפרשים" ו"קישורים" של *קטע היעד* — מה
+/// שיושב על אותה שורה בספר המפרש. הטסטים נועלים את חוט ההזרקה: בלי
+/// `onNavigateToLink` התפריט חייב להישאר כשהיה (שלושת המשטחים חולקים אותו).
+Link _link({
+  String path2 = 'רש"י על שבת',
+  int index2 = 5,
+  String connectionType = LinkTypes.commentary,
+}) {
+  return Link(
+    heRef: 'רש"י פסוק א',
+    index1: 12,
+    path2: path2,
+    index2: index2,
+    connectionType: connectionType,
+    targetCategoryId: 3,
+  );
+}
+
+class _MenuProbe extends StatelessWidget {
+  const _MenuProbe({required this.onEntries, this.onNavigateToLink});
+
+  final ValueChanged<List<AppContextMenuEntry>> onEntries;
+  final void Function(Link)? onNavigateToLink;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () => onEntries(
+        ContextMenuUtils.buildCommentaryContextMenu(
+          context: context,
+          link: _link(),
+          openBookCallback: (_) {},
+          fontSize: 16,
+          removeNikud: false,
+          removePunctuation: false,
+          savedSelectedText: 'טקסט מסומן',
+          onCopySelected: () {},
+          onNavigateToLink: onNavigateToLink,
+        ),
+      ),
+      child: const Text('פתח'),
+    );
+  }
+}
+
+void main() {
+  tearDown(TargetLineLinksService.resetInstanceForTesting);
+
+  Future<List<AppContextMenuEntry>> buildMenu(
+    WidgetTester tester, {
+    void Function(Link)? onNavigateToLink,
+  }) async {
+    List<AppContextMenuEntry>? captured;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _MenuProbe(
+            onEntries: (entries) => captured = entries,
+            onNavigateToLink: onNavigateToLink,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('פתח'));
+    await tester.pump();
+    return captured!;
+  }
+
+  group('הצגת הפריטים בתפריט', () {
+    testWidgets('בלי onNavigateToLink התפריט נשאר כשהיה', (tester) async {
+      final labels = (await buildMenu(tester)).map((e) => e.label);
+
+      expect(labels, isNot(contains('מפרשים')));
+      expect(labels, isNot(contains('קישורים')));
+      expect(labels, contains('העתק'));
+      expect(labels, contains('פתח ספר זה בחלון נפרד'));
+    });
+
+    testWidgets('עם onNavigateToLink נוספים שני הפריטים', (tester) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [],
+      );
+      final labels = (await buildMenu(
+        tester,
+        onNavigateToLink: (_) {},
+      )).map((e) => e.label).toList();
+
+      expect(labels, contains('מפרשים'));
+      expect(labels, contains('קישורים'));
+    });
+
+    testWidgets('הפריטים מופיעים אחרי ההעתקות ולפני פתיחת הספר', (
+      tester,
+    ) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [],
+      );
+      final labels = (await buildMenu(
+        tester,
+        onNavigateToLink: (_) {},
+      )).map((e) => e.label).toList();
+
+      // indexOf מחזיר -1 לפריט חסר, ולכן קודם מוודאים שכולם קיימים — אחרת
+      // ההשוואות היו עוברות דווקא כשהפריטים נעלמו.
+      expect(labels, containsAll(<String>['מפרשים', 'קישורים']));
+      expect(
+        labels.indexOf('מפרשים'),
+        greaterThan(labels.indexOf('העתק את כל הפסקה')),
+      );
+      expect(
+        labels.indexOf('קישורים'),
+        greaterThan(labels.indexOf('מפרשים')),
+      );
+      expect(
+        labels.indexOf('קישורים'),
+        lessThan(labels.indexOf('פתח ספר זה בחלון נפרד')),
+      );
+    });
+
+    testWidgets('הפריטים הקיימים נשמרים לצד החדשים', (tester) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [],
+      );
+      final labels = (await buildMenu(
+        tester,
+        onNavigateToLink: (_) {},
+      )).map((e) => e.label);
+
+      expect(labels, contains('העתק'));
+      expect(labels, contains('העתק את כל הפסקה'));
+      expect(labels, contains('פתח ספר זה בחלון נפרד'));
+      expect(labels, contains('דווח על טעות בספר'));
+    });
+  });
+
+  group('תוכן תתי-התפריטים', () {
+    testWidgets('"מפרשים" מציג מפרשים על קטע היעד, "קישורים" את ההפניות', (
+      tester,
+    ) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [
+          _link(path2: 'מהרש"א', connectionType: LinkTypes.commentary),
+          _link(path2: 'עין משפט', connectionType: LinkTypes.einMishpat),
+        ],
+      );
+      TargetLineLinksService.instance.prefetch(_link());
+      await tester.pumpAndSettle();
+
+      final entries = await buildMenu(tester, onNavigateToLink: (_) {});
+      final commentaries = entries.firstWhere((e) => e.label == 'מפרשים');
+      final links = entries.firstWhere((e) => e.label == 'קישורים');
+
+      expect(commentaries.childrenBuilder!().single.label, contains('מהרש"א'));
+      expect(links.childrenBuilder!().single.label, contains('עין משפט'));
+    });
+
+    testWidgets('לחיצה על מפרש-של-מפרש מנווטת אליו', (tester) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [
+          _link(path2: 'מהרש"א', index2: 21),
+        ],
+      );
+      TargetLineLinksService.instance.prefetch(_link());
+      await tester.pumpAndSettle();
+
+      Link? navigated;
+      final entries = await buildMenu(
+        tester,
+        onNavigateToLink: (l) => navigated = l,
+      );
+      entries
+          .firstWhere((e) => e.label == 'מפרשים')
+          .childrenBuilder!()
+          .single
+          .onTap!();
+
+      expect(navigated!.path2, 'מהרש"א');
+      expect(navigated!.index2, 21);
+    });
+
+    testWidgets('לפריטי היעד יש תצוגה מקדימה ברפרוף', (tester) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [_link(path2: 'מהרש"א')],
+      );
+      TargetLineLinksService.instance.prefetch(_link());
+      await tester.pumpAndSettle();
+
+      final entries = await buildMenu(tester, onNavigateToLink: (_) {});
+      final child = entries
+          .firstWhere((e) => e.label == 'מפרשים')
+          .childrenBuilder!()
+          .single;
+
+      expect(child.hoverPreviewBuilder, isNotNull);
+    });
+
+    testWidgets('קטע בלי מפרשים מקבל פריט אפור', (tester) async {
+      TargetLineLinksService.resetInstanceForTesting(
+        loader: (_, _, _) async => [
+          _link(path2: 'עין משפט', connectionType: LinkTypes.einMishpat),
+        ],
+      );
+      TargetLineLinksService.instance.prefetch(_link());
+      await tester.pumpAndSettle();
+
+      final entries = await buildMenu(tester, onNavigateToLink: (_) {});
+
+      expect(
+        entries.firstWhere((e) => e.label == 'מפרשים').enabled,
+        isFalse,
+      );
+      expect(
+        entries.firstWhere((e) => e.label == 'קישורים').enabled,
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/widgets/app_context_menu_test.dart
+++ b/test/widgets/app_context_menu_test.dart
@@ -924,6 +924,48 @@ void main() {
     },
   );
 
+  testWidgets(
+    'childrenRefreshStream: תת-תפריט עם ילדים מושבתים משבית את פריט האב',
+    (tester) async {
+      final controller = StreamController<Object?>.broadcast();
+      addTearDown(controller.close);
+      var loaded = false;
+      final key = GlobalKey<AppContextMenuRegionState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppContextMenuRegion(
+              key: key,
+              menuBuilder: (_, _) => [
+                AppContextMenuEntry(
+                  label: 'מפרשים',
+                  childrenRefreshStream: controller.stream,
+                  childrenBuilder: () => [
+                    AppContextMenuEntry(
+                      label: loaded ? 'אין מפרשים' : 'טוען…',
+                      enabled: false,
+                    ),
+                  ],
+                ),
+              ],
+              child: const SizedBox(width: 200, height: 200),
+            ),
+          ),
+        ),
+      );
+
+      await key.currentState!.openMenuAt(const Offset(100, 100));
+      await tester.pumpAndSettle();
+      loaded = true;
+      controller.add(null);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SubmenuButton), findsNothing);
+      expect(find.text('מפרשים'), findsOneWidget);
+    },
+  );
+
   testWidgets('openMenuAt: קריאה כפולה אינה פותחת שני תפריטים', (tester) async {
     final key = GlobalKey<AppContextMenuRegionState>();
 

--- a/test/widgets/app_context_menu_test.dart
+++ b/test/widgets/app_context_menu_test.dart
@@ -667,6 +667,97 @@ void main() {
     );
   });
 
+  group('onHoverEnter — טעינה מקדימה של תוכן התפריט', () {
+    Future<int> hoverEnterCount(
+      WidgetTester tester, {
+      required bool withCallback,
+      bool moveAwayAndBack = false,
+    }) async {
+      var calls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: AppContextMenuRegion(
+                onHoverEnter: withCallback ? () => calls++ : null,
+                menuBuilder: (_, _) => [
+                  AppContextMenuEntry(label: 'העתק', onTap: () {}),
+                ],
+                child: const SizedBox(
+                  width: 100,
+                  height: 100,
+                  child: ColoredBox(color: Colors.amber),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+
+      final center = tester.getCenter(find.byType(AppContextMenuRegion));
+      await gesture.moveTo(center);
+      await tester.pumpAndSettle();
+      if (moveAwayAndBack) {
+        await gesture.moveTo(Offset.zero);
+        await tester.pumpAndSettle();
+        await gesture.moveTo(center);
+        await tester.pumpAndSettle();
+      }
+      return calls;
+    }
+
+    testWidgets('ריחוף על האזור מפעיל את ה-callback', (tester) async {
+      expect(await hoverEnterCount(tester, withCallback: true), 1);
+    });
+
+    testWidgets('יציאה וחזרה מפעילות שוב (ה-prefetch עצמו אידמפוטנטי)', (
+      tester,
+    ) async {
+      expect(
+        await hoverEnterCount(
+          tester,
+          withCallback: true,
+          moveAwayAndBack: true,
+        ),
+        2,
+      );
+    });
+
+    testWidgets('בלי onHoverEnter לא נוסף MouseRegion עוטף', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: AppContextMenuRegion(
+                menuBuilder: (_, _) => [
+                  AppContextMenuEntry(label: 'העתק', onTap: () {}),
+                ],
+                child: const SizedBox(width: 100, height: 100),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(AppContextMenuRegion),
+          matching: find.byType(MouseRegion),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('הריחוף אינו פותח את התפריט מעצמו', (tester) async {
+      await hoverEnterCount(tester, withCallback: true);
+      expect(find.text('העתק'), findsNothing);
+    });
+  });
+
   // ───────────────────────────────────────────────────────────────────────
   // openMenuAt — פתיחה פרוגרמטית (משמש ל-long press ב-PDF)
   // ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
לחיצה ימנית על פריט מפרש או קישור הציגה עד היום רק העתקה, פתיחה ודיווח. מעכשיו נוספים שני תתי-תפריטים — "מפרשים" ו"קישורים" — של השורה בספר היעד עצמו, כך שאפשר לרדת מרש"י למהרש"א בלי לפתוח את רש"י כספר.

שתי הרשימות מגיעות משאילתה אחת על שורת היעד ומופרדות לפי LinkTypes.isDependentTextLink. הטעינה מתחילה בריחוף (בהשהיה, שסמן חולף מעל רשימת מפרשים לא יפתח שאילתה לכל פריט בדרך), כך שהתפריט נבנה עם נתונים מוכנים והפריט אפור מיד כשאין תוכן.

השירות משותף לשלושת המשטחים דרך buildCommentaryContextMenu: פאנל המפרשים, חלונית הקישורים ומפרשי ה-PDF.

- מטמון LRU חסום, עם מזהה-דור שמנטרל תוצאות מלפני החלפת ספרייה
- זהות היעד במפתח כוללת אישי/רשמי, אחרת שני ספרים באותה כותרת התחלפו
- כשל טעינה אינו מקובע: ריחוף או לחיצה חדשים מנסים שוב, בלי לולאת שאילתות
- CommentaryService.sortingEraForLink נחשף כדי שמפרידי הדורות יתאימו למיון