### PR TITLE
תיקון: "מפרשים נוספים" בספר רש"י הצביע על אוצר לעזי רש"י במקום על הגמרא

### DIFF
--- a/lib/data/data_providers/database_library_provider.dart
+++ b/lib/data/data_providers/database_library_provider.dart
@@ -306,6 +306,9 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
   final hasLinkRanges = _hasLinkRangeTables(db);
   final anchorSelect = _anchorSelectColumns(hasLinkAnchor);
   final anchorJoin = _anchorJoinClause(hasLinkAnchor, displayedSide: 1);
+  final provenanceSelect = _hasLinkBaseProvenanceColumn(db)
+      ? 'l.baseProvenance as baseProvenance,'
+      : '0 as baseProvenance,';
   // בפאנל של תצוגת המקור מוצג צד ה-source של הקישור (side=0).
   final rangeEndSelect = _rangeEndSelectColumns(hasLinkRanges);
   final rangeEndJoin = _rangeEndJoinClause(hasLinkRanges, panelSide: 0);
@@ -349,6 +352,7 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
           NULL as targetFileType,
           $rangeEndSelect
           $anchorSelect
+          $provenanceSelect
           'SOURCE' as connectionTypeName
         FROM anchors a
         JOIN link l ON l.id = a.linkId
@@ -390,6 +394,7 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
         NULL as targetFileType,
         $rangeEndSelect
         $anchorSelect
+        $provenanceSelect
         'SOURCE' as connectionTypeName
       FROM anchors a
       JOIN link l ON l.id = a.linkId
@@ -412,6 +417,14 @@ List<Map<String, dynamic>> _loadInverseSourceRows(
 bool _hasLinkAnchorTable(sqlite3.Database db) => db
     .select(
       "SELECT 1 FROM sqlite_master WHERE type='table' AND name='link_anchor' LIMIT 1",
+    )
+    .isNotEmpty;
+
+/// `baseProvenance` — קיימת רק במסדים חדשים; במסד ישן כל הקישורים מקבלים 0
+/// והעדפת המקור נשארת כפי שהייתה.
+bool _hasLinkBaseProvenanceColumn(sqlite3.Database db) => db
+    .select(
+      "SELECT 1 FROM pragma_table_info('link') WHERE name = 'baseProvenance' LIMIT 1",
     )
     .isNotEmpty;
 
@@ -3131,6 +3144,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           index2End: row['targetRangeEndLineIndex'] != null
               ? (row['targetRangeEndLineIndex'] as int) + 1
               : null,
+          baseProvenance: row['baseProvenance'] as int? ?? 0,
         );
       }).toList();
 
@@ -3204,6 +3218,7 @@ class DatabaseLibraryProvider implements LibraryProvider {
           index2End: row['targetRangeEndLineIndex'] != null
               ? (row['targetRangeEndLineIndex'] as int) + 1
               : null,
+          baseProvenance: row['baseProvenance'] as int? ?? 0,
         );
       }).toList();
       return links;

