### PR TITLE
תיקון: חיפוש בספר רץ מחדש בכל חזרה לטאב

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -613,8 +613,11 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Area | Test File |
 |------|-----------|
 | Screen actions (overflow, layout) | `test/text_book/view/text_book_screen_actions_test.dart` |
+| שימור חלונית הניווט במעבר טאב | `test/text_book/view/text_book_nav_panel_preserved_test.dart` |
+| יעד סיור לחלונית הניווט (מפתח יציב) | `test/text_book/view/widgets/nav_panel_tour_target_test.dart` |
 | Search controller sync | `test/text_book/text_book_search_query_sync_test.dart` |
 | Search screen | `test/text_book/view/text_book_search_screen_test.dart` |
+| קאש שורות הספר לחיפוש (שחרור בטאב רקע) | `test/text_book/view/text_book_search_content_cache_test.dart` |
 | TOC navigator UI | `test/text_book/view/toc_navigator_screen_test.dart` |
 | TOC navigator internals | `test/text_book/view/toc_navigator_internals_test.dart` |
 | Combined view helpers (shouldShow…) | `test/text_book/view/combined_view/combined_book_screen_test.dart` |

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -35,6 +35,7 @@ import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/library/view/library_browser.dart';
 import 'package:otzaria/tabs/reading_screen.dart';
 import 'package:otzaria/text_book/view/text_book_screen.dart';
+import 'package:otzaria/text_book/view/widgets/nav_panel_tour_target.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
@@ -1938,7 +1939,9 @@ class MainWindowScreenState extends State<MainWindowScreen>
       final buttonRect =
           _rectForGlobalKey(textBookNavigationTourTargetKey) ??
           _rectForGlobalKey(pdfBookNavigationTourTargetKey);
-      final panelRect = _rectForGlobalKey(textBookNavPanelTourTargetKey);
+      final panelRect = _rectForGlobalKey(
+        activeTextBookNavPanelTourTargetKey,
+      );
       return [
         ?buttonRect,
         ?panelRect,
@@ -2116,8 +2119,8 @@ class MainWindowScreenState extends State<MainWindowScreen>
     return _navData.indexWhere((item) => item.screen == screen);
   }
 
-  Rect? _rectForGlobalKey(GlobalKey key, {double inflate = 4}) {
-    final context = key.currentContext;
+  Rect? _rectForGlobalKey(GlobalKey? key, {double inflate = 4}) {
+    final context = key?.currentContext;
     if (context == null || !context.mounted) {
       return null;
     }

--- a/lib/text_book/models/search_results.dart
+++ b/lib/text_book/models/search_results.dart
@@ -8,11 +8,16 @@ class TextSearchResult {
   /// לצורך גלילה מדויקת. null בתוצאות ממנוע החיפוש, שאינו מוסר מיקום.
   final int? matchOffset;
 
+  /// אורך השורה הנקייה, בקואורדינטות של [matchOffset]. מאפשר לגלול אל ההופעה
+  /// גם כשתוכן הספר שוחרר מהזיכרון ואינו זמין לחישוב.
+  final int? lineLength;
+
   TextSearchResult({
     required this.snippet,
     required this.index,
     required this.query,
     required this.address,
     this.matchOffset,
+    this.lineLength,
   });
 }

--- a/lib/text_book/utils/section_search_utils.dart
+++ b/lib/text_book/utils/section_search_utils.dart
@@ -95,6 +95,14 @@ double matchFractionInLine(
   return (offset / clean.length).clamp(0.0, 1.0);
 }
 
+/// שבר המיקום של ההופעה בשורה כשטקסט השורה עצמו אינו זמין — למשל אחרי ששוחרר
+/// עותק שורות הספר. מחזיר 0 כשאין נתונים, ואז הגלילה מתייחסת לתחילת הקטע.
+double matchFractionFromLineLength({int? matchOffset, int? lineLength}) {
+  if (matchOffset == null || lineLength == null) return 0;
+  if (matchOffset <= 0 || lineLength <= 0) return 0;
+  return (matchOffset / lineLength).clamp(0.0, 1.0);
+}
+
 /// האם תוצאת החיפוש [query] נחתה בגוף הערת שוליים של [rawLine] בלבד —
 /// המונח נמצא בהערה אך לא בטקסט הראשי. משמש לפתיחת חלונית ההערות בפתיחת
 /// תוצאה, כשהספר לבדו אינו מציג את ההתאמה (גוף ההערה מוסר מהטקסט הראשי).
@@ -249,6 +257,7 @@ class _SearchWorkerHost {
                   address: raw['address'] as String,
                   query: raw['query'] as String,
                   matchOffset: raw['matchOffset'] as int?,
+                  lineLength: raw['lineLength'] as int?,
                 ),
               )
               .toList(growable: false),
@@ -408,6 +417,7 @@ class SectionSearchWorkerRuntime {
                 'address': cleanAddress,
                 'query': query,
                 'matchOffset': match.start,
+                'lineLength': cleanLines[i].length,
               });
               if (results.length >= _maxSearchResults) {
                 break;

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -49,6 +49,7 @@ import 'package:otzaria/text_book/view/tabbed_commentary_panel.dart';
 import 'package:otzaria/text_book/view/text_book_scaffold.dart';
 import 'package:otzaria/text_book/view/text_book_search_screen.dart';
 import 'package:otzaria/text_book/view/toc_navigator_screen.dart';
+import 'package:otzaria/text_book/view/widgets/nav_panel_tour_target.dart';
 import 'package:otzaria/text_book/view/alt_toc_sidebar_view.dart';
 import 'package:otzaria/utils/navigation/open_book.dart';
 import 'package:otzaria/data/book_locator.dart';
@@ -181,9 +182,6 @@ String _createTextBookTextExport(_TextExportRequest request) {
 
 final GlobalKey textBookNavigationTourTargetKey = GlobalKey(
   debugLabel: 'text_book_navigation_tour_target',
-);
-final GlobalKey textBookNavPanelTourTargetKey = GlobalKey(
-  debugLabel: 'text_book_nav_panel_tour_target',
 );
 final GlobalKey textBookCommentatorsTourTargetKey = GlobalKey(
   debugLabel: 'text_book_commentators_tour_target',
@@ -2574,12 +2572,10 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       minMainContentWidth: 520,
       onClose: () =>
           context.read<TextBookBloc>().add(const ToggleLeftPane(false)),
-      paneContent: widget.enableTourTargets
-          ? KeyedSubtree(
-              key: textBookNavPanelTourTargetKey,
-              child: _buildLeftPaneContent(state),
-            )
-          : _buildLeftPaneContent(state),
+      paneContent: TextBookNavPanelTourTarget(
+        isActiveTab: widget.enableTourTargets,
+        child: _buildLeftPaneContent(state),
+      ),
       mainContent: _buildHTMLViewer(state),
       isResizable: true,
       minPaneWidth: 200,

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -210,6 +210,15 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     });
   }
 
