### PR TITLE
תיקון: מחוון הגלילה בקישורים ובהערות הופיע בשמאל ולא בימין כמו במפרשים

### DIFF
--- a/lib/personal_notes/widgets/personal_notes_sidebar.dart
+++ b/lib/personal_notes/widgets/personal_notes_sidebar.dart
@@ -5,6 +5,7 @@ import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:pdfrx/pdfrx.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/core/messages/notes_messages.dart';
@@ -25,6 +26,7 @@ import 'package:otzaria/personal_notes/services/personal_note_draft_service.dart
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
+import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 
 class PersonalNotesSidebar extends StatefulWidget {
@@ -62,6 +64,13 @@ class PersonalNotesSidebarState extends State<PersonalNotesSidebar>
   bool get wantKeepAlive => true;
   final PersonalNoteDraftService _draftService = PersonalNoteDraftService();
   final ValueNotifier<List<int>> _visibleLineIndices = ValueNotifier(const []);
+  final ItemScrollController _itemScrollController = ItemScrollController();
+  final ItemPositionsListener _itemPositionsListener =
+      ItemPositionsListener.create();
+  // פריט = הערה, והערה ארוכה עשויה להיות גבוהה מהמסך. בלי ה-offsetController
+  // גרירת האגודל הייתה נעצרת על גבולות פריטים ולא מזיזה כלום בתוכה.
+  final ScrollOffsetController _scrollOffsetController =
+      ScrollOffsetController();
 
   @override
   void initState() {
@@ -504,9 +513,18 @@ class PersonalNotesSidebarState extends State<PersonalNotesSidebar>
       );
     }
 
-    return ListView(
-      padding: EdgeInsets.zero,
-      children: items,
+    return ScrollablePositionedListScrollbar(
+      scrollController: _itemScrollController,
+      itemPositionsListener: _itemPositionsListener,
+      offsetController: _scrollOffsetController,
+      itemCount: items.length,
+      child: ScrollablePositionedList.builder(
+        itemScrollController: _itemScrollController,
+        itemPositionsListener: _itemPositionsListener,
+        scrollOffsetController: _scrollOffsetController,
+        itemCount: items.length,
+        itemBuilder: (context, index) => items[index],
+      ),
     );
   }
 

--- a/lib/widgets/commentary/links_list_view.dart
+++ b/lib/widgets/commentary/links_list_view.dart
@@ -23,6 +23,8 @@ import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
 import 'package:otzaria/widgets/smart_text/smart_text.dart';
 import 'package:otzaria/text_book/view/selection/selection_sync_controller.dart';
 import 'package:otzaria/text_book/view/selection/selection_hit_test.dart';
+import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 @visibleForTesting
 RenderSettings buildSelectedLinkRenderSettings({
@@ -274,7 +276,13 @@ class LinksListView extends StatefulWidget {
 
 class _LinksListViewState extends State<LinksListView> {
   final TextEditingController _searchController = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
+  final ItemScrollController _itemScrollController = ItemScrollController();
+  final ItemPositionsListener _itemPositionsListener =
+      ItemPositionsListener.create();
+  // פריט = קישור, ומורחב הוא עשוי להיות גבוה מהמסך. בלי ה-offsetController
+  // גרירת האגודל הייתה נעצרת על גבולות פריטים ולא מזיזה כלום בתוך קישור כזה.
+  final ScrollOffsetController _scrollOffsetController =
+      ScrollOffsetController();
   String _searchQuery = '';
   final Map<String, Future<String>> _contentCache = {};
   final Map<String, bool> _expanded = {};
@@ -305,7 +313,6 @@ class _LinksListViewState extends State<LinksListView> {
       _handleExternalSelectionChange,
     );
     _searchController.dispose();
-    _scrollController.dispose();
     super.dispose();
   }
 
@@ -329,10 +336,10 @@ class _LinksListViewState extends State<LinksListView> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted ||
             widget.contentScopeKey != contentScopeKey ||
-            !_scrollController.hasClients) {
+            !_itemScrollController.isAttached) {
           return;
         }
-        _scrollController.jumpTo(0);
+        _itemScrollController.jumpTo(index: 0);
       });
     }
   }
@@ -633,13 +640,21 @@ class _LinksListViewState extends State<LinksListView> {
           return _buildEmptyMessage('לא נמצאו קישורים התואמים לחיפוש');
         }
 