--- a/lib/models/links.dart
+++ b/lib/models/links.dart
@@ -106,6 +106,11 @@ class Link {
   /// קישור-טווח: אינדקס (1-based) של השורה האחרונה בטווח בצד המקושר, או null.
   final int? index2End;
 
+  /// מהימנות כיוון הקישור (עמודת `baseProvenance` במסד): 2 = יחס בסיס מוצהר,
+  /// 1 = הוסק מכותרת "X על Y", 0 = ציטוט לטרלי. מבדיל את המקור האמיתי מציטוט
+  /// כשלשורה אחת יש כמה קישורי SOURCE.
+  final int baseProvenance;
+
   /// Creates a new instance of [Link] with the provided parameters.
   Link({
     required this.heRef,
@@ -126,6 +131,7 @@ class Link {
     this.anchorSpans = const [],
     this.heRefEnd,
     this.index2End,
+    this.baseProvenance = 0,
   });
 
   static final LinkedHashMap<String, Future<String>> _contentCache =
@@ -313,7 +319,8 @@ class Link {
       anchorSpans = const [],
       // קישורי-טווח מגיעים רק ממסד הנתונים (link_range), לא מקבצי JSON.
       heRefEnd = null,
-      index2End = null;
+      index2End = null,
+      baseProvenance = 0;
 }
 
 /// Retrieves a list of [Link] objects for the given list of [indexes] and the [links] to be processed.

--- a/lib/text_book/utils/link_processing.dart
+++ b/lib/text_book/utils/link_processing.dart
@@ -12,7 +12,12 @@ List<Link> mergeLinksByIdentity(
   };
 
   for (final link in incoming) {
-    merged[_linkIdentityKey(link)] = link;
+    final key = _linkIdentityKey(link);
+    final existingLink = merged[key];
+    if (existingLink == null ||
+        link.baseProvenance >= existingLink.baseProvenance) {
+      merged[key] = link;
+    }
   }
 
   final links = merged.values.toList();

--- a/lib/text_book/view/sibling_commentaries_menu.dart
+++ b/lib/text_book/view/sibling_commentaries_menu.dart
@@ -39,13 +39,19 @@ class SiblingCommentariesController {
 
   /// מאתר את קישור ה-SOURCE הווירטואלי של השורה (הקפיצה מפרש→מקור). מוחזר null
   /// כשהשורה אינה בספר מפרש — ואז אין להציג את הפריט כלל.
+  /// לשורה יכולים להיות כמה קישורי SOURCE; נבחר בעל ה-[Link.baseProvenance]
+  /// הגבוה — יחס הבסיס המוצהר ולא ציטוט לטרלי שנשמר במסד בכיוון ההפוך.
   Link? sourceLinkForLine(Map<int, List<Link>> linksByLine, int lineIndex) {
     final links = linksByLine[lineIndex];
     if (links == null) return null;
+    Link? best;
     for (final link in links) {
-      if (LinkTypes.isVirtualSource(link.connectionType)) return link;
+      if (!LinkTypes.isVirtualSource(link.connectionType)) continue;
+      if (best == null || link.baseProvenance > best.baseProvenance) {
+        best = link;
+      }
     }
-    return null;
+    return best;
   }
 
   /// בונה את פריט התפריט "מפרשים נוספים על <כתובת המקור>", או null כשאין מקור

--- a/test/data_providers/database_library_provider_test.dart
+++ b/test/data_providers/database_library_provider_test.dart
@@ -335,6 +335,76 @@ void main() {
       }
     });
 
+    test('SOURCE inverse נושא את baseProvenance של הקישור כשהעמודה קיימת', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'otzaria_db_provenance',
+      );
+      final dbPath = path.join(tempDir.path, 'db.sqlite');
+      final db = sqlite3.sqlite3.open(dbPath);
+
+      try {
+        db.execute(
+          'CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT, categoryId INTEGER, fileType TEXT)',
+        );
+        db.execute(
+          'CREATE TABLE line (id INTEGER PRIMARY KEY, lineIndex INTEGER, heRef TEXT)',
+        );
+        db.execute(
+          'CREATE TABLE connection_type (id INTEGER PRIMARY KEY, name TEXT)',
+        );
+        db.execute(
+          'CREATE TABLE link (id INTEGER PRIMARY KEY, sourceBookId INTEGER, sourceLineId INTEGER, targetLineId INTEGER, targetBookId INTEGER, connectionTypeId INTEGER, baseProvenance INTEGER NOT NULL DEFAULT 0)',
+        );
+
+        // רש"י (3) מקושר גם מהבסיס (1, יחס מוצהר) וגם מספר תלוי ששמור בכיוון
+        // ההפוך (2, ציטוט לטרלי) — שני קישורי SOURCE לאותה שורה.
+        db.execute(
+          "INSERT INTO book (id, title, categoryId, fileType) VALUES (1, 'בבא קמא', 7, 'txt')",
+        );
+        db.execute(
+          "INSERT INTO book (id, title, categoryId, fileType) VALUES (2, 'אוצר לעזי רש''י', 9, 'txt')",
+        );
+        db.execute(
+          "INSERT INTO book (id, title, categoryId, fileType) VALUES (3, 'רש''י על בבא קמא', 8, 'txt')",
+        );
+        db.execute(
+          "INSERT INTO line (id, lineIndex, heRef) VALUES (10, 0, 'א')",
+        );
+        db.execute(
+          "INSERT INTO line (id, lineIndex, heRef) VALUES (20, 4, 'ה')",
+        );
+        db.execute(
+          "INSERT INTO line (id, lineIndex, heRef) VALUES (30, 7, 'ז')",
+        );
+        db.execute(
+          "INSERT INTO connection_type (id, name) VALUES (1, 'COMMENTARY')",
+        );
+        db.execute(
+          'INSERT INTO link (sourceBookId, sourceLineId, targetLineId, targetBookId, connectionTypeId, baseProvenance) VALUES (2, 30, 20, 3, 1, 0)',
+        );
+        db.execute(
+          'INSERT INTO link (sourceBookId, sourceLineId, targetLineId, targetBookId, connectionTypeId, baseProvenance) VALUES (1, 10, 20, 3, 1, 2)',
+        );
+
+        final rows = DatabaseLibraryProvider.loadBookLinksRowsForTesting(
+          dbPath: dbPath,
+          title: 'רש\'י על בבא קמא',
+          categoryId: 8,
+          fileType: 'txt',
+        );
+
+        final provenanceByTitle = {
+          for (final row in rows)
+            row['targetBookTitle'] as String: row['baseProvenance'],
+        };
+        expect(provenanceByTitle['בבא קמא'], 2);
+        expect(provenanceByTitle['אוצר לעזי רש\'י'], 0);
+      } finally {
+        db.close();
+        await tempDir.delete(recursive: true);
+      }
+    });
+
     test('חלון שורות חלקי וסיכום כלל־ספרי נשארים עקביים', () async {
       final tempDir = await Directory.systemTemp.createTemp('otzaria_db_range');
       final dbPath = path.join(tempDir.path, 'db.sqlite');

--- a/test/text_book/sibling_commentaries_menu_test.dart
+++ b/test/text_book/sibling_commentaries_menu_test.dart
@@ -5,14 +5,19 @@ import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/text_book/view/sibling_commentaries_menu.dart';
 
-Link _sourceLink({int index1 = 5}) => Link(
+Link _sourceLink({
+  int index1 = 5,
+  String path2 = 'ברכות',
+  int baseProvenance = 0,
+}) => Link(
   heRef: 'ברכות ד ב',
   index1: index1,
-  path2: 'ברכות',
+  path2: path2,
   index2: 10,
   connectionType: LinkTypes.source,
   targetCategoryId: 3,
   targetFileType: 'text',
+  baseProvenance: baseProvenance,
 );
 
 Link _commentaryLink(String title) => Link(
@@ -37,6 +42,31 @@ void main() {
         LinkTypes.source,
       );
       expect(c.sourceLinkForLine(linksByLine, 6), isNull);
+      c.dispose();
+    });
+
+    test('sourceLinkForLine מעדיף את יחס הבסיס המוצהר על ציטוט לטרלי', () {
+      final c = SiblingCommentariesController(loadSiblings: (_) async => []);
+      // סדר הקישורים בשורה אלפביתי לפי path2, ולכן הציטוט הלטרלי קודם.
+      final linksByLine = {
+        5: [
+          _sourceLink(path2: 'אוצר לעזי רש"י'),
+          _sourceLink(path2: 'בבא קמא', baseProvenance: 2),
+        ],
+      };
+      expect(c.sourceLinkForLine(linksByLine, 5)?.path2, 'בבא קמא');
+      c.dispose();
+    });
+
+    test('sourceLinkForLine שומר על הראשון כשה-provenance שווה', () {
+      final c = SiblingCommentariesController(loadSiblings: (_) async => []);
+      final linksByLine = {
+        5: [
+          _sourceLink(path2: 'ברכות', baseProvenance: 2),
+          _sourceLink(path2: 'שבת', baseProvenance: 2),
+        ],
+      };
+      expect(c.sourceLinkForLine(linksByLine, 5)?.path2, 'ברכות');
       c.dispose();
     });
 

--- a/test/text_book/utils/link_processing_test.dart
+++ b/test/text_book/utils/link_processing_test.dart
@@ -10,6 +10,7 @@ Link makeLink({
   String connectionType = 'reference',
   int? start,
   int? end,
+  int baseProvenance = 0,
 }) {
   return Link(
     heRef: heRef,
@@ -19,6 +20,7 @@ Link makeLink({
     connectionType: connectionType,
     start: start,
     end: end,
+    baseProvenance: baseProvenance,
   );
 }
 
@@ -42,6 +44,16 @@ void main() {
 
       expect(merged, hasLength(1));
       expect(merged.first.heRef, 'חדש');
+    });
+
+    test('קישור חלש אינו דורס provenance גבוה באותה זהות', () {
+      final existing = [makeLink(baseProvenance: 2)];
+      final incoming = [makeLink(baseProvenance: 0)];
+
+      final merged = mergeLinksByIdentity(existing, incoming);
+
+      expect(merged, hasLength(1));
+      expect(merged.single.baseProvenance, 2);
     });
 
     test('קישורים עם start/end שונים נחשבים נפרדים', () {
@@ -212,6 +224,24 @@ void main() {
       expect(result.links, hasLength(300));
       expect(result.visibleLinks, hasLength(1));
       expect(result.visibleLinks.first.index1, 1);
+    });
+
+    test('מסלול isolate שומר provenance גבוה מול קישור נכנס זהה', () async {
+      final result = await processLinksForState(
+        existingLinks: [
+          makeLink(index1: 1, baseProvenance: 2),
+          for (var i = 2; i <= 251; i++) makeLink(index1: i, index2: i),
+        ],
+        incomingLinks: [makeLink(index1: 1, baseProvenance: 0)],
+        replaceExisting: false,
+        visibleIndices: [0],
+        selectedIndices: const {},
+      );
+
+      expect(
+        result.links.singleWhere((link) => link.index1 == 1).baseProvenance,
+        2,
+      );
     });
   });
 


### PR DESCRIPTION
## הבאג

בספר מפרש, תת-התפריט **"מפרשים נוספים על …"** הצביע על הספר הלא נכון בשורות שיש בהן ערך מ**"אוצר לעזי רש"י"**.

לדוגמה ב"רש"י על בבא קמא" דף צז: במקום *"מפרשים נוספים על בבא קמא צז"* הוצג *"מפרשים נוספים על אוצר לעזי רש"י"*, וממילא גם רשימת המפרשים שבתת-התפריט הייתה של הספר הלא נכון. בשורות רש"י בלי לעז הפריט עבד כשורה.

## שורש הבעיה

1. **הנתונים** — קישורי הספר "אוצר לעזי רש"י" (bookId 5813) שמורים ב-`seforim.db` בכיוון ההפוך לקונבנציה: `sourceBookId` = הלעז, `targetBookId` = ספר הרש"י, `connectionType = COMMENTARY` (3,845 קישורים). בקישור רגיל ה-source הוא ספר הבסיס.

2. **השאילתה ההפוכה** — `_loadInverseSourceRows` מייצרת קישור `SOURCE` וירטואלי לכל קישור תלוי-טקסט שבו הספר הפתוח הוא ה-target. בקישורי הלעז ההנחה הזאת שקרית, ולכן לשורת רש"י עם לעז נוצרים **שני** קישורי SOURCE:

   | ספר המקור | סוג | `baseProvenance` |
   |---|---|---|
   | אוצר לעזי רש"י | COMMENTARY | 0 (ציטוט לטרלי) |
   | בבא קמא | COMMENTARY | 2 (יחס בסיס מוצהר) |

3. **הבחירה** — `mergeLinksByIdentity` ממיין את קישורי השורה לפי `path2` אלפביתית, ו-`sourceLinkForLine` החזיר את הראשון. **א**וצר לעזי רש"י הקדים את **ב**בא קמא, ולכן הציטוט הלטרלי "ניצח" תמיד.

הבאג אינו נובע מפיצ'ר לעזי רש"י — הקישורים ההפוכים קיימים במסד מלכתחילה. הוא נוכח מאז 45b1449d3 (הפיצ'ר "מפרשים נוספים על הדף", issue #435), שהניח מקור אחד לכל שורה. ההיקף רחב מהלעז: **105,059** שורות במסד יש להן יותר ממועמד-מקור אחד, וכולן נבחרו לפי אלפבית.

## התיקון

לעמודה `link.baseProvenance` שבמסד יש תיעוד מפורש בסכמה — *"Boosts declared > inferred > lateral citations in the SOURCE virtual view's ORDER BY clause"* — והקוד פשוט לא השתמש בה מעולם (אפס מופעים בריפו). התיקון מחבר אותה:

- **`lib/models/links.dart`** — שדה `baseProvenance` (ברירת מחדל 0).
- **`lib/data/data_providers/database_library_provider.dart`** — העמודה נקראת **רק בזרוע ההפוכה (SOURCE)**, מאחורי `_hasLinkBaseProvenanceColumn` לתאימות מסד ישן.
- **`lib/text_book/view/sibling_commentaries_menu.dart`** — `sourceLinkForLine` בוחר את בעל ה-`baseProvenance` הגבוה במקום את הראשון.

### למה זה לא נוגע בשום דבר אחר

- שורה עם קישור SOURCE אחד (הרוב המוחלט) — התנהגות זהה לחלוטין; ההעדפה חלה רק בהתנגשות.
- **`baseProvenance = 0` לא מסונן.** 539,580 קישורים תלויים לגיטימיים נושאים 0 (למשל `בבא קמא → חברותא על בבא קמא`, `טור → בית יוסף`); סינון היה מוחק להם את הפיצ'ר. העדפה בלבד אינה פוגעת בהם.
- מסד ללא העמודה (זה שנבנה ע"י המיגרציה המקומית) — כולם 0, התנהגות זהה לקודם.
- כיסוי: כל **3,605** שורות הרש"י שיש להן לעז — לכולן, 100%, קיים גם קישור-מקור עם `baseProvenance > 0`.

## בדיקות

- `flutter analyze` על הקבצים שנגעו — נקי. `dart format` — ללא שינוי.
- `flutter test` — 38 טסטים עוברים: `sibling_commentaries_menu_test` (2 טסטים חדשים: העדפה + תיקו), `data_providers/database_library_provider_test` (טסט חדש שיוצר את הטבלה **עם** העמודה ואומת שהערכים מגיעים), וכן `models/links_test`, `link_processing_test`, `commentary_reverse_links_test`.
- אימות מול `seforim.db` האמיתי: השאילתה המתוקנת מחזירה `בבא קמא (prov=2)` לצד `אוצר לעזי רש"י (prov=0)`, והבחירה נופלת על בבא קמא.
- אימות שהשדה שורד את גבול ה-`Isolate` (מעל 250 קישורים → מסלול `Isolate.run` ב-`processLinksForState`): נבדק ואומת.

## רדיוס ההשפעה — לתשומת לב הסוקר

התיקון אינו מוגבל למקרה הלעז. במסד האמיתי 105,059 שורות-תצוגה נושאות יותר מקישור SOURCE אחד, ומתוכן **13,935** שורות משנות בחירה. הרוב שיפור מובהק, אבל בכ-1,500 שורות הבחירה זזה מהספר הספציפי אל ספר הבסיס הכללי — לפי דעת המסד:

| ספר | לפני | אחרי | שורות |
|---|---|---|---|
| מזרחי | רש"י על שמות | שמות | 1,160 |
| גור אריה על שמות | רש"י על שמות | שמות | 934 |
| נקודות הכסף | טורי זהב על שו"ע יו"ד | שולחן ערוך, יורה דעה | 537 |
| פסקי תוספות על תענית | תוספות על תענית | תענית | 51 |

בספרים האלה `שמות → מזרחי` מסומן במסד `prov=2` בעוד `רש"י על שמות → מזרחי` מסומן `prov=0`, כלומר ספריא הצהירה שהבסיס של מזרחי הוא החומש. הקוד נאמן למסד — אבל למי שקורא נושא-כלי של רש"י, "מפרשים נוספים על רש"י על שמות" הוא לעתים התשובה המועילה יותר. **זו החלטת מוצר ולא באג**, ואם ההעדפה הזאת אינה רצויה אפשר לחדד אותה בהמשך (למשל העדפת ספר-מקור שהוא עצמו `dependenceType != NULL`, כלומר הספציפי לפני הכללי) — לא נכלל כאן כדי לשמור על תיקון ממוקד.

## מה נשאר פתוח (מחוץ להיקף)

- **תווית "מקור" בפאנל הקישורים**: בספר רש"י, "אוצר לעזי רש"י" עדיין מופיע שם בתווית "מקור". הקישור אמיתי ורק התווית לא מדויקת; תיקונה מחייב סינון של הזרוע ההפוכה, ששובר ספרים אחרים.
- **51,364 שורות עמומות**: שורות שכל מועמדי ה-SOURCE שלהן `prov=0` (כולן במשפחת "הערות על חברותא על X") נשארות בבחירה אלפביתית ולכן לא עקבית. המסד אינו נותן שם שום אות להכרעה.
- **מסד שנבנה מקומית**: `baseProvenance` אינה ב-DDL של `lib/migration/` — היא מגיעה רק מכלי הבנייה של seforim.db. במסד כזה כל הקישורים 0 והבאג יישאר (מכוסה ב-guard, בלי שגיאה).

## סקירת QA

התיקון נבדק בסוכן QA נפרד. לא נמצא ממצא חמור. אומתו: נכונות ה-SQL בשתי הזרועות, שרידות השדה בכל הצינור (אין `copyWith`/`toJson` ל-`Link`, אין בנייה מחדש במסלול), התאמת ה-guard למסד ישן, והיעדר השפעה על פאנל המפרשים/הקישורים/PDF. פער כיסוי שדווח (הענף שבו העמודה קיימת) נסגר בטסט חדש. ממצא תיאורטי שנשאר במודע: `_linkIdentityKey` אינו כולל `baseProvenance`, כך שקישור-משתמש מיובא שמשכפל זהות של קישור רשמי היה דורס `prov=2` ב-0 — במסד האמיתי אין אף התנגשות כזאת.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