+  /// [TickerMode] כבוי מסמן שהטאב עבר לרקע (ראו `TickerMode` ב-`ReadingScreen`).
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!TickerMode.valuesOf(context).enabled) {
+      _releaseContentCache();
+    }
+  }
+
   @override
   void didUpdateWidget(TextBookSearchView oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -298,8 +307,8 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     _searchTextUpdated();
   }
 
-  /// טוען את תוכן הספר פעם אחת ושומר אותו לחיי החלונית. כישלון מאפס את
-  /// ה-Future כדי לאפשר ניסיון חוזר בחיפוש הבא.
+  /// טוען את תוכן הספר פעם אחת ושומר אותו עד לשחרור. כישלון — או שחרור בזמן
+  /// הטעינה — מאפס את ה-Future כדי לאפשר ניסיון חוזר בחיפוש הבא.
   Future<List<String>> _ensureContent() async {
     final existing = _contentFuture;
     if (existing != null) {
@@ -309,7 +318,9 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     _contentFuture = future;
     try {
       final lines = await future;
-      _content = lines;
+      if (identical(_contentFuture, future)) {
+        _content = lines;
+      }
       return lines;
     } catch (_) {
       if (identical(_contentFuture, future)) {
@@ -317,6 +328,13 @@ class TextBookSearchViewState extends State<TextBookSearchView>
       }
       rethrow;
     }
+  }
+
+  /// משחרר את עותק שורות הספר שנטען לחיפוש, כך שטאבי רקע אינם מחזיקים עותק כל
+  /// אחד. התוצאות שעל המסך נשמרות, והחיפוש הבא יטען מחדש לפי הצורך.
+  void _releaseContentCache() {
+    _content = null;
+    _contentFuture = null;
   }
 
   Future<void> _searchTextUpdated() async {
@@ -594,7 +612,10 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     }
     final lineText = _lineTextAt(result.index, loadedState);
     final intraLineFraction = lineText == null
-        ? 0.0
+        ? matchFractionFromLineLength(
+            matchOffset: result.matchOffset,
+            lineLength: result.lineLength,
+          )
         : matchFractionInLine(
             lineText,
             result.query,
@@ -646,19 +667,22 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     _scrollResultsToIndex(nextIndex, onlyIfNotVisible: true);
   }
 
-  /// טקסט השורה לצורך דיוק גלילה אל המילה: קודם התוכן שנטען לחיפוש, ואם
-  /// אינו זמין — התוכן שב-state (מלא בטאב פעיל אחרי חימום). null אם השורה
-  /// לא זמינה — ואז נופלים לגלילה לתחילת השורה.
+  /// טקסט השורה לצורך דיוק גלילה אל המילה: קודם התוכן שנטען לחיפוש, ואם אינו
+  /// זמין — התוכן שב-state. null כשהשורה אינה זמינה.
+  ///
+  /// שורה שתוכנה שוחרר מוחזרת מה-state כ-placeholder ריק, ולכן ריק נחשב כאן
+  /// כלא-זמין — אחרת החישוב היה נותן שבר 0 ומאבד את הגלילה אל ההופעה.
   String? _lineTextAt(int index, TextBookLoaded loadedState) {
     if (index < 0) {
       return null;
     }
     final content = _content;
     if (content != null && index < content.length) {
-      return content[index];
+      return content[index].isEmpty ? null : content[index];
     }
     if (index < loadedState.content.length) {
-      return loadedState.content[index];
+      final line = loadedState.content[index];
+      return line.isEmpty ? null : line;
     }
     return null;
   }

--- a/lib/text_book/view/widgets/nav_panel_tour_target.dart
+++ b/lib/text_book/view/widgets/nav_panel_tour_target.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// חלונית הניווט של טאב הטקסט הפעיל, כיעד להדגשה בסיור המודרך.
+///
+/// כל הטאבים הפתוחים חיים בעץ במקביל, ולכן אי-אפשר להצמיד מפתח גלובלי אחד
+/// לכולם — הטאב הפעיל מפרסם כאן את המפתח שלו.
+GlobalKey? activeTextBookNavPanelTourTargetKey;
+
+/// עוטף את חלונית הניווט של ספר טקסט במפתח יציב, ומפרסם אותו כיעד לסיור
+/// המודרך כל עוד [isActiveTab] נכון.
+///
+/// עטיפה שמתווספת ונעלמת לפי [isActiveTab] הייתה מחליפה את מבנה העץ באותו
+/// מקום, ו-Flutter משמיד אז את כל תת-העץ — החיפוש והניווט אובדים בכל מעבר טאב.
+class TextBookNavPanelTourTarget extends StatefulWidget {
+  /// האם זה הטאב הפעיל, כלומר זו החלונית שהסיור המודרך צריך להדגיש.
+  final bool isActiveTab;
+
+  final Widget child;
+
+  const TextBookNavPanelTourTarget({
+    super.key,
+    required this.isActiveTab,
+    required this.child,
+  });
+
+  @override
+  State<TextBookNavPanelTourTarget> createState() =>
+      _TextBookNavPanelTourTargetState();
+}
+
+class _TextBookNavPanelTourTargetState
+    extends State<TextBookNavPanelTourTarget> {
+  final GlobalKey _paneKey = GlobalKey(
+    debugLabel: 'text_book_nav_panel_tour_target',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _syncTourTarget();
+  }
+
+  @override
+  void didUpdateWidget(covariant TextBookNavPanelTourTarget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncTourTarget();
+  }
+
+  @override
+  void dispose() {
+    if (activeTextBookNavPanelTourTargetKey == _paneKey) {
+      activeTextBookNavPanelTourTargetKey = null;
+    }
+    super.dispose();
+  }
+
+  /// הניקוי מותנה בבעלות על הפרסום, כדי שלא יימחק פרסום של טאב אחר — הטאב
+  /// הנכנס והיוצא מתעדכנים באותו frame ובסדר לא מובטח.
+  void _syncTourTarget() {
+    if (widget.isActiveTab) {
+      activeTextBookNavPanelTourTargetKey = _paneKey;
+    } else if (activeTextBookNavPanelTourTargetKey == _paneKey) {
+      activeTextBookNavPanelTourTargetKey = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return KeyedSubtree(key: _paneKey, child: widget.child);
+  }
+}

--- a/test/text_book/utils/section_search_utils_test.dart
+++ b/test/text_book/utils/section_search_utils_test.dart
@@ -177,6 +177,31 @@ void main() {
       expect(results[1].index, 0);
     });
 
+    test('כל תוצאה נושאת את אורך השורה הנקייה לגלילה בלי התוכן', () async {
+      const line = 'אמר רבי יהודה דבר אחד ועוד אמר יהודה בן גרוש דבר אחר';
+      final results = await searchInContent(
+        content: [line],
+        query: 'יהודה',
+        patternSource: literalPatternSource('יהודה'),
+      );
+      expect(results.length, 2);
+      for (final result in results) {
+        expect(result.lineLength, line.length);
+        expect(
+          matchFractionFromLineLength(
+            matchOffset: result.matchOffset,
+            lineLength: result.lineLength,
+          ),
+          matchFractionInLine(
+            line,
+            'יהודה',
+            matchOffset: result.matchOffset,
+            pattern: literalPattern('יהודה'),
+          ),
+        );
+      }
+    });
+
     test('הופעות קרובות — כל snippet מכיל רק את ההופעה שלו', () async {
       final results = await searchInContent(
         content: ['אמר רבי יהודה דבר אחד ועוד אמר יהודה בן גרוש דבר אחר'],
@@ -411,6 +436,47 @@ void main() {
         pattern: literalPattern('ברא אלהים'),
       );
       expect(fraction, greaterThan(0));
+    });
+  });
+
+  group('matchFractionFromLineLength', () {
+    test('שבר מחושב מההיסט ומאורך השורה', () {
+      expect(
+        matchFractionFromLineLength(matchOffset: 25, lineLength: 100),
+        0.25,
+      );
+    });
+
+    test('היסט בתחילת השורה — שבר 0', () {
+      expect(matchFractionFromLineLength(matchOffset: 0, lineLength: 100), 0);
+    });
+
+    test('נתונים חסרים — שבר 0', () {
+      expect(matchFractionFromLineLength(matchOffset: 25, lineLength: null), 0);
+      expect(
+        matchFractionFromLineLength(matchOffset: null, lineLength: 100),
+        0,
+      );
+      expect(matchFractionFromLineLength(matchOffset: 25, lineLength: 0), 0);
+    });
+
+    test('היסט מעבר לאורך השורה נחתך ל-1', () {
+      expect(matchFractionFromLineLength(matchOffset: 200, lineLength: 100), 1);
+    });
+
+    test('מסכים עם החישוב מטקסט השורה כשהשורה זמינה', () {
+      const line = 'יהודה אמר ועוד אמר יהודה דבר';
+      final fromText = matchFractionInLine(
+        line,
+        'יהודה',
+        matchOffset: 19,
+        pattern: literalPattern('יהודה'),
+      );
+      final fromLength = matchFractionFromLineLength(
+        matchOffset: 19,
+        lineLength: line.length,
+      );
+      expect(fromLength, closeTo(fromText, 0.001));
     });
   });
 

