### PR TITLE
הצגת הערות וקישורים באמצעות המקלדת (תצוגה מקדימה בסמנים)

### DIFF
--- a/lib/shortcuts/keyboard_shortcuts.dart
+++ b/lib/shortcuts/keyboard_shortcuts.dart
@@ -172,6 +172,18 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
     final nextSegmentShortcut = shortcutOf('key-shortcut-next-segment');
     final prevTocShortcut = shortcutOf('key-shortcut-prev-toc');
     final nextTocShortcut = shortcutOf('key-shortcut-next-toc');
+    final anchorPreviewToggleShortcut = shortcutOf(
+      ShortcutValidator.anchorPreviewToggleKey,
+    );
+    final anchorPreviewNextShortcut = shortcutOf(
+      ShortcutValidator.anchorPreviewNextKey,
+    );
+    final anchorPreviewPrevShortcut = shortcutOf(
+      ShortcutValidator.anchorPreviewPrevKey,
+    );
+    final anchorPreviewOpenShortcut = shortcutOf(
+      ShortcutValidator.anchorPreviewOpenKey,
+    );
 
     // דיאלוג/תפריט פתוח = route מעל מסך הבית ב-root Navigator. קיצורי ניווט
     // סוגרים אותו לפני המעבר; קיצורי טאבים מנוטרלים כדי לא לפעול על מסך שברקע.
@@ -263,6 +275,18 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
         navNotifier = navTab.navPreviousTocNotifier;
       } else if (ShortcutHelper.matchesShortcut(event, nextTocShortcut)) {
         navNotifier = navTab.navNextTocNotifier;
+      } else if (anchorPreviewToggleShortcut.isNotEmpty &&
+          ShortcutHelper.matchesShortcut(event, anchorPreviewToggleShortcut)) {
+        navNotifier = navTab.anchorPreviewToggleNotifier;
+      } else if (anchorPreviewNextShortcut.isNotEmpty &&
+          ShortcutHelper.matchesShortcut(event, anchorPreviewNextShortcut)) {
+        navNotifier = navTab.anchorPreviewNextNotifier;
+      } else if (anchorPreviewPrevShortcut.isNotEmpty &&
+          ShortcutHelper.matchesShortcut(event, anchorPreviewPrevShortcut)) {
+        navNotifier = navTab.anchorPreviewPrevNotifier;
+      } else if (anchorPreviewOpenShortcut.isNotEmpty &&
+          ShortcutHelper.matchesShortcut(event, anchorPreviewOpenShortcut)) {
+        navNotifier = navTab.anchorPreviewOpenNotifier;
       }
       if (navNotifier != null) {
         navNotifier.value++;
@@ -481,6 +505,16 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
       final settingsBloc = context.read<SettingsBloc>();
       final newFullscreenState = !settingsBloc.state.isFullscreen;
       FullscreenHelper.toggleFullscreen(context, newFullscreenState);
+      return KeyEventResult.handled;
+    }
+
+    // ESC - סגירת מצב הסמנים (לפני יציאה ממסך מלא: זו הפעולה ה"קרובה" יותר
+    // למשתמש כשהמצב פתוח). נבלע רק כשהמצב אכן פעיל.
+    if (isReadingScreen &&
+        navTab is TextBookTab &&
+        navTab.anchorPreviewActive.value &&
+        ShortcutHelper.matchesShortcut(event, 'escape')) {
+      navTab.anchorPreviewToggleNotifier.value++;
       return KeyEventResult.handled;
     }
 