-        return ListView.builder(
-          controller: _scrollController,
+        return ScrollablePositionedListScrollbar(
+          scrollController: _itemScrollController,
+          itemPositionsListener: _itemPositionsListener,
+          offsetController: _scrollOffsetController,
           itemCount: filteredLinks.length,
-          itemBuilder: (context, index) {
-            final link = filteredLinks[index];
-            return _buildExpansionTile(link);
-          },
+          child: ScrollablePositionedList.builder(
+            itemScrollController: _itemScrollController,
+            itemPositionsListener: _itemPositionsListener,
+            scrollOffsetController: _scrollOffsetController,
+            itemCount: filteredLinks.length,
+            itemBuilder: (context, index) {
+              final link = filteredLinks[index];
+              return _buildExpansionTile(link);
+            },
+          ),
         );
       },
     );

--- a/test/personal_notes/widgets/personal_notes_sidebar_scrollbar_test.dart
+++ b/test/personal_notes/widgets/personal_notes_sidebar_scrollbar_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_bloc.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_event.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_state.dart';
+import 'package:otzaria/personal_notes/models/personal_note.dart';
+import 'package:otzaria/personal_notes/widgets/personal_notes_sidebar.dart';
+import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+import '../../test_helpers/memory_cache_provider.dart';
+
+/// רגרסיה: חלונית ההערות הייתה `ListView` בלי מסילה משלה, ולכן קיבלה את פס
+/// הגלילה האוטומטי של הפאנל — שנדחף לקצה החיצוני, כלומר לשמאל. באותה חלונית
+/// לשונית המפרשים הציגה מסילה בימין, וכל לשונית הראתה את הפס בצד אחר.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  PersonalNote note(int index) => PersonalNote(
+    id: 'note-$index',
+    bookId: 'ספר בדיקה',
+    lineNumber: index + 1,
+    displayTitle: 'הערה בשורה ${index + 1}',
+    lastKnownLineNumber: index + 1,
+    status: PersonalNoteStatus.located,
+    content: 'תוכן הערה $index',
+    contentPlain: 'תוכן הערה $index',
+    contentFormat: PersonalNoteContentFormat.plain,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  Future<void> pumpSidebar(WidgetTester tester, {int noteCount = 30}) async {
+    final notesBloc = _StubNotesBloc(
+      List.generate(noteCount, note),
+    );
+    addTearDown(notesBloc.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          // האפליקציה כולה RTL (locale he_IL); בלי זה הצד נמדד הפוך.
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: BlocProvider<PersonalNotesBloc>.value(
+              value: notesBloc,
+              child: PersonalNotesSidebar(
+                bookId: 'ספר בדיקה',
+                onNavigateToLine: (_) {},
+                visibleLineIndices: const [],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('המסילה בקצה ימין של החלונית, לא בשמאל', (tester) async {
+    await pumpSidebar(tester);
+
+    final barRect = tester.getRect(
+      find.byType(ScrollablePositionedListScrollbar),
+    );
+    final listRect = tester.getRect(find.byType(ScrollablePositionedList));
+
+    expect(
+      listRect.right,
+      lessThan(barRect.right),
+      reason: 'המסילה חייבת לתפוס את הקצה הימני והרשימה להצטמצם לפניה',
+    );
+    expect(
+      listRect.left,
+      barRect.left,
+      reason: 'אין מסילה בקצה השמאלי — הרשימה מגיעה עד לשם',
+    );
+  });
+
+  testWidgets('המסילה והרשימה חולקות offsetController', (tester) async {
+    // הערה ארוכה עשויה להיות גבוהה מהמסך. בלי ה-offsetController האגודל נוחת
+    // רק על גבולות פריטים, וגרירה בתוך הערה כזו אינה מזיזה כלום.
+    await pumpSidebar(tester);
+
+    final bar = tester.widget<ScrollablePositionedListScrollbar>(
+      find.byType(ScrollablePositionedListScrollbar),
+    );
+    final list = tester.widget<ScrollablePositionedList>(
+      find.byType(ScrollablePositionedList),
+    );
+
+    expect(bar.offsetController, isNotNull);
+    expect(bar.offsetController, same(list.scrollOffsetController));
+  });
+
+  testWidgets('אין מה לגלול — אין מסילה ואין צמצום של הרשימה', (tester) async {
+    await pumpSidebar(tester, noteCount: 1);
+
+    final barRect = tester.getRect(
+      find.byType(ScrollablePositionedListScrollbar),
+    );
+    final listRect = tester.getRect(find.byType(ScrollablePositionedList));
+
+    expect(listRect.right, barRect.right);
+  });
+}
+
+class _StubNotesBloc extends Bloc<PersonalNotesEvent, PersonalNotesState>
+    implements PersonalNotesBloc {
+  _StubNotesBloc(this.notes) : super(const PersonalNotesState.initial()) {
+    on<PersonalNotesEvent>((event, emit) {
+      if (event is LoadPersonalNotes) {
+        emit(
+          state.copyWith(
+            bookId: event.bookId,
+            locatedNotes: notes,
+            isLoading: false,
+          ),
+        );
+      }
+    });
+  }
+
+  final List<PersonalNote> notes;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/personal_notes/widgets/personal_notes_sidebar_scrollbar_test.dart
+++ b/test/personal_notes/widgets/personal_notes_sidebar_scrollbar_test.dart
@@ -12,9 +12,6 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../test_helpers/memory_cache_provider.dart';
 
-/// רגרסיה: חלונית ההערות הייתה `ListView` בלי מסילה משלה, ולכן קיבלה את פס
-/// הגלילה האוטומטי של הפאנל — שנדחף לקצה החיצוני, כלומר לשמאל. באותה חלונית
-/// לשונית המפרשים הציגה מסילה בימין, וכל לשונית הראתה את הפס בצד אחר.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -36,10 +33,12 @@ void main() {
     updatedAt: DateTime(2026, 1, 1),
   );
 
-  Future<void> pumpSidebar(WidgetTester tester, {int noteCount = 30}) async {
-    final notesBloc = _StubNotesBloc(
-      List.generate(noteCount, note),
-    );
+  Future<void> pumpSidebar(
+    WidgetTester tester, {
+    int noteCount = 30,
+    List<PersonalNote>? notes,
+  }) async {
+    final notesBloc = _StubNotesBloc(notes ?? List.generate(noteCount, note));
     addTearDown(notesBloc.close);
 
     await tester.pumpWidget(
@@ -84,8 +83,6 @@ void main() {
   });
 
   testWidgets('המסילה והרשימה חולקות offsetController', (tester) async {
-    // הערה ארוכה עשויה להיות גבוהה מהמסך. בלי ה-offsetController האגודל נוחת
-    // רק על גבולות פריטים, וגרירה בתוך הערה כזו אינה מזיזה כלום.
     await pumpSidebar(tester);
 
     final bar = tester.widget<ScrollablePositionedListScrollbar>(
@@ -97,6 +94,53 @@ void main() {
 
     expect(bar.offsetController, isNotNull);
     expect(bar.offsetController, same(list.scrollOffsetController));
+  });
+
+  testWidgets('גרירת המסילה גוללת בתוך הערה יחידה וארוכה', (tester) async {
+    final longContent = List.filled(200, 'שורה ארוכה לבדיקה').join('\n');
+    final longNote = PersonalNote(
+      id: 'long-note',
+      bookId: 'ספר בדיקה',
+      lineNumber: 1,
+      displayTitle: 'הערה ארוכה',
+      lastKnownLineNumber: 1,
+      status: PersonalNoteStatus.located,
+      content: longContent,
+      contentPlain: longContent,
+      contentFormat: PersonalNoteContentFormat.plain,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    );
+    await pumpSidebar(tester, notes: [longNote]);
+
+    await tester.tap(find.byTooltip('פתח'));
+    await tester.pumpAndSettle();
+
+    final scrollbar = find.byType(ScrollablePositionedListScrollbar);
+    final scrollbarRect = tester.getRect(scrollbar);
+    final listFinder = find.byType(ScrollablePositionedList);
+    final list = tester.widget<ScrollablePositionedList>(listFinder);
+    expect(
+      tester.getRect(listFinder).right,
+      lessThan(scrollbarRect.right),
+      reason: 'הערה גבוהה מציגה מסילה ותופסת לה מקום בפריסה',
+    );
+    expect(
+      list.itemPositionsNotifier!.itemPositions.value.single.itemLeadingEdge,
+      closeTo(0, 0.01),
+    );
+
+    await tester.dragFrom(
+      Offset(scrollbarRect.right - 6, scrollbarRect.top + 20),
+      Offset(0, scrollbarRect.height - 40),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      list.itemPositionsNotifier!.itemPositions.value.single.itemLeadingEdge,
+      lessThan(-0.1),
+      reason: 'ה־offsetController מאפשר למסילה לגלול בתוך אותו פריט',
+    );
   });
 
   testWidgets('אין מה לגלול — אין מסילה ואין צמצום של הרשימה', (tester) async {

--- a/test/text_book/view/selected_line_links_view_test.dart
+++ b/test/text_book/view/selected_line_links_view_test.dart
@@ -961,7 +961,7 @@ void main() {
       // Divider(height: 1) חסר thickness => DividerTheme.thickness ?? 0.0.
       final dividerThickness =
           DividerTheme.of(
-            tester.element(find.byType(ListView)),
+            tester.element(find.byType(SelectedLineLinksView)),
           ).thickness ??
           0.0;
       expect(shapeOf(tester, 0).bottom.width, dividerThickness);
@@ -971,7 +971,7 @@ void main() {
       await pumpTwo(tester);
 
       final dividerColor = Theme.of(
-        tester.element(find.byType(ListView)),
+        tester.element(find.byType(SelectedLineLinksView)),
       ).dividerColor;
       expect(shapeOf(tester, 0).bottom.color, dividerColor);
     });
@@ -1038,7 +1038,7 @@ void main() {
       );
 
       final surface = Theme.of(
-        tester.element(find.byType(ListView)),
+        tester.element(find.byType(SelectedLineLinksView)),
       ).colorScheme.surface;
       final painted = tester
           .widgetList<Container>(find.byType(Container))

--- a/test/widgets/commentary/links_list_view_shared_test.dart
+++ b/test/widgets/commentary/links_list_view_shared_test.dart
@@ -43,6 +43,25 @@ Link _link({
   connectionType: connectionType,
 );
 
+class _LongContentLink extends Link {
+  _LongContentLink({
+    required super.heRef,
+    required super.index1,
+    required super.path2,
+    required super.index2,
+    required super.connectionType,
+    required this._content,
+  });
+
+  final String _content;
+
+  @override
+  Future<String> get content => Future.value(_content);
+
+  @override
+  Future<String> get displayReference => Future.value(fallbackDisplayReference);
+}
+
 /// בונה את הרשימה המשותפת **בלי** `BlocProvider<TextBookBloc>` — כך שכל
 /// קריאה ל-`read<TextBookBloc>()` בתוכה תיכשל ותיתפס כאן.
 Future<Set<String>?> _pumpWithoutTextBookBloc(
@@ -253,10 +272,8 @@ void main() {
   ) async {
     final links = List.generate(
       30,
-      (index) => _link(
-        path2: 'ספר-$index',
-        connectionType: LinkTypes.mesoratHashas,
-      ),
+      (index) =>
+          _link(path2: 'ספר-$index', connectionType: LinkTypes.mesoratHashas),
     );
     CommentaryService.seedEraCache({
       for (var index = 0; index < 30; index++)
@@ -308,16 +325,11 @@ void main() {
     );
   });
 
-  // רגרסיה: הרשימה הייתה `ListView` בלי מסילה משלה, ולכן קיבלה את פס הגלילה
-  // האוטומטי של הפאנל — שנדחף לקצה החיצוני, כלומר לשמאל. באותה חלונית לשונית
-  // המפרשים הציגה מסילה בימין, וכל לשונית הראתה את הפס בצד אחר.
   testWidgets('המסילה בקצה ימין של הרשימה, לא בשמאל', (tester) async {
     final links = List.generate(
       30,
-      (index) => _link(
-        path2: 'ספר-$index',
-        connectionType: LinkTypes.mesoratHashas,
-      ),
+      (index) =>
+          _link(path2: 'ספר-$index', connectionType: LinkTypes.mesoratHashas),
     );
     CommentaryService.seedEraCache({
       for (var index = 0; index < 30; index++)
@@ -365,8 +377,6 @@ void main() {
       reason: 'אין מסילה בקצה השמאלי — הרשימה מגיעה עד לשם',
     );
 
-    // קישור מורחב עשוי להיות גבוה מהמסך. בלי ה-offsetController האגודל נוחת
-    // רק על גבולות פריטים, וגרירה בתוך קישור כזה אינה מזיזה כלום.
     final bar = tester.widget<ScrollablePositionedListScrollbar>(
       find.byType(ScrollablePositionedListScrollbar),
     );
@@ -375,6 +385,72 @@ void main() {
     );
     expect(bar.offsetController, isNotNull);
     expect(bar.offsetController, same(list.scrollOffsetController));
+  });
+
+  testWidgets('גרירת המסילה גוללת בתוך קישור יחיד ומורחב', (tester) async {
+    final longContent = List.filled(200, 'תוכן ארוך לבדיקה').join('\n');
+    final link = _LongContentLink(
+      heRef: 'קישור ארוך, א',
+      index1: 1,
+      path2: 'קישור ארוך',
+      index2: 1,
+      connectionType: LinkTypes.mesoratHashas,
+      content: longContent,
+    );
+    CommentaryService.seedEraCache({'קישור ארוך': CommentaryEra.other});
+    addTearDown(CommentaryService.clearEraCache);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: BlocProvider<SettingsBloc>.value(
+            value: _FakeSettingsBloc(),
+            child: Scaffold(
+              body: LinksListView(
+                links: [link],
+                chipSourceLinks: [link],
+                openBookTitle: 'שבת',
+                selectedLinkTypes: const {},
+                onSelectedLinkTypesChanged: (_) {},
+                openBookCallback: (_) {},
+                fontSize: 16,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(ExpansionTile));
+    await tester.pumpAndSettle();
+
+    final scrollbar = find.byType(ScrollablePositionedListScrollbar);
+    final scrollbarRect = tester.getRect(scrollbar);
+    final listFinder = find.byType(ScrollablePositionedList);
+    final list = tester.widget<ScrollablePositionedList>(listFinder);
+    expect(
+      tester.getRect(listFinder).right,
+      lessThan(scrollbarRect.right),
+      reason: 'קישור מורחב וגבוה מציג מסילה',
+    );
+    expect(
+      list.itemPositionsNotifier!.itemPositions.value.single.itemLeadingEdge,
+      closeTo(0, 0.01),
+    );
+
+    await tester.dragFrom(
+      Offset(scrollbarRect.right - 6, scrollbarRect.top + 20),
+      Offset(0, scrollbarRect.height - 40),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      list.itemPositionsNotifier!.itemPositions.value.single.itemLeadingEdge,
+      lessThan(-0.1),
+      reason: 'ה־offsetController מאפשר למסילה לגלול בתוך אותו קישור',
+    );
   });
 
   group('מבנה — שני הצדדים צורכים את אותה רשימה', () {

--- a/test/widgets/commentary/links_list_view_shared_test.dart
+++ b/test/widgets/commentary/links_list_view_shared_test.dart
@@ -11,7 +11,9 @@ import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_event.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/widgets/commentary/links_list_view.dart';
+import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
 import 'package:otzaria/widgets/lists/filter_chips_widget.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../helpers/memory_settings_cache.dart';
 
@@ -279,23 +281,100 @@ void main() {
       ),
     );
 
+    final list = find.byType(ScrollablePositionedList);
     await tester.pumpWidget(view('עמוד-א'));
-    for (var i = 0; i < 20 && find.byType(ListView).evaluate().isEmpty; i++) {
+    for (var i = 0; i < 20 && list.evaluate().isEmpty; i++) {
       await tester.pump(const Duration(milliseconds: 50));
     }
-    expect(find.byType(ListView), findsOneWidget);
+    expect(list, findsOneWidget);
     final stateBefore = tester.state(find.byType(LinksListView));
-    final listBefore = tester.widget<ListView>(find.byType(ListView));
-    listBefore.controller!.jumpTo(500);
-    await tester.pump();
-    expect(listBefore.controller!.offset, greaterThan(0));
+
+    await tester.drag(list, const Offset(0, -600));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('ספר-0'),
+      findsNothing,
+      reason: 'גללנו למטה — ראש הרשימה יצא מהמסך',
+    );
 
     await tester.pumpWidget(view('עמוד-ב'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    final listAfter = tester.widget<ListView>(find.byType(ListView));
     expect(tester.state(find.byType(LinksListView)), same(stateBefore));
-    expect(listAfter.controller!.offset, 0);
+    expect(
+      find.text('ספר-0'),
+      findsOneWidget,
+      reason: 'החלפת הקטע חייבת להחזיר את הרשימה לראשה',
+    );
+  });
+
+  // רגרסיה: הרשימה הייתה `ListView` בלי מסילה משלה, ולכן קיבלה את פס הגלילה
+  // האוטומטי של הפאנל — שנדחף לקצה החיצוני, כלומר לשמאל. באותה חלונית לשונית
+  // המפרשים הציגה מסילה בימין, וכל לשונית הראתה את הפס בצד אחר.
+  testWidgets('המסילה בקצה ימין של הרשימה, לא בשמאל', (tester) async {
+    final links = List.generate(
+      30,
+      (index) => _link(
+        path2: 'ספר-$index',
+        connectionType: LinkTypes.mesoratHashas,
+      ),
+    );
+    CommentaryService.seedEraCache({
+      for (var index = 0; index < 30; index++)
+        'ספר-$index': CommentaryEra.other,
+    });
+    addTearDown(CommentaryService.clearEraCache);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          // האפליקציה כולה RTL (locale he_IL); בלי זה הצד נמדד הפוך.
+          textDirection: TextDirection.rtl,
+          child: BlocProvider<SettingsBloc>.value(
+            value: _FakeSettingsBloc(),
+            child: Scaffold(
+              body: LinksListView(
+                links: links,
+                chipSourceLinks: links,
+                openBookTitle: 'שבת',
+                selectedLinkTypes: const {},
+                onSelectedLinkTypesChanged: (_) {},
+                openBookCallback: (_) {},
+                fontSize: 16,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final barRect = tester.getRect(
+      find.byType(ScrollablePositionedListScrollbar),
+    );
+    final listRect = tester.getRect(find.byType(ScrollablePositionedList));
+
+    expect(
+      listRect.right,
+      lessThan(barRect.right),
+      reason: 'המסילה חייבת לתפוס את הקצה הימני והרשימה להצטמצם לפניה',
+    );
+    expect(
+      listRect.left,
+      barRect.left,
+      reason: 'אין מסילה בקצה השמאלי — הרשימה מגיעה עד לשם',
+    );
+
+    // קישור מורחב עשוי להיות גבוה מהמסך. בלי ה-offsetController האגודל נוחת
+    // רק על גבולות פריטים, וגרירה בתוך קישור כזה אינה מזיזה כלום.
+    final bar = tester.widget<ScrollablePositionedListScrollbar>(
+      find.byType(ScrollablePositionedListScrollbar),
+    );
+    final list = tester.widget<ScrollablePositionedList>(
+      find.byType(ScrollablePositionedList),
+    );
+    expect(bar.offsetController, isNotNull);
+    expect(bar.offsetController, same(list.scrollOffsetController));
   });
 
   group('מבנה — שני הצדדים צורכים את אותה רשימה', () {


### PR DESCRIPTION
## הבעיה

בחלונית המפרשים/קישורים/הערות שבמסך העיון (ובצורת הדף), לשונית "מפרשים" הציגה את מחוון הגלילה בצד ימין — ליד תחילת הטקסט — ואילו "קישורים" ו"הערות" הציגו אותו בצד שמאל. אותה חלונית, שני צדדים.

## שורש הבעיה

רק לשונית המפרשים מחזיקה מסילה משלה, `ScrollablePositionedListScrollbar`, שיושבת בקצה תחילת הקריאה (ימין בעברית) ותופסת מקום בפריסה.

"קישורים" ו"הערות" היו `ListView` בלי מסילה, ולכן קיבלו את פס הגלילה האוטומטי של `AdaptiveSidePane`. הוא נדחף לקצה החיצוני של הפאנל, ובפאנל הזה (`centerStart`) הקצה החיצוני הוא שמאל.

## התיקון

שתי הרשימות עברו לאותה מסילה כמו המפרשים. **לא** הועבר פס ה-Material לימין: הוא צף בקצה, ושם יושבת ידית שינוי הגודל — הבאג שתוקן ב-`94dea4bef`. המסילה שלנו תופסת 12px בפריסה ורק 4px נחדרים בידית (`kPaneHandleInnerReach`), ולכן היא חיה שם בשלום, כפי שהיא עושה בלשונית המפרשים כבר היום.

`offsetController` מחובר בשתיהן: קישור מורחב או הערה ארוכה עשויים להיות גבוהים מהמסך, ובלעדיו האגודל נוחת רק על גבולות פריטים והגרירה בתוכם לא מזיזה כלום.

התיקון חל על שני הצדדים שצורכים את הרכיבים המשותפים — כרטיסיית הטקסט וחלונית ה-PDF.

## טסטים

- `test/widgets/commentary/links_list_view_shared_test.dart` — מיקום המסילה בימין, חיבור ה-`offsetController`, והטסט של איפוס הגלילה בהחלפת קטע נמדד עכשיו לפי חזרת ראש הרשימה למסך.
- `test/personal_notes/widgets/personal_notes_sidebar_scrollbar_test.dart` (חדש) — מיקום המסילה בימין, חיבור ה-`offsetController`, והיעדר מסילה כשאין מה לגלול.

`flutter analyze` נקי; `test/text_book/`, `test/personal_notes/`, `test/widgets/commentary/`, `test/pdf_book/` — הכול עובר.

🤖 Generated with [Claude Code](https://claude.com/claude-code)