--- a/test/text_book/view/text_book_nav_panel_preserved_test.dart
+++ b/test/text_book/view/text_book_nav_panel_preserved_test.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/bookmarks/bloc/bookmark_bloc.dart';
+import 'package:otzaria/bookmarks/bloc/bookmark_state.dart';
+import 'package:otzaria/core/focus_repository.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/personal_notes/personal_notes_system.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
+import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
+import 'package:otzaria/tabs/bloc/tabs_state.dart';
+import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/view/text_book_screen.dart';
+import 'package:otzaria/text_book/view/toc_navigator_screen.dart';
+import 'package:otzaria/text_book/view/widgets/nav_panel_tour_target.dart';
+import 'package:otzaria/tools/shamor_zachor/providers/shamor_zachor_data_provider.dart';
+import 'package:otzaria/tools/shamor_zachor/providers/shamor_zachor_progress_provider.dart';
+import 'package:otzaria/tour/bloc/tour_cubit.dart';
+import 'package:provider/provider.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+import '../../test_helpers/memory_cache_provider.dart';
+
+/// חלונית הניווט של ספר טקסט חייבת לשרוד מעבר בין טאב פעיל לטאב רקע.
+///
+/// `enableTourTargets` מתהפך בכל מעבר טאב, וכשהוא שינה את מבנה העץ של החלונית
+/// Flutter השמיד את כל תת-העץ שלה — ולכן החיפוש-בספר רץ מחדש בכל חזרה לטאב.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FocusRepository focusRepository;
+  late _FakeShamorZachorDataProvider shamorZachorDataProvider;
+  late _FakeShamorZachorProgressProvider shamorZachorProgressProvider;
+  late _TestBookmarkBloc bookmarkBloc;
+  late PersonalNotesBloc personalNotesBloc;
+  late TourCubit tourCubit;
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+    DataRepository.instance.library = Future.value(
+      Library(categories: const []),
+    );
+    focusRepository = FocusRepository()..resetForTesting();
+    shamorZachorDataProvider = _FakeShamorZachorDataProvider();
+    shamorZachorProgressProvider = _FakeShamorZachorProgressProvider();
+    bookmarkBloc = _TestBookmarkBloc();
+    personalNotesBloc = PersonalNotesBloc();
+    tourCubit = TourCubit();
+    activeTextBookNavPanelTourTargetKey = null;
+  });
+
+  tearDown(() async {
+    await bookmarkBloc.close();
+    await personalNotesBloc.close();
+    await tourCubit.close();
+    focusRepository.resetForTesting();
+  });
+
+  /// מעלה את מסך הספר עם חלונית הניווט פתוחה, ומחזיר בקר להחלפת הטאב הפעיל.
+  Future<_ActiveTabController> pumpScreen(WidgetTester tester) async {
+    final book = TextBook(title: 'ספר בדיקה');
+    final bloc = _TestTextBookBloc(_loadedState(book));
+    final tab = TextBookTab(book: book, index: 0, blocOverride: bloc);
+    final tabsBloc = _TestTabsBloc(TabsState(tabs: [tab], currentTabIndex: 0));
+    final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await bloc.close();
+      await tabsBloc.close();
+      await settingsBloc.close();
+      tab.dispose();
+    });
+
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    late StateSetter setHostState;
+    var isActiveTab = true;
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          Provider<FocusRepository>.value(value: focusRepository),
+          ChangeNotifierProvider<ShamorZachorDataProvider>.value(
+            value: shamorZachorDataProvider,
+          ),
+          ChangeNotifierProvider<ShamorZachorProgressProvider>.value(
+            value: shamorZachorProgressProvider,
+          ),
+        ],
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: bloc),
+            BlocProvider<TabsBloc>.value(value: tabsBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+            BlocProvider<BookmarkBloc>.value(value: bookmarkBloc),
+            BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+            BlocProvider<TourCubit>.value(value: tourCubit),
+          ],
+          child: MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                setHostState = setState;
+                return TextBookViewerBloc(
+                  tab: tab,
+                  isInCombinedView: false,
+                  enableTourTargets: isActiveTab,
+                  openBookCallback: (_) {},
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    return _ActiveTabController(
+      tester: tester,
+      setActiveTab: (value) => setHostState(() => isActiveTab = value),
+    );
+  }
+
+  testWidgets('מצב חלונית הניווט נשמר במעבר טאב וחזרה', (tester) async {
+    final controller = await pumpScreen(tester);
+
+    expect(find.byType(TocViewer), findsOneWidget);
+    final stateBeforeSwitch = tester.state(find.byType(TocViewer));
+
+    await controller.setActive(false);
+    await controller.setActive(true);
+
+    expect(find.byType(TocViewer), findsOneWidget);
+    expect(
+      tester.state(find.byType(TocViewer)),
+      same(stateBeforeSwitch),
+      reason: 'החלונית נבנתה מאפס — לכן החיפוש-בספר רץ מחדש בכל חזרה לטאב',
+    );
+  });
+
+  testWidgets('יעד הסיור מצביע על חלונית הניווט של הטאב הפעיל', (tester) async {
+    final controller = await pumpScreen(tester);
+
+    final key = activeTextBookNavPanelTourTargetKey;
+    expect(key, isNotNull);
+    expect(
+      find.descendant(of: find.byKey(key!), matching: find.byType(TocViewer)),
+      findsOneWidget,
+    );
+
+    // המפתח נשאר תקף גם אחרי מעבר לרקע וחזרה.
+    await controller.setActive(false);
+    await controller.setActive(true);
+
+    expect(activeTextBookNavPanelTourTargetKey, isNotNull);
+    expect(activeTextBookNavPanelTourTargetKey!.currentContext, isNotNull);
+  });
+}
+
+class _ActiveTabController {
+  _ActiveTabController({required this.tester, required this.setActiveTab});
+
+  final WidgetTester tester;
+  final void Function(bool) setActiveTab;
+
+  Future<void> setActive(bool value) async {
+    setActiveTab(value);
+    await tester.pump();
+  }
+}
+
+TextBookLoaded _loadedState(TextBook book) {
+  return TextBookLoaded(
+    book: book,
+    showLeftPane: true,
+    content: const ['שורה א', 'שורה ב', 'שורה ג'],
+    fontSize: 18,
+    showSplitView: false,
+    activeCommentators: const [],
+    commentatorGroups: const [],
+    availableCommentators: const [],
+    links: const <Link>[],
+    visibleLinks: const <Link>[],
+    linksByLine: const {},
+    tableOfContents: const [],
+    removeNikud: false,
+    removePunctuation: false,
+    visibleIndices: const [0],
+    selectedIndex: 0,
+    pinLeftPane: true,
+    searchText: '',
+    currentTitle: 'סימן א',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+    searchMode: SearchMode.exact,
+  );
+}
+
+class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
+    implements TextBookBloc {
+  _TestTextBookBloc(super.initialState) {
+    on<TextBookEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {
+  _TestSettingsBloc(super.initialState) {
+    on<SettingsEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestTabsBloc extends Cubit<TabsState> implements TabsBloc {
+  _TestTabsBloc(super.initialState);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestBookmarkBloc extends Cubit<BookmarkState> implements BookmarkBloc {
+  _TestBookmarkBloc() : super(BookmarkState.initial());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeShamorZachorDataProvider extends ShamorZachorDataProvider {
+  @override
+  bool get hasData => false;
+
+  @override
+  Future<void> ensureLoaded() async {}
+}
+
+class _FakeShamorZachorProgressProvider extends ShamorZachorProgressProvider {
+  @override
+  Future<void> ensureLoaded() async {}
+}

--- a/test/text_book/view/text_book_search_content_cache_test.dart
+++ b/test/text_book/view/text_book_search_content_cache_test.dart
@@ -1,0 +1,374 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/models/search_results.dart';
+import 'package:otzaria/text_book/view/text_book_search_screen.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+import '../../support/search_engine_test_init.dart';
+import '../../test_helpers/memory_cache_provider.dart';
+
+/// חלונית החיפוש בטאב שיורד לרקע: התוצאות נשמרות, ועותק שורות הספר משוחרר.
+///
+/// הרקע מדומה דרך [TickerMode], כמו ב-`ReadingScreen`. הצגת תוצאות מאצילה את
+/// ההדגשה למנוע הנייטיבי, ולכן טסטים שמציגים תוצאות מדולגים בלי build זמין.
+Future<void> main() async {
+  final engineReady = await tryInitSearchEngine();
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  setUp(() {
+    // בלי ספרייה מדומה, אתחול החלונית ניגש למסד הנתונים האמיתי.
+    DataRepository.instance.library = Future.value(
+      Library(categories: const []),
+    );
+  });
+
+  /// בונה את חלונית החיפוש בתוך [TickerMode] שניתן לכבות.
+  ///
+  /// [simpleSearchRunner] ברירת המחדל אינו מחזיר תוצאות, כדי שהטסט לא יהיה
+  /// תלוי במנוע הנייטיבי שמדגיש אותן.
+  Future<_Harness> pumpSearchView(
+    WidgetTester tester, {
+    required Future<List<String>> Function() contentLoader,
+    Future<List<TextSearchResult>> Function(List<String>, String)?
+    simpleSearchRunner,
+  }) async {
+    final textBookBloc = _TestTextBookBloc(_loadedState());
+    final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+    final focusNode = FocusNode();
+
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await textBookBloc.close();
+      await settingsBloc.close();
+      focusNode.dispose();
+    });
+
+    late StateSetter setHostState;
+    var isVisible = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: textBookBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          ],
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              setHostState = setState;
+              return Scaffold(
+                body: TickerMode(
+                  enabled: isVisible,
+                  child: TextBookSearchView(
+                    contentLoader: contentLoader,
+                    scrollControler: ItemScrollController(),
+                    focusNode: focusNode,
+                    closeLeftPaneCallback: () {},
+                    initialQuery: '',
+                    simpleSearchRunner:
+                        simpleSearchRunner ?? _noResultsSearchRunner,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    return _Harness(
+      tester: tester,
+      setVisibility: (value) => setHostState(() => isVisible = value),
+    );
+  }
+
+  group('קאש שורות הספר', () {
+    testWidgets('חיפוש טוען את שורות הספר פעם אחת בלבד', (tester) async {
+      var loadCount = 0;
+      final harness = await pumpSearchView(
+        tester,
+        contentLoader: () async {
+          loadCount++;
+          return const ['אב אברהם', 'יצחק'];
+        },
+      );
+
+      await harness.search('אב');
+      expect(loadCount, 1);
+
+      await harness.search('יצחק');
+      expect(loadCount, 1, reason: 'תוכן הספר כבר בקאש — אין לטעון שוב');
+    });
+
+    testWidgets('מעבר לרקע משחרר את עותק שורות הספר', (tester) async {
+      var loadCount = 0;
+      final harness = await pumpSearchView(
+        tester,
+        contentLoader: () async {
+          loadCount++;
+          return const ['אב אברהם', 'יצחק'];
+        },
+      );
+
+      await harness.search('אב');
+      expect(loadCount, 1);
+
+      await harness.setVisible(false);
+      await harness.setVisible(true);
+      await harness.search('יצחק');
+
+      expect(
+        loadCount,
+        2,
+        reason: 'הקאש שוחרר ברקע, ולכן החיפוש הבא טוען את הספר מחדש',
+      );
+    });
+
+    testWidgets('שהייה ברקע בלי חיפוש חדש אינה טוענת את הספר', (tester) async {
+      var loadCount = 0;
+      final harness = await pumpSearchView(
+        tester,
+        contentLoader: () async {
+          loadCount++;
+          return const ['אב אברהם'];
+        },
+      );
+
+      await harness.search('אב');
+      await harness.setVisible(false);
+      await harness.setVisible(true);
+
+      expect(loadCount, 1, reason: 'שחרור קאש אינו טעינה מחדש');
+    });
+
+    testWidgets('מעבר לרקע בזמן טעינת התוכן לא מחזיר את הקאש', (tester) async {
+      var loadCount = 0;
+      final loaders = <Completer<List<String>>>[];
+      final harness = await pumpSearchView(
+        tester,
+        contentLoader: () {
+          loadCount++;
+          final completer = Completer<List<String>>();
+          loaders.add(completer);
+          return completer.future;
+        },
+      );
+
+      await harness.type('אב');
+      expect(loaders, hasLength(1));
+
+      // הטאב יורד לרקע בעוד הטעינה באוויר, ורק אחר-כך היא מסתיימת.
+      await harness.setVisible(false);
+      loaders.first.complete(const ['אב אברהם', 'יצחק']);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await harness.setVisible(true);
+      await harness.search('יצחק');
+
+      expect(
+        loadCount,
+        2,
+        reason: 'תוצאת טעינה שהגיעה אחרי השחרור אינה אמורה לחזור לקאש',
+      );
+    });
+
+    testWidgets('כשל טעינה מאפשר ניסיון חוזר בחיפוש הבא', (tester) async {
+      var loadCount = 0;
+      final harness = await pumpSearchView(
+        tester,
+        contentLoader: () async {
+          loadCount++;
+          if (loadCount == 1) throw StateError('טעינה נכשלה');
+          return const ['אב אברהם'];
+        },
+      );
+
+      await harness.search('אב');
+      await harness.search('אברהם');
+
+      expect(loadCount, 2);
+    });
+  });
+
+  group('שימור תוצאות במעבר טאב', () {
+    testWidgets('חזרה מהרקע אינה מריצה את החיפוש מחדש', (tester) async {
+      var searchCount = 0;
+      final harness = await pumpSearchView(
+        tester,
+        contentLoader: () async => const ['אב אברהם'],
+        simpleSearchRunner: (content, query) async {
+          searchCount++;
+          return const [];
+        },
+      );
+
+      await harness.search('אב');
+      expect(searchCount, 1);
+
+      await harness.setVisible(false);
+      await harness.setVisible(true);
+
+      expect(
+        searchCount,
+        1,
+        reason: 'חזרה לטאב אינה חיפוש חדש — התוצאות אמורות להיות בזיכרון',
+      );
+    });
+
+    testWidgets(
+      'התוצאות שעל המסך נשמרות במעבר לרקע וחזרה',
+      (tester) async {
+        var searchCount = 0;
+        final harness = await pumpSearchView(
+          tester,
+          contentLoader: () async => const ['אב אברהם'],
+          simpleSearchRunner: (content, query) async {
+            searchCount++;
+            return _resultsFor(query);
+          },
+        );
+
+        await harness.search('אב');
+        expect(find.text('כתובת-אב'), findsOneWidget);
+        expect(find.text('נמצאו 1 תוצאות'), findsOneWidget);
+
+        await harness.setVisible(false);
+        await harness.setVisible(true);
+
+        expect(find.text('כתובת-אב'), findsOneWidget);
+        expect(find.text('נמצאו 1 תוצאות'), findsOneWidget);
+        expect(searchCount, 1);
+      },
+      skip: !engineReady,
+    );
+
+    testWidgets(
+      'חיפוש חדש אחרי חזרה מהרקע מציג את התוצאות החדשות',
+      (tester) async {
+        final harness = await pumpSearchView(
+          tester,
+          contentLoader: () async => const ['אב אברהם', 'יצחק'],
+          simpleSearchRunner: (content, query) async => _resultsFor(query),
+        );
+
+        await harness.search('אב');
+        expect(find.text('כתובת-אב'), findsOneWidget);
+
+        await harness.setVisible(false);
+        await harness.setVisible(true);
+        await harness.search('יצחק');
+
+        expect(find.text('כתובת-יצחק'), findsOneWidget);
+        expect(find.text('כתובת-אב'), findsNothing);
+      },
+      skip: !engineReady,
+    );
+  });
+}
+
+class _Harness {
+  _Harness({required this.tester, required this.setVisibility});
+
+  final WidgetTester tester;
+  final void Function(bool) setVisibility;
+
+  /// מקליד שאילתה וממתין לחלוף ה-debounce של שדה החיפוש (200ms), אבל לא
+  /// לסיום החיפוש עצמו.
+  Future<void> type(String query) async {
+    await tester.enterText(find.byType(TextField).first, query);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+
+  Future<void> search(String query) async {
+    await type(query);
+    await tester.pump();
+    await tester.pump();
+  }
+
+  Future<void> setVisible(bool value) async {
+    setVisibility(value);
+    await tester.pump();
+  }
+}
+
+Future<List<TextSearchResult>> _noResultsSearchRunner(
+  List<String> content,
+  String query,
+) async => const [];
+
+List<TextSearchResult> _resultsFor(String query) {
+  return [
+    TextSearchResult(
+      snippet: 'תוצאה עבור $query',
+      index: 0,
+      query: query,
+      address: 'כתובת-$query',
+    ),
+  ];
+}
+
+TextBookLoaded _loadedState() {
+  return TextBookLoaded(
+    book: TextBook(title: 'ספר בדיקה'),
+    showLeftPane: true,
+    content: const ['שורה א'],
+    fontSize: 18,
+    showSplitView: false,
+    activeCommentators: const [],
+    commentatorGroups: const [],
+    availableCommentators: const [],
+    links: const [],
+    visibleLinks: const [],
+    linksByLine: const {},
+    tableOfContents: const [],
+    removeNikud: false,
+    visibleIndices: const [0],
+    selectedIndex: 0,
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+}
+
+class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
+    implements TextBookBloc {
+  _TestTextBookBloc(super.initialState) {
+    on<TextBookEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {
+  _TestSettingsBloc(super.initialState) {
+    on<SettingsEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/text_book/view/widgets/nav_panel_tour_target_test.dart
+++ b/test/text_book/view/widgets/nav_panel_tour_target_test.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/text_book/view/widgets/nav_panel_tour_target.dart';
+
+/// ילד עם State שסופר יצירות — כך אפשר להוכיח שהחלונית לא נבנתה מאפס.
+class _Probe extends StatefulWidget {
+  const _Probe();
+
+  @override
+  State<_Probe> createState() => _ProbeState();
+}
+
+class _ProbeState extends State<_Probe> {
+  static int initCount = 0;
+  static int disposeCount = 0;
+  int taps = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    initCount++;
+  }
+
+  @override
+  void dispose() {
+    disposeCount++;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () => setState(() => taps++),
+      child: Text('taps: $taps'),
+    );
+  }
+}
+
+/// עוטף את [TextBookNavPanelTourTarget] בבורר שמדמה מעבר בין טאב פעיל לרקע.
+class _Host extends StatefulWidget {
+  const _Host({required this.initialIsActive});
+
+  final bool initialIsActive;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  late bool isActive = widget.initialIsActive;
+
+  void setActive(bool value) => setState(() => isActive = value);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextBookNavPanelTourTarget(
+      isActiveTab: isActive,
+      child: const _Probe(),
+    );
+  }
+}
+
+void main() {
+  setUp(() {
+    _ProbeState.initCount = 0;
+    _ProbeState.disposeCount = 0;
+    activeTextBookNavPanelTourTargetKey = null;
+  });
+
+  Future<_HostState> pumpHost(
+    WidgetTester tester, {
+    bool isActive = true,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(home: _Host(initialIsActive: isActive)),
+    );
+    return tester.state<_HostState>(find.byType(_Host));
+  }
+
+  testWidgets('מעבר בין טאב פעיל לרקע וחזרה לא בונה את החלונית מחדש', (
+    tester,
+  ) async {
+    final host = await pumpHost(tester);
+    expect(_ProbeState.initCount, 1);
+
+    host.setActive(false);
+    await tester.pump();
+    host.setActive(true);
+    await tester.pump();
+
+    expect(
+      _ProbeState.initCount,
+      1,
+      reason: 'החלונית נבנתה מאפס — מצב החיפוש והניווט אובד',
+    );
+    expect(_ProbeState.disposeCount, 0);
+  });
+
+  testWidgets('מצב פנימי של החלונית נשמר במעבר לרקע וחזרה', (tester) async {
+    final host = await pumpHost(tester);
+
+    await tester.tap(find.byType(TextButton));
+    await tester.pump();
+    expect(find.text('taps: 1'), findsOneWidget);
+
+    host.setActive(false);
+    await tester.pump();
+    host.setActive(true);
+    await tester.pump();
+
+    expect(find.text('taps: 1'), findsOneWidget);
+  });
+
+  testWidgets('הטאב הפעיל מפרסם את מפתח החלונית שלו', (tester) async {
+    await pumpHost(tester);
+
+    final key = activeTextBookNavPanelTourTargetKey;
+    expect(key, isNotNull);
+    expect(key!.currentContext, isNotNull);
+    expect(
+      find.descendant(
+        of: find.byKey(key),
+        matching: find.byType(_Probe),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('טאב רקע אינו מפרסם מפתח', (tester) async {
+    await pumpHost(tester, isActive: false);
+
+    expect(activeTextBookNavPanelTourTargetKey, isNull);
+  });
+
+  testWidgets('הפעלת טאב שהיה ברקע מפרסמת את המפתח שלו', (tester) async {
+    final host = await pumpHost(tester, isActive: false);
+    expect(activeTextBookNavPanelTourTargetKey, isNull);
+
+    host.setActive(true);
+    await tester.pump();
+
+    expect(activeTextBookNavPanelTourTargetKey, isNotNull);
+  });
+
+  testWidgets('טאב שיורד לרקע לבדו מנקה את הפרסום', (tester) async {
+    final host = await pumpHost(tester);
+    expect(activeTextBookNavPanelTourTargetKey, isNotNull);
+
+    host.setActive(false);
+    await tester.pump();
+
+    expect(
+      activeTextBookNavPanelTourTargetKey,
+      isNull,
+      reason: 'הסיור לא אמור להדגיש חלונית של טאב שאינו על המסך',
+    );
+  });
+
+  /// שני טאבים חיים במקביל ומתעדכנים באותו frame; הבדיקה מריצה את שני כיווני
+  /// המעבר, כי סדר העדכון בין הטאבים אינו מובטח.
+  Future<void> expectPublishFollowsActiveTab(
+    WidgetTester tester, {
+    required int from,
+    required int to,
+  }) async {
+    late StateSetter setOuterState;
+    var activeIndex = from;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            setOuterState = setState;
+            return Column(
+              children: [
+                for (var i = 0; i < 2; i++)
+                  TextBookNavPanelTourTarget(
+                    key: ValueKey(i),
+                    isActiveTab: i == activeIndex,
+                    child: SizedBox(key: ValueKey('child-$i')),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
+    final firstKey = activeTextBookNavPanelTourTargetKey;
+    expect(firstKey, isNotNull);
+
+    setOuterState(() => activeIndex = to);
+    await tester.pump();
+
+    final secondKey = activeTextBookNavPanelTourTargetKey;
+    expect(secondKey, isNotNull, reason: 'הפרסום של הטאב הנכנס נמחק');
+    expect(secondKey, isNot(firstKey));
+    expect(
+      find.descendant(
+        of: find.byKey(secondKey!),
+        matching: find.byKey(ValueKey('child-$to')),
+      ),
+      findsOneWidget,
+      reason: 'הפרסום צריך להצביע על החלונית של הטאב הפעיל',
+    );
+  }
+
+  testWidgets('מעבר קדימה בין טאבים מעביר את הפרסום לטאב הנכנס', (
+    tester,
+  ) async {
+    await expectPublishFollowsActiveTab(tester, from: 0, to: 1);
+  });
+
+  testWidgets('מעבר אחורה בין טאבים מעביר את הפרסום לטאב הנכנס', (
+    tester,
+  ) async {
+    await expectPublishFollowsActiveTab(tester, from: 1, to: 0);
+  });
+
+  testWidgets('סגירת הטאב הפעיל מנקה את הפרסום', (tester) async {
+    await pumpHost(tester);
+    expect(activeTextBookNavPanelTourTargetKey, isNotNull);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+    expect(activeTextBookNavPanelTourTargetKey, isNull);
+  });
+
+  testWidgets('סגירת טאב רקע לא מוחקת את הפרסום של הטאב הפעיל', (
+    tester,
+  ) async {
+    late StateSetter setOuterState;
+    var showBackgroundTab = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            setOuterState = setState;
+            return Column(
+              children: [
+                const TextBookNavPanelTourTarget(
+                  key: ValueKey('active'),
+                  isActiveTab: true,
+                  child: SizedBox(),
+                ),
+                if (showBackgroundTab)
+                  const TextBookNavPanelTourTarget(
+                    key: ValueKey('background'),
+                    isActiveTab: false,
+                    child: SizedBox(),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
+    final activeKey = activeTextBookNavPanelTourTargetKey;
+    expect(activeKey, isNotNull);
+
+    setOuterState(() => showBackgroundTab = false);
+    await tester.pump();
+
+    expect(activeTextBookNavPanelTourTargetKey, activeKey);
+  });
+}


### PR DESCRIPTION
## הבעיה

חיפוש בתוך ספר → מעבר לטאב אחר → חזרה = החיפוש רץ מחדש מאפס. התוצאות, התוצאה המסומנת, ומצב לשונית הניווט אבדו, וגם עץ התוכן נבנה מחדש בכל מעבר טאב.

## שורש הבעיה

`_buildBody` עטפה את חלונית הניווט ב-`KeyedSubtree` **רק** בטאב הפעיל:

```dart
paneContent: widget.enableTourTargets
    ? KeyedSubtree(key: textBookNavPanelTourTargetKey, child: _buildLeftPaneContent(state))
    : _buildLeftPaneContent(state),
```

`enableTourTargets` הוא `i == currentTabIndex` (`ReadingScreen`), כלומר הוא מתהפך בכל מעבר טאב. סוג הווידג'ט באותו מקום בעץ משתנה, `Widget.canUpdate` נכשל, ו-Flutter משמיד את כל תת-העץ. בחזרה לטאב נוצר `TextBookSearchViewState` חדש, ו-`initState` → `_initializeBookPath` → `_runInitialSearch()` הריץ חיפוש מלא.

ה-keep-alive של הטאבים ושל לשוניות הסרגל עבד כשורה — רק העטיפה המותנית שברה אותו.

## התיקון

**1. מבנה עץ קבוע** — `TextBookNavPanelTourTarget` (חדש) עוטף את החלונית במפתח יציב לכל חיי הטאב, ומפרסם אותו ב-`activeTextBookNavPanelTourTargetKey` כשהטאב פעיל. הניקוי מותנה בבעלות על הפרסום, כך שהטאב היוצא לא מוחק את הפרסום של הנכנס (שניהם מתעדכנים באותו frame, בסדר לא מובטח), ומאידך הסיור לא מקבל מלבן של חלונית בטאב רקע.

**2. שחרור זיכרון** — עכשיו שהחלונית שורדת, עותק שורות הספר שהיא טוענת לחיפוש היה נשאר חי בכל טאב רקע. לכן הוא משוחרר כשהטאב יורד לרקע (`TickerMode` — אותו איתות ש-`_TabVisibilityBridge` משתמש בו). התוצאות שעל המסך נשמרות; רק חיפוש חדש באותו ספר יטען אותו שוב — בדיוק כמו חיפוש ראשון בספר שנפתח כרגע. בנוסף, טעינה שמסתיימת אחרי שחרור אינה חוזרת לקאש.

**3. דיוק גלילה בלי התוכן** — כל תוצאת חיפוש פשוט נושאת את אורך השורה הנקייה, כך שלחיצה על תוצאה שנשמרה גוללת אל ההופעה עצמה גם כשהתוכן שוחרר (קודם השבר חושב מטקסט השורה, ששורה משוחררת מחזירה כ-placeholder ריק).

## מה זה חוסך

מעבר טאב חדל לשלם: בנייה מחדש של עץ התוכן (אלפי ערכים), טעינה חוזרת של כל שורות הספר מה-DB, וחיפוש מלא. בזיכרון: טאבי רקע אינם מחזיקים עותק ספר כל אחד (מגה-בייטים בספר גדול).

## בדיקות

11 קבצים, 4 חדשים:

| נושא | קובץ |
|---|---|
| שימור מצב החלונית ברמת המסך | `test/text_book/view/text_book_nav_panel_preserved_test.dart` |
| מפתח יציב + מחזור הפרסום לסיור | `test/text_book/view/widgets/nav_panel_tour_target_test.dart` |
| שחרור קאש שורות הספר בטאב רקע | `test/text_book/view/text_book_search_content_cache_test.dart` |
| שבר גלילה מאורך השורה | `test/text_book/utils/section_search_utils_test.dart` |

הטסט המרכזי אומת כשומר רגרסיה: על הקוד הקודם `_TocViewerState` חוזר `defunct` (הושמד) והוא נכשל.

`flutter analyze` על `lib` + `test` נקי, `dart format` הורץ על הקבצים שנגעתי בהם, ו-`flutter test test/text_book/ test/navigation/ test/tour/` — 1296 טסטים עוברים.

## הערה לעתיד (לא בטווח ה-PR)

`_SearchWorkerHost` מחזיק עותק גלובלי אחד של הספר שחופש לאחרון (`_lastSentContent` + הקאש בתוך ה-worker). אחרי השחרור כאן העותק הזה תקוע — החיפוש הבא מקצה רשימה חדשה ולכן לעולם לא ישתמש בו שוב. שווה להוסיף שם שחרור מותנה-בעלות, מחוץ ל-PR הזה.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