--- a/lib/shortcuts/shortcut_validator.dart
+++ b/lib/shortcuts/shortcut_validator.dart
@@ -8,6 +8,16 @@ class ShortcutValidator {
   static const String openAdvancedSearchKey =
       'key-shortcut-open-advanced-search';
 
+  /// תצוגה מקדימה של סמני-עוגן במקלדת — חלופה לריחוף בעכבר.
+  /// ה-toggle מקבל ברירת מחדל (F2, מקש שאינו נחסם בזמן הקלדה); הניווט
+  /// בתוך המצב נעשה בחיצים שנתפסים במסך עצמו ולא כקיצור גלובלי, ולכן
+  /// next/prev/open אופציונליים וברירת המחדל שלהם ריקה.
+  static const String anchorPreviewToggleKey =
+      'key-shortcut-anchor-preview-toggle';
+  static const String anchorPreviewNextKey = 'key-shortcut-anchor-preview-next';
+  static const String anchorPreviewPrevKey = 'key-shortcut-anchor-preview-prev';
+  static const String anchorPreviewOpenKey = 'key-shortcut-anchor-preview-open';
+
   static const Set<Set<String>> _compatibleShortcutGroups = {
     {
       'key-shortcut-add-note',
@@ -111,6 +121,10 @@ class ShortcutValidator {
     'key-shortcut-next-segment',
     'key-shortcut-prev-toc',
     'key-shortcut-next-toc',
+    anchorPreviewToggleKey,
+    anchorPreviewNextKey,
+    anchorPreviewPrevKey,
+    anchorPreviewOpenKey,
     // פתיחת כלים — אופציונלי, ללא ברירת מחדל (ראה openToolShortcutKeys).
     'key-shortcut-open-tool-calendar',
     'key-shortcut-open-tool-shamor-zachor',
@@ -159,6 +173,11 @@ class ShortcutValidator {
     'key-shortcut-next-segment': 'alt+arrowdown',
     'key-shortcut-prev-toc': 'alt+pageup',
     'key-shortcut-next-toc': 'alt+pagedown',
+    anchorPreviewToggleKey: 'f2',
+    // RTL: קדימה בסדר הקריאה = שמאלה.
+    anchorPreviewNextKey: 'alt+arrowleft',
+    anchorPreviewPrevKey: 'alt+arrowright',
+    anchorPreviewOpenKey: 'alt+enter',
     'key-shortcut-open-tool-calendar': '',
     'key-shortcut-open-tool-shamor-zachor': '',
     'key-shortcut-open-tool-measurements': '',
@@ -210,6 +229,10 @@ class ShortcutValidator {
     'key-shortcut-next-segment': 'הקטע הבא',
     'key-shortcut-prev-toc': 'הדף/פרק הקודם',
     'key-shortcut-next-toc': 'הדף/פרק הבא',
+    anchorPreviewToggleKey: 'מצב סמנים: הצגת הערות וקישורים במקלדת',
+    anchorPreviewNextKey: 'מצב סמנים: הסמן הבא',
+    anchorPreviewPrevKey: 'מצב סמנים: הסמן הקודם',
+    anchorPreviewOpenKey: 'מצב סמנים: פתיחת היעד',
     'key-shortcut-open-tool-calendar': 'פתיחת לוח שנה',
     'key-shortcut-open-tool-shamor-zachor': 'פתיחת שמור וזכור',
     'key-shortcut-open-tool-measurements': 'פתיחת מדות ושיעורים',

--- a/lib/tabs/models/text_tab.dart
+++ b/lib/tabs/models/text_tab.dart
@@ -84,6 +84,19 @@ class TextBookTab extends OpenedTab {
   final ValueNotifier<int> navPreviousTocNotifier = ValueNotifier<int>(0);
   final ValueNotifier<int> navNextTocNotifier = ValueNotifier<int>(0);
 
+  /// counter-ים לתצוגה מקדימה של סמני-עוגן מהמקלדת (חלופה לריחוף בעכבר).
+  /// המאזין הוא מסך הספר; כל הגדלה = פעולה יחידה.
+  /// toggle — כניסה/יציאה ממצב סמנים; next/prev — מעבר לסמן ופתיחת החלונית;
+  /// open — פתיחת יעד הסמן הפעיל (כמו לחיצה על כותרת החלונית).
+  final ValueNotifier<int> anchorPreviewToggleNotifier = ValueNotifier<int>(0);
+  final ValueNotifier<int> anchorPreviewNextNotifier = ValueNotifier<int>(0);
+  final ValueNotifier<int> anchorPreviewPrevNotifier = ValueNotifier<int>(0);
+  final ValueNotifier<int> anchorPreviewOpenNotifier = ValueNotifier<int>(0);
+
+  /// האם מצב הסמנים פעיל כרגע (מצב, לא counter). המסך כותב, שכבת הקיצורים
+  /// קוראת — כדי ש-Escape ייסגר את המצב רק כשהוא פתוח ולא ייבלע לחינם.
+  final ValueNotifier<bool> anchorPreviewActive = ValueNotifier<bool>(false);
+
   List<String>? commentators;
   bool _lastSplitView = false;
   bool _lastShowPageShapeView = false;
@@ -200,6 +213,11 @@ class TextBookTab extends OpenedTab {
     navNextSegmentNotifier.dispose();
     navPreviousTocNotifier.dispose();
     navNextTocNotifier.dispose();
+    anchorPreviewToggleNotifier.dispose();
+    anchorPreviewNextNotifier.dispose();
+    anchorPreviewPrevNotifier.dispose();
+    anchorPreviewOpenNotifier.dispose();
+    anchorPreviewActive.dispose();
     bloc.close();
     super.dispose();
   }

--- a/lib/text_book/utils/anchor_keyboard_navigator.dart
+++ b/lib/text_book/utils/anchor_keyboard_navigator.dart
@@ -1,0 +1,143 @@
+/// ניווט בין סמני-עוגן בשורות הספר באמצעות המקלדת.
+///
+/// הסמנים עצמם נבנים ב-[injectLinkAnchorMarkers] ומזוהים ב-URL בתור
+/// `otzaria://anchor?ref=<line>_<i>`, כאשר `i` הוא המקום בתוך *רשימת
+/// העוגנים של אותה שורה* — היא-היא הרשימה ש-`_anchorLinkFromUrl` בונה.
+/// המודול הזה מספק את אותו מיפוי בכיוון ההפוך: מהמקום הנוכחי אל הסמן
+/// הבא/הקודם, כדי שקיצור מקלדת יוכל לפתוח את אותה חלונית תצוגה מקדימה
+/// שנפתחת בריחוף — בלי מיקום עכבר.
+library;
+
+import 'package:otzaria/models/links.dart';
+
+/// מקומו של סמן-עוגן בספר: שורת מקור (0-based) והמקום בתוך עוגני השורה.
+class AnchorCursor {
+  final int line;
+  final int index;
+
+  const AnchorCursor(this.line, this.index);
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnchorCursor && other.line == line && other.index == index;
+
+  @override
+  int get hashCode => Object.hash(line, index);
+
+  @override
+  String toString() => 'AnchorCursor($line, $index)';
+}
+
+/// עוגני שורה [line0] (0-based) — בדיוק אותו סינון וסדר שבהם נבנו הסמנים
+/// בשורה, כדי שהאינדקס יהיה זהה לזה שב-`otzaria://anchor?ref=`.
+///
+/// [linksByLine] ממופה במפתחות 1-based (כמו במסד ובקישורים).
+List<Link> anchorLinksForLine(
+  Map<int, List<Link>> linksByLine,
+  int line0,
+) {
+  final links = linksByLine[line0 + 1];
+  if (links == null || links.isEmpty) return const <Link>[];
+  return links.where((link) => link.anchorStart != null).toList();
+}
+
+/// מספר העוגנים בשורה [line0].
+int anchorCountForLine(Map<int, List<Link>> linksByLine, int line0) =>
+    anchorLinksForLine(linksByLine, line0).length;
+
+/// הסמן הבא אחרי [from] (או הראשון בספר כש-[from] הוא null), בסריקה קדימה
+/// עד [lineCount]. `null` — אין עוד סמנים.
+///
+/// הסריקה היא על המפתחות שקיימים ב-[linksByLine] ולא על כל שורות הספר, כדי
+/// שספר עם עשרות אלפי שורות ומעט עוגנים לא ייסרק שורה-שורה.
+AnchorCursor? nextAnchor(
+  Map<int, List<Link>> linksByLine,
+  int lineCount, {
+  AnchorCursor? from,
+}) {
+  if (from != null) {
+    final inSameLine = anchorCountForLine(linksByLine, from.line);
+    if (from.index + 1 < inSameLine) {
+      return AnchorCursor(from.line, from.index + 1);
+    }
+  }
+  final startLine = from == null ? 0 : from.line + 1;
+  for (final line in _anchorLinesFrom(
+    linksByLine,
+    lineCount,
+    startLine,
+    forward: true,
+  )) {
+    return AnchorCursor(line, 0);
+  }
+  return null;
+}
+
+/// הסמן שלפני [from] (או האחרון בספר כש-[from] הוא null).
+AnchorCursor? previousAnchor(
+  Map<int, List<Link>> linksByLine,
+  int lineCount, {
+  AnchorCursor? from,
+}) {
+  if (from != null && from.index > 0) {
+    return AnchorCursor(from.line, from.index - 1);
+  }
+  final startLine = from == null ? lineCount - 1 : from.line - 1;
+  for (final line in _anchorLinesFrom(
+    linksByLine,
+    lineCount,
+    startLine,
+    forward: false,
+  )) {
+    return AnchorCursor(line, anchorCountForLine(linksByLine, line) - 1);
+  }
+  return null;
+}
+
+/// הסמן הראשון בשורה [line0] או אחריה; ואם אין כזה — האחרון שלפניה.
+/// משמש לנקודת הפתיחה של מצב המקלדת, שמתחילה מהשורה הנבחרת/הנגללת.
+AnchorCursor? anchorNearLine(
+  Map<int, List<Link>> linksByLine,
+  int lineCount,
+  int line0,
+) {
+  final atLine = anchorCountForLine(linksByLine, line0);
+  if (atLine > 0) return AnchorCursor(line0, 0);
+  final ahead = nextAnchor(
+    linksByLine,
+    lineCount,
+    from: AnchorCursor(line0, atLine),
+  );
+  if (ahead != null) return ahead;
+  return previousAnchor(
+    linksByLine,
+    lineCount,
+    from: AnchorCursor(line0, 0),
+  );
+}
+
+/// שורות (0-based) שיש בהן עוגנים, מ-[startLine] והלאה/והחזרה, בסדר.
+Iterable<int> _anchorLinesFrom(
+  Map<int, List<Link>> linksByLine,
+  int lineCount,
+  int startLine, {
+  required bool forward,
+}) {
+  final lines = linksByLine.keys
+      .map((line1) => line1 - 1)
+      .where(
+        (line0) =>
+            line0 >= 0 &&
+            line0 < lineCount &&
+            (forward ? line0 >= startLine : line0 <= startLine) &&
+            anchorCountForLine(linksByLine, line0) > 0,
+      )
+      .toList();
+  lines.sort(forward ? (a, b) => a.compareTo(b) : (a, b) => b.compareTo(a));
+  return lines;
+}
+
+/// ה-URL של סמן — כדי שמסלול המקלדת ייכנס לאותו קוד טיפול כמו ריחוף/לחיצה
+/// ולא ישכפל את פענוח הקישור.
+String anchorUrlFor(AnchorCursor cursor) =>
+    'otzaria://anchor?ref=${cursor.line}_${cursor.index}';

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -69,6 +69,7 @@ import 'package:otzaria/text_book/utils/numbered_note_markers.dart';
 import 'package:otzaria/widgets/misc/link_preview_overlay.dart';
 import 'package:otzaria/text_book/utils/note_inline_render.dart';
 import 'package:otzaria/text_book/utils/reading_segments.dart';
+import 'package:otzaria/text_book/utils/anchor_keyboard_navigator.dart';
 import 'package:otzaria/text_book/utils/reading_segment_navigation.dart';
 import 'package:otzaria/text_book/utils/section_search_utils.dart';
 import 'package:otzaria/text_book/view/widgets/continuous_reading_paragraph.dart';
@@ -541,6 +542,150 @@ class _CombinedViewState extends State<CombinedView> {
     LinkPreviewOverlay.scheduleHide();
   }
 
+  // ── מצב סמנים במקלדת ─────────────────────────────────────────────────────
+  //
+  // מסלול קלט *נוסף* לאותה חלונית, לצד הריחוף — קוד הריחוף שלמעלה אינו
+  // משתנה, והעכבר ממשיך לעבוד גם כשהמצב דלוק. שני ההבדלים היחידים: המיקום
+  // נגזר מהשורה במקום ממיקום העכבר, והחלונית נפתחת ב-`hoverMode: false` —
+  // כלומר נשארת פתוחה עד Escape במקום להיסגר ביציאת סמן שאינו קיים.
+
+  /// כניסה/יציאה ממצב סמנים. בכניסה נפתחת חלונית על הסמן הקרוב לשורה
+  /// הנוכחית; אם אין בספר סמנים כלל — הודעה, והמצב אינו נדלק.
+  void _onAnchorPreviewToggle() {
+    if (_disposed || !mounted) return;
+    if (_anchorKeyboardMode) {
+      _exitAnchorKeyboardMode();
+      return;
+    }
+    final state = _textBookBloc.state;
+    if (state is! TextBookLoaded) return;
+    final cursor = anchorNearLine(
+      state.linksByLine,
+      state.content.length,
+      state.selectedIndices.isNotEmpty
+          ? state.selectedIndices.first
+          : widget.tab.index,
+    );
+    if (cursor == null) {
+      UiSnack.show('אין סמני הערות או קישורים בספר זה');
+      return;
+    }
+    setState(() => _anchorKeyboardMode = true);
+    widget.tab.anchorPreviewActive.value = true;
+    unawaited(_goToAnchor(cursor));
+  }
+
+  void _onAnchorPreviewNext() => unawaited(_stepAnchor(forward: true));
+
+  void _onAnchorPreviewPrev() => unawaited(_stepAnchor(forward: false));
+
+  /// פתיחת יעד הסמן הפעיל — זהה ללחיצה על כותרת החלונית.
+  void _onAnchorPreviewOpen() {
+    if (_disposed || !mounted || !_anchorKeyboardMode) return;
+    final cursor = _anchorKeyboardCursor;
+    if (cursor == null) return;
+    final anchor = _anchorLinkFromUrl(anchorUrlFor(cursor));
+    if (anchor == null) return;
+    _exitAnchorKeyboardMode();
+    unawaited(_openPreviewDestination(anchor.link, sourceLine: anchor.line));
+  }
+
+  void _exitAnchorKeyboardMode() {
+    _cancelPendingAnchorHover();
+    LinkPreviewOverlay.dismiss();
+    _setActiveAnchor(null, null);
+    _anchorKeyboardCursor = null;
+    widget.tab.anchorPreviewActive.value = false;
+    if (mounted) setState(() => _anchorKeyboardMode = false);
+  }
+
+  /// מעבר לסמן הבא/הקודם. הקיצור פועל גם כשהמצב כבוי — אז הוא מדליק אותו —
+  /// כדי שקיצור אחד יספיק למי שלא רוצה לזכור שניים.
+  Future<void> _stepAnchor({required bool forward}) async {
+    if (_disposed || !mounted) return;
+    final state = _textBookBloc.state;
+    if (state is! TextBookLoaded) return;
+    if (!_anchorKeyboardMode) {
+      _onAnchorPreviewToggle();
+      return;
+    }
+    final lineCount = state.content.length;
+    final next = forward
+        ? nextAnchor(state.linksByLine, lineCount, from: _anchorKeyboardCursor)
+        : previousAnchor(
+            state.linksByLine,
+            lineCount,
+            from: _anchorKeyboardCursor,
+          );
+    if (next == null) {
+      UiSnack.show(forward ? 'זה הסמן האחרון בספר' : 'זה הסמן הראשון בספר');
+      return;
+    }
+    await _goToAnchor(next);
+  }
+
+  /// גלילה אל הסמן (אם אינו גלוי), ואז פתיחת החלונית עליו.
+  ///
+  /// הפתיחה נדחית לסוף הפריים שאחרי הגלילה, כי `itemPositions` מתעדכן רק
+  /// כשה-layout כבר סופי — לפני זה נקודת העיגון תהיה של המיקום הקודם.
+  Future<void> _goToAnchor(AnchorCursor cursor) async {
+    final state = _textBookBloc.state;
+    if (state is! TextBookLoaded) return;
+    final anchor = _anchorLinkFromUrl(anchorUrlFor(cursor));
+    if (anchor == null) return;
+
+    _anchorKeyboardCursor = cursor;
+    _cancelPendingAnchorHover();
+    prefetchLinkPreview(anchor.link);
+
+    if (_visibleSegmentPosition(state, cursor.line) == null) {
+      await _scrollToSourceLine(state, cursor.line);
+      if (_disposed || !mounted) return;
+    }
+    await WidgetsBinding.instance.endOfFrame;
+    // הקיצור נלחץ שוב בזמן הגלילה — הסמן הזה כבר לא הרלוונטי.
+    if (_disposed || !mounted || _anchorKeyboardCursor != cursor) return;
+
+    final position = _anchorPreviewPosition(state, cursor.line);
+    if (position == null) return;
+    _showLinkPreview(
+      anchor.link,
+      position,
+      hoverMode: false,
+      activeAnchor: (line: anchor.line, index: anchor.index),
+    );
+  }
+
+  /// המיקום המוצג של ה-segment שמכיל את שורת [line], או null אם אינו גלוי.
+  ItemPosition? _visibleSegmentPosition(TextBookLoaded state, int line) {
+    final target = state.readingSegments.isNotEmpty
+        ? segmentIndexForLine(state.readingSegments, line)
+        : line;
+    for (final position in widget.tab.positionsListener.itemPositions.value) {
+      if (position.index == target) return position;
+    }
+    return null;
+  }
+
+  /// נקודת העיגון של החלונית: הקצה הימני-תחתון של השורה בתוך אזור הקריאה
+  /// (RTL — `_offsetNearPoint` מצמיד את קצה החלונית הימני לנקודה ומציב אותה
+  /// מתחתיה). כשהשורה עדיין אינה במיקומים — מרכז אזור הקריאה, כדי שהחלונית
+  /// תיפתח במקום סביר ולא תיעלם.
+  Offset? _anchorPreviewPosition(TextBookLoaded state, int line) {
+    final box = _anchorViewportKey.currentContext?.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return null;
+    final height = box.size.height;
+    final position = _visibleSegmentPosition(state, line);
+    final dy = position == null
+        ? height / 2
+        : (position.itemTrailingEdge * height).clamp(0.0, height);
+    final dx = (box.size.width - _kAnchorPreviewInset).clamp(
+      0.0,
+      box.size.width,
+    );
+    return box.localToGlobal(Offset(dx, dy));
+  }
+
   // מצב הרצף האחרון שנצפה — לזיהוי החלפת מצב שמחייבת שחזור מיקום.
   bool? _lastContinuousReadingMode;
 
@@ -581,6 +726,16 @@ class _CombinedViewState extends State<CombinedView> {
   ScrollController? _previewScrollController;
   final DictionaryLookupRepository _dictionaryLookupRepository =
       DictionaryLookupRepository.instance;
+
+  // ── מצב סמנים במקלדת ─────────────────────────────────────────────────────
+  // חלופה לריחוף בעכבר: מעבר בין סמני-העוגן של הספר ופתיחת אותה חלונית
+  // תצוגה מקדימה. אחיזה ב-RenderBox של הרשימה — ממנו נגזר מיקום החלונית.
+  final GlobalKey _anchorViewportKey = GlobalKey();
+  bool _anchorKeyboardMode = false;
+  AnchorCursor? _anchorKeyboardCursor;
+
+  /// מרווח מהקצה הימני של אזור הקריאה לנקודת העיגון של החלונית (RTL).
+  static const double _kAnchorPreviewInset = 24;
 
   @override
   void initState() {
@@ -633,6 +788,12 @@ class _CombinedViewState extends State<CombinedView> {
         LoadPersonalNotes(widget.tab.book.title),
       );
     });
+
+    // מצב סמנים במקלדת — הקיצורים הגלובליים מגלגלים counter בטאב.
+    widget.tab.anchorPreviewToggleNotifier.addListener(_onAnchorPreviewToggle);
+    widget.tab.anchorPreviewNextNotifier.addListener(_onAnchorPreviewNext);
+    widget.tab.anchorPreviewPrevNotifier.addListener(_onAnchorPreviewPrev);
+    widget.tab.anchorPreviewOpenNotifier.addListener(_onAnchorPreviewOpen);
 
     // האזנה לשינויים במיקומי הפריטים כדי לאפס את הבחירה בגלילה
     widget.tab.positionsListener.itemPositions.addListener(_onScroll);
@@ -755,6 +916,15 @@ class _CombinedViewState extends State<CombinedView> {
     );
     _disposed = true;
     _cancelPendingAnchorHover();
+    widget.tab.anchorPreviewToggleNotifier.removeListener(
+      _onAnchorPreviewToggle,
+    );
+    widget.tab.anchorPreviewNextNotifier.removeListener(_onAnchorPreviewNext);
+    widget.tab.anchorPreviewPrevNotifier.removeListener(_onAnchorPreviewPrev);
+    widget.tab.anchorPreviewOpenNotifier.removeListener(_onAnchorPreviewOpen);
+    // הטאב שורד את המסך (החלפת כרטיסייה) — המצב חייב להתאפס איתו, אחרת
+    // Escape ייבלע בכרטיסייה הבאה בלי שיש מה לסגור.
+    widget.tab.anchorPreviewActive.value = false;
     LinkPreviewOverlay.dismiss();
     _previewScrollController?.dispose();
     widget.tab.positionsListener.itemPositions.removeListener(_onScroll);
@@ -1793,39 +1963,45 @@ class _CombinedViewState extends State<CombinedView> {
 
     // המצב ב-key מאלץ יצירת רשימה חדשה בהחלפת מצב רציף, כך שהפריים הראשון
     // כבר מצויר ב-initialScrollIndex הנכון — בלי הבזק של מיקום שגוי.
-    return ScrollablePositionedList.builder(
-      key: ValueKey(
-        'combined-${widget.tab.book.title}-${state.continuousReadingMode}',
-      ),
-      initialScrollIndex: clampedInitial,
-      initialAlignment: kReadingAnchorAlignment,
-      itemPositionsListener: widget.tab.positionsListener,
-      itemScrollController: widget.tab.scrollController,
-      scrollOffsetController: widget.tab.mainOffsetController,
-      itemCount: itemCount,
-      itemBuilder: (context, index) {
-        ExpansibleController controller = ExpansibleController();
-        // מבודד את שכבת הצביעה של כל פריט - rebuild של פריט בודד (בחירה/
-        // הדגשה) או emit של warming לא יצבע מחדש את כל ה-viewport.
-        final tile = RepaintBoundary(
-          child: buildExpansiomTile(controller, index, state, noteMap),
-        );
-        final sourceBannerKind = _sourceBannerKind;
-        if (index == 0 && sourceBannerKind != null) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              BookSourceBanner(
-                kind: sourceBannerKind,
-                bookTitle: widget.tab.book.title,
-                fontSize: widget.textSize,
-              ),
-              tile,
-            ],
+    // KeyedSubtree אינו מוסיף RenderObject ולכן אינו משנה layout — הוא רק
+    // נותן ל-[_anchorViewportKey] אחיזה ב-RenderBox של הרשימה, שממנו נגזר
+    // מיקום החלונית בפתיחה מהמקלדת (שבה אין מיקום עכבר).
+    return KeyedSubtree(
+      key: _anchorViewportKey,
+      child: ScrollablePositionedList.builder(
+        key: ValueKey(
+          'combined-${widget.tab.book.title}-${state.continuousReadingMode}',
+        ),
+        initialScrollIndex: clampedInitial,
+        initialAlignment: kReadingAnchorAlignment,
+        itemPositionsListener: widget.tab.positionsListener,
+        itemScrollController: widget.tab.scrollController,
+        scrollOffsetController: widget.tab.mainOffsetController,
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          ExpansibleController controller = ExpansibleController();
+          // מבודד את שכבת הצביעה של כל פריט - rebuild של פריט בודד (בחירה/
+          // הדגשה) או emit של warming לא יצבע מחדש את כל ה-viewport.
+          final tile = RepaintBoundary(
+            child: buildExpansiomTile(controller, index, state, noteMap),
           );
-        }
-        return tile;
-      },
+          final sourceBannerKind = _sourceBannerKind;
+          if (index == 0 && sourceBannerKind != null) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                BookSourceBanner(
+                  kind: sourceBannerKind,
+                  bookTitle: widget.tab.book.title,
+                  fontSize: widget.textSize,
+                ),
+                tile,
+              ],
+            );
+          }
+          return tile;
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
## מה זה עושה

חלונית התצוגה המקדימה של מפרש/הערה/קישור (`LinkPreviewOverlay`) נפתחת היום בריחוף עכבר בלבד. ה-PR מוסיף **מסלול קלט שני — מקלדת — לאותה חלונית**, בלי לשנות את מסלול הריחוף. שניהם פועלים במקביל: הריחוף ממשיך לעבוד גם כשמצב הסמנים דלוק.

| קיצור | פעולה |
|---|---|
| `F2` | כניסה/יציאה ממצב סמנים; בכניסה נפתחת חלונית על הסמן הקרוב לשורה הנוכחית |
| `Alt+←` / `Alt+→` | הסמן הבא / הקודם (RTL: קדימה = שמאלה), עם גלילה אליו אם צריך |
| `Alt+Enter` | פתיחת היעד (כמו לחיצה על כותרת החלונית) |
| `Escape` | סגירה |

כל הקיצורים ניתנים להגדרה מחדש דרך `ShortcutValidator` ומסך ההגדרות.

## למה ככה

הבעיה האמיתית איננה "קיצור מקשים" אלא שלעכבר יש מיקום ולמקלדת אין. שני החלקים החסרים היו מושג של "הסמן הנוכחי" ונקודת עיגון לחלונית — כל השאר כבר קיים בקוד.

- **`anchor_keyboard_navigator.dart`** — המיפוי ההפוך של `injectLinkAnchorMarkers`: מהמקום הנוכחי אל הסמן הבא/הקודם, לפי אותו סינון (`anchorStart != null`) ואותו סדר שבו נבנו הסמנים, כך שהאינדקס זהה לזה שב-`otzaria://anchor?ref=<line>_<i>` ו-`_anchorLinkFromUrl` מפענח אותו ללא שינוי. הסריקה על מפתחות `linksByLine` ולא על כל שורות הספר, כדי שספר עם עשרות אלפי שורות ומעט עוגנים לא ייסרק שורה-שורה.
- **`hoverMode: false`** — חלונית שנפתחה מהמקלדת נשארת פתוחה עד `Escape`, במקום להיסגר ביציאת סמן עכבר שאינו קיים. הפרמטר כבר היה שם.
- **נקודת העיגון** נגזרת מ-`itemPositions` של השורה בתוך אזור הקריאה; `_offsetNearPoint` הקיים מטפל בהצמדה ל-RTL ובחיתוך לגבולות המסך.
- **`KeyedSubtree`** סביב הרשימה אינו מוסיף `RenderObject` ולכן אינו משנה layout — הוא רק נותן אחיזה ב-`RenderBox` של הרשימה.
- **סמני העוגן נשארים `TextSpan`** בכוונה ולא הופכים ל-`WidgetSpan` עם `GlobalKey` לכל סמן: שני `WidgetSpan` בפסקת RTL מוצגים בסדר תוכן הפוך (ההערה הקיימת ב-`link_anchor_markers.dart:110`). לכן העיגון הוא ברמת השורה ולא ברמת האות.

## מה לא נעשה

- מומש ב-`CombinedView` בלבד. `simple_text_viewer.dart` (צורת הדף) ו-`continuous_reading_paragraph.dart` מחברים גם הם `onAnchorHover` וצריכים את אותו חיבור — עדיף בהמשך, ומוטב דרך הוצאת הלוגיקה ל-controller משותף במקום שילוש.
- הפופאפ אינו `FocusScope`, ולכן אין `Tab` לניווט *בתוך* החלונית. "פתח, קרא, Esc" — תוספת נפרדת.
- `Escape` יוצא מהמצב כולו (ולא סוגר חלונית ומשאיר את המצב). אם תעדיפו התנהגות דו-שלבית, זה שינוי קטן.

## ⚠️ לא נבדק בבנייה

הקוד נכתב מול `dev` והשמות אומתו מול הקוד, אבל **לא הורצו `flutter analyze` ו-`flutter test`** — לא היה Flutter SDK בסביבה שבה נכתב. צריך בנייה ובדיקה ידנית לפני מיזוג, ויתכן שנדרש `dart format`.

## הדמיה

יש הדמיית HTML עצמאית של האינטראקציה (שלושת סוגי הסמנים, אותו אלגוריתם מיקום RTL, ריחוף ומקלדת במקביל) כדי להרגיש את ה-UX לפני קומפילציה. אשמח לצרף אם זה עוזר לדיון.
