### PR TITLE
תיקון: חלונית התצוגה המקדימה מהבהבת בריחוף על סמן-עוגן

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -457,11 +457,6 @@ class _CombinedViewState extends State<CombinedView> {
     widget.openBookCallback(tab);
   }
 
-  Link? _previewLinkFromUrl(String url) {
-    final anchor = _anchorLinkFromUrl(url);
-    return anchor?.link ?? inlineLinkFromPreviewUrl(url);
-  }
-
   /// [activeAnchor] — כשהחלונית נפתחה מסמן-אות, הסמן מודגש כל עוד היא פתוחה.
   void _showLinkPreview(
     Link link,
@@ -520,19 +515,16 @@ class _CombinedViewState extends State<CombinedView> {
     LinkPreviewOverlay.cancelScheduledHide();
     _cancelPendingAnchorHover();
 
-    // הסמן שחלוניתו מוצגת מסומן כ"פעיל", והסימון מרנדר מחדש את השורה.
-    // הרינדור מחליף את ה-TextSpan ואת ה-MouseRegion שבתוכו, ולכן פלאטר
-    // מדווח onExit ואחריו onEnter למרות שהעכבר לא זז — מה שסוגר את החלונית
-    // ופותח אותה מחדש, ונראה כהבהוב. כניסה חוזרת לאותו סמן אינה כוונת
-    // משתמש אלא תוצר של הרינדור, ודי בביטול הסגירה המתוזמנת שנעשה למעלה.
-    final reentered = _anchorLinkFromUrl(url);
-    if (reentered != null &&
-        reentered.line == _activeAnchorLine &&
-        reentered.index == _activeAnchorIndex) {
+    // סימון העוגן מחליף את MouseRegion ויוצר exit/enter מלאכותיים.
+    // הסגירה כבר בוטלה לעיל; אין לתזמן פתיחה מחדש לאותו עוגן.
+    final anchor = _anchorLinkFromUrl(url);
+    if (anchor != null &&
+        anchor.line == _activeAnchorLine &&
+        anchor.index == _activeAnchorIndex) {
       return;
     }
 
-    final previewLink = _previewLinkFromUrl(url);
+    final previewLink = anchor?.link ?? inlineLinkFromPreviewUrl(url);
     if (previewLink != null) prefetchLinkPreview(previewLink);
     _anchorHoverTimer = Timer(const Duration(milliseconds: 280), () {
       if (_disposed || !mounted) return;

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -519,6 +519,19 @@ class _CombinedViewState extends State<CombinedView> {
     }
     LinkPreviewOverlay.cancelScheduledHide();
     _cancelPendingAnchorHover();
+
+    // הסמן שחלוניתו מוצגת מסומן כ"פעיל", והסימון מרנדר מחדש את השורה.
+    // הרינדור מחליף את ה-TextSpan ואת ה-MouseRegion שבתוכו, ולכן פלאטר
+    // מדווח onExit ואחריו onEnter למרות שהעכבר לא זז — מה שסוגר את החלונית
+    // ופותח אותה מחדש, ונראה כהבהוב. כניסה חוזרת לאותו סמן אינה כוונת
+    // משתמש אלא תוצר של הרינדור, ודי בביטול הסגירה המתוזמנת שנעשה למעלה.
+    final reentered = _anchorLinkFromUrl(url);
+    if (reentered != null &&
+        reentered.line == _activeAnchorLine &&
+        reentered.index == _activeAnchorIndex) {
+      return;
+    }
+
     final previewLink = _previewLinkFromUrl(url);
     if (previewLink != null) prefetchLinkPreview(previewLink);
     _anchorHoverTimer = Timer(const Duration(milliseconds: 280), () {

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -517,11 +517,6 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     return (link: anchorLinks[index], line: line, index: index);
   }
 
-  Link? _previewLinkFromUrl(String url, TextBookLoaded state) {
-    final anchor = _anchorLinkFromUrl(url, state);
-    return anchor?.link ?? inlineLinkFromPreviewUrl(url);
-  }
-
   Future<void> _openAnchorTarget(Link link) async {
     LinkPreviewOverlay.dismiss();
     final tab = await buildLinkTargetTab(link);
@@ -577,7 +572,15 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     _cancelPendingPreview();
     final currentState = context.read<TextBookBloc>().state;
     if (currentState is TextBookLoaded) {
-      final previewLink = _previewLinkFromUrl(url, currentState);
+      // סימון העוגן מחליף את MouseRegion ויוצר exit/enter מלאכותיים.
+      // הסגירה כבר בוטלה לעיל; אין לתזמן פתיחה מחדש לאותו עוגן.
+      final anchor = _anchorLinkFromUrl(url, currentState);
+      if (anchor != null &&
+          anchor.line == _activeAnchorLine &&
+          anchor.index == _activeAnchorIndex) {
+        return;
+      }
+      final previewLink = anchor?.link ?? inlineLinkFromPreviewUrl(url);
       if (previewLink != null) prefetchLinkPreview(previewLink);
     }
     _previewHoverTimer = Timer(const Duration(milliseconds: 280), () {

--- a/test/text_book/view/combined_view/combined_book_screen_test.dart
+++ b/test/text_book/view/combined_view/combined_book_screen_test.dart
@@ -21,6 +21,9 @@ import 'package:otzaria/text_book/view/combined_view/combined_book_screen.dart';
 import 'package:otzaria/text_book/view/selection/enhanced_gesture_detector.dart';
 import 'package:otzaria/text_book/view/selection/selection_sync_controller.dart';
 import 'package:otzaria/widgets/misc/app_context_menu.dart';
+import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
+import 'package:otzaria/widgets/misc/link_preview_overlay.dart';
+import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../../../test_helpers/memory_cache_provider.dart';
 
@@ -419,6 +422,82 @@ void main() {
 
     expect(textBookBloc.addWasCalled, isFalse);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('כניסה חוזרת לעוגן הפעיל אינה בונה מחדש את הפופאפ', (
+    tester,
+  ) async {
+    final link = Link(
+      heRef: 'מפרש א, א',
+      index1: 1,
+      path2: 'מפרש א',
+      index2: 1,
+      connectionType: 'commentary',
+      anchorStart: 0,
+      anchorLabel: 'א',
+    );
+    final textBookBloc = _RecordingTextBookBloc(
+      _loadedState().copyWith(
+        links: [link],
+        linksByLine: {
+          1: [link],
+        },
+      ),
+    );
+    final personalNotesBloc = _TestPersonalNotesBloc(
+      const PersonalNotesState.initial(),
+    );
+    final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+    final tab = TextBookTab(book: TextBook(title: 'ספר בדיקה'), index: 0);
+    addTearDown(textBookBloc.close);
+    addTearDown(personalNotesBloc.close);
+    addTearDown(settingsBloc.close);
+    addTearDown(tab.dispose);
+    addTearDown(LinkPreviewOverlay.dismiss);
+
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<TextBookBloc>.value(value: textBookBloc),
+          BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: CombinedView(
+              data: const ['שורה א'],
+              openBookCallback: (_) {},
+              openLeftPaneTab: (_, {searchText}) {},
+              textSize: 18,
+              showCommentaryAsExpansionTiles: false,
+              tab: tab,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const url = 'otzaria://anchor?ref=0_0';
+    var smartText = tester
+        .widgetList<SmartTextWidget>(find.byType(SmartTextWidget))
+        .firstWhere((widget) => widget.text.contains(url));
+    smartText.onAnchorHover!(url, const Offset(100, 100));
+    await tester.pump(const Duration(milliseconds: 300));
+    final firstPreview = tester.element(find.byType(LinkHoverPreviewContent));
+
+    await tester.pump();
+    smartText = tester
+        .widgetList<SmartTextWidget>(find.byType(SmartTextWidget))
+        .firstWhere((widget) => widget.text.contains(url));
+    smartText.onAnchorHoverExit!(url);
+    smartText.onAnchorHover!(url, const Offset(100, 100));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      tester.element(find.byType(LinkHoverPreviewContent)),
+      same(firstPreview),
+    );
   });
 
   testWidgets(

--- a/test/text_book/view/page_shape/simple_text_viewer_test.dart
+++ b/test/text_book/view/page_shape/simple_text_viewer_test.dart
@@ -98,7 +98,7 @@ void main() {
     expect(openedTab, kNotesTabIndex);
   });
 
-  testWidgets('בצורת הדף ריחוף על עוגן נקודה ועל עוגן טווח מציג פופאפ', (
+  testWidgets('כניסה חוזרת לעוגן בצורת הדף אינה בונה פופאפ מחדש', (
     tester,
   ) async {
     final pointLink = Link(
@@ -173,6 +173,22 @@ void main() {
     );
     await tester.pump(const Duration(milliseconds: 300));
     expect(find.byType(LinkHoverPreviewContent), findsOneWidget);
+    final firstPreview = tester.element(find.byType(LinkHoverPreviewContent));
+
+    await tester.pump();
+    final activeSmartText = tester
+        .widgetList<SmartTextWidget>(find.byType(SmartTextWidget))
+        .firstWhere((widget) => widget.text.contains('link-anchor-active'));
+    activeSmartText.onAnchorHoverExit!('otzaria://anchor?ref=0_0');
+    activeSmartText.onAnchorHover!(
+      'otzaria://anchor?ref=0_0',
+      const Offset(100, 100),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(
+      tester.element(find.byType(LinkHoverPreviewContent)),
+      same(firstPreview),
+    );
 
     LinkPreviewOverlay.dismiss();
     smartText.onAnchorHover!(


### PR DESCRIPTION
## הבאג

בריחוף על סמן‑עוגן, חלונית התצוגה המקדימה נפתחת — ומיד אחר כך **נסגרת ונפתחת שוב**, מה שנראה למשתמש כהבהוב או "רענון" של החלונית. העכבר לא זז בכלל.

## השרשרת

1. ריחוף → אחרי 280ms `_showLinkPreview` נקרא ומציג את החלונית
2. במקביל נקרא `_setActiveAnchor(line, index)` שמסמן את הסמן כפעיל
3. הסימון גורם ל‑`setState`, וה‑HTML של השורה נבנה מחדש עם `link-anchor-active`
4. הבנייה מחדש **מחליפה את ה‑`TextSpan` ואת ה‑`MouseRegion` שבתוכו** (הם נוצרים ב‑`_SmartTextWidgetFactory.buildTextSpan`)
5. פלאטר מזהה `MouseRegion` חדש ומדווח `onExit` על הישן ו‑`onEnter` על החדש — **למרות שהמצביע לא זז**
6. `onExit` → `_handleAnchorHoverExit` → `LinkPreviewOverlay.scheduleHide()`
7. `onEnter` → `_handleAnchorHover` → טיימר 280ms חדש → החלונית נפתחת מחדש

כלומר הסימון הפעיל, שנועד לשפר את החיווי, מפעיל בעצמו מחדש את מסלול הריחוף.

## התיקון

כניסה חוזרת לסמן שכבר מסומן כפעיל אינה כוונת משתמש אלא תוצר של הרינדור, ולכן אין לפתוח מחדש. `LinkPreviewOverlay.cancelScheduledHide()` שנקרא כבר בראש הפונקציה מבטל את הסגירה שתוזמנה ב‑`onExit`, כך שהחלונית פשוט נשארת פתוחה:

```dart
final anchor = _anchorLinkFromUrl(url);
if (anchor != null &&
    anchor.line == _activeAnchorLine &&
    anchor.index == _activeAnchorIndex) {
  return;
}
```

התיקון ממוקם אחרי `cancelScheduledHide()` ואחרי `_cancelPendingAnchorHover()`, כך שגם הסגירה המתוזמנת וגם טיימר ההצגה הממתין מבוטלים — ורק אחר כך נבלמת הפתיחה המחודשת.

## מה לא משתנה

- ריחוף על סמן **אחר** ממשיך להחליף את החלונית כרגיל
- יציאה אמיתית של העכבר ממשיכה לסגור (`onExit` → `scheduleHide`)
- קיבוע החלונית בלחיצה, הגלילה איתה, וסגירתה בהקשה מחוצה לה — כולם ללא שינוי
- מסלולי הריחוף האחרים (`note-marker`, `book-note`, `note`, קישורי inline) אינם נוגעים ב‑`_activeAnchor*` ולכן אינם מושפעים

## אימות

אומת בבנייה מקומית של Windows: לפני התיקון החלונית נפתחת ומתרעננת באופן עקבי בכל ריחוף על סמן‑עוגן; אחרי התיקון היא נפתחת פעם אחת ונשארת.

**צורת הדף:** אותה שרשרת קיימת גם ב‑`simple_text_viewer.dart`, ולכן אותו guard הוחל גם שם. נוספו טסטי רגרסיה לשתי התצוגות שמוודאים כי לאחר `onExit`/`onEnter` מלאכותיים נשאר אותו מופע של חלונית התצוגה המקדימה.
