### PR TITLE
תיקון: AltGr שובר כל קיצור עם alt בפריסת מקלדת לא-לטינית

### DIFF
--- a/lib/shortcuts/shortcut_helper.dart
+++ b/lib/shortcuts/shortcut_helper.dart
@@ -72,7 +72,18 @@ class ShortcutHelper {
     final metaPressed =
         isMetaPressed ?? HardwareKeyboard.instance.isMetaPressed;
 
-    if (requiresCtrl != null && requiresCtrl != controlPressed) {
+    // AltGr: בפריסות לא-לטיניות (עברית, רוסית ועוד) מקש Alt הימני הוא AltGr,
+    // ו-Windows/Linux מדווחים עליו כ-Ctrl+Alt יחד. בלי ההתאמה הזו כל קיצור
+    // עם `alt` ובלי `ctrl` נשבר למי שלוחץ על Alt הימני — כולל קיצורי הניווט
+    // המוגדרים כברירת מחדל (`alt+arrowup/down`, `alt+pageup/down`).
+    //
+    // ההקלה צרה בכוונה: היא חלה רק כשהקיצור דורש `alt`, אינו דורש `ctrl`,
+    // ובפועל שני המקשים לחוצים — כלומר בדיוק חתימת AltGr.
+    final ctrlFromAltGr =
+        requiresAlt && !hasCtrlToken && controlPressed && altPressed;
+    final effectiveControlPressed = ctrlFromAltGr ? false : controlPressed;
+
+    if (requiresCtrl != null && requiresCtrl != effectiveControlPressed) {
       return false;
     }
     if (requiresShift != shiftPressed) {

--- a/test/shortcuts/shortcut_helper_test.dart
+++ b/test/shortcuts/shortcut_helper_test.dart
@@ -14,6 +14,81 @@ void main() {
   tearDown(() => ShortcutHelper.isMacForTesting = null);
 
   group('ShortcutHelper.matchesShortcut', () {
+    group('AltGr (Alt ימני בפריסה לא-לטינית) מדווח כ-Ctrl+Alt', () {
+      final arrowUp = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.arrowUp,
+        logicalKey: LogicalKeyboardKey.arrowUp,
+        timeStamp: Duration.zero,
+      );
+
+      test('קיצור alt בלבד מותאם גם כשה-Ctrl מגיע מ-AltGr', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'alt+arrowup',
+            isAltPressed: true,
+            isControlPressed: true,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isTrue,
+        );
+      });
+
+      test('קיצור alt בלבד ממשיך להיות מותאם ללחיצת Alt רגילה', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'alt+arrowup',
+            isAltPressed: true,
+            isControlPressed: false,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isTrue,
+        );
+      });
+
+      test('Ctrl בלי Alt אינו נחשב AltGr ואינו מותאם לקיצור alt', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'alt+arrowup',
+            isAltPressed: false,
+            isControlPressed: true,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isFalse,
+        );
+      });
+
+      test('קיצור שדורש ctrl במפורש אינו מושפע מההקלה', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'ctrl+arrowup',
+            isAltPressed: false,
+            isControlPressed: true,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isTrue,
+        );
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'ctrl+arrowup',
+            isAltPressed: true,
+            isControlPressed: false,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isFalse,
+        );
+      });
+    });
+
     test('מזהה meta רק כש-meta לחוץ', () {
       final event = KeyDownEvent(
         physicalKey: PhysicalKeyboardKey.keyV,


### PR DESCRIPTION
## הבעיה

בפריסות מקלדת לא-לטיניות (עברית, רוסית ועוד) מקש **Alt הימני הוא AltGr**, ו-Windows/Linux מדווחים עליו כ-**Ctrl+Alt יחד**. `matchesShortcut` דורש התאמה מדויקת של מצב Control, ולכן כל קיצור שמוגדר עם `alt` ובלי `ctrl` פשוט לא נתפס למי שלוחץ על Alt הימני.

**זה פוגע בארבעה קיצורים שהם ברירת מחדל:**

| קיצור | פעולה |
|---|---|
| `alt+arrowup` | הקטע הקודם |
| `alt+arrowdown` | הקטע הבא |
| `alt+pageup` | הדף/פרק הקודם |
| `alt+pagedown` | הדף/פרק הבא |

משתמש שמקליד בעברית ולוחץ על Alt הימני — הקיצורים האלה לא עובדים אצלו, בלי שום חיווי למה.

## איך זה אומת

בבנייה מקומית עם אבחון בשכבת הקיצורים, בלחיצה על Alt הימני + חץ:

```
alt=true  shift=false  ctrl=true  meta=false  match=false
```

`ctrl=true` בלי שנלחץ Ctrl — זו חתימת AltGr. `event.logicalKey` זוהה נכון (`eq=true`), וההתאמה נכשלה **רק** בגלל ה-Control העודף.

## התיקון

הקלה צרה ב-`matchesShortcut`: התעלמות מ-Control **רק** כשמצטברים שלושת התנאים של AltGr — הקיצור דורש `alt`, אינו דורש `ctrl`, ובפועל שני המקשים לחוצים.

```dart
final ctrlFromAltGr =
    requiresAlt && !hasCtrlToken && controlPressed && altPressed;
final effectiveControlPressed = ctrlFromAltGr ? false : controlPressed;
```

הרעיון עצמו אינו חדש בקובץ — `matchesShortcut` כבר מתעלם ממצב Control הפיזי ב-macOS מסיבה דומה (שם `ctrl` מתורגם ל-Command).

## טסטים

נוספו ארבעה טסטים ב-`test/shortcuts/shortcut_helper_test.dart`:

- קיצור `alt` בלבד מותאם גם כשה-Ctrl מגיע מ-AltGr
- קיצור `alt` בלבד ממשיך להיות מותאם ללחיצת Alt רגילה (בלי רגרסיה)
- `Ctrl` בלי `Alt` אינו נחשב AltGr ואינו מותאם לקיצור `alt`
- קיצור שדורש `ctrl` במפורש אינו מושפע מההקלה

**הרצה מקומית: 38/38 עוברים** (34 קיימים + 4 חדשים).

## שיקול שכדאי לשים עליו עין

אחרי התיקון, לחיצת **Ctrl+Alt אמיתית** (שני המקשים בכוונה) תתאים גם לקיצור שמוגדר `alt` בלבד. כרגע אין ב-`defaultShortcuts` שום קיצור עם `ctrl+alt`, ולכן אין התנגשות בפועל — אבל משתמש שיגדיר קיצור `ctrl+alt+X` בעצמו עלול לקבל התאמה כפולה. אם מעדיפים למנוע זאת לחלוטין, אפשר להצר עוד: להחיל את ההקלה רק כשהמקש הפיזי הוא `altRight`. לא עשיתי זאת כדי לא להסתמך על הבחנה בין Alt שמאלי לימני, שאינה זמינה באופן אחיד בכל הפלטפורמות.
