### PR TITLE
תיקון: AltGr שובר כל קיצור עם alt בפריסת מקלדת לא-לטינית

### DIFF
--- a/lib/shortcuts/keyboard_shortcuts.dart
+++ b/lib/shortcuts/keyboard_shortcuts.dart
@@ -122,7 +122,7 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
     if (_isEditing()) {
       final isModifierPressed =
           HardwareKeyboard.instance.isControlPressed ||
-          HardwareKeyboard.instance.isAltPressed ||
+          ShortcutHelper.isAltModifierPressed ||
           HardwareKeyboard.instance.isMetaPressed;
 
       if (!isModifierPressed) {

--- a/lib/shortcuts/shortcut_helper.dart
+++ b/lib/shortcuts/shortcut_helper.dart
@@ -33,7 +33,24 @@ class ShortcutHelper {
   @visibleForTesting
   static bool? isMacForTesting;
 
+  /// override לבדיקת דיווח AltGr הייחודי ל-Windows.
+  @visibleForTesting
+  static bool? isWindowsForTesting;
+
   static bool get _treatCtrlAsMeta => isMacForTesting ?? _isMac;
+  static bool get _treatRightAltAsAltGr =>
+      isWindowsForTesting ?? (!kIsWeb && Platform.isWindows);
+
+  /// האם לחוץ Alt רגיל או AltGr, גם כשהמערכת מדווחת עליו כ-AltGraph.
+  static bool get isAltModifierPressed {
+    final keyboard = HardwareKeyboard.instance;
+    return keyboard.isAltPressed || _isAltGrPressed(keyboard);
+  }
+
+  static bool _isAltGrPressed(HardwareKeyboard keyboard) =>
+      keyboard.isLogicalKeyPressed(LogicalKeyboardKey.altGraph) ||
+      (_treatRightAltAsAltGr &&
+          keyboard.isPhysicalKeyPressed(PhysicalKeyboardKey.altRight));
 
   /// בודק אם האירוע [event] תואם להגדרת הקיצור [shortcutSetting].
   ///
@@ -45,6 +62,7 @@ class ShortcutHelper {
     bool? isControlPressed,
     bool? isShiftPressed,
     bool? isAltPressed,
+    bool? isAltGrPressed,
     bool? isMetaPressed,
   }) {
     if (event is! KeyDownEvent) return false;
@@ -64,24 +82,17 @@ class ShortcutHelper {
         : hasMetaToken;
 
     // בדיקת modifiers
-    final controlPressed =
-        isControlPressed ?? HardwareKeyboard.instance.isControlPressed;
-    final shiftPressed =
-        isShiftPressed ?? HardwareKeyboard.instance.isShiftPressed;
-    final altPressed = isAltPressed ?? HardwareKeyboard.instance.isAltPressed;
-    final metaPressed =
-        isMetaPressed ?? HardwareKeyboard.instance.isMetaPressed;
+    final keyboard = HardwareKeyboard.instance;
+    final controlPressed = isControlPressed ?? keyboard.isControlPressed;
+    final shiftPressed = isShiftPressed ?? keyboard.isShiftPressed;
+    final altPressed = isAltPressed ?? keyboard.isAltPressed;
+    final altGrPressed = isAltGrPressed ?? _isAltGrPressed(keyboard);
+    final effectiveAltPressed = altPressed || altGrPressed;
+    final metaPressed = isMetaPressed ?? keyboard.isMetaPressed;
 
-    // AltGr: בפריסות לא-לטיניות (עברית, רוסית ועוד) מקש Alt הימני הוא AltGr,
-    // ו-Windows/Linux מדווחים עליו כ-Ctrl+Alt יחד. בלי ההתאמה הזו כל קיצור
-    // עם `alt` ובלי `ctrl` נשבר למי שלוחץ על Alt הימני — כולל קיצורי הניווט
-    // המוגדרים כברירת מחדל (`alt+arrowup/down`, `alt+pageup/down`).
-    //
-    // ההקלה צרה בכוונה: היא חלה רק כשהקיצור דורש `alt`, אינו דורש `ctrl`,
-    // ובפועל שני המקשים לחוצים — כלומר בדיוק חתימת AltGr.
-    final ctrlFromAltGr =
-        requiresAlt && !hasCtrlToken && controlPressed && altPressed;
-    final effectiveControlPressed = ctrlFromAltGr ? false : controlPressed;
+    // AltGr עשוי להוסיף Control סינתטי; מדכאים אותו תמיד כדי שהאירוע לא
+    // יתאים בו-זמנית גם ל-alt וגם ל-ctrl+alt.
+    final effectiveControlPressed = altGrPressed ? false : controlPressed;
 
     if (requiresCtrl != null && requiresCtrl != effectiveControlPressed) {
       return false;
@@ -89,7 +100,7 @@ class ShortcutHelper {
     if (requiresShift != shiftPressed) {
       return false;
     }
-    if (requiresAlt != altPressed) return false;
+    if (requiresAlt != effectiveAltPressed) return false;
     if (requiresMeta != metaPressed) return false;
 
     // מציאת המקש הראשי (לא modifier)
@@ -162,6 +173,9 @@ class ShortcutHelper {
     bool hasAlt = false;
     bool hasMeta = false;
     String? mainKey;
+    final hasAltGr =
+        keys.contains(LogicalKeyboardKey.altGraph) ||
+        (_treatRightAltAsAltGr && keys.contains(LogicalKeyboardKey.altRight));
 
     for (final key in keys) {
       if (key == LogicalKeyboardKey.control ||
@@ -174,7 +188,8 @@ class ShortcutHelper {
         hasShift = true;
       } else if (key == LogicalKeyboardKey.alt ||
           key == LogicalKeyboardKey.altLeft ||
-          key == LogicalKeyboardKey.altRight) {
+          key == LogicalKeyboardKey.altRight ||
+          key == LogicalKeyboardKey.altGraph) {
         hasAlt = true;
       } else if (key == LogicalKeyboardKey.meta ||
           key == LogicalKeyboardKey.metaLeft ||
@@ -184,6 +199,8 @@ class ShortcutHelper {
         mainKey = getKeyLabel(key);
       }
     }
+
+    if (hasAltGr) hasCtrl = false;
 
     // ב-Mac גם Cmd וגם Control מתורגמים לאותו token קנוני `ctrl`. זה שומר
     // על תאימות בין-פלטפורמות (אותו `ctrl+f` עובד בכל מערכת) ומונע יצירת
@@ -256,12 +273,15 @@ class ShortcutHelper {
 
   /// ממיר מחרוזת קיצור (כגון `'ctrl+f'`) ל-[ShortcutActivator].
   ///
-  /// מחזיר [SingleActivator] עם modifiers מתאימים.
+  /// מחזיר מפעיל קיצור עם modifiers מתאימים.
   /// אם המחרוזת אינה ניתנת לניתוח, מחזיר `null`.
   ///
   /// ב-Mac ה-token `ctrl` ממופה ל-`meta: true` כדי שמתפעלי קיצור (Flutter
-  /// `Shortcuts` widget) יזהו לחיצת Command.
-  static ShortcutActivator? activatorFromShortcut(String shortcut) {
+  /// `Shortcuts` widget) יזהו לחיצת Command, אלא אם [mapCtrlToMeta] הוא false.
+  static ShortcutActivator? activatorFromShortcut(
+    String shortcut, {
+    bool mapCtrlToMeta = true,
+  }) {
     final parts = shortcut.toLowerCase().split('+');
     final hasCtrlToken = parts.contains('ctrl') || parts.contains('control');
     final hasMetaToken = parts.contains('meta');
@@ -270,7 +290,8 @@ class ShortcutHelper {
 
     final bool useControl;
     final bool useMeta;
-    if (_treatCtrlAsMeta) {
+    final treatCtrlAsMeta = mapCtrlToMeta && _treatCtrlAsMeta;
+    if (treatCtrlAsMeta) {
       useControl = false;
       useMeta = hasCtrlToken || hasMetaToken;
     } else {
@@ -282,21 +303,104 @@ class ShortcutHelper {
     if (mainKeyName == null) return null;
 
     LogicalKeyboardKey? logicalKey;
+    PhysicalKeyboardKey? physicalTrigger;
     if (mainKeyName.length == 1) {
       final code = mainKeyName.codeUnitAt(0);
       if (code >= 97 && code <= 122) {
-        logicalKey = LogicalKeyboardKey(0x00000061 + (code - 97));
+        final offset = code - 97;
+        logicalKey = LogicalKeyboardKey(0x00000061 + offset);
+        physicalTrigger = PhysicalKeyboardKey(
+          PhysicalKeyboardKey.keyA.usbHidUsage + offset,
+        );
       }
     }
     logicalKey ??= KeyMap.keyFor(mainKeyName);
     if (logicalKey == null) return null;
 
+    if (hasAlt) {
+      return _AltAwareShortcutActivator(
+        logicalKey,
+        physicalTrigger: physicalTrigger,
+        control: useControl,
+        shift: hasShift,
+        meta: useMeta,
+      );
+    }
+
     return SingleActivator(
       logicalKey,
       control: useControl,
       shift: hasShift,
-      alt: hasAlt,
       meta: useMeta,
     );
   }
+}
+
+class _AltAwareShortcutActivator extends ShortcutActivator {
+  const _AltAwareShortcutActivator(
+    this.trigger, {
+    required this.physicalTrigger,
+    required this.control,
+    required this.shift,
+    required this.meta,
+  });
+
+  final LogicalKeyboardKey trigger;
+  final PhysicalKeyboardKey? physicalTrigger;
+  final bool control;
+  final bool shift;
+  final bool meta;
+
+  @override
+  Iterable<LogicalKeyboardKey>? get triggers =>
+      physicalTrigger != null ? null : [trigger];
+
+  @override
+  bool accepts(KeyEvent event, HardwareKeyboard state) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) return false;
+
+    final altGrPressed = ShortcutHelper._isAltGrPressed(state);
+    final effectiveControlPressed = altGrPressed
+        ? false
+        : state.isControlPressed;
+    if (control != effectiveControlPressed ||
+        shift != state.isShiftPressed ||
+        !(state.isAltPressed || altGrPressed) ||
+        meta != state.isMetaPressed) {
+      return false;
+    }
+
+    return physicalTrigger != null
+        ? event.physicalKey == physicalTrigger
+        : event.logicalKey == trigger;
+  }
+
+  @override
+  String debugDescribeKeys() {
+    final modifiers = <String>[
+      if (control) 'ctrl',
+      if (shift) 'shift',
+      'alt',
+      if (meta) 'meta',
+    ];
+    return [...modifiers, ShortcutHelper.getKeyLabel(trigger)].join('+');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is _AltAwareShortcutActivator &&
+      other.trigger == trigger &&
+      other.physicalTrigger == physicalTrigger &&
+      other.control == control &&
+      other.shift == shift &&
+      other.meta == meta;
+
+  @override
+  int get hashCode => Object.hash(
+    trigger,
+    physicalTrigger,
+    control,
+    shift,
+    meta,
+  );
 }

--- a/lib/shortcuts/shortcut_helper.dart
+++ b/lib/shortcuts/shortcut_helper.dart
@@ -72,7 +72,18 @@ class ShortcutHelper {
     final metaPressed =
         isMetaPressed ?? HardwareKeyboard.instance.isMetaPressed;
 
-    if (requiresCtrl != null && requiresCtrl != controlPressed) {
+    // AltGr: בפריסות לא-לטיניות (עברית, רוסית ועוד) מקש Alt הימני הוא AltGr,
+    // ו-Windows/Linux מדווחים עליו כ-Ctrl+Alt יחד. בלי ההתאמה הזו כל קיצור
+    // עם `alt` ובלי `ctrl` נשבר למי שלוחץ על Alt הימני — כולל קיצורי הניווט
+    // המוגדרים כברירת מחדל (`alt+arrowup/down`, `alt+pageup/down`).
+    //
+    // ההקלה צרה בכוונה: היא חלה רק כשהקיצור דורש `alt`, אינו דורש `ctrl`,
+    // ובפועל שני המקשים לחוצים — כלומר בדיוק חתימת AltGr.
+    final ctrlFromAltGr =
+        requiresAlt && !hasCtrlToken && controlPressed && altPressed;
+    final effectiveControlPressed = ctrlFromAltGr ? false : controlPressed;
+
+    if (requiresCtrl != null && requiresCtrl != effectiveControlPressed) {
       return false;
     }
     if (requiresShift != shiftPressed) {

--- a/lib/tools/calendar/calendar_screen.dart
+++ b/lib/tools/calendar/calendar_screen.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/printing/view/printing_screen.dart';
-import 'package:otzaria/shortcuts/key_map.dart';
 import 'package:otzaria/settings/settings_exports.dart';
+import 'package:otzaria/shortcuts/shortcut_helper.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/widgets/layout/floating_panel.dart'
     show kMainPanelMinWidth, kSideBySideMinWidth;
@@ -190,49 +190,23 @@ class CalendarWidgetState extends State<CalendarWidget> {
     final configuredShortcut = shortcuts[key];
     final configuredActivator = configuredShortcut == null
         ? null
-        : _activatorFromShortcut(configuredShortcut);
+        : ShortcutHelper.activatorFromShortcut(
+            configuredShortcut,
+            mapCtrlToMeta: false,
+          );
     if (configuredShortcut != null && configuredActivator == null) {
       debugPrint('Invalid shortcut for $key: $configuredShortcut');
     }
 
-    final fallbackActivator = _activatorFromShortcut(fallback);
+    final fallbackActivator = ShortcutHelper.activatorFromShortcut(
+      fallback,
+      mapCtrlToMeta: false,
+    );
     if (fallbackActivator == null) {
       debugPrint('Invalid fallback shortcut for $key: $fallback');
     }
 
     return configuredActivator ?? fallbackActivator;
-  }
-
-  static const _modifiers = {'ctrl', 'control', 'shift', 'alt', 'meta'};
-
-  ShortcutActivator? _activatorFromShortcut(String shortcut) {
-    final parts = shortcut.toLowerCase().split('+');
-    final hasCtrl = parts.contains('ctrl') || parts.contains('control');
-    final hasShift = parts.contains('shift');
-    final hasAlt = parts.contains('alt');
-    final hasMeta = parts.contains('meta');
-
-    final mainKeyName = parts.where((p) => !_modifiers.contains(p)).firstOrNull;
-    if (mainKeyName == null) return null;
-
-    LogicalKeyboardKey? logicalKey;
-    if (mainKeyName.length == 1) {
-      // אות יחידה a–z
-      final code = mainKeyName.codeUnitAt(0);
-      if (code >= 97 && code <= 122) {
-        logicalKey = LogicalKeyboardKey(0x00000061 + (code - 97));
-      }
-    }
-    logicalKey ??= KeyMap.keyFor(mainKeyName);
-    if (logicalKey == null) return null;
-
-    return SingleActivator(
-      logicalKey,
-      control: hasCtrl,
-      shift: hasShift,
-      alt: hasAlt,
-      meta: hasMeta,
-    );
   }
 
   void _navigateMonth(BuildContext context, {required bool forward}) {

--- a/lib/tools/shamor_zachor/screens/shamor_zachor_main_screen.dart
+++ b/lib/tools/shamor_zachor/screens/shamor_zachor_main_screen.dart
@@ -14,8 +14,8 @@ import '../widgets/add_books_to_tracking_dialog.dart';
 import '../models/book_model.dart';
 import 'book_detail_screen.dart';
 import 'package:otzaria/settings/settings_exports.dart';
+import 'package:otzaria/shortcuts/shortcut_helper.dart';
 import 'package:otzaria/shortcuts/shortcut_validator.dart';
-import 'package:otzaria/shortcuts/key_map.dart';
 import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria/widgets/navigation/app_top_bar.dart';
 import 'package:otzaria/widgets/controls/segmented_control.dart';
@@ -309,37 +309,6 @@ class _ShamorZachorMainScreenState extends State<ShamorZachorMainScreen>
     return KeyEventResult.ignored;
   }
 
-  static const _modifiers = {'ctrl', 'control', 'shift', 'alt', 'meta'};
-
-  ShortcutActivator? _activatorFromShortcut(String shortcut) {
-    final parts = shortcut.toLowerCase().split('+');
-    final hasCtrl = parts.contains('ctrl') || parts.contains('control');
-    final hasShift = parts.contains('shift');
-    final hasAlt = parts.contains('alt');
-    final hasMeta = parts.contains('meta');
-
-    final mainKeyName = parts.where((p) => !_modifiers.contains(p)).firstOrNull;
-    if (mainKeyName == null) return null;
-
-    LogicalKeyboardKey? logicalKey;
-    if (mainKeyName.length == 1) {
-      final code = mainKeyName.codeUnitAt(0);
-      if (code >= 97 && code <= 122) {
-        logicalKey = LogicalKeyboardKey(0x00000061 + (code - 97));
-      }
-    }
-    logicalKey ??= KeyMap.keyFor(mainKeyName);
-    if (logicalKey == null) return null;
-
-    return SingleActivator(
-      logicalKey,
-      control: hasCtrl,
-      shift: hasShift,
-      alt: hasAlt,
-      meta: hasMeta,
-    );
-  }
-
   void _scrollContent({required bool forward}) {
     if (!_contentScrollController.hasClients) return;
     final position = _contentScrollController.position;
@@ -423,12 +392,18 @@ class _ShamorZachorMainScreenState extends State<ShamorZachorMainScreen>
 
     return CallbackShortcuts(
       bindings: {
-        _activatorFromShortcut(cycleFilterShortcutSetting) ??
+        ShortcutHelper.activatorFromShortcut(
+              cycleFilterShortcutSetting,
+              mapCtrlToMeta: false,
+            ) ??
             const SingleActivator(LogicalKeyboardKey.keyS, control: true): () {
           if (_isTextFieldFocused()) return;
           _cycleFilter();
         },
-        _activatorFromShortcut(searchShortcutSetting) ??
+        ShortcutHelper.activatorFromShortcut(
+              searchShortcutSetting,
+              mapCtrlToMeta: false,
+            ) ??
             const SingleActivator(LogicalKeyboardKey.keyF, control: true): () {
           _focusSearchField();
         },

--- a/test/shortcuts/custom_shortcut_dialog_test.dart
+++ b/test/shortcuts/custom_shortcut_dialog_test.dart
@@ -28,10 +28,12 @@ void main() {
   // מקובעת כדי שהערך הקנוני יהיה זהה בכל סביבת ריצה.
   setUp(() {
     ShortcutHelper.isMacForTesting = false;
+    ShortcutHelper.isWindowsForTesting = false;
     FocusRepository().resetForTesting();
   });
   tearDown(() {
     ShortcutHelper.isMacForTesting = null;
+    ShortcutHelper.isWindowsForTesting = null;
     FocusRepository().resetForTesting();
   });
 
@@ -173,6 +175,67 @@ void main() {
       await confirm(tester);
 
       expect(await result, 'alt+q');
+    });
+
+    testWidgets('AltGraph מובחן נשמר כ-alt', (tester) async {
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(LogicalKeyboardKey.altGraph, PhysicalKeyboardKey.altRight),
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.arrowUp,
+          logicalKey: LogicalKeyboardKey.arrowUp,
+          timeStamp: Duration.zero,
+        ),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'alt+arrowup');
+    });
+
+    testWidgets('AltGr של Windows אינו שומר Control סינתטי', (tester) async {
+      ShortcutHelper.isWindowsForTesting = true;
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(
+          LogicalKeyboardKey.controlLeft,
+          PhysicalKeyboardKey.controlLeft,
+        ),
+        _modifier(LogicalKeyboardKey.altRight, PhysicalKeyboardKey.altRight),
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.arrowUp,
+          logicalKey: LogicalKeyboardKey.arrowUp,
+          timeStamp: Duration.zero,
+        ),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'alt+arrowup');
+    });
+
+    testWidgets('Ctrl+Alt שמאלי נשמר במפורש כ-ctrl+alt', (tester) async {
+      ShortcutHelper.isWindowsForTesting = true;
+      final result = await openDialog(tester);
+
+      sendKeys(tester, [
+        _modifier(
+          LogicalKeyboardKey.controlLeft,
+          PhysicalKeyboardKey.controlLeft,
+        ),
+        _modifier(LogicalKeyboardKey.altLeft, PhysicalKeyboardKey.altLeft),
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.arrowUp,
+          logicalKey: LogicalKeyboardKey.arrowUp,
+          timeStamp: Duration.zero,
+        ),
+      ]);
+      await tester.pump();
+      await confirm(tester);
+
+      expect(await result, 'ctrl+alt+arrowup');
     });
   });
 

--- a/test/shortcuts/keyboard_shortcuts_test.dart
+++ b/test/shortcuts/keyboard_shortcuts_test.dart
@@ -38,6 +38,7 @@ import 'package:otzaria/tabs/tabs_repository.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/widgets/text/rtl_text_field.dart';
 import 'package:provider/provider.dart';
 import '../helpers/memory_settings_cache.dart';
 
@@ -120,8 +121,14 @@ void main() {
 
   // הטסטים שולחים Control פיזי. ב-macOS `ctrl` מתורגם ל-Meta, ולכן בלי קיבוע
   // זה הקיצורים (Ctrl+Shift+L/C/T) לא היו מזוהים והטסטים נכשלים על Mac/CI.
-  setUp(() => ShortcutHelper.isMacForTesting = false);
-  tearDown(() => ShortcutHelper.isMacForTesting = null);
+  setUp(() {
+    ShortcutHelper.isMacForTesting = false;
+    ShortcutHelper.isWindowsForTesting = false;
+  });
+  tearDown(() {
+    ShortcutHelper.isMacForTesting = null;
+    ShortcutHelper.isWindowsForTesting = null;
+  });
 
   group('KeyboardShortcuts', () {
     late MockSettingsBloc settingsBloc;
@@ -805,7 +812,11 @@ void main() {
       FocusRepository().resetForTesting();
     });
 
-    Future<void> pumpWithTab(WidgetTester tester, OpenedTab tab) async {
+    Future<void> pumpWithTab(
+      WidgetTester tester,
+      OpenedTab tab, {
+      Widget child = const SizedBox(width: 100, height: 100),
+    }) async {
       final tabsBloc = _StubTabsBloc(
         TabsState(tabs: [tab], currentTabIndex: 0),
       );
@@ -830,7 +841,7 @@ void main() {
             home: Scaffold(
               body: KeyboardShortcuts(
                 onFindRefRequested: () {},
-                child: const SizedBox(width: 100, height: 100),
+                child: child,
               ),
             ),
           ),
@@ -844,6 +855,35 @@ void main() {
       await tester.sendKeyDownEvent(key);
       await tester.sendKeyUpEvent(key);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+      await tester.pump();
+    }
+
+    Future<void> sendAltGr(WidgetTester tester, LogicalKeyboardKey key) async {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(
+        LogicalKeyboardKey.altRight,
+        physicalKey: PhysicalKeyboardKey.altRight,
+      );
+      await tester.sendKeyDownEvent(key);
+      await tester.sendKeyUpEvent(key);
+      await tester.sendKeyUpEvent(
+        LogicalKeyboardKey.altRight,
+        physicalKey: PhysicalKeyboardKey.altRight,
+      );
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+    }
+
+    Future<void> sendCtrlAlt(
+      WidgetTester tester,
+      LogicalKeyboardKey key,
+    ) async {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.altLeft);
+      await tester.sendKeyDownEvent(key);
+      await tester.sendKeyUpEvent(key);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
       await tester.pump();
     }
 
@@ -870,6 +910,63 @@ void main() {
 
       await sendAlt(tester, LogicalKeyboardKey.pageDown);
       expect(tab.navNextTocNotifier.value, 1);
+    });
+
+    testWidgets('AltGr של Windows מפעיל קיצור alt דרך מצב HardwareKeyboard', (
+      tester,
+    ) async {
+      ShortcutHelper.isWindowsForTesting = true;
+      final tab = TextBookTab(
+        book: TextBook(title: 'ספר בדיקה'),
+        index: 0,
+        blocOverride: _StubTextBookBloc(),
+      );
+      addTearDown(tab.dispose);
+
+      await pumpWithTab(tester, tab);
+      await sendAltGr(tester, LogicalKeyboardKey.arrowUp);
+
+      expect(tab.navPreviousSegmentNotifier.value, 1);
+    });
+
+    testWidgets('AltGr אינו מסונן כששדה RTL מחזיק פוקוס', (tester) async {
+      ShortcutHelper.isWindowsForTesting = true;
+      final focusNode = FocusNode();
+      final tab = TextBookTab(
+        book: TextBook(title: 'ספר בדיקה'),
+        index: 0,
+        blocOverride: _StubTextBookBloc(),
+      );
+      addTearDown(() {
+        focusNode.dispose();
+        tab.dispose();
+      });
+
+      await pumpWithTab(
+        tester,
+        tab,
+        child: RtlTextField(focusNode: focusNode, autofocus: true),
+      );
+      await tester.pump();
+      expect(focusNode.hasFocus, isTrue);
+
+      await sendAltGr(tester, LogicalKeyboardKey.arrowUp);
+
+      expect(tab.navPreviousSegmentNotifier.value, 1);
+    });
+
+    testWidgets('Ctrl+Alt שמאלי אינו מפעיל קיצור alt בלבד', (tester) async {
+      final tab = TextBookTab(
+        book: TextBook(title: 'ספר בדיקה'),
+        index: 0,
+        blocOverride: _StubTextBookBloc(),
+      );
+      addTearDown(tab.dispose);
+
+      await pumpWithTab(tester, tab);
+      await sendCtrlAlt(tester, LogicalKeyboardKey.arrowUp);
+
+      expect(tab.navPreviousSegmentNotifier.value, 0);
     });
 
     testWidgets(

--- a/test/shortcuts/shortcut_helper_test.dart
+++ b/test/shortcuts/shortcut_helper_test.dart
@@ -14,6 +14,81 @@ void main() {
   tearDown(() => ShortcutHelper.isMacForTesting = null);
 
   group('ShortcutHelper.matchesShortcut', () {
+    group('AltGr (Alt ימני בפריסה לא-לטינית) מדווח כ-Ctrl+Alt', () {
+      final arrowUp = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.arrowUp,
+        logicalKey: LogicalKeyboardKey.arrowUp,
+        timeStamp: Duration.zero,
+      );
+
+      test('קיצור alt בלבד מותאם גם כשה-Ctrl מגיע מ-AltGr', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'alt+arrowup',
+            isAltPressed: true,
+            isControlPressed: true,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isTrue,
+        );
+      });
+
+      test('קיצור alt בלבד ממשיך להיות מותאם ללחיצת Alt רגילה', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'alt+arrowup',
+            isAltPressed: true,
+            isControlPressed: false,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isTrue,
+        );
+      });
+
+      test('Ctrl בלי Alt אינו נחשב AltGr ואינו מותאם לקיצור alt', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'alt+arrowup',
+            isAltPressed: false,
+            isControlPressed: true,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isFalse,
+        );
+      });
+
+      test('קיצור שדורש ctrl במפורש אינו מושפע מההקלה', () {
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'ctrl+arrowup',
+            isAltPressed: false,
+            isControlPressed: true,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isTrue,
+        );
+        expect(
+          ShortcutHelper.matchesShortcut(
+            arrowUp,
+            'ctrl+arrowup',
+            isAltPressed: true,
+            isControlPressed: false,
+            isShiftPressed: false,
+            isMetaPressed: false,
+          ),
+          isFalse,
+        );
+      });
+    });
+
     test('מזהה meta רק כש-meta לחוץ', () {
       final event = KeyDownEvent(
         physicalKey: PhysicalKeyboardKey.keyV,

--- a/test/shortcuts/shortcut_helper_test.dart
+++ b/test/shortcuts/shortcut_helper_test.dart
@@ -14,80 +14,6 @@ void main() {
   tearDown(() => ShortcutHelper.isMacForTesting = null);
 
   group('ShortcutHelper.matchesShortcut', () {
-    group('AltGr (Alt ימני בפריסה לא-לטינית) מדווח כ-Ctrl+Alt', () {
-      final arrowUp = KeyDownEvent(
-        physicalKey: PhysicalKeyboardKey.arrowUp,
-        logicalKey: LogicalKeyboardKey.arrowUp,
-        timeStamp: Duration.zero,
-      );
-
-      test('קיצור alt בלבד מותאם גם כשה-Ctrl מגיע מ-AltGr', () {
-        expect(
-          ShortcutHelper.matchesShortcut(
-            arrowUp,
-            'alt+arrowup',
-            isAltPressed: true,
-            isControlPressed: true,
-            isShiftPressed: false,
-            isMetaPressed: false,
-          ),
-          isTrue,
-        );
-      });
-
-      test('קיצור alt בלבד ממשיך להיות מותאם ללחיצת Alt רגילה', () {
-        expect(
-          ShortcutHelper.matchesShortcut(
-            arrowUp,
-            'alt+arrowup',
-            isAltPressed: true,
-            isControlPressed: false,
-            isShiftPressed: false,
-            isMetaPressed: false,
-          ),
-          isTrue,
-        );
-      });
-
-      test('Ctrl בלי Alt אינו נחשב AltGr ואינו מותאם לקיצור alt', () {
-        expect(
-          ShortcutHelper.matchesShortcut(
-            arrowUp,
-            'alt+arrowup',
-            isAltPressed: false,
-            isControlPressed: true,
-            isShiftPressed: false,
-            isMetaPressed: false,
-          ),
-          isFalse,
-        );
-      });
-
-      test('קיצור שדורש ctrl במפורש אינו מושפע מההקלה', () {
-        expect(
-          ShortcutHelper.matchesShortcut(
-            arrowUp,
-            'ctrl+arrowup',
-            isAltPressed: false,
-            isControlPressed: true,
-            isShiftPressed: false,
-            isMetaPressed: false,
-          ),
-          isTrue,
-        );
-        expect(
-          ShortcutHelper.matchesShortcut(
-            arrowUp,
-            'ctrl+arrowup',
-            isAltPressed: true,
-            isControlPressed: false,
-            isShiftPressed: false,
-            isMetaPressed: false,
-          ),
-          isFalse,
-        );
-      });
-
     test('מזהה meta רק כש-meta לחוץ', () {
       final event = KeyDownEvent(
         physicalKey: PhysicalKeyboardKey.keyV,
@@ -642,6 +568,81 @@ void main() {
       );
     });
   });
+  group('AltGr — Alt ימני בפריסה לא-לטינית מדווח כ-Ctrl+Alt', () {
+    final arrowUp = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.arrowUp,
+      logicalKey: LogicalKeyboardKey.arrowUp,
+      timeStamp: Duration.zero,
+    );
+
+    test('קיצור alt בלבד מותאם גם כשה-Ctrl מגיע מ-AltGr', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'alt+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isMetaPressed: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('קיצור alt בלבד ממשיך להיות מותאם ללחיצת Alt רגילה', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'alt+arrowup',
+          isControlPressed: false,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isMetaPressed: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('Ctrl בלי Alt אינו נחשב AltGr ואינו מותאם לקיצור alt', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'alt+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: false,
+          isMetaPressed: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('קיצור שדורש ctrl במפורש אינו מושפע מההקלה', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'ctrl+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: false,
+          isMetaPressed: false,
+        ),
+        isTrue,
+      );
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'ctrl+arrowup',
+          isControlPressed: false,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isMetaPressed: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
 }
 
 /// אירוע מקש אות בפריסה עברית: `physicalKey` תקין, `logicalKey` הוא התו העברי

--- a/test/shortcuts/shortcut_helper_test.dart
+++ b/test/shortcuts/shortcut_helper_test.dart
@@ -87,7 +87,6 @@ void main() {
           isFalse,
         );
       });
-    });
 
     test('מזהה meta רק כש-meta לחוץ', () {
       final event = KeyDownEvent(

--- a/test/shortcuts/shortcut_helper_test.dart
+++ b/test/shortcuts/shortcut_helper_test.dart
@@ -7,11 +7,16 @@ import 'package:otzaria/shortcuts/shortcut_validator.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // כברירת מחדל קובעים פלטפורמה שאינה Mac, כך שהקבוצות הבודקות סמנטיקת Control
-  // לא תלויות בפלטפורמת הריצה (ב-macOS `ctrl` מתורגם ל-Meta). הקבוצה הייעודית
-  // ל-macOS שלהלן עושה override ל-true ב-setUp שלה.
-  setUp(() => ShortcutHelper.isMacForTesting = false);
-  tearDown(() => ShortcutHelper.isMacForTesting = null);
+  // קיבוע הפלטפורמה מונע תלות במערכת שמריצה את הטסטים; הקבוצה הייעודית
+  // ל-macOS דורסת את הערך לפי הצורך.
+  setUp(() {
+    ShortcutHelper.isMacForTesting = false;
+    ShortcutHelper.isWindowsForTesting = false;
+  });
+  tearDown(() {
+    ShortcutHelper.isMacForTesting = null;
+    ShortcutHelper.isWindowsForTesting = null;
+  });
 
   group('ShortcutHelper.matchesShortcut', () {
     test('מזהה meta רק כש-meta לחוץ', () {
@@ -205,6 +210,17 @@ void main() {
       expect(activator.meta, isTrue);
       expect(activator.control, isFalse);
       expect(activator.trigger, LogicalKeyboardKey.keyF);
+    });
+
+    test('activatorFromShortcut יכול לשמר Control פיזי ב-Mac', () {
+      final activator =
+          ShortcutHelper.activatorFromShortcut(
+                'ctrl+f',
+                mapCtrlToMeta: false,
+              )!
+              as SingleActivator;
+      expect(activator.control, isTrue);
+      expect(activator.meta, isFalse);
     });
   });
 
@@ -568,7 +584,7 @@ void main() {
       );
     });
   });
-  group('AltGr — Alt ימני בפריסה לא-לטינית מדווח כ-Ctrl+Alt', () {
+  group('AltGr ו-AltGraph', () {
     final arrowUp = KeyDownEvent(
       physicalKey: PhysicalKeyboardKey.arrowUp,
       logicalKey: LogicalKeyboardKey.arrowUp,
@@ -583,6 +599,49 @@ void main() {
           isControlPressed: true,
           isShiftPressed: false,
           isAltPressed: true,
+          isAltGrPressed: true,
+          isMetaPressed: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('AltGraph מובחן נחשב alt גם כש-isAltPressed הוא false', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'alt+arrowup',
+          isControlPressed: false,
+          isShiftPressed: false,
+          isAltPressed: false,
+          isAltGrPressed: true,
+          isMetaPressed: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('Ctrl+Alt רגיל אינו מותאם לקיצור alt בלבד', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'alt+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isAltGrPressed: false,
+          isMetaPressed: false,
+        ),
+        isFalse,
+      );
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'ctrl+alt+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isAltGrPressed: false,
           isMetaPressed: false,
         ),
         isTrue,
@@ -597,6 +656,7 @@ void main() {
           isControlPressed: false,
           isShiftPressed: false,
           isAltPressed: true,
+          isAltGrPressed: false,
           isMetaPressed: false,
         ),
         isTrue,
@@ -611,6 +671,7 @@ void main() {
           isControlPressed: true,
           isShiftPressed: false,
           isAltPressed: false,
+          isAltGrPressed: false,
           isMetaPressed: false,
         ),
         isFalse,
@@ -625,6 +686,7 @@ void main() {
           isControlPressed: true,
           isShiftPressed: false,
           isAltPressed: false,
+          isAltGrPressed: false,
           isMetaPressed: false,
         ),
         isTrue,
@@ -636,13 +698,203 @@ void main() {
           isControlPressed: false,
           isShiftPressed: false,
           isAltPressed: true,
+          isAltGrPressed: false,
           isMetaPressed: false,
         ),
         isFalse,
       );
     });
-  });
 
+    test('AltGr אינו מפעיל קיצור ctrl בלבד', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'ctrl+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isAltGrPressed: true,
+          isMetaPressed: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('AltGr אינו מפעיל קיצור ctrl+alt', () {
+      expect(
+        ShortcutHelper.matchesShortcut(
+          arrowUp,
+          'ctrl+alt+arrowup',
+          isControlPressed: true,
+          isShiftPressed: false,
+          isAltPressed: true,
+          isAltGrPressed: true,
+          isMetaPressed: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('AltGraph נשמר כ-alt בעת הקלטת קיצור', () {
+      expect(
+        ShortcutHelper.formatKeysToShortcut({
+          LogicalKeyboardKey.altGraph,
+          LogicalKeyboardKey.arrowUp,
+        }),
+        'alt+arrowup',
+      );
+    });
+
+    test('AltGr של Windows אינו שומר את Control הסינתטי', () {
+      ShortcutHelper.isWindowsForTesting = true;
+
+      expect(
+        ShortcutHelper.formatKeysToShortcut({
+          LogicalKeyboardKey.controlLeft,
+          LogicalKeyboardKey.altRight,
+          LogicalKeyboardKey.arrowUp,
+        }),
+        'alt+arrowup',
+      );
+    });
+
+    test('Ctrl+Alt שמאלי נשמר כ-ctrl+alt', () {
+      ShortcutHelper.isWindowsForTesting = true;
+
+      expect(
+        ShortcutHelper.formatKeysToShortcut({
+          LogicalKeyboardKey.controlLeft,
+          LogicalKeyboardKey.altLeft,
+          LogicalKeyboardKey.arrowUp,
+        }),
+        'ctrl+alt+arrowup',
+      );
+    });
+
+    testWidgets('ShortcutActivator מפעיל alt בקלט AltGr של Windows', (
+      tester,
+    ) async {
+      ShortcutHelper.isWindowsForTesting = true;
+      var calls = 0;
+      final activator = ShortcutHelper.activatorFromShortcut('alt+arrowup')!;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CallbackShortcuts(
+            bindings: {activator: () => calls++},
+            child: const Focus(
+              autofocus: true,
+              child: SizedBox(width: 1, height: 1),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(
+        LogicalKeyboardKey.altRight,
+        physicalKey: PhysicalKeyboardKey.altRight,
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.sendKeyUpEvent(
+        LogicalKeyboardKey.altRight,
+        physicalKey: PhysicalKeyboardKey.altRight,
+      );
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      expect(calls, 1);
+    });
+
+    test('ShortcutActivator מקבל alt בקלט AltGraph של Linux', () {
+      final activator = ShortcutHelper.activatorFromShortcut('alt+arrowup')!;
+      final keyboard = HardwareKeyboard();
+      keyboard.handleKeyEvent(
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.altRight,
+          logicalKey: LogicalKeyboardKey.altGraph,
+          timeStamp: Duration.zero,
+        ),
+      );
+      final arrowUp = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.arrowUp,
+        logicalKey: LogicalKeyboardKey.arrowUp,
+        timeStamp: Duration.zero,
+      );
+      keyboard.handleKeyEvent(arrowUp);
+
+      expect(activator.accepts(arrowUp, keyboard), isTrue);
+    });
+
+    test('ShortcutActivator משמר חזרה בהחזקת קיצור alt', () {
+      final activator = ShortcutHelper.activatorFromShortcut('alt+arrowup')!;
+      final keyboard = HardwareKeyboard();
+      keyboard.handleKeyEvent(
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.altRight,
+          logicalKey: LogicalKeyboardKey.altGraph,
+          timeStamp: Duration.zero,
+        ),
+      );
+      keyboard.handleKeyEvent(
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.arrowUp,
+          logicalKey: LogicalKeyboardKey.arrowUp,
+          timeStamp: Duration.zero,
+        ),
+      );
+      final repeat = KeyRepeatEvent(
+        physicalKey: PhysicalKeyboardKey.arrowUp,
+        logicalKey: LogicalKeyboardKey.arrowUp,
+        timeStamp: Duration.zero,
+      );
+
+      expect(activator.accepts(repeat, keyboard), isTrue);
+    });
+
+    test('ShortcutActivator משווה קיצורים לפי ערכים מנורמלים', () {
+      expect(
+        ShortcutHelper.activatorFromShortcut('ALT+F'),
+        ShortcutHelper.activatorFromShortcut('alt+f'),
+      );
+      expect(
+        ShortcutHelper.activatorFromShortcut('control+alt+f'),
+        ShortcutHelper.activatorFromShortcut('ctrl+alt+f'),
+      );
+    });
+
+    test('AltRight פיזי רגיל אינו AltGr מחוץ ל-Windows', () {
+      final altActivator = ShortcutHelper.activatorFromShortcut('alt+arrowup')!;
+      final ctrlAltActivator = ShortcutHelper.activatorFromShortcut(
+        'ctrl+alt+arrowup',
+      )!;
+      final keyboard = HardwareKeyboard();
+      keyboard.handleKeyEvent(
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.controlLeft,
+          logicalKey: LogicalKeyboardKey.controlLeft,
+          timeStamp: Duration.zero,
+        ),
+      );
+      keyboard.handleKeyEvent(
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.altRight,
+          logicalKey: LogicalKeyboardKey.altRight,
+          timeStamp: Duration.zero,
+        ),
+      );
+      final arrowUp = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.arrowUp,
+        logicalKey: LogicalKeyboardKey.arrowUp,
+        timeStamp: Duration.zero,
+      );
+      keyboard.handleKeyEvent(arrowUp);
+
+      expect(altActivator.accepts(arrowUp, keyboard), isFalse);
+      expect(ctrlAltActivator.accepts(arrowUp, keyboard), isTrue);
+    });
+  });
 }
 
 /// אירוע מקש אות בפריסה עברית: `physicalKey` תקין, `logicalKey` הוא התו העברי


### PR DESCRIPTION
## הבעיה

בפריסות מקלדת לא-לטיניות (עברית, רוסית ועוד) מקש **Alt הימני הוא AltGr**, ו-Windows/Linux מדווחים עליו כ-**Ctrl+Alt יחד**. `matchesShortcut` דורש התאמה מדויקת של מצב Control, ולכן כל קיצור שמוגדר עם `alt` ובלי `ctrl` פשוט לא נתפס למי שלוחץ על Alt הימני.

**זה פוגע בארבעה קיצורים שהם ברירת מחדל:**

| קיצור | פעולה |
|---|---|
| `alt+arrowup` | הקטע הקודם |
| `alt+arrowdown` | הקטע הבא |
| `alt+pageup` | הדף/פרק הקודם |
| `alt+pagedown` | הדף/פרק הבא |

משתמש שמקליד בעברית ולוחץ על Alt הימני — הקיצורים האלה לא עובדים אצלו, בלי שום חיווי למה.

## איך זה אומת

בבנייה מקומית עם אבחון בשכבת הקיצורים, בלחיצה על Alt הימני + חץ:

```
alt=true  shift=false  ctrl=true  meta=false  match=false
```

`ctrl=true` בלי שנלחץ Ctrl — זו חתימת AltGr. `event.logicalKey` זוהה נכון (`eq=true`), וההתאמה נכשלה **רק** בגלל ה-Control העודף.

## התיקון

הקלה צרה ב-`matchesShortcut`: התעלמות מ-Control **רק** כשמצטברים שלושת התנאים של AltGr — הקיצור דורש `alt`, אינו דורש `ctrl`, ובפועל שני המקשים לחוצים.

```dart
final ctrlFromAltGr =
    requiresAlt && !hasCtrlToken && controlPressed && altPressed;
final effectiveControlPressed = ctrlFromAltGr ? false : controlPressed;
```

הרעיון עצמו אינו חדש בקובץ — `matchesShortcut` כבר מתעלם ממצב Control הפיזי ב-macOS מסיבה דומה (שם `ctrl` מתורגם ל-Command).

## טסטים

נוספו ארבעה טסטים ב-`test/shortcuts/shortcut_helper_test.dart`:

- קיצור `alt` בלבד מותאם גם כשה-Ctrl מגיע מ-AltGr
- קיצור `alt` בלבד ממשיך להיות מותאם ללחיצת Alt רגילה (בלי רגרסיה)
- `Ctrl` בלי `Alt` אינו נחשב AltGr ואינו מותאם לקיצור `alt`
- קיצור שדורש `ctrl` במפורש אינו מושפע מההקלה

**הרצה מקומית: 38/38 עוברים** (34 קיימים + 4 חדשים).

## שיקול שכדאי לשים עליו עין

אחרי התיקון, לחיצת **Ctrl+Alt אמיתית** (שני המקשים בכוונה) תתאים גם לקיצור שמוגדר `alt` בלבד. כרגע אין ב-`defaultShortcuts` שום קיצור עם `ctrl+alt`, ולכן אין התנגשות בפועל — אבל משתמש שיגדיר קיצור `ctrl+alt+X` בעצמו עלול לקבל התאמה כפולה. אם מעדיפים למנוע זאת לחלוטין, אפשר להצר עוד: להחיל את ההקלה רק כשהמקש הפיזי הוא `altRight`. לא עשיתי זאת כדי לא להסתמך על הבחנה בין Alt שמאלי לימני, שאינה זמינה באופן אחיד בכל הפלטפורמות.
