### PR TITLE
כלים: תפריט פעולות לכל קובייה, סידור בגרירה, ותיקוני משגר

### DIFF
--- a/.github/workflows/flutter_tests.yml
+++ b/.github/workflows/flutter_tests.yml
@@ -40,7 +40,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
-          if echo "$files" | grep -qE 'search|smart_text|toc_filter|snippet|pubspec\.yaml|flutter_test_config|flutter_tests\.yml'; then
+          if echo "$files" | grep -qE 'search|history|smart_text|toc_filter|snippet|pubspec\.yaml|flutter_test_config|flutter_tests\.yml'; then
             echo "build_engine=true" >> "$GITHUB_OUTPUT"
           else
             echo "build_engine=false" >> "$GITHUB_OUTPUT"

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -393,6 +393,12 @@ class MainWindowScreenState extends State<MainWindowScreen>
     (d) => d.screen == null,
   );
 
+  /// האם לחיצה על פריט הניווט [index] אמורה לסגור את פאנל הכלים. כל פריט הוא
+  /// מסך — פרט ל"כלים" עצמו, שרק מחליף את מצב הפאנל.
+  @visibleForTesting
+  static bool shouldCloseToolsLauncherOnNavTap(int index) =>
+      index >= 0 && index < _navData.length && _navData[index].screen != null;
+
   /// אינדקס "הגדרות" בתוך `_navData`. תוספים מוצמדים-לסרגל מוזרקים
   /// _אחרי_ פריט הכלים ו_לפני_ פריט ההגדרות.
   static final int _settingsNavIndex = _navData.indexWhere(
@@ -481,8 +487,9 @@ class MainWindowScreenState extends State<MainWindowScreen>
     required Set<String> pinnedBuiltInIds,
     required Set<String> hiddenBuiltInIds,
     required bool isOfflineMode,
+    List<String> builtInToolsOrder = const [],
   }) {
-    final builtIns = kBuiltInToolsCatalog
+    final builtIns = orderedBuiltInTools(builtInToolsOrder)
         .where(
           (m) =>
               pinnedBuiltInIds.contains(m.toolId) &&
@@ -1442,6 +1449,9 @@ class MainWindowScreenState extends State<MainWindowScreen>
     }
 
     if (state.currentScreen != _lastScreen) {
+      // גם מסלולי ניווט שאינם סרגל הניווט (קיצורי מקלדת, סימניות, קישור עמוק)
+      // חייבים לסגור את הפאנל — ה-scrim שלו מכסה רק את אזור התוכן.
+      _closeToolsLauncher();
       if (_lastScreen == Screen.library) {
         final libraryState = libraryBrowserKey.currentState;
         if (libraryState != null) {
@@ -2914,6 +2924,9 @@ class MainWindowScreenState extends State<MainWindowScreen>
                                                                     isOfflineMode:
                                                                         settingsState
                                                                             .isOfflineMode,
+                                                                    builtInToolsOrder:
+                                                                        settingsState
+                                                                            .builtInToolsOrder,
                                                                   );
                                                                   return BlocBuilder<
                                                                     TabsBloc,
@@ -3087,6 +3100,8 @@ class MainWindowScreenState extends State<MainWindowScreen>
                                                     .hiddenBuiltInToolIds,
                                                 isOfflineMode:
                                                     settingsState.isOfflineMode,
+                                                builtInToolsOrder: settingsState
+                                                    .builtInToolsOrder,
                                               );
                                               final hideTools =
                                                   _isAllToolsHidden(
@@ -3355,6 +3370,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
     }
     final pinnedEnd = effectiveSettingsIdx + pinnedItems.length;
     if (index < pinnedEnd) {
+      _closeToolsLauncher();
       openToolTabById(
         context,
         pinnedItems[index - effectiveSettingsIdx].toolId,
@@ -3378,6 +3394,9 @@ class MainWindowScreenState extends State<MainWindowScreen>
       _toggleToolsLauncher();
       return;
     }
+    // מעבר מסך סוגר את פאנל הכלים — ה-scrim שלו מכסה רק את אזור התוכן, ולכן
+    // בלי זה הוא נשאר צף מעל המסך החדש.
+    if (shouldCloseToolsLauncherOnNavTap(index)) _closeToolsLauncher();
 
     final currentIndex = _getSelectedIndex(currentScreen);
     if (index == currentIndex &&

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -503,6 +503,23 @@ class MainWindowScreenState extends State<MainWindowScreen>
     return [...builtIns, ...plugins];
   }
 
+  /// מזהי הכלים המוצמדים לסרגל הניווט, בסדר התצוגה. עוטף [_resolvePinnedItems]
+  /// כדי שהסדר יהיה בר-בדיקה בלי לחשוף את טיפוס הפריט הפרטי.
+  @visibleForTesting
+  static List<String> pinnedToolIdsForNavRail({
+    required PluginSystemState pluginState,
+    required Set<String> pinnedBuiltInIds,
+    required Set<String> hiddenBuiltInIds,
+    required bool isOfflineMode,
+    List<String> builtInToolsOrder = const [],
+  }) => _resolvePinnedItems(
+    pluginState: pluginState,
+    pinnedBuiltInIds: pinnedBuiltInIds,
+    hiddenBuiltInIds: hiddenBuiltInIds,
+    isOfflineMode: isOfflineMode,
+    builtInToolsOrder: builtInToolsOrder,
+  ).map((item) => item.toolId).toList();
+
   @override
   void initState() {
     super.initState();
@@ -3468,7 +3485,12 @@ class MainWindowScreenState extends State<MainWindowScreen>
       imageAsset: item.imageAsset,
       label: item.label,
       isSelected: isSelected,
-      onTap: () => openToolTabById(context, item.toolId),
+      onTap: () {
+        // הכלי נפתח בעיון גם כשזה המסך הנוכחי, ואז אין שינוי מסך שיסגור את
+        // פאנל הכלים — לכן הסגירה מפורשת, כמו במסלול ה-NavigationBar.
+        _closeToolsLauncher();
+        openToolTabById(context, item.toolId);
+      },
       compact: compact,
     );
   }

--- a/lib/plugins/bloc/plugin_system_bloc.dart
+++ b/lib/plugins/bloc/plugin_system_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_state.dart';
@@ -48,7 +49,10 @@ class PluginSystemBloc extends Bloc<PluginSystemEvent, PluginSystemState> {
     on<PinPluginToNavRailRequested>(_onPinPluginToNavRailRequested);
     on<UnpinPluginFromNavRailRequested>(_onUnpinPluginFromNavRailRequested);
     on<SetPluginShowInToolsRequested>(_onSetPluginShowInToolsRequested);
-    on<ReorderPluginsRequested>(_onReorderPluginsRequested);
+    on<ReorderPluginsRequested>(
+      _onReorderPluginsRequested,
+      transformer: sequential(),
+    );
     on<EnablePluginRequested>(_onEnablePluginRequested);
     on<DisablePluginRequested>(_onDisablePluginRequested);
     on<SetPluginPermissionRequested>(_onSetPluginPermissionRequested);

--- a/lib/settings/engine/settings_bloc.dart
+++ b/lib/settings/engine/settings_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/theme/app_fonts.dart';
@@ -68,7 +69,10 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<ClearProtectedModePassword>(_onClearProtectedModePassword);
     on<UpdateHiddenBuiltInToolIds>(_onUpdateHiddenBuiltInToolIds);
     on<UpdateBuiltInToolsPinnedToNavRail>(_onUpdateBuiltInToolsPinnedToNavRail);
-    on<UpdateBuiltInToolsOrder>(_onUpdateBuiltInToolsOrder);
+    on<UpdateBuiltInToolsOrder>(
+      _onUpdateBuiltInToolsOrder,
+      transformer: sequential(),
+    );
     on<UpdateSettingsLanguageCode>(_onUpdateSettingsLanguageCode);
   }
 

--- a/lib/settings/engine/settings_bloc.dart
+++ b/lib/settings/engine/settings_bloc.dart
@@ -68,6 +68,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<ClearProtectedModePassword>(_onClearProtectedModePassword);
     on<UpdateHiddenBuiltInToolIds>(_onUpdateHiddenBuiltInToolIds);
     on<UpdateBuiltInToolsPinnedToNavRail>(_onUpdateBuiltInToolsPinnedToNavRail);
+    on<UpdateBuiltInToolsOrder>(_onUpdateBuiltInToolsOrder);
     on<UpdateSettingsLanguageCode>(_onUpdateSettingsLanguageCode);
   }
 
@@ -141,6 +142,8 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         builtInToolsPinnedToNavRail:
             (settings['builtInToolsPinnedToNavRail'] as Set<String>?) ??
             <String>{},
+        builtInToolsOrder:
+            (settings['builtInToolsOrder'] as List<String>?) ?? <String>[],
         settingsLanguageCode:
             (settings['settingsLanguageCode'] as String?) ??
             kDefaultSettingsLanguageCode,
@@ -284,6 +287,14 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         builtInToolsPinnedToNavRail: event.builtInToolsPinnedToNavRail,
       ),
     );
+  }
+
+  Future<void> _onUpdateBuiltInToolsOrder(
+    UpdateBuiltInToolsOrder event,
+    Emitter<SettingsState> emit,
+  ) async {
+    await _repository.updateBuiltInToolsOrder(event.builtInToolsOrder);
+    emit(state.copyWith(builtInToolsOrder: event.builtInToolsOrder));
   }
 
   Future<void> _onUpdateDarkMode(

--- a/lib/settings/engine/settings_event.dart
+++ b/lib/settings/engine/settings_event.dart
@@ -450,6 +450,15 @@ class UpdateBuiltInToolsPinnedToNavRail extends SettingsEvent {
   List<Object?> get props => [builtInToolsPinnedToNavRail];
 }
 
+class UpdateBuiltInToolsOrder extends SettingsEvent {
+  final List<String> builtInToolsOrder;
+
+  const UpdateBuiltInToolsOrder(this.builtInToolsOrder);
+
+  @override
+  List<Object?> get props => [builtInToolsOrder];
+}
+
 class UpdateSettingsLanguageCode extends SettingsEvent {
   final String settingsLanguageCode;
 

--- a/lib/settings/engine/settings_repository.dart
+++ b/lib/settings/engine/settings_repository.dart
@@ -210,6 +210,7 @@ class SettingsRepository {
     keyCompactMenuMode,
     keyHiddenBuiltInToolIds,
     keyBuiltInToolsPinnedToNavRail,
+    keyBuiltInToolsOrder,
     keyProtectedModeEnabled,
     keyProtectedModePasswordHash,
     keyCalendarNotificationsEnabled,

--- a/lib/settings/engine/settings_repository.dart
+++ b/lib/settings/engine/settings_repository.dart
@@ -97,6 +97,9 @@ class SettingsRepository {
   static const String keyBuiltInToolsPinnedToNavRail =
       'key-builtin-tools-pinned-to-nav-rail';
 
+  /// CSV של סדר הכלים המובנים שהמשתמש קבע. הסדר משמעותי — אינו ממוין.
+  static const String keyBuiltInToolsOrder = 'key-builtin-tools-order';
+
   // Protected Mode Settings
   static const String keyProtectedModeEnabled = 'key-protected-mode-enabled';
   static const String keyProtectedModePasswordHash =
@@ -429,6 +432,12 @@ class SettingsRepository {
           defaultValue: '',
         ),
       ),
+      'builtInToolsOrder': _parseToolIdList(
+        _settings.getValue<String>(
+          keyBuiltInToolsOrder,
+          defaultValue: '',
+        ),
+      ),
 
       // Protected Mode
       'protectedModeEnabled': _settings.getValue<bool>(
@@ -706,6 +715,10 @@ class SettingsRepository {
     );
   }
 
+  Future<void> updateBuiltInToolsOrder(List<String> value) async {
+    await _settings.setValue(keyBuiltInToolsOrder, value.join(','));
+  }
+
   /// פירוק רשימת מזהי כלים מ-CSV. מתעלם מערכים ריקים ומ-whitespace.
   static Set<String> _parseToolIdSet(String raw) {
     if (raw.isEmpty) return <String>{};
@@ -714,6 +727,16 @@ class SettingsRepository {
         .map((e) => e.trim())
         .where((e) => e.isNotEmpty)
         .toSet();
+  }
+
+  /// פירוק סדר מזהי כלים מ-CSV, תוך שמירת הסדר וללא כפילויות.
+  static List<String> _parseToolIdList(String raw) {
+    if (raw.isEmpty) return const <String>[];
+    final seen = <String>{};
+    return [
+      for (final id in raw.split(','))
+        if (id.trim().isNotEmpty && seen.add(id.trim())) id.trim(),
+    ];
   }
 
   /// סדרת מזהי כלים ל-CSV. ממוין דטרמיניסטית.

--- a/lib/settings/engine/settings_state.dart
+++ b/lib/settings/engine/settings_state.dart
@@ -72,6 +72,9 @@ class SettingsState extends Equatable {
   /// מזהי כלים מובנים שהמשתמש הצמיד לסרגל הניווט הראשי.
   final Set<String> builtInToolsPinnedToNavRail;
 
+  /// סדר הכלים המובנים שהמשתמש קבע (מזהים, לפי הסדר). ריק = סדר הקטלוג.
+  final List<String> builtInToolsOrder;
+
   /// בחירת שפת מסך ההגדרות בלבד: קוד שפה, או `system` להתאמה אוטומטית.
   /// אינה משפיעה על שאר האפליקציה. ראה [resolveSettingsLanguage].
   final String settingsLanguageCode;
@@ -124,6 +127,7 @@ class SettingsState extends Equatable {
     this.mergeUserBooksIntoLibrary = false,
     this.hiddenBuiltInToolIds = const <String>{},
     this.builtInToolsPinnedToNavRail = const <String>{},
+    this.builtInToolsOrder = const <String>[],
     this.settingsLanguageCode = kDefaultSettingsLanguageCode,
     this._softwareAndBookUpdatesEnabled,
   });
@@ -222,6 +226,7 @@ class SettingsState extends Equatable {
     bool? mergeUserBooksIntoLibrary,
     Set<String>? hiddenBuiltInToolIds,
     Set<String>? builtInToolsPinnedToNavRail,
+    List<String>? builtInToolsOrder,
     String? settingsLanguageCode,
     bool? softwareAndBookUpdatesEnabled,
   }) {
@@ -284,6 +289,7 @@ class SettingsState extends Equatable {
       hiddenBuiltInToolIds: hiddenBuiltInToolIds ?? this.hiddenBuiltInToolIds,
       builtInToolsPinnedToNavRail:
           builtInToolsPinnedToNavRail ?? this.builtInToolsPinnedToNavRail,
+      builtInToolsOrder: builtInToolsOrder ?? this.builtInToolsOrder,
       settingsLanguageCode: settingsLanguageCode ?? this.settingsLanguageCode,
       softwareAndBookUpdatesEnabled:
           softwareAndBookUpdatesEnabled ?? this.softwareAndBookUpdatesEnabled,
@@ -344,6 +350,7 @@ class SettingsState extends Equatable {
     mergeUserBooksIntoLibrary,
     hiddenBuiltInToolIds,
     builtInToolsPinnedToNavRail,
+    builtInToolsOrder,
     settingsLanguageCode,
     softwareAndBookUpdatesEnabled,
   ];

--- a/lib/settings/panels/tools_management_panel.dart
+++ b/lib/settings/panels/tools_management_panel.dart
@@ -297,7 +297,8 @@ class _ToolsManagementPanelState extends State<ToolsManagementPanel> {
 
   List<Widget> _builtInToolRows(SettingsState state) {
     return [
-      for (final meta in kBuiltInToolsCatalog)
+      // אותו סדר שהמשתמש רואה במשגר הכלים, כולל סדר שהוא קבע בעצמו.
+      for (final meta in orderedBuiltInTools(state.builtInToolsOrder))
         _BuiltInToolRow(
           meta: meta,
           hidden: state.hiddenBuiltInToolIds.contains(meta.toolId),

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -205,7 +205,6 @@ class BackupService {
     // דגל פנימי שמסמן שברירות המחדל נכתבו לדיסק.
     'settings_initialized',
   };
-
   /// מפתחות ההגדרות שהגיבוי אוסף כשאין גישה ל-Hive box (ראה [_backupSettings]).
   /// כולל את הקיצורים הדינמיים, שמפתחותיהם נגזרים מהתוספים המותקנים.
   static List<String> get fallbackSettingsKeys => [

--- a/lib/tools/built_in_tools_catalog.dart
+++ b/lib/tools/built_in_tools_catalog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria/tools/tool_order.dart';
 import 'package:otzaria_icons/otzaria_icons.dart';
 
 /// מטא-דאטה לתצוגה של כלי מובנה.
@@ -86,3 +87,47 @@ const List<BuiltInToolMeta> kBuiltInToolsCatalog = [
     iconFilled: FluentIcons.text_quote_24_filled,
   ),
 ];
+
+/// הקטלוג לפי סדר התצוגה שנקבע ב-[BuiltInToolMeta.order] — הבסיס לכל סידור,
+/// גם כשלמשתמש אין סדר משלו.
+List<BuiltInToolMeta> get _catalogInDisplayOrder =>
+    [...kBuiltInToolsCatalog]..sort((a, b) => a.order.compareTo(b.order));
+
+/// הכלים המובנים לפי הסדר שהמשתמש קבע ב-[customOrder] (מזהים, לפי הסדר).
+///
+/// מזהה שאינו בקטלוג מתעלמים ממנו; כלי שאינו ב-[customOrder] (כלי חדש שנוסף
+/// בגרסה מאוחרת) נספח בסוף לפי סדר הקטלוג.
+List<BuiltInToolMeta> orderedBuiltInTools(List<String> customOrder) {
+  final base = _catalogInDisplayOrder;
+  if (customOrder.isEmpty) return base;
+  final byId = {for (final meta in base) meta.toolId: meta};
+  final ordered = <BuiltInToolMeta>[];
+  final seen = <String>{};
+  for (final toolId in customOrder) {
+    final meta = byId[toolId];
+    if (meta == null || !seen.add(toolId)) continue;
+    ordered.add(meta);
+  }
+  for (final meta in base) {
+    if (!seen.contains(meta.toolId)) ordered.add(meta);
+  }
+  return ordered;
+}
+
+/// סדר מזהי הכלים המובנים לאחר הפלת [sourceId] לפני [targetId] או אחריו.
+///
+/// [currentOrder] יכול להיות חלקי או ריק — הבסיס תמיד מנורמל לרשימה מלאה,
+/// כדי שהסדר שיישמר יכיל את כל הכלים ולא ייווצרו מזהים חסרים.
+List<String> reorderedBuiltInToolIds(
+  List<String> currentOrder,
+  String sourceId,
+  String targetId, {
+  required bool placeAfter,
+}) {
+  return reorderIdsAroundTarget(
+    orderedBuiltInTools(currentOrder).map((meta) => meta.toolId).toList(),
+    sourceId,
+    targetId,
+    placeAfter: placeAfter,
+  );
+}

--- a/lib/tools/built_in_tools_catalog.dart
+++ b/lib/tools/built_in_tools_catalog.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:otzaria/tools/tool_order.dart';
@@ -90,8 +91,14 @@ const List<BuiltInToolMeta> kBuiltInToolsCatalog = [
 
 /// הקטלוג לפי סדר התצוגה שנקבע ב-[BuiltInToolMeta.order] — הבסיס לכל סידור,
 /// גם כשלמשתמש אין סדר משלו.
-List<BuiltInToolMeta> get _catalogInDisplayOrder =>
-    [...kBuiltInToolsCatalog]..sort((a, b) => a.order.compareTo(b.order));
+///
+/// המיון יציב (insertionSort): שני כלים עם אותו order שומרים על סדר ההצהרה,
+/// אחרת הסדר שהמשתמש שמר היה זז בין הרצות.
+List<BuiltInToolMeta> get _catalogInDisplayOrder {
+  final ordered = [...kBuiltInToolsCatalog];
+  insertionSort(ordered, compare: (a, b) => a.order.compareTo(b.order));
+  return ordered;
+}
 
 /// הכלים המובנים לפי הסדר שהמשתמש קבע ב-[customOrder] (מזהים, לפי הסדר).
 ///

--- a/lib/tools/tool_catalog_entry.dart
+++ b/lib/tools/tool_catalog_entry.dart
@@ -34,11 +34,12 @@ class ToolCatalogEntry {
   bool get isPlugin => plugin != null;
   bool get isDevelopment => plugin?.isDevelopment ?? false;
 
-  factory ToolCatalogEntry.fromBuiltIn(BuiltInToolMeta meta) =>
+  /// [order] דוחק את סדר הקטלוג — משמש כשהמשתמש קבע סדר משלו לכלים המובנים.
+  factory ToolCatalogEntry.fromBuiltIn(BuiltInToolMeta meta, {int? order}) =>
       ToolCatalogEntry(
         toolId: meta.toolId,
         label: meta.label,
-        order: meta.order,
+        order: order ?? meta.order,
         icon: meta.icon,
         iconFilled: meta.iconFilled,
         imageIcon: meta.imageIcon,
@@ -145,15 +146,19 @@ class ToolUnavailable extends ToolLookupResult {
 }
 
 /// הכלים הזמינים להצגה במשגר.
+///
+/// [builtInToolsOrder] הוא סדר הכלים המובנים שהמשתמש קבע; ריק = סדר הקטלוג.
 List<ToolCatalogEntry> buildToolCatalog({
   required Set<String> hiddenBuiltInToolIds,
   required bool isOfflineMode,
   required PluginSystemState pluginState,
+  List<String> builtInToolsOrder = const [],
 }) {
+  final orderedBuiltIns = orderedBuiltInTools(builtInToolsOrder);
   final entries = <ToolCatalogEntry>[
-    for (final meta in kBuiltInToolsCatalog)
-      if (!hiddenBuiltInToolIds.contains(meta.toolId))
-        ToolCatalogEntry.fromBuiltIn(meta),
+    for (var i = 0; i < orderedBuiltIns.length; i++)
+      if (!hiddenBuiltInToolIds.contains(orderedBuiltIns[i].toolId))
+        ToolCatalogEntry.fromBuiltIn(orderedBuiltIns[i], order: i),
   ];
 
   if (pluginState is PluginSystemLoaded) {

--- a/lib/tools/tool_order.dart
+++ b/lib/tools/tool_order.dart
@@ -1,0 +1,20 @@
+/// סדר מזהים חדש לאחר הפלת [sourceId] על קו ההוספה שלפני [targetId]
+/// (`placeAfter: false`) או שאחריו (`placeAfter: true`).
+///
+/// מזהה חסר או הפלה על עצמו מחזירים את הסדר כמות שהוא.
+List<String> reorderIdsAroundTarget(
+  List<String> ids,
+  String sourceId,
+  String targetId, {
+  required bool placeAfter,
+}) {
+  final result = List<String>.from(ids);
+  if (sourceId == targetId) return result;
+  final sourceIndex = result.indexOf(sourceId);
+  if (sourceIndex < 0 || !result.contains(targetId)) return result;
+  result.removeAt(sourceIndex);
+  // מחפשים את היעד *אחרי* הסרת המקור, אחרת האינדקס זז בפריט אחד.
+  final targetIndex = result.indexOf(targetId);
+  result.insert(placeAfter ? targetIndex + 1 : targetIndex, sourceId);
+  return result;
+}

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -6,16 +6,23 @@ import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
+import 'package:otzaria/plugins/bloc/plugin_system_state.dart';
+import 'package:otzaria/plugins/view/plugin_actions.dart';
+import 'package:otzaria/plugins/view/plugin_settings_screen.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_event.dart';
 import 'package:otzaria/settings/services/safer_mode_guard.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_state.dart';
 import 'package:otzaria/tabs/models/combined_tab.dart';
 import 'package:otzaria/tabs/models/tool_tab.dart';
 import 'package:otzaria/theme/theme_exports.dart';
+import 'package:otzaria/tools/built_in_tools_catalog.dart';
 import 'package:otzaria/tools/tool_catalog_entry.dart';
+import 'package:otzaria/tools/tool_order.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
 import 'package:otzaria/widgets/layout/app_card.dart';
+import 'package:otzaria/widgets/misc/app_popup_menu.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
 
 const String kBuiltInToolsGroupLabel = 'כלים';
@@ -75,12 +82,17 @@ List<ToolCatalogEntry> orderedToolEntries(List<ToolCatalogEntry> entries) => [
 @visibleForTesting
 const double kToolTileTargetWidth = 104;
 
+/// המרווח בקצה ימין שמפנה מקום לפס הגלילה, כדי שלא יעלה על הקוביות.
+@visibleForTesting
+const double kToolGridScrollbarGutter = 14;
+
 /// מספר העמודות ברשת לרוחב פאנל נתון.
 @visibleForTesting
 int toolGridColumns(double width) =>
     (width / kToolTileTargetWidth).floor().clamp(2, 5);
 
-/// האינדקס המסומן הבא בניווט מקלדת.
+/// האינדקס המסומן הבא בניווט מקלדת. `-1` = אין סימון, והחץ הראשון מסמן את
+/// הקובייה הראשונה.
 @visibleForTesting
 int nextHighlightIndex({
   required int current,
@@ -89,6 +101,41 @@ int nextHighlightIndex({
 }) {
   if (total <= 0) return 0;
   return (current + delta).clamp(0, total - 1);
+}
+
+/// האם שתי רשומות שייכות לאותה קבוצת תצוגה, כלומר האם מותר לסדר ביניהן.
+///
+/// כלי מובנה ותוסף אינם מתערבבים, וגם תוסף שהורשה להקדים את הכלים המובנים
+/// יושב בקבוצה נפרדת מתוסף רגיל.
+@visibleForTesting
+bool canReorderBetween(ToolCatalogEntry source, ToolCatalogEntry target) =>
+    source.toolId != target.toolId &&
+    source.isPlugin == target.isPlugin &&
+    source.sortGroupPriority == target.sortGroupPriority;
+
+/// פעולה בתפריט הקובייה. מקור אמת אחד — נצרך גם בכפתור ⋯ וגם בבדיקות.
+/// [onTap] ריק (`null`) = הפעולה מוצגת מעומעמת (למשל הזזה בקצה הקבוצה).
+/// [children] הופך את הפעולה לתת-תפריט, ואז [onTap] אינו בשימוש.
+@visibleForTesting
+class ToolTileAction {
+  final IconData icon;
+  final String label;
+  final VoidCallback? onTap;
+  final bool isDestructive;
+
+  /// מפריד מעל הפעולה — מפריד את הפעולות ההרסניות משאר התפריט.
+  final bool dividerBefore;
+
+  final List<ToolTileAction>? children;
+
+  const ToolTileAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.isDestructive = false,
+    this.dividerBefore = false,
+    this.children,
+  });
 }
 
 /// תוכן פאנל הכלים: חיפוש למעלה, ומתחתיו רשת קוביות מקובצת.
@@ -110,19 +157,26 @@ class ToolsLauncherPanel extends StatefulWidget {
 
 class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   final TextEditingController _searchController = TextEditingController();
+  final ScrollController _gridScrollController = ScrollController();
   late final FocusNode _searchFocusNode = FocusNode(
     onKeyEvent: _handleSearchFieldKey,
   );
   String _query = '';
 
   /// הקובייה המסומנת בניווט מקלדת, כאינדקס ברשימה המסוננת השטוחה.
-  int _highlightedIndex = 0;
+  /// `-1` = אין סימון, כדי שלא ייראה כאילו הכלי הראשון נבחר.
+  int _highlightedIndex = -1;
   List<ToolCatalogEntry> _keyboardEntries = const [];
   int _keyboardColumns = 2;
+
+  /// הכלי שזז אחרון ומספר ההזזה — מריצים פעימת הדגשה על הקובייה שזזה.
+  String? _movedToolId;
+  int _moveNonce = 0;
 
   @override
   void dispose() {
     _searchController.dispose();
+    _gridScrollController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
   }
@@ -178,6 +232,13 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     });
   }
 
+  void _activateHighlighted(List<ToolCatalogEntry> entries) {
+    if (entries.isEmpty) return;
+    widget.onToolSelected(
+      entries[_highlightedIndex.clamp(0, entries.length - 1)],
+    );
+  }
+
   KeyEventResult _handleKey(
     KeyEvent event,
     List<ToolCatalogEntry> entries,
@@ -205,9 +266,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         return KeyEventResult.handled;
       case LogicalKeyboardKey.enter:
       case LogicalKeyboardKey.numpadEnter:
-        if (_highlightedIndex < entries.length) {
-          widget.onToolSelected(entries[_highlightedIndex]);
-        }
+        _activateHighlighted(entries);
         return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;
@@ -215,6 +274,164 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
 
   KeyEventResult _handleSearchFieldKey(FocusNode _, KeyEvent event) =>
       _handleKey(event, _keyboardEntries, _keyboardColumns);
+
+  // ── סידור מחדש ──────────────────────────────────────────────────────────────
+
+  /// סידור אפשרי רק ברשימה המלאה: בחיפוש הקוביות מסוננות, ו"השכן" על המסך
+  /// אינו השכן האמיתי בסדר.
+  bool get _isReorderEnabled => _query.trim().isEmpty;
+
+  void _reorder({
+    required ToolCatalogEntry source,
+    required ToolCatalogEntry target,
+    required bool placeAfter,
+  }) {
+    if (!canReorderBetween(source, target)) return;
+    final pluginBloc = context.read<PluginSystemBloc>();
+    final settingsBloc = context.read<SettingsBloc>();
+    final pluginState = pluginBloc.state;
+
+    // שיגור מושהה לפריים הבא: הרשת נבנית בתוך LayoutBuilder, ושיגור בזמן
+    // הבנייה מפיל את Flutter על הפעלה-מחדש של רכיבי Overlay.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (source.isPlugin) {
+        if (pluginState is! PluginSystemLoaded) return;
+        pluginBloc.add(
+          ReorderPluginsRequested(
+            reorderIdsAroundTarget(
+              pluginState.plugins.map((plugin) => plugin.pluginId).toList(),
+              source.toolId,
+              target.toolId,
+              placeAfter: placeAfter,
+            ),
+          ),
+        );
+      } else {
+        settingsBloc.add(
+          UpdateBuiltInToolsOrder(
+            reorderedBuiltInToolIds(
+              settingsBloc.state.builtInToolsOrder,
+              source.toolId,
+              target.toolId,
+              placeAfter: placeAfter,
+            ),
+          ),
+        );
+      }
+      setState(() {
+        _movedToolId = source.toolId;
+        _moveNonce++;
+      });
+    });
+  }
+
+  /// פעולות הקובייה, בסדר שבו הן מוצגות בתפריט ⋯.
+  List<ToolTileAction> _tileActions(
+    ToolCatalogEntry entry, {
+    required VoidCallback? onMoveEarlier,
+    required VoidCallback? onMoveLater,
+    required VoidCallback? onMoveToStart,
+    required VoidCallback? onMoveToEnd,
+  }) {
+    final plugin = entry.plugin;
+    return [
+      ToolTileAction(
+        icon: FluentIcons.re_order_dots_vertical_24_regular,
+        label: 'הזזה',
+        onTap: null,
+        children: [
+          // RtlIcon בשורת התפריט מהפך את החץ, כך שיצביע לכיוון ההזזה בפועל.
+          ToolTileAction(
+            icon: FluentIcons.arrow_left_24_regular,
+            label: 'הזז אחורה',
+            onTap: onMoveEarlier,
+          ),
+          ToolTileAction(
+            icon: FluentIcons.arrow_right_24_regular,
+            label: 'הזז קדימה',
+            onTap: onMoveLater,
+          ),
+          ToolTileAction(
+            icon: FluentIcons.arrow_previous_24_regular,
+            label: 'הזז לתחילה',
+            onTap: onMoveToStart,
+          ),
+          ToolTileAction(
+            icon: FluentIcons.arrow_next_24_regular,
+            label: 'הזז לסוף',
+            onTap: onMoveToEnd,
+          ),
+        ],
+      ),
+      if (plugin != null)
+        ToolTileAction(
+          icon: FluentIcons.shield_24_regular,
+          label: 'ניהול הרשאות',
+          onTap: () => showPluginSettingsDialog(context, plugin),
+        ),
+      ToolTileAction(
+        icon: _isPinnedToNavRail(entry)
+            ? FluentIcons.pin_off_24_regular
+            : FluentIcons.pin_24_regular,
+        label: _isPinnedToNavRail(entry)
+            ? 'הסר מסרגל הניווט'
+            : 'הצמד לסרגל הניווט',
+        onTap: () => _togglePinToNavRail(entry),
+      ),
+      ToolTileAction(
+        icon: FluentIcons.eye_off_24_regular,
+        label: 'הסתר מהממשק',
+        onTap: () => _hideFromInterface(entry),
+      ),
+      if (plugin != null)
+        ToolTileAction(
+          icon: plugin.enabled
+              ? FluentIcons.pause_circle_24_regular
+              : FluentIcons.play_circle_24_regular,
+          label: plugin.enabled ? 'השבת' : 'הפעל',
+          onTap: () => togglePluginEnabled(context, plugin),
+        ),
+      if (plugin != null)
+        ToolTileAction(
+          icon: FluentIcons.delete_24_regular,
+          label: 'מחק תוסף',
+          isDestructive: true,
+          dividerBefore: true,
+          onTap: () => showDeletePluginDialog(context, plugin),
+        ),
+    ];
+  }
+
+  bool _isPinnedToNavRail(ToolCatalogEntry entry) =>
+      entry.plugin?.pinnedToNavRail ??
+      context.read<SettingsBloc>().state.builtInToolsPinnedToNavRail.contains(
+        entry.toolId,
+      );
+
+  void _togglePinToNavRail(ToolCatalogEntry entry) {
+    final plugin = entry.plugin;
+    if (plugin != null) {
+      togglePluginPinnedToNavRail(context, plugin);
+      return;
+    }
+    final bloc = context.read<SettingsBloc>();
+    final next = Set<String>.from(bloc.state.builtInToolsPinnedToNavRail);
+    if (!next.add(entry.toolId)) next.remove(entry.toolId);
+    bloc.add(UpdateBuiltInToolsPinnedToNavRail(next));
+  }
+
+  void _hideFromInterface(ToolCatalogEntry entry) {
+    final plugin = entry.plugin;
+    if (plugin != null) {
+      togglePluginShowInTools(context, plugin);
+      return;
+    }
+    final bloc = context.read<SettingsBloc>();
+    final next = Set<String>.from(bloc.state.hiddenBuiltInToolIds)
+      ..add(entry.toolId);
+    bloc.add(UpdateHiddenBuiltInToolIds(next));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -224,6 +441,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       hiddenBuiltInToolIds: settingsState.hiddenBuiltInToolIds,
       isOfflineMode: settingsState.isOfflineMode,
       pluginState: pluginState,
+      builtInToolsOrder: settingsState.builtInToolsOrder,
     );
     final entries = orderedToolEntries(filterToolEntries(allEntries, _query));
     final openToolIds = _openToolIds(context.watch<TabsBloc>().state);
@@ -313,15 +531,10 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       ),
       onChanged: (value) => setState(() {
         _query = value;
-        _highlightedIndex = 0;
+        // בחיפוש התוצאה הראשונה מסומנת (Enter יפתח אותה); בלי חיפוש אין סימון.
+        _highlightedIndex = value.trim().isEmpty ? -1 : 0;
       }),
-      onSubmitted: (_) {
-        if (entries.isNotEmpty) {
-          widget.onToolSelected(
-            entries[_highlightedIndex.clamp(0, entries.length - 1)],
-          );
-        }
-      },
+      onSubmitted: (_) => _activateHighlighted(entries),
     );
   }
 
@@ -342,7 +555,9 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   Widget _buildGrid(List<ToolCatalogEntry> entries, Set<String> openToolIds) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final columns = toolGridColumns(constraints.maxWidth);
+        final columns = toolGridColumns(
+          constraints.maxWidth - kToolGridScrollbarGutter,
+        );
         _keyboardColumns = columns;
         final groups = groupToolEntries(entries);
         var runningIndex = 0;
@@ -351,54 +566,315 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         return Focus(
           autofocus: false,
           onKeyEvent: (_, event) => _handleKey(event, entries, columns),
-          child: ListView(
-            padding: EdgeInsets.zero,
-            children: [
-              for (var i = 0; i < groups.length; i++) ...[
-                if (i > 0)
-                  const Padding(
-                    padding: EdgeInsets.only(
-                      top: AppTokens.spaceMD,
+          child: ScrollConfiguration(
+            behavior: const _RightScrollbarBehavior(),
+            child: ListView(
+              controller: _gridScrollController,
+              // הרווח בימין שמור לפס הגלילה, כדי שלא יעלה על הקוביות.
+              padding: const EdgeInsets.only(right: kToolGridScrollbarGutter),
+              children: [
+                for (var i = 0; i < groups.length; i++) ...[
+                  if (i > 0)
+                    const Padding(
+                      padding: EdgeInsets.only(
+                        top: AppTokens.spaceMD,
+                        bottom: AppTokens.spaceSM,
+                      ),
+                      child: Divider(height: 1),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      top: AppTokens.spaceSM,
                       bottom: AppTokens.spaceSM,
                     ),
-                    child: Divider(height: 1),
-                  ),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    top: AppTokens.spaceSM,
-                    bottom: AppTokens.spaceSM,
-                  ),
-                  child: Text(
-                    groups[i].label,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: theme.colorScheme.secondary,
-                      fontWeight: FontWeight.bold,
+                    child: Text(
+                      groups[i].label,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.secondary,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
-                ),
-                GridView.count(
-                  crossAxisCount: columns,
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  mainAxisSpacing: AppTokens.spaceSM,
-                  crossAxisSpacing: AppTokens.spaceSM,
-                  childAspectRatio: 1.0,
-                  children: [
-                    for (final entry in groups[i].entries)
-                      ToolTile(
-                        entry: entry,
-                        isOpen: openToolIds.contains(entry.toolId),
-                        isHighlighted: runningIndex++ == _highlightedIndex,
-                        onTap: () => widget.onToolSelected(entry),
-                      ),
-                  ],
-                ),
+                  GridView.count(
+                    crossAxisCount: columns,
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    mainAxisSpacing: AppTokens.spaceSM,
+                    crossAxisSpacing: AppTokens.spaceSM,
+                    childAspectRatio: 1.0,
+                    children: [
+                      for (var j = 0; j < groups[i].entries.length; j++)
+                        _buildTile(
+                          group: groups[i].entries,
+                          indexInGroup: j,
+                          flatIndex: runningIndex++,
+                          openToolIds: openToolIds,
+                        ),
+                    ],
+                  ),
+                ],
+                const SizedBox(height: AppTokens.spaceMD),
               ],
-              const SizedBox(height: AppTokens.spaceMD),
-            ],
+            ),
           ),
         );
       },
+    );
+  }
+
+  Widget _buildTile({
+    required List<ToolCatalogEntry> group,
+    required int indexInGroup,
+    required int flatIndex,
+    required Set<String> openToolIds,
+  }) {
+    final entry = group[indexInGroup];
+    final canReorder = _isReorderEnabled;
+    final isFirst = indexInGroup == 0;
+    final isLast = indexInGroup == group.length - 1;
+    VoidCallback? moveTo(
+      int targetIndex, {
+      required bool enabled,
+      required bool placeAfter,
+    }) => enabled
+        ? () => _reorder(
+            source: entry,
+            target: group[targetIndex],
+            placeAfter: placeAfter,
+          )
+        : null;
+
+    return _ReorderableToolTile(
+      key: ValueKey(entry.toolId),
+      entry: entry,
+      canDrag: canReorder,
+      onAcceptSource: (source, {required placeAfter}) =>
+          _reorder(source: source, target: entry, placeAfter: placeAfter),
+      tile: ToolTile(
+        entry: entry,
+        isOpen: openToolIds.contains(entry.toolId),
+        isHighlighted: flatIndex == _highlightedIndex,
+        movePulse: entry.toolId == _movedToolId ? _moveNonce : 0,
+        actions: _tileActions(
+          entry,
+          onMoveEarlier: moveTo(
+            indexInGroup - 1,
+            enabled: canReorder && !isFirst,
+            placeAfter: false,
+          ),
+          onMoveLater: moveTo(
+            indexInGroup + 1,
+            enabled: canReorder && !isLast,
+            placeAfter: true,
+          ),
+          onMoveToStart: moveTo(
+            0,
+            enabled: canReorder && !isFirst,
+            placeAfter: false,
+          ),
+          onMoveToEnd: moveTo(
+            group.length - 1,
+            enabled: canReorder && !isLast,
+            placeAfter: true,
+          ),
+        ),
+        onTap: () => widget.onToolSelected(entry),
+      ),
+    );
+  }
+}
+
+/// פס הגלילה של רשת הכלים תמיד בקצה ימין, בתוך המרווח ששמור לו — כך אינו
+/// מצטייר על הקוביות ואינו מתנגש בידית שינוי הרוחב שבקצה שמאל.
+class _RightScrollbarBehavior extends MaterialScrollBehavior {
+  const _RightScrollbarBehavior();
+
+  @override
+  Widget buildScrollbar(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) {
+    if (axisDirectionToAxis(details.direction) != Axis.vertical) return child;
+    switch (getPlatform(context)) {
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return Scrollbar(
+          controller: details.controller,
+          scrollbarOrientation: ScrollbarOrientation.right,
+          child: child,
+        );
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        return child;
+    }
+  }
+}
+
+/// עוטף קובייה ביכולת גרירה לסידור מחדש: גוררים קובייה, וקו ההוספה מראה בין
+/// אילו קוביות היא תיפול — לפי חצי הקובייה שהסמן נמצא בו, כמו סידור לשוניות
+/// בדפדפן. במגע הגרירה מתחילה בלחיצה ארוכה, כדי לא לחטוף את הגלילה.
+class _ReorderableToolTile extends StatefulWidget {
+  final ToolCatalogEntry entry;
+  final ToolTile tile;
+  final bool canDrag;
+  final void Function(ToolCatalogEntry source, {required bool placeAfter})
+  onAcceptSource;
+
+  const _ReorderableToolTile({
+    super.key,
+    required this.entry,
+    required this.tile,
+    required this.canDrag,
+    required this.onAcceptSource,
+  });
+
+  @override
+  State<_ReorderableToolTile> createState() => _ReorderableToolTileState();
+}
+
+class _ReorderableToolTileState extends State<_ReorderableToolTile> {
+  /// `true` = הקובייה הנגררת תיפול *אחרי* הקובייה הזאת בסדר.
+  bool _placeAfter = false;
+
+  bool get _isTouch => switch (defaultTargetPlatform) {
+    TargetPlatform.android || TargetPlatform.iOS => true,
+    _ => false,
+  };
+
+  /// בכיוון RTL "לפני" הוא הצד הימני של הקובייה, ולכן סמן בחצי הימני מציב
+  /// לפניה וסמן בחצי השמאלי מציב אחריה.
+  void _updateSide(Offset globalPointer) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) return;
+    final local = box.globalToLocal(globalPointer);
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    final inLeadingHalf = local.dx < box.size.width / 2;
+    final placeAfter = isRtl ? inLeadingHalf : !inLeadingHalf;
+    if (placeAfter != _placeAfter) setState(() => _placeAfter = placeAfter);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<ToolCatalogEntry>(
+      onWillAcceptWithDetails: (details) =>
+          widget.canDrag && canReorderBetween(details.data, widget.entry),
+      onMove: (details) => _updateSide(details.offset),
+      onAcceptWithDetails: (details) =>
+          widget.onAcceptSource(details.data, placeAfter: _placeAfter),
+      builder: (context, candidates, _) {
+        final tile = _DropInsertionIndicator(
+          placeAfter: candidates.isEmpty ? null : _placeAfter,
+          child: widget.tile,
+        );
+        if (!widget.canDrag) return tile;
+
+        final feedback = _ToolDragFeedback(entry: widget.entry);
+        final placeholder = Opacity(opacity: 0.35, child: widget.tile);
+        return _isTouch
+            ? LongPressDraggable<ToolCatalogEntry>(
+                data: widget.entry,
+                dragAnchorStrategy: pointerDragAnchorStrategy,
+                feedback: feedback,
+                childWhenDragging: placeholder,
+                child: tile,
+              )
+            : Draggable<ToolCatalogEntry>(
+                data: widget.entry,
+                dragAnchorStrategy: pointerDragAnchorStrategy,
+                feedback: feedback,
+                childWhenDragging: placeholder,
+                child: tile,
+              );
+      },
+    );
+  }
+}
+
+/// מפתח קו ההוספה שמוצג בגרירה, בצד שאליו הקובייה תיפול.
+@visibleForTesting
+const Key kToolDropIndicatorKey = Key('tool-drop-indicator');
+
+/// קו ההוספה בקצה הקובייה. [placeAfter] ריק = הגרירה אינה מעל הקובייה הזאת.
+class _DropInsertionIndicator extends StatelessWidget {
+  static const double lineWidth = 3;
+
+  final bool? placeAfter;
+  final Widget child;
+
+  const _DropInsertionIndicator({
+    required this.placeAfter,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final side = placeAfter;
+    if (side == null) return child;
+    final cs = Theme.of(context).colorScheme;
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        child,
+        PositionedDirectional(
+          top: 2,
+          bottom: 2,
+          start: side ? null : 0,
+          end: side ? 0 : null,
+          child: Container(
+            key: kToolDropIndicatorKey,
+            width: lineWidth,
+            decoration: BoxDecoration(
+              color: cs.primary,
+              borderRadius: BorderRadius.circular(lineWidth),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// מה שצף מתחת לסמן בזמן גרירת קובייה.
+class _ToolDragFeedback extends StatelessWidget {
+  final ToolCatalogEntry entry;
+
+  const _ToolDragFeedback({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: cs.surfaceContainerHighest,
+          borderRadius: AppTokens.borderRadiusAll,
+          boxShadow: [
+            BoxShadow(
+              color: cs.shadow.withValues(alpha: 0.3),
+              blurRadius: 8,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            entry.imageIcon != null
+                ? ImageIcon(AssetImage(entry.imageIcon!), size: 18)
+                : Icon(entry.icon, size: 18),
+            const SizedBox(width: 8),
+            Text(
+              entry.label,
+              style: const TextStyle(fontWeight: FontWeight.w500),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -407,11 +883,18 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
 class ToolTile extends StatelessWidget {
   static const double iconBoxSize = 32;
   static const double iconSize = 16;
+  static const double menuButtonSize = 26;
 
   final ToolCatalogEntry entry;
   final bool isOpen;
   final bool isHighlighted;
   final VoidCallback onTap;
+
+  /// פעולות תפריט ⋯. ריק = הקובייה מוצגת בלי כפתור פעולות.
+  final List<ToolTileAction> actions;
+
+  /// מזהה פעימת ההזזה: כל שינוי מריץ אנימציית הדגשה קצרה. 0 = ללא פעימה.
+  final int movePulse;
 
   const ToolTile({
     super.key,
@@ -419,15 +902,16 @@ class ToolTile extends StatelessWidget {
     required this.isOpen,
     required this.isHighlighted,
     required this.onTap,
+    this.actions = const [],
+    this.movePulse = 0,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    return Tooltip(
-      message: entry.plugin?.name ?? entry.label,
-      waitDuration: const Duration(milliseconds: 600),
+    return _MovePulse(
+      nonce: movePulse,
       child: AppCard(
         onTap: onTap,
         selected: isHighlighted,
@@ -467,16 +951,22 @@ class ToolTile extends StatelessWidget {
                 ),
               ),
             ),
+            if (actions.isNotEmpty)
+              PositionedDirectional(
+                top: 0,
+                start: 0,
+                child: _buildMenuButton(cs),
+              ),
             if (entry.isDevelopment)
               PositionedDirectional(
-                top: 2,
-                start: 2,
+                bottom: 2,
+                start: 4,
                 child: _Badge(label: 'DEV', color: cs.tertiary),
               ),
             if (isOpen)
               PositionedDirectional(
-                top: 2,
-                end: 2,
+                top: 4,
+                end: 4,
                 child: Icon(
                   FluentIcons.checkmark_circle_16_filled,
                   size: 12,
@@ -489,6 +979,72 @@ class ToolTile extends StatelessWidget {
     );
   }
 
+  Widget _buildMenuButton(ColorScheme cs) {
+    return SizedBox(
+      width: menuButtonSize,
+      height: menuButtonSize,
+      child: AppPopupMenuButton<VoidCallback>(
+        tooltip: 'אפשרויות נוספות',
+        icon: Icon(
+          FluentIcons.more_vertical_24_regular,
+          size: 15,
+          color: cs.secondary,
+        ),
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(
+          minWidth: menuButtonSize,
+          minHeight: menuButtonSize,
+        ),
+        onSelected: (action) => action(),
+        itemBuilder: (context) {
+          final metrics =
+              Theme.of(context).extension<AppMenuMetrics>() ??
+              AppMenuMetrics.create(compactMenus: false);
+          return [
+            for (final action in actions) ...[
+              if (action.dividerBefore) const PopupMenuDivider(),
+              _menuItem(context, metrics, action),
+            ],
+          ];
+        },
+      ),
+    );
+  }
+
+  PopupMenuEntry<VoidCallback> _menuItem(
+    BuildContext context,
+    AppMenuMetrics metrics,
+    ToolTileAction action,
+  ) {
+    final children = action.children;
+    // תת-תפריט שכל פעולותיו מושבתות מרונדר כשורה מעומעמת רגילה: שורת תת-תפריט
+    // נפתחת בלחיצה על ה-InkWell הפנימי שלה גם כשהפריט מושבת.
+    if (children != null && children.any((child) => child.onTap != null)) {
+      return buildAppSubmenuPopupMenuItem<VoidCallback>(
+        context: context,
+        metrics: metrics,
+        label: action.label,
+        icon: action.icon,
+        menuChildren: [
+          for (final child in children) _menuItem(context, metrics, child),
+        ],
+        onSelected: (selected) => selected(),
+      );
+    }
+    return buildAppPopupMenuItem<VoidCallback>(
+      context,
+      AppMenuEntry<VoidCallback>(
+        value: action.onTap ?? () {},
+        label: action.label,
+        icon: action.icon,
+        enabled: action.onTap != null,
+        isDestructive: action.isDestructive,
+      ),
+      metrics,
+      null,
+    );
+  }
+
   Widget _buildIcon(ColorScheme cs) {
     if (entry.imageIcon != null) {
       return ImageIcon(
@@ -498,6 +1054,72 @@ class ToolTile extends StatelessWidget {
       );
     }
     return Icon(entry.icon, size: iconSize, color: cs.onSecondaryContainer);
+  }
+}
+
+/// פעימת הדגשה קצרה על קובייה שזזה — מראה למשתמש לאן היא נחתה.
+class _MovePulse extends StatefulWidget {
+  final int nonce;
+  final Widget child;
+
+  const _MovePulse({required this.nonce, required this.child});
+
+  @override
+  State<_MovePulse> createState() => _MovePulseState();
+}
+
+class _MovePulseState extends State<_MovePulse>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    duration: const Duration(milliseconds: 320),
+    vsync: this,
+    value: 1.0,
+  );
+  late final Animation<double> _progress = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.easeOut,
+  );
+
+  @override
+  void didUpdateWidget(covariant _MovePulse oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.nonce != oldWidget.nonce && widget.nonce != 0) {
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return AnimatedBuilder(
+      animation: _progress,
+      builder: (context, child) {
+        final remaining = 1.0 - _progress.value;
+        if (remaining == 0) return child!;
+        return Transform.scale(
+          scale: 1.0 - 0.06 * remaining,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: AppTokens.borderRadiusAll,
+              boxShadow: [
+                BoxShadow(
+                  color: cs.primary.withValues(alpha: 0.35 * remaining),
+                  blurRadius: 12 * remaining,
+                ),
+              ],
+            ),
+            child: child,
+          ),
+        );
+      },
+      child: widget.child,
+    );
   }
 }
 

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -96,7 +97,8 @@ const double kToolTileTargetWidth = 104;
 @visibleForTesting
 const double kToolGridScrollbarGutter = 14;
 
-/// מספר העמודות ברשת לרוחב פאנל נתון.
+/// מספר העמודות ברשת לרוחב נתון. הרוחב שמועבר הוא זה שנשאר לקוביות — כלומר
+/// לאחר הפחתת [kToolGridScrollbarGutter].
 @visibleForTesting
 int toolGridColumns(double width) =>
     (width / kToolTileTargetWidth).floor().clamp(2, 5);
@@ -363,7 +365,13 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       final current = pluginState.plugins
           .map((plugin) => plugin.pluginId)
           .toList();
-      if (const ListEquality<String>().equals(current, pendingPlugins)) {
+      // גם כשקבוצת התוספים עצמה השתנתה (התקנה, הסרה, כישלון בשמירה) הבסיס
+      // הממתין אינו רלוונטי — אחרת הוא היה נשאר לנצח ומשגר סדר חסר מזהה.
+      if (const ListEquality<String>().equals(current, pendingPlugins) ||
+          !const SetEquality<String>().equals(
+            current.toSet(),
+            pendingPlugins.toSet(),
+          )) {
         _pendingPluginOrder = null;
       }
     }
@@ -492,6 +500,9 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     );
     _clearSettledPendingOrders(settingsState, pluginState);
     final entries = orderedToolEntries(filterToolEntries(allEntries, _query));
+    // הרשימה התקצרה (כלי הוסתר) — סימון שיצא מהטווח היה נשאר בלי חיווי, אבל
+    // Enter היה פותח כלי אחר.
+    if (_highlightedIndex >= entries.length) _highlightedIndex = -1;
     final openToolIds = _openToolIds(context.watch<TabsBloc>().state);
     _keyboardEntries = entries;
 
@@ -706,6 +717,9 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         isOpen: openToolIds.contains(entry.toolId),
         isHighlighted: flatIndex == _highlightedIndex,
         movePulse: entry.toolId == _movedToolId ? _moveNonce : 0,
+        // בלי זה הפוקוס נשאר על מסלול התפריט שנסגר, ומקשי הפאנל (Escape,
+        // חצים, Enter) מפסיקים לעבוד עד לחיצה על שדה החיפוש.
+        onMenuClosed: () => _searchFocusNode.requestFocus(),
         actions: _tileActions(
           entry,
           onMoveEarlier: moveTo(
@@ -797,7 +811,9 @@ class _ReorderableToolTileState extends State<_ReorderableToolTile> {
 
   /// בכיוון RTL "לפני" הוא הצד הימני של הקובייה, ולכן סמן בחצי הימני מציב
   /// לפניה וסמן בחצי השמאלי מציב אחריה.
-  void _updateSide(Offset globalPointer) {
+  void _updateSide(ToolCatalogEntry source, Offset globalPointer) {
+    // Flutter מדווח על תזוזה גם ליעדים שנדחו, כולל הקובייה הנגררת עצמה.
+    if (!canReorderBetween(source, widget.entry)) return;
     final box = context.findRenderObject() as RenderBox?;
     if (box == null || !box.hasSize) return;
     final local = box.globalToLocal(globalPointer);
@@ -812,7 +828,7 @@ class _ReorderableToolTileState extends State<_ReorderableToolTile> {
     return DragTarget<ToolCatalogEntry>(
       onWillAcceptWithDetails: (details) =>
           widget.canDrag && canReorderBetween(details.data, widget.entry),
-      onMove: (details) => _updateSide(details.offset),
+      onMove: (details) => _updateSide(details.data, details.offset),
       onAcceptWithDetails: (details) =>
           widget.onAcceptSource(details.data, placeAfter: _placeAfter),
       builder: (context, candidates, _) {
@@ -832,7 +848,7 @@ class _ReorderableToolTileState extends State<_ReorderableToolTile> {
                 childWhenDragging: placeholder,
                 child: tile,
               )
-            : Draggable<ToolCatalogEntry>(
+            : _SlopDraggable<ToolCatalogEntry>(
                 data: widget.entry,
                 dragAnchorStrategy: pointerDragAnchorStrategy,
                 feedback: feedback,
@@ -842,6 +858,63 @@ class _ReorderableToolTileState extends State<_ReorderableToolTile> {
       },
     );
   }
+}
+
+/// מרחק התזוזה שממנו לחיצה נחשבת גרירה.
+///
+/// ה-`Draggable` הרגיל תופס את המחווה כבר בפיקסל אחד בעכבר, ואז לחיצה שבה
+/// היד רעדה קלות אינה מגיעה ללחצן שבקובייה — הכלי לא נפתח והתפריט לא נפתח.
+const double _kToolDragSlop = 12;
+
+/// מזהה גרירה מיידי עם סף תזוזה גדול מברירת המחדל. תומך במצביע מדויק בלבד:
+/// במגע הגרירה מתחילה בלחיצה ארוכה, כדי לא לחטוף את הגלילה.
+class _SlopMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
+  _SlopMultiDragGestureRecognizer({super.debugOwner})
+    : super(
+        supportedDevices: const {
+          PointerDeviceKind.mouse,
+          PointerDeviceKind.trackpad,
+          PointerDeviceKind.stylus,
+          PointerDeviceKind.invertedStylus,
+        },
+      );
+
+  @override
+  MultiDragPointerState createNewPointerState(PointerDownEvent event) =>
+      _SlopPointerState(event.position, event.kind, gestureSettings);
+
+  @override
+  String get debugDescription => 'tool tile drag';
+}
+
+class _SlopPointerState extends MultiDragPointerState {
+  _SlopPointerState(super.initialPosition, super.kind, super.gestureSettings);
+
+  @override
+  void checkForResolutionAfterMove() {
+    if ((pendingDelta?.distance ?? 0) > _kToolDragSlop) {
+      resolve(GestureDisposition.accepted);
+    }
+  }
+
+  @override
+  void accepted(GestureMultiDragStartCallback starter) =>
+      starter(initialPosition);
+}
+
+class _SlopDraggable<T extends Object> extends Draggable<T> {
+  const _SlopDraggable({
+    required super.child,
+    required super.feedback,
+    super.data,
+    super.dragAnchorStrategy,
+    super.childWhenDragging,
+  });
+
+  @override
+  MultiDragGestureRecognizer createRecognizer(
+    GestureMultiDragStartCallback onStart,
+  ) => _SlopMultiDragGestureRecognizer(debugOwner: this)..onStart = onStart;
 }
 
 /// מפתח קו ההוספה שמוצג בגרירה, בצד שאליו הקובייה תיפול.
@@ -947,6 +1020,9 @@ class ToolTile extends StatelessWidget {
   /// מזהה פעימת ההזזה: כל שינוי מריץ אנימציית הדגשה קצרה. 0 = ללא פעימה.
   final int movePulse;
 
+  /// נקרא כשתפריט הפעולות נסגר — הפאנל מחזיר לעצמו את הפוקוס למקלדת.
+  final VoidCallback? onMenuClosed;
+
   const ToolTile({
     super.key,
     required this.entry,
@@ -955,6 +1031,7 @@ class ToolTile extends StatelessWidget {
     required this.onTap,
     this.actions = const [],
     this.movePulse = 0,
+    this.onMenuClosed,
   });
 
   @override
@@ -1047,6 +1124,7 @@ class ToolTile extends StatelessWidget {
           minHeight: menuButtonSize,
         ),
         onSelected: (action) => action(),
+        onMenuClosed: onMenuClosed,
         itemBuilder: (context) {
           final metrics =
               Theme.of(context).extension<AppMenuMetrics>() ??
@@ -1150,9 +1228,10 @@ class _MovePulseState extends State<_MovePulse>
     final cs = Theme.of(context).colorScheme;
     return AnimatedBuilder(
       animation: _progress,
+      // מבנה העץ קבוע גם במנוחה: החלפת מבנה בתחילת הפעימה ובסופה הייתה בונה
+      // את הקובייה מחדש ומאפסת את מצב הריחוף שלה.
       builder: (context, child) {
         final remaining = 1.0 - _progress.value;
-        if (remaining == 0) return child!;
         return Transform.scale(
           scale: 1.0 - 0.06 * remaining,
           child: DecoratedBox(

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -11,6 +12,7 @@ import 'package:otzaria/plugins/view/plugin_actions.dart';
 import 'package:otzaria/plugins/view/plugin_settings_screen.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/settings/services/safer_mode_guard.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_state.dart';
@@ -58,16 +60,24 @@ List<ToolCatalogEntry> filterToolEntries(
 typedef ToolGroup = ({String label, List<ToolCatalogEntry> entries});
 
 /// מקבץ רשומות עוקבות לפי סוגן בלי לשנות את סדר הקטלוג.
+///
+/// הפיצול הוא גם לפי קבוצת המיון, ולא לפי התווית בלבד: כשכל הכלים המובנים
+/// מוסתרים, שתי קבוצות התוספים (זו שהורשתה להקדים אותם וזו הרגילה) נהיות
+/// עוקבות, וקבוצה מאוחדת הייתה מייצרת פעולות הזזה פעילות שאינן עושות דבר.
 @visibleForTesting
 List<ToolGroup> groupToolEntries(List<ToolCatalogEntry> entries) {
   final groups = <ToolGroup>[];
+  int? lastPriority;
   for (final entry in entries) {
     final label = entry.isPlugin ? kPluginsGroupLabel : kBuiltInToolsGroupLabel;
-    if (groups.isNotEmpty && groups.last.label == label) {
+    if (groups.isNotEmpty &&
+        groups.last.label == label &&
+        lastPriority == entry.sortGroupPriority) {
       groups.last.entries.add(entry);
     } else {
       groups.add((label: label, entries: [entry]));
     }
+    lastPriority = entry.sortGroupPriority;
   }
   return groups;
 }
@@ -100,6 +110,8 @@ int nextHighlightIndex({
   required int total,
 }) {
   if (total <= 0) return 0;
+  // ממצב "אין סימון" כל חץ מסמן את הקובייה הראשונה, ולא מדלג delta קוביות.
+  if (current < 0) return 0;
   return (current + delta).clamp(0, total - 1);
 }
 
@@ -172,6 +184,11 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   /// הכלי שזז אחרון ומספר ההזזה — מריצים פעימת הדגשה על הקובייה שזזה.
   String? _movedToolId;
   int _moveNonce = 0;
+
+  /// הסדר ששוגר וטרם חזר מה-bloc. בסיס לחישוב הזזה נוספת שמגיעה לפני שהמצב
+  /// התיישר. `null` = אין שיגור באוויר.
+  List<String>? _pendingBuiltInOrder;
+  List<String>? _pendingPluginOrder;
 
   @override
   void dispose() {
@@ -279,7 +296,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
 
   /// סידור אפשרי רק ברשימה המלאה: בחיפוש הקוביות מסוננות, ו"השכן" על המסך
   /// אינו השכן האמיתי בסדר.
-  bool get _isReorderEnabled => _query.trim().isEmpty;
+  bool get _isReorderEnabled => normalizeToolSearchText(_query).isEmpty;
 
   void _reorder({
     required ToolCatalogEntry source,
@@ -289,41 +306,67 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     if (!canReorderBetween(source, target)) return;
     final pluginBloc = context.read<PluginSystemBloc>();
     final settingsBloc = context.read<SettingsBloc>();
-    final pluginState = pluginBloc.state;
 
     // שיגור מושהה לפריים הבא: הרשת נבנית בתוך LayoutBuilder, ושיגור בזמן
     // הבנייה מפיל את Flutter על הפעלה-מחדש של רכיבי Overlay.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (source.isPlugin) {
+        final pluginState = pluginBloc.state;
         if (pluginState is! PluginSystemLoaded) return;
-        pluginBloc.add(
-          ReorderPluginsRequested(
-            reorderIdsAroundTarget(
-              pluginState.plugins.map((plugin) => plugin.pluginId).toList(),
-              source.toolId,
-              target.toolId,
-              placeAfter: placeAfter,
-            ),
-          ),
+        // הסדר ששוגר לפני רגע הוא הבסיס עד שה-bloc מתיישר, אחרת הזזה שנייה
+        // מהירה מחושבת מהסדר הישן ומוחקת את הראשונה.
+        final base =
+            _pendingPluginOrder ??
+            pluginState.plugins.map((plugin) => plugin.pluginId).toList();
+        final ordered = reorderIdsAroundTarget(
+          base,
+          source.toolId,
+          target.toolId,
+          placeAfter: placeAfter,
         );
+        _pendingPluginOrder = ordered;
+        pluginBloc.add(ReorderPluginsRequested(ordered));
       } else {
-        settingsBloc.add(
-          UpdateBuiltInToolsOrder(
-            reorderedBuiltInToolIds(
-              settingsBloc.state.builtInToolsOrder,
-              source.toolId,
-              target.toolId,
-              placeAfter: placeAfter,
-            ),
-          ),
+        final ordered = reorderedBuiltInToolIds(
+          _pendingBuiltInOrder ?? settingsBloc.state.builtInToolsOrder,
+          source.toolId,
+          target.toolId,
+          placeAfter: placeAfter,
         );
+        _pendingBuiltInOrder = ordered;
+        settingsBloc.add(UpdateBuiltInToolsOrder(ordered));
       }
       setState(() {
         _movedToolId = source.toolId;
         _moveNonce++;
       });
     });
+  }
+
+  /// מנקה את הסדר הממתין ברגע שה-bloc התיישר עליו. חייב לקרות ב-build, כי שם
+  /// מגיע ה-state המעודכן.
+  void _clearSettledPendingOrders(
+    SettingsState settingsState,
+    PluginSystemState pluginState,
+  ) {
+    final pendingBuiltIn = _pendingBuiltInOrder;
+    if (pendingBuiltIn != null &&
+        const ListEquality<String>().equals(
+          settingsState.builtInToolsOrder,
+          pendingBuiltIn,
+        )) {
+      _pendingBuiltInOrder = null;
+    }
+    final pendingPlugins = _pendingPluginOrder;
+    if (pendingPlugins != null && pluginState is PluginSystemLoaded) {
+      final current = pluginState.plugins
+          .map((plugin) => plugin.pluginId)
+          .toList();
+      if (const ListEquality<String>().equals(current, pendingPlugins)) {
+        _pendingPluginOrder = null;
+      }
+    }
   }
 
   /// פעולות הקובייה, בסדר שבו הן מוצגות בתפריט ⋯.
@@ -380,8 +423,12 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         onTap: () => _togglePinToNavRail(entry),
       ),
       ToolTileAction(
-        icon: FluentIcons.eye_off_24_regular,
-        label: 'הסתר מהממשק',
+        // תוסף מוצמד לסרגל הניווט נשאר בקטלוג גם כשהוא מוסתר, ולכן התווית
+        // חייבת לשקף את מצבו בפועל — אחרת הלחיצה הבאה מחזירה אותו בשקט.
+        icon: (plugin?.showInTools ?? true)
+            ? FluentIcons.eye_off_24_regular
+            : FluentIcons.eye_24_regular,
+        label: (plugin?.showInTools ?? true) ? 'הסתר מהממשק' : 'הצג בממשק',
         onTap: () => _hideFromInterface(entry),
       ),
       if (plugin != null)
@@ -443,6 +490,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       pluginState: pluginState,
       builtInToolsOrder: settingsState.builtInToolsOrder,
     );
+    _clearSettledPendingOrders(settingsState, pluginState);
     final entries = orderedToolEntries(filterToolEntries(allEntries, _query));
     final openToolIds = _openToolIds(context.watch<TabsBloc>().state);
     _keyboardEntries = entries;
@@ -532,7 +580,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       onChanged: (value) => setState(() {
         _query = value;
         // בחיפוש התוצאה הראשונה מסומנת (Enter יפתח אותה); בלי חיפוש אין סימון.
-        _highlightedIndex = value.trim().isEmpty ? -1 : 0;
+        _highlightedIndex = normalizeToolSearchText(value).isEmpty ? -1 : 0;
       }),
       onSubmitted: (_) => _activateHighlighted(entries),
     );
@@ -574,7 +622,9 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
               padding: const EdgeInsets.only(right: kToolGridScrollbarGutter),
               children: [
                 for (var i = 0; i < groups.length; i++) ...[
-                  if (i > 0)
+                  // קבוצות עוקבות באותה תווית (תוספים לפני/אחרי הכלים המובנים)
+                  // נראות כמקטע אחד — הכותרת והמפריד מוצגים רק במעבר תווית.
+                  if (i > 0 && groups[i].label != groups[i - 1].label)
                     const Padding(
                       padding: EdgeInsets.only(
                         top: AppTokens.spaceMD,
@@ -582,19 +632,20 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
                       ),
                       child: Divider(height: 1),
                     ),
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      top: AppTokens.spaceSM,
-                      bottom: AppTokens.spaceSM,
-                    ),
-                    child: Text(
-                      groups[i].label,
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        color: theme.colorScheme.secondary,
-                        fontWeight: FontWeight.bold,
+                  if (i == 0 || groups[i].label != groups[i - 1].label)
+                    Padding(
+                      padding: const EdgeInsets.only(
+                        top: AppTokens.spaceSM,
+                        bottom: AppTokens.spaceSM,
+                      ),
+                      child: Text(
+                        groups[i].label,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: theme.colorScheme.secondary,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
-                  ),
                   GridView.count(
                     crossAxisCount: columns,
                     shrinkWrap: true,

--- a/lib/utils/file/page_converter.dart
+++ b/lib/utils/file/page_converter.dart
@@ -13,6 +13,14 @@ import 'package:pdfrx/pdfrx.dart';
 // A cache for the generated page maps to avoid rebuilding them on every conversion.
 final _pageMapCache = <String, PageMap>{};
 
+typedef PdfAnchorsReader =
+    Future<List<({int page, String ref})>> Function(
+      String pdfPath,
+    );
+
+@visibleForTesting
+PdfAnchorsReader? pdfAnchorsReaderForTesting;
+
 /// TTL לרשומות מטמון העוגנים המתמיד — נגזר מהמדיניות של מטמון ה-outline.
 const _persistentAnchorCacheTtl = Duration(days: 90);
 
@@ -104,15 +112,20 @@ Future<List<({int page, String ref})>> _getPdfAnchors(String pdfPath) async {
     }
   }
 
-  PdfDocument? doc;
   final List<({int page, String ref})> anchors;
-  try {
-    doc = await PdfDocument.openFile(pdfPath);
-    anchors = collectPdfAnchors(await doc.loadOutline());
-  } finally {
-    // המתנה לשחרור בפועל — הטאב הסופי עשוי לפתוח מיד את אותו PDF, וה-worker
-    // היחיד של pdfrx חייב להשתחרר מהמסמך הזה קודם.
-    await doc?.dispose();
+  final readerForTesting = pdfAnchorsReaderForTesting;
+  if (readerForTesting != null) {
+    anchors = await readerForTesting(pdfPath);
+  } else {
+    PdfDocument? doc;
+    try {
+      doc = await PdfDocument.openFile(pdfPath);
+      anchors = collectPdfAnchors(await doc.loadOutline());
+    } finally {
+      // המתנה לשחרור בפועל — הטאב הסופי עשוי לפתוח מיד את אותו PDF, וה-worker
+      // היחיד של pdfrx חייב להשתחרר מהמסמך הזה קודם.
+      await doc?.dispose();
+    }
   }
 
   // גם רשימה ריקה נשמרת — PDF ללא outline לא ייפתח וייסרק מחדש בכל המרה.

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -254,6 +254,11 @@ class AppPopupMenuButton<T> extends StatefulWidget {
   /// ובריחוף יוצג צבע מוגבר — שימושי לכפתורי מצב פעיל (כמו מיון).
   final bool highlighted;
 
+  /// נקרא כשהתפריט נסגר — גם בבחירת פעולה וגם בביטול. המסלול היחיד להחזרת
+  /// הפוקוס למי שמנוהל במקלדת: אחרי סגירת התפריט הפוקוס נשאר על ה-scope של
+  /// המסלול, ולא חוזר לרכיב שפתח אותו.
+  final VoidCallback? onMenuClosed;
+
   const AppPopupMenuButton({
     super.key,
     this.entries,
@@ -270,6 +275,7 @@ class AppPopupMenuButton<T> extends StatefulWidget {
     this.initialValue,
     this.iconData,
     this.highlighted = false,
+    this.onMenuClosed,
   });
 
   @override
@@ -330,6 +336,7 @@ class _AppPopupMenuButtonState<T> extends State<AppPopupMenuButton<T>> {
       offset: widget.offset,
     );
     if (mounted) setState(() => _isMenuOpen = false);
+    widget.onMenuClosed?.call();
 
     if (selected != null) {
       widget.onSelected?.call(selected);

--- a/lib/widgets/misc/rtl_icon.dart
+++ b/lib/widgets/misc/rtl_icon.dart
@@ -49,6 +49,8 @@ class RtlIcon extends StatelessWidget {
     FluentIcons.arrow_left_24_regular: FluentIcons.arrow_right_24_regular,
     FluentIcons.arrow_right_24_filled: FluentIcons.arrow_left_24_filled,
     FluentIcons.arrow_left_24_filled: FluentIcons.arrow_right_24_filled,
+    FluentIcons.arrow_previous_24_regular: FluentIcons.arrow_next_24_regular,
+    FluentIcons.arrow_next_24_regular: FluentIcons.arrow_previous_24_regular,
     FluentIcons.calendar_24_regular: FluentIcons.calendar_rtl_24_regular,
     FluentIcons.calendar_24_filled: FluentIcons.calendar_rtl_24_filled,
     FluentIcons.panel_left_24_regular: FluentIcons.panel_right_24_regular,

--- a/test/history/bloc/history_split_tab_test.dart
+++ b/test/history/bloc/history_split_tab_test.dart
@@ -9,6 +9,7 @@ import 'package:otzaria/tabs/models/combined_tab.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
 
 import '../../helpers/memory_settings_cache.dart';
+import '../../support/search_engine_test_init.dart';
 
 /// היסטוריה של טאב מפוצל: טאב מפוצל אינו ספר, ולכן בלי פירוק לחלוניות אף
 /// מפגש קריאה בפיצול לא היה נרשם — אובדן שקט של "איפה קראתי".
@@ -27,8 +28,9 @@ class _MemoryHistoryRepository extends HistoryRepository {
   }
 }
 
-void main() {
+Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  final engineReady = await tryInitSearchEngine();
 
   setUp(() async {
     await Settings.init(cacheProvider: MemorySettingsCache());
@@ -47,22 +49,26 @@ void main() {
     return bloc;
   }
 
-  test('AddHistory על טאב מפוצל רושם רשומה לכל חלונית', () async {
-    final bloc = await loadedBloc(_MemoryHistoryRepository());
+  test(
+    'AddHistory על טאב מפוצל רושם רשומה לכל חלונית',
+    () async {
+      final bloc = await loadedBloc(_MemoryHistoryRepository());
 
-    final split = CombinedTab(
-      rightTab: search('שאלה א'),
-      leftTab: search('שאלה ב'),
-    );
-    bloc.add(AddHistory(split));
-    await bloc.stream.firstWhere((s) => s.history.length == 2);
+      final split = CombinedTab(
+        rightTab: search('שאלה א'),
+        leftTab: search('שאלה ב'),
+      );
+      bloc.add(AddHistory(split));
+      await bloc.stream.firstWhere((s) => s.history.length == 2);
 
-    // החלונית הראשונה בסדר התצוגה נשארת בראש ההיסטוריה.
-    expect(bloc.state.history.map((b) => b.book.title), [
-      'שאלה א',
-      'שאלה ב',
-    ]);
-  });
+      // החלונית הראשונה בסדר התצוגה נשארת בראש ההיסטוריה.
+      expect(bloc.state.history.map((b) => b.book.title), [
+        'שאלה א',
+        'שאלה ב',
+      ]);
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
 
   test('טאב רגיל רושם רשומה אחת', () async {
     final bloc = await loadedBloc(_MemoryHistoryRepository());
@@ -71,78 +77,98 @@ void main() {
     await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
 
     expect(bloc.state.history.map((b) => b.book.title), ['יחיד']);
-  });
+  }, skip: engineReady ? false : searchEngineSkipReason);
 
-  test('AddHistoryForTabs מפרק כל טאב מפוצל שברשימה', () async {
-    final bloc = await loadedBloc(_MemoryHistoryRepository());
+  test(
+    'AddHistoryForTabs מפרק כל טאב מפוצל שברשימה',
+    () async {
+      final bloc = await loadedBloc(_MemoryHistoryRepository());
 
-    bloc.add(
-      AddHistoryForTabs([
-        search('רגיל'),
-        CombinedTab(rightTab: search('מפוצל א'), leftTab: search('מפוצל ב')),
-      ]),
-    );
-    await bloc.stream.firstWhere((s) => s.history.length == 3);
+      bloc.add(
+        AddHistoryForTabs([
+          search('רגיל'),
+          CombinedTab(rightTab: search('מפוצל א'), leftTab: search('מפוצל ב')),
+        ]),
+      );
+      await bloc.stream.firstWhere((s) => s.history.length == 3);
 
-    expect(bloc.state.history.map((b) => b.book.title).toSet(), {
-      'רגיל',
-      'מפוצל א',
-      'מפוצל ב',
-    });
-  });
+      expect(bloc.state.history.map((b) => b.book.title).toSet(), {
+        'רגיל',
+        'מפוצל א',
+        'מפוצל ב',
+      });
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
 
-  test('CaptureStateForHistory שומר את כל החלוניות בהשטפה', () async {
-    final repository = _MemoryHistoryRepository();
-    final bloc = await loadedBloc(repository);
+  test(
+    'CaptureStateForHistory שומר את כל החלוניות בהשטפה',
+    () async {
+      final repository = _MemoryHistoryRepository();
+      final bloc = await loadedBloc(repository);
 
-    final split = CombinedTab(rightTab: search('א'), leftTab: search('ב'));
-    bloc.add(CaptureStateForHistory(split));
-    await pumpEventQueue();
+      final split = CombinedTab(rightTab: search('א'), leftTab: search('ב'));
+      bloc.add(CaptureStateForHistory(split));
+      await pumpEventQueue();
 
-    // ה-snapshot ממתין ב-debounce; FlushHistory הוא מה שרץ ביציאה מהמסך.
-    bloc.add(FlushHistory());
-    await bloc.stream.firstWhere((s) => s.history.length == 2);
+      // ה-snapshot ממתין ב-debounce; FlushHistory הוא מה שרץ ביציאה מהמסך.
+      bloc.add(FlushHistory());
+      await bloc.stream.firstWhere((s) => s.history.length == 2);
 
-    expect(repository.stored, hasLength(2));
-  });
+      expect(repository.stored, hasLength(2));
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
 
-  test('אותה שאילתה בשתי חלוניות אינה נרשמת פעמיים', () async {
-    final bloc = await loadedBloc(_MemoryHistoryRepository());
+  test(
+    'אותה שאילתה בשתי חלוניות אינה נרשמת פעמיים',
+    () async {
+      final bloc = await loadedBloc(_MemoryHistoryRepository());
 
-    final split = CombinedTab(
-      rightTab: search('אותה שאילתה'),
-      leftTab: search('אותה שאילתה'),
-    );
-    bloc.add(CaptureStateForHistory(split));
-    await pumpEventQueue();
-    bloc.add(FlushHistory());
-    await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
+      final split = CombinedTab(
+        rightTab: search('אותה שאילתה'),
+        leftTab: search('אותה שאילתה'),
+      );
+      bloc.add(CaptureStateForHistory(split));
+      await pumpEventQueue();
+      bloc.add(FlushHistory());
+      await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
 
-    expect(bloc.state.history, hasLength(1));
-  });
+      expect(bloc.state.history, hasLength(1));
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
 
-  test('טאב שאינו מפוצל ממשיך לרשום רשומה אחת', () async {
-    final bloc = await loadedBloc(_MemoryHistoryRepository());
+  test(
+    'טאב שאינו מפוצל ממשיך לרשום רשומה אחת',
+    () async {
+      final bloc = await loadedBloc(_MemoryHistoryRepository());
 
-    bloc.add(AddHistory(search('בודד')));
-    await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
+      bloc.add(AddHistory(search('בודד')));
+      await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
 
-    expect(bloc.state.history, hasLength(1));
-    expect(bloc.state.history.first.book.title, 'בודד');
-  });
+      expect(bloc.state.history, hasLength(1));
+      expect(bloc.state.history.first.book.title, 'בודד');
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
 
-  test('חלונית עם שאילתה ריקה אינה נרשמת', () async {
-    final bloc = await loadedBloc(_MemoryHistoryRepository());
+  test(
+    'חלונית עם שאילתה ריקה אינה נרשמת',
+    () async {
+      final bloc = await loadedBloc(_MemoryHistoryRepository());
 
-    final empty = SearchingTab('ריק', null);
-    addTearDown(empty.dispose);
-    final split = CombinedTab(rightTab: search('יש'), leftTab: empty);
+      final empty = SearchingTab('ריק', null);
+      addTearDown(empty.dispose);
+      final split = CombinedTab(rightTab: search('יש'), leftTab: empty);
 
-    bloc.add(AddHistory(split));
-    await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
-    await pumpEventQueue();
+      bloc.add(AddHistory(split));
+      await bloc.stream.firstWhere((s) => s.history.isNotEmpty);
+      await pumpEventQueue();
 
-    expect(bloc.state.history, hasLength(1));
-    expect(bloc.state.history.first.book.title, 'יש');
-  });
+      expect(bloc.state.history, hasLength(1));
+      expect(bloc.state.history.first.book.title, 'יש');
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
 }

--- a/test/navigation/pinned_nav_items_order_test.dart
+++ b/test/navigation/pinned_nav_items_order_test.dart
@@ -1,0 +1,128 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/navigation/view/main_window_screen.dart';
+import 'package:otzaria/plugins/bloc/plugin_system_state.dart';
+import 'package:otzaria/plugins/models/installed_plugin.dart';
+import 'package:otzaria/plugins/models/plugin_manifest.dart';
+
+InstalledPlugin _plugin(String id, {bool pinnedToNavRail = true}) =>
+    InstalledPlugin(
+      pluginId: id,
+      name: id,
+      version: '1.0.0',
+      installPath: '/plugins/$id',
+      entrypointPath: 'index.html',
+      enabled: true,
+      pinned: false,
+      pinnedToNavRail: pinnedToNavRail,
+      showInTools: true,
+      allowOrderBeforeBuiltInsGranted: false,
+      networkAccessGranted: false,
+      manifest: PluginManifest(
+        schemaVersion: 1,
+        id: id,
+        name: id,
+        version: '1.0.0',
+        description: 'test',
+        author: 'tester',
+        homepage: '',
+        entrypoint: 'index.html',
+        minAppVersion: '1.0.0',
+        sdkVersion: '1.x',
+        permissions: const [],
+        networkEnabled: false,
+        networkAllowlist: const [],
+        toolTabTitle: id,
+        toolTabOrder: 900,
+        allowOrderBeforeBuiltIns: false,
+        defaultPinned: false,
+        publishedDataTypes: const [],
+        toolTabIconName: 'apps',
+      ),
+      installedAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    );
+
+List<String> _pinned({
+  Set<String> pinnedBuiltIns = const {},
+  Set<String> hiddenBuiltIns = const {},
+  List<String> order = const [],
+  List<InstalledPlugin> plugins = const [],
+  bool offline = false,
+}) => MainWindowScreenState.pinnedToolIdsForNavRail(
+  pluginState: PluginSystemLoaded(plugins),
+  pinnedBuiltInIds: pinnedBuiltIns,
+  hiddenBuiltInIds: hiddenBuiltIns,
+  isOfflineMode: offline,
+  builtInToolsOrder: order,
+);
+
+/// סרגל הניווט חייב להציג את הכלים המוצמדים באותו סדר שהמשתמש רואה במשגר
+/// הכלים — אחרת אותו כלי יושב בשני מקומות שונים בשני מסכים.
+void main() {
+  test('בלי סדר מותאם: הסדר לפי שדה order של הקטלוג', () {
+    expect(
+      _pinned(
+        pinnedBuiltIns: const {'builtin.measurements', 'builtin.notes'},
+      ),
+      ['builtin.notes', 'builtin.measurements'],
+    );
+  });
+
+  test('סדר מותאם של המשתמש נשמר גם בסרגל', () {
+    expect(
+      _pinned(
+        pinnedBuiltIns: const {'builtin.measurements', 'builtin.notes'},
+        order: const ['builtin.measurements', 'builtin.notes'],
+      ),
+      ['builtin.measurements', 'builtin.notes'],
+    );
+  });
+
+  test('כלי מוסתר שהוצמד בעבר אינו מופיע', () {
+    expect(
+      _pinned(
+        pinnedBuiltIns: const {'builtin.calendar', 'builtin.gematria'},
+        hiddenBuiltIns: const {'builtin.calendar'},
+      ),
+      ['builtin.gematria'],
+    );
+  });
+
+  test('כלים מובנים לפני תוספים', () {
+    expect(
+      _pinned(
+        pinnedBuiltIns: const {'builtin.calendar'},
+        plugins: [_plugin('com.example.a')],
+      ),
+      ['builtin.calendar', 'com.example.a'],
+    );
+  });
+
+  test('תוסף שאינו מוצמד אינו מופיע', () {
+    expect(
+      _pinned(plugins: [_plugin('com.example.a', pinnedToNavRail: false)]),
+      isEmpty,
+    );
+  });
+
+  test('מזהה בסדר השמור שאינו מוצמד אינו מוסיף פריט', () {
+    expect(
+      _pinned(
+        pinnedBuiltIns: const {'builtin.gematria'},
+        order: const ['builtin.calendar', 'builtin.gematria'],
+      ),
+      ['builtin.gematria'],
+    );
+  });
+
+  // אם האייקון היה נעלם מהפריט, ה-assert בבנייה היה נופל — הבדיקה מוודאת
+  // שכלי עם לוגו (שמור וזכור) עובר את המסלול בשלום.
+  test('כלי עם נכס תמונה במקום אייקון נבנה בלי לזרוק', () {
+    expect(
+      _pinned(pinnedBuiltIns: const {'builtin.shamor_zachor'}),
+      ['builtin.shamor_zachor'],
+    );
+    expect(FluentIcons.apps_24_regular, isNotNull);
+  });
+}

--- a/test/navigation/tools_launcher_close_on_nav_test.dart
+++ b/test/navigation/tools_launcher_close_on_nav_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/navigation/view/main_window_screen.dart';
+
+/// לחיצה על פריט ניווט שהוא מסך חייבת לסגור את פאנל הכלים — ה-scrim שלו מכסה
+/// רק את אזור התוכן, ולכן בלי הסגירה הוא נשאר צף מעל המסך החדש.
+void main() {
+  group('shouldCloseToolsLauncherOnNavTap', () {
+    test('פריט "כלים" עצמו אינו סוגר — הוא רק מחליף מצב', () {
+      final toolsIndex =
+          List.generate(
+            6,
+            (i) => i,
+          ).firstWhere(
+            (i) => !MainWindowScreenState.shouldCloseToolsLauncherOnNavTap(i),
+          );
+      expect(
+        MainWindowScreenState.shouldCloseToolsLauncherOnNavTap(toolsIndex),
+        isFalse,
+      );
+    });
+
+    test('כל שאר פריטי הניווט סוגרים את הפאנל', () {
+      final closing = <int>[];
+      for (var i = 0; i < 6; i++) {
+        if (MainWindowScreenState.shouldCloseToolsLauncherOnNavTap(i)) {
+          closing.add(i);
+        }
+      }
+      // ספריה, איתור, עיון, חיפוש, הגדרות — הכול פרט לפריט "כלים".
+      expect(closing, hasLength(5));
+      expect(
+        closing.contains(0),
+        isTrue,
+        reason: 'ספריה הוא הפריט הראשון, והבאג המקורי היה בו',
+      );
+    });
+
+    test('אינדקס מחוץ לטווח אינו זורק', () {
+      expect(
+        MainWindowScreenState.shouldCloseToolsLauncherOnNavTap(-1),
+        isFalse,
+      );
+      expect(
+        MainWindowScreenState.shouldCloseToolsLauncherOnNavTap(99),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/plugins/bloc/plugin_system_bloc_reorder_test.dart
+++ b/test/plugins/bloc/plugin_system_bloc_reorder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
@@ -90,6 +92,20 @@ class _FakeRepo implements PluginRegistryRepository {
   dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
 }
 
+class _DelayedReorderRepo extends _FakeRepo {
+  final completions = <Completer<void>>[];
+
+  _DelayedReorderRepo(super.plugins);
+
+  @override
+  Future<void> reorderPlugins(List<String> orderedPluginIds) async {
+    reorderCalls.add(List.of(orderedPluginIds));
+    final completion = Completer<void>();
+    completions.add(completion);
+    await completion.future;
+  }
+}
+
 void main() {
   group('PluginSystemBloc ReorderPluginsRequested handler', () {
     test('forwards the ordered ids to repository.reorderPlugins', () async {
@@ -150,6 +166,24 @@ void main() {
       await expectLater(bloc.stream, emitsThrough(isA<PluginSystemLoaded>()));
 
       expect(repo.reorderCalls.single, isEmpty);
+    });
+
+    test('serializes rapid reorder requests', () async {
+      final repo = _DelayedReorderRepo([_plugin(id: 'a')]);
+      final bloc = PluginSystemBloc(repository: repo);
+      addTearDown(bloc.close);
+
+      const first = ['a', 'b'];
+      const second = ['b', 'a'];
+      bloc.add(const ReorderPluginsRequested(first));
+      bloc.add(const ReorderPluginsRequested(second));
+      await Future<void>.delayed(Duration.zero);
+      expect(repo.reorderCalls, [first]);
+
+      repo.completions.single.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(repo.reorderCalls, [first, second]);
+      repo.completions.last.complete();
     });
   });
 }

--- a/test/settings/services/backup_service_test.dart
+++ b/test/settings/services/backup_service_test.dart
@@ -71,6 +71,64 @@ void main() {
     expect(shamorZachor.containsKey('other:key'), isFalse);
   });
 
+  // רשימת המפתחות ב-_backupSettings קשיחה; הטסט הזה הוא השומר שמונע השמטה של
+  // התאמות הכלים (סדר, הסתרה, הצמדה) בגיבוי הבא.
+  test('createBackup כולל את הגדרות הכלים ומשחזר אותן', () async {
+    await Settings.setValue<String>(
+      SettingsRepository.keyBuiltInToolsOrder,
+      'builtin.gematria,builtin.calendar',
+    );
+    await Settings.setValue<String>(
+      SettingsRepository.keyHiddenBuiltInToolIds,
+      'builtin.notes',
+    );
+    await Settings.setValue<String>(
+      SettingsRepository.keyBuiltInToolsPinnedToNavRail,
+      'builtin.calendar',
+    );
+
+    final result = await BackupService.createBackup(
+      includeSettings: true,
+      includeBookmarks: false,
+      includeHistory: false,
+      includeNotes: false,
+      includeWorkspaces: false,
+      includeShamorZachor: false,
+      includePlugins: false,
+    );
+
+    final settings =
+        (jsonDecode(await File(result.path).readAsString())
+                as Map<String, dynamic>)['settings']
+            as Map<String, dynamic>;
+    expect(
+      settings[SettingsRepository.keyBuiltInToolsOrder],
+      'builtin.gematria,builtin.calendar',
+    );
+    expect(
+      settings[SettingsRepository.keyHiddenBuiltInToolIds],
+      'builtin.notes',
+    );
+    expect(
+      settings[SettingsRepository.keyBuiltInToolsPinnedToNavRail],
+      'builtin.calendar',
+    );
+
+    await Settings.setValue<String>(
+      SettingsRepository.keyBuiltInToolsOrder,
+      '',
+    );
+    await BackupService.restoreFromBackup(result.path);
+
+    expect(
+      Settings.getValue<String>(
+        SettingsRepository.keyBuiltInToolsOrder,
+        defaultValue: '',
+      ),
+      'builtin.gematria,builtin.calendar',
+    );
+  });
+
   test('restoreFromBackup משחזר טיפוסים ישירות ל-Hive', () async {
     final backupDir = Directory(p.join(tempDir.path, 'manual_backups'));
     await backupDir.create(recursive: true);

--- a/test/settings/settings_bloc_test.dart
+++ b/test/settings/settings_bloc_test.dart
@@ -532,6 +532,48 @@ void main() {
       );
     });
 
+    group('UpdateBuiltInToolsOrder', () {
+      const order = ['builtin.gematria', 'builtin.calendar'];
+
+      blocTest<SettingsBloc, SettingsState>(
+        'persists the order and emits state with the new order',
+        build: () {
+          when(
+            mockRepository.updateBuiltInToolsOrder(order),
+          ).thenAnswer((_) async {});
+          return settingsBloc;
+        },
+        act: (bloc) => bloc.add(const UpdateBuiltInToolsOrder(order)),
+        expect: () => [
+          settingsBloc.state.copyWith(builtInToolsOrder: order),
+        ],
+        verify: (_) {
+          verify(mockRepository.updateBuiltInToolsOrder(order)).called(1);
+        },
+      );
+
+      blocTest<SettingsBloc, SettingsState>(
+        'initial state has no custom order',
+        build: () => settingsBloc,
+        verify: (bloc) => expect(bloc.state.builtInToolsOrder, isEmpty),
+      );
+
+      // הסדר משמעותי — שתי רשימות באותם מזהים בסדר שונה הן מצבים שונים.
+      test('state equality is order sensitive', () {
+        final a = SettingsState.initial().copyWith(
+          builtInToolsOrder: const ['a', 'b'],
+        );
+        final b = SettingsState.initial().copyWith(
+          builtInToolsOrder: const ['b', 'a'],
+        );
+        expect(a, isNot(b));
+        expect(
+          a,
+          SettingsState.initial().copyWith(builtInToolsOrder: const ['a', 'b']),
+        );
+      });
+    });
+
     // חייב לרוץ אחרון: Settings.init גלובלי, והקבוצות הקודמות מסתמכות על
     // כך שהניקוי נכשל בשקט כש-Settings לא מאותחל.
     group('ניקוי פר-ספר בעקבות שינוי ברירת מחדל', () {

--- a/test/settings/settings_bloc_test.dart
+++ b/test/settings/settings_bloc_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
@@ -557,6 +558,35 @@ void main() {
         build: () => settingsBloc,
         verify: (bloc) => expect(bloc.state.builtInToolsOrder, isEmpty),
       );
+
+      test('שומר הזזות מהירות לפי סדר הבקשות', () async {
+        const firstOrder = ['builtin.calendar', 'builtin.gematria'];
+        const secondOrder = ['builtin.gematria', 'builtin.calendar'];
+        final firstWrite = Completer<void>();
+        final secondWrite = Completer<void>();
+        when(
+          mockRepository.updateBuiltInToolsOrder(firstOrder),
+        ).thenAnswer((_) => firstWrite.future);
+        when(
+          mockRepository.updateBuiltInToolsOrder(secondOrder),
+        ).thenAnswer((_) => secondWrite.future);
+        final secondStarted = untilCalled(
+          mockRepository.updateBuiltInToolsOrder(secondOrder),
+        );
+
+        settingsBloc.add(const UpdateBuiltInToolsOrder(firstOrder));
+        settingsBloc.add(const UpdateBuiltInToolsOrder(secondOrder));
+        await Future<void>.delayed(Duration.zero);
+        verify(mockRepository.updateBuiltInToolsOrder(firstOrder)).called(1);
+        verifyNever(mockRepository.updateBuiltInToolsOrder(secondOrder));
+
+        firstWrite.complete();
+        await secondStarted;
+        secondWrite.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(settingsBloc.state.builtInToolsOrder, secondOrder);
+      });
 
       // הסדר משמעותי — שתי רשימות באותם מזהים בסדר שונה הן מצבים שונים.
       test('state equality is order sensitive', () {

--- a/test/settings/settings_repository_test.dart
+++ b/test/settings/settings_repository_test.dart
@@ -813,6 +813,65 @@ void main() {
       ).called(1);
     });
 
+    test('updateBuiltInToolsOrder stores CSV in order, not sorted', () async {
+      await repository.updateBuiltInToolsOrder([
+        'builtin.gematria',
+        'builtin.calendar',
+      ]);
+
+      verify(
+        mockSettingsWrapper.setValue(
+          SettingsRepository.keyBuiltInToolsOrder,
+          'builtin.gematria,builtin.calendar',
+        ),
+      ).called(1);
+    });
+
+    test('loadSettings parses builtInToolsOrder preserving order', () async {
+      when(
+        mockSettingsWrapper.getValue<bool>(
+          'settings_initialized',
+          defaultValue: false,
+        ),
+      ).thenReturn(true);
+      when(
+        mockSettingsWrapper.getValue<String>(
+          SettingsRepository.keyBuiltInToolsOrder,
+          defaultValue: '',
+        ),
+      ).thenReturn('builtin.gematria, builtin.calendar,,builtin.gematria');
+
+      final settings = await repository.loadSettings();
+
+      expect(
+        settings['builtInToolsOrder'],
+        equals(['builtin.gematria', 'builtin.calendar']),
+        reason: 'הסדר נשמר, רווחים נחתכים, וכפילויות/ערכים ריקים מסוננים',
+      );
+    });
+
+    test(
+      'loadSettings returns an empty order when nothing was saved',
+      () async {
+        when(
+          mockSettingsWrapper.getValue<bool>(
+            'settings_initialized',
+            defaultValue: false,
+          ),
+        ).thenReturn(true);
+        when(
+          mockSettingsWrapper.getValue<String>(
+            SettingsRepository.keyBuiltInToolsOrder,
+            defaultValue: '',
+          ),
+        ).thenReturn('');
+
+        final settings = await repository.loadSettings();
+
+        expect(settings['builtInToolsOrder'], isEmpty);
+      },
+    );
+
     test('loadSettings parses hiddenBuiltInToolIds CSV into a Set', () async {
       // מאתחלים את כל ה-defaults הנדרשים כדי ש-loadSettings יסיים בלי
       // null-cast errors — אבל ה-stubs לערכי ברירת מחדל מספקים את זה דרך

--- a/test/tabs/bloc/tool_tab_dedupe_test.dart
+++ b/test/tabs/bloc/tool_tab_dedupe_test.dart
@@ -38,17 +38,23 @@ void main() {
       TextBookTab(book: TextBook(title: title), index: 0);
 
   test('OpenOrFocusTab על תוסף פתוח ממקד ואינו מוסיף כרטיסיה', () async {
-    // כל אירוע נצרך בנפרד: OpenOrFocusTab ו-AddTab רשומים בטרנספורמרים
-    // נפרדים ולכן אינם מובטחים לרוץ בסדר ההוספה.
+    final toolOpened = bloc.stream.firstWhere(
+      (state) => state.tabs.length == 1 && state.currentTabIndex == 0,
+    );
     bloc.add(OpenOrFocusTab(tool('com.example.plugin')));
-    await pumpEventQueue();
-    bloc.add(AddTab(book('בראשית')));
-    await pumpEventQueue();
-    expect(bloc.state.tabs.length, 2);
-    expect(bloc.state.currentTabIndex, 1);
+    await toolOpened;
 
+    final bookOpened = bloc.stream.firstWhere(
+      (state) => state.tabs.length == 2 && state.currentTabIndex == 1,
+    );
+    bloc.add(AddTab(book('בראשית')));
+    await bookOpened;
+
+    final toolFocused = bloc.stream.firstWhere(
+      (state) => state.tabs.length == 2 && state.currentTabIndex == 0,
+    );
     bloc.add(OpenOrFocusTab(tool('com.example.plugin')));
-    await pumpEventQueue();
+    await toolFocused;
 
     expect(bloc.state.tabs.length, 2, reason: 'לא נפתחה כרטיסיה נוספת');
     expect(bloc.state.currentTabIndex, 0, reason: 'המיקוד עבר לתוסף הקיים');

--- a/test/tools/built_in_tools_catalog_test.dart
+++ b/test/tools/built_in_tools_catalog_test.dart
@@ -70,9 +70,9 @@ void main() {
     });
 
     test('orders fit within the built-in range (<1000)', () {
-      // userOrderToolTabOffset = 1000 ⇒ תוספים בעלי userOrder מוקצים החל
-      // מ-1000+ כדי להישאר *אחרי* הכלים המובנים. אם כלי מובנה מקבל
-      // order ≥ 1000, הוא ערבב עם תוספים בלשונית הכלים.
+      // הפרדת הכלים מהתוספים נשענת על sortGroupPriority, אך שדה order של
+      // הכלים המובנים נצרך גם בסרגלים; הטווח <1000 נשמר לעקביות עם
+      // InstalledPlugin.userOrderToolTabOffset.
       for (final m in kBuiltInToolsCatalog) {
         expect(
           m.order,

--- a/test/tools/built_in_tools_order_test.dart
+++ b/test/tools/built_in_tools_order_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/tools/built_in_tools_catalog.dart';
+import 'package:otzaria/tools/tool_order.dart';
+
+List<String> _ids(List<String> customOrder) =>
+    orderedBuiltInTools(customOrder).map((meta) => meta.toolId).toList();
+
+void main() {
+  group('orderedBuiltInTools', () {
+    test('ללא סדר מותאם — סדר התצוגה של הקטלוג (שדה order)', () {
+      final ids = _ids(const []);
+      expect(ids.first, 'builtin.calendar');
+      // notes=25 יושב צמוד ל"שמור וזכור"=20 ולפני "מדות ושיעורים"=30.
+      expect(
+        ids.indexOf('builtin.notes'),
+        lessThan(ids.indexOf('builtin.measurements')),
+      );
+      expect(ids.length, kBuiltInToolsCatalog.length);
+    });
+
+    test('סדר מותאם מלא נשמר כמו שהוא', () {
+      final reversed = _ids(const []).reversed.toList();
+      expect(_ids(reversed), reversed);
+    });
+
+    test('סדר חלקי — הכלים שצוינו תחילה, השאר בסדר הקטלוג', () {
+      final ids = _ids(const ['builtin.gematria', 'builtin.notes']);
+      expect(ids.take(2), ['builtin.gematria', 'builtin.notes']);
+      expect(ids.length, kBuiltInToolsCatalog.length);
+      expect(ids.toSet().length, ids.length);
+    });
+
+    test('מזהה שאינו בקטלוג מסונן ואינו מוסיף פריט רפאים', () {
+      final ids = _ids(const ['plugin.ghost', 'builtin.gematria']);
+      expect(ids.first, 'builtin.gematria');
+      expect(ids.contains('plugin.ghost'), isFalse);
+      expect(ids.length, kBuiltInToolsCatalog.length);
+    });
+
+    test('כפילות בסדר השמור אינה משכפלת כלי', () {
+      final ids = _ids(const [
+        'builtin.gematria',
+        'builtin.gematria',
+        'builtin.calendar',
+      ]);
+      expect(ids.take(2), ['builtin.gematria', 'builtin.calendar']);
+      expect(ids.toSet().length, ids.length);
+    });
+
+    test('כלי מובנה חדש שאינו בסדר השמור מופיע ואינו נעלם', () {
+      final ids = _ids(const ['builtin.gematria']);
+      for (final meta in kBuiltInToolsCatalog) {
+        expect(ids, contains(meta.toolId));
+      }
+    });
+  });
+
+  group('reorderIdsAroundTarget', () {
+    const ids = ['a', 'b', 'c', 'd'];
+
+    test('הפלה אחרי היעד מציבה מיד אחריו', () {
+      expect(reorderIdsAroundTarget(ids, 'a', 'c', placeAfter: true), [
+        'b',
+        'c',
+        'a',
+        'd',
+      ]);
+    });
+
+    test('הפלה לפני היעד מציבה מיד לפניו', () {
+      expect(reorderIdsAroundTarget(ids, 'd', 'b', placeAfter: false), [
+        'a',
+        'd',
+        'b',
+        'c',
+      ]);
+    });
+
+    test('גרירה אחורה עם placeAfter מציבה אחרי היעד', () {
+      expect(reorderIdsAroundTarget(ids, 'd', 'a', placeAfter: true), [
+        'a',
+        'd',
+        'b',
+        'c',
+      ]);
+    });
+
+    test('הפלה לפני הראשון מציבה בראש', () {
+      expect(
+        reorderIdsAroundTarget(ids, 'c', 'a', placeAfter: false).first,
+        'c',
+      );
+    });
+
+    test('הפלה אחרי האחרון מציבה בסוף', () {
+      expect(reorderIdsAroundTarget(ids, 'a', 'd', placeAfter: true).last, 'a');
+    });
+
+    test('הפלה על עצמו אינה משנה', () {
+      expect(reorderIdsAroundTarget(ids, 'b', 'b', placeAfter: true), ids);
+      expect(reorderIdsAroundTarget(ids, 'b', 'b', placeAfter: false), ids);
+    });
+
+    test('מזהה חסר אינו משנה ואינו זורק', () {
+      expect(reorderIdsAroundTarget(ids, 'x', 'b', placeAfter: true), ids);
+      expect(reorderIdsAroundTarget(ids, 'b', 'x', placeAfter: false), ids);
+    });
+
+    test('אינו משנה את רשימת הקלט', () {
+      final input = List<String>.from(ids);
+      reorderIdsAroundTarget(input, 'a', 'c', placeAfter: true);
+      expect(input, ids);
+    });
+
+    test('שכן צמוד: קדימה ואז אחורה מחזירים לסדר המקורי', () {
+      final forward = reorderIdsAroundTarget(ids, 'a', 'b', placeAfter: true);
+      expect(forward.take(2), ['b', 'a']);
+      final back = reorderIdsAroundTarget(forward, 'a', 'b', placeAfter: false);
+      expect(back, ids);
+    });
+  });
+
+  group('reorderedBuiltInToolIds', () {
+    test('הזזה קדימה מציבה את הכלי אחרי שכנו', () {
+      final base = _ids(const []);
+      final result = reorderedBuiltInToolIds(
+        const [],
+        base[0],
+        base[1],
+        placeAfter: true,
+      );
+      expect(result.take(2), [base[1], base[0]]);
+      expect(result.length, base.length);
+    });
+
+    test('הזזה אחורה מציבה את הכלי לפני שכנו', () {
+      final base = _ids(const []);
+      final result = reorderedBuiltInToolIds(
+        const [],
+        base[2],
+        base[1],
+        placeAfter: false,
+      );
+      expect(result.take(3), [base[0], base[2], base[1]]);
+    });
+
+    test('הזזה לסוף שומרת את שאר הסדר', () {
+      final base = _ids(const []);
+      final result = reorderedBuiltInToolIds(
+        const [],
+        base.first,
+        base.last,
+        placeAfter: true,
+      );
+      expect(result.last, base.first);
+      expect(result.first, base[1]);
+      expect(result.toSet().length, base.length);
+    });
+
+    test('מקור ויעד זהים — הסדר אינו משתנה', () {
+      final base = _ids(const []);
+      expect(
+        reorderedBuiltInToolIds(const [], base[3], base[3], placeAfter: true),
+        base,
+      );
+    });
+
+    test('מזהה שאינו קיים — הסדר אינו משתנה', () {
+      final base = _ids(const []);
+      expect(
+        reorderedBuiltInToolIds(const [], 'nope', base[0], placeAfter: true),
+        base,
+      );
+      expect(
+        reorderedBuiltInToolIds(const [], base[0], 'nope', placeAfter: false),
+        base,
+      );
+    });
+
+    test('התוצאה תמיד מלאה — גם כשהבסיס השמור חלקי', () {
+      final result = reorderedBuiltInToolIds(
+        const ['builtin.gematria'],
+        'builtin.calendar',
+        'builtin.gematria',
+        placeAfter: false,
+      );
+      expect(result.length, kBuiltInToolsCatalog.length);
+      expect(result.take(2), ['builtin.calendar', 'builtin.gematria']);
+    });
+
+    test('הסדר שנשמר יציב: החלה חוזרת מחזירה את אותה רשימה', () {
+      final once = reorderedBuiltInToolIds(
+        const [],
+        'builtin.gematria',
+        'builtin.calendar',
+        placeAfter: false,
+      );
+      expect(_ids(once), once);
+    });
+  });
+}

--- a/test/tools/tool_catalog_test.dart
+++ b/test/tools/tool_catalog_test.dart
@@ -232,12 +232,16 @@ void main() {
         builtInToolsOrder: order,
       ).map((e) => e.toolId).toList();
 
-      expect(ids(const []), ids(const []));
-      expect(ids(const []).first, 'builtin.calendar');
-      expect(
-        ids(const []).indexOf('builtin.notes'),
-        lessThan(ids(const []).indexOf('builtin.measurements')),
-      );
+      // עוגן מפורש: זה הסדר שהמשתמש רואה כשלא סידר בעצמו כלום.
+      expect(ids(const []), [
+        'builtin.calendar',
+        'builtin.shamor_zachor',
+        'builtin.notes',
+        'builtin.measurements',
+        'builtin.gematria',
+        'builtin.aramaic_dictionary',
+        'builtin.acronyms_dictionary',
+      ]);
     });
   });
 

--- a/test/tools/tool_catalog_test.dart
+++ b/test/tools/tool_catalog_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_state.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
 import 'package:otzaria/plugins/models/plugin_manifest.dart';
+import 'package:otzaria/tools/built_in_tools_catalog.dart';
 import 'package:otzaria/tools/tool_catalog_entry.dart';
 
 InstalledPlugin _plugin(
@@ -184,6 +185,59 @@ void main() {
           .map((e) => e.toolId)
           .toList();
       expect(pluginIds, ['p.first', 'p.second']);
+    });
+
+    test('סדר הכלים המובנים שהמשתמש קבע גובר על סדר הקטלוג', () {
+      final entries = buildToolCatalog(
+        hiddenBuiltInToolIds: const {},
+        isOfflineMode: false,
+        pluginState: PluginSystemInitial(),
+        builtInToolsOrder: const ['builtin.gematria', 'builtin.calendar'],
+      );
+      final ids = entries.map((e) => e.toolId).toList();
+      expect(ids.take(2), ['builtin.gematria', 'builtin.calendar']);
+      expect(ids.length, kBuiltInToolsCatalog.length);
+    });
+
+    test('סדר מותאם אינו מבטל את הסתרת כלי', () {
+      final entries = buildToolCatalog(
+        hiddenBuiltInToolIds: const {'builtin.gematria'},
+        isOfflineMode: false,
+        pluginState: PluginSystemInitial(),
+        builtInToolsOrder: const ['builtin.gematria', 'builtin.calendar'],
+      );
+      final ids = entries.map((e) => e.toolId);
+      expect(ids, isNot(contains('builtin.gematria')));
+      expect(ids.first, 'builtin.calendar');
+    });
+
+    test('סדר מותאם אינו מקדם כלי מובנה לפני תוסף שהורשה להקדים', () {
+      final entries = buildToolCatalog(
+        hiddenBuiltInToolIds: const {},
+        isOfflineMode: false,
+        pluginState: PluginSystemLoaded([
+          _plugin('p.first', order: 1, allowOrderBeforeBuiltIns: true),
+        ]),
+        builtInToolsOrder: const ['builtin.gematria'],
+      );
+      expect(entries.first.toolId, 'p.first');
+      expect(entries[1].toolId, 'builtin.gematria');
+    });
+
+    test('סדר מותאם ריק משמר את סדר התצוגה המקורי', () {
+      List<String> ids(List<String> order) => buildToolCatalog(
+        hiddenBuiltInToolIds: const {},
+        isOfflineMode: false,
+        pluginState: PluginSystemInitial(),
+        builtInToolsOrder: order,
+      ).map((e) => e.toolId).toList();
+
+      expect(ids(const []), ids(const []));
+      expect(ids(const []).first, 'builtin.calendar');
+      expect(
+        ids(const []).indexOf('builtin.notes'),
+        lessThan(ids(const []).indexOf('builtin.measurements')),
+      );
     });
   });
 

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -1336,8 +1337,11 @@ void main() {
       required bool beforeTarget,
       bool release = true,
     }) async {
+      // עכבר ולא מגע: בשולחן העבודה הגרירה מוגבלת למצביע מדויק, כדי שהחלקה
+      // במגע תמשיך לגלול את הרשת.
       final gesture = await tester.startGesture(
         tester.getCenter(find.text(from)),
+        kind: PointerDeviceKind.mouse,
       );
       await tester.pump(const Duration(milliseconds: 50));
       final target = tester.getRect(
@@ -1472,6 +1476,98 @@ void main() {
         );
         expect(find.byKey(kToolDropIndicatorKey), findsNothing);
       });
+    });
+
+    // הבאג: Draggable רגיל תופס את המחווה כבר בפיקסל אחד בעכבר, ואז לחיצה
+    // שהיד רעדה בה לא הגיעה ללחצן — הכלי לא נפתח.
+    testWidgets('לחיצה עם רעידת עכבר קטנה עדיין פותחת את הכלי', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.text('לוח שנה')),
+          kind: PointerDeviceKind.mouse,
+        );
+        await gesture.moveBy(const Offset(2, 1));
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(selected.single.toolId, 'builtin.calendar');
+      });
+    });
+
+    testWidgets('לחיצה עם רעידת עכבר קטנה עדיין פותחת את תפריט ⋯', (
+      tester,
+    ) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        final gesture = await tester.startGesture(
+          tester.getCenter(_menuButtonOf('לוח שנה')),
+          kind: PointerDeviceKind.mouse,
+        );
+        await gesture.moveBy(const Offset(2, 1));
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(find.text('הסתר מהממשק'), findsOneWidget);
+      });
+    });
+
+    // במגע בשולחן העבודה (מסך מגע ב-Windows) הגלילה חשובה יותר מהגרירה, ולכן
+    // הסידור שם נעשה דרך תפריט ⋯.
+    testWidgets('החלקה במגע בשולחן העבודה אינה מסדרת ואינה פותחת כלי', (
+      tester,
+    ) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.text('לוח שנה')),
+        );
+        await gesture.moveTo(tester.getCenter(find.text('גימטריה')));
+        await tester.pump();
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(
+          settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
+          isEmpty,
+        );
+      });
+    });
+
+    testWidgets('אחרי פעולה בתפריט המקלדת חוזרת לפאנל', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await openMenu(tester, 'גימטריה');
+        await tapMenuItem(tester, 'הצמד לסרגל הניווט');
+
+        // Escape מטופל ב-onKeyEvent של שדה החיפוש; אם הפוקוס נשאר על מסלול
+        // התפריט שנסגר — הוא לא יגיע לפאנל.
+        final searchField = tester.widget<TextField>(find.byType(TextField));
+        expect(searchField.focusNode!.hasFocus, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+        expect(_selectedCardCount(tester), 1);
+      });
+    });
+
+    testWidgets('סימון שיצא מהטווח מתאפס כשהרשימה מתקצרת', (tester) async {
+      await pumpPanel(tester);
+      for (var i = 0; i < kBuiltInToolsCatalog.length + 2; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      }
+      await tester.pump();
+      expect(_selectedCardCount(tester), 1);
+
+      await pumpPanel(
+        tester,
+        pluginState: PluginSystemLoaded(const []),
+        settings: SettingsState.initial().copyWith(
+          hiddenBuiltInToolIds: const {'builtin.acronyms_dictionary'},
+        ),
+      );
+      expect(_selectedCardCount(tester), 0);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('גרירה אינה פותחת את הכלי', (tester) async {

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -390,6 +390,25 @@ void main() {
     test('רשימה ריקה — אין קבוצות', () {
       expect(groupToolEntries(const []), isEmpty);
     });
+
+    // בלי הפיצול הזה, קבוצה מאוחדת הייתה מייצרת פעולות הזזה פעילות בין תוספים
+    // שאסור לסדר ביניהם — ולכן פעולה שאינה עושה דבר.
+    test('שתי קבוצות תוספים עוקבות אינן מתמזגות', () {
+      final groups = groupToolEntries([
+        _pluginEntry(
+          'com.example.leading',
+          'תוסף מקדים',
+          allowOrderBeforeBuiltIns: true,
+        ),
+        _pluginEntry('com.example.regular', 'תוסף רגיל'),
+      ]);
+      expect(groups, hasLength(2));
+      expect(groups.map((g) => g.label), [
+        kPluginsGroupLabel,
+        kPluginsGroupLabel,
+      ]);
+      expect(groups.first.entries.single.toolId, 'com.example.leading');
+    });
   });
 
   // ניווט המקלדת ממופה לאינדקס ברשימה השטוחה, ולכן היא חייבת להיות בסדר
@@ -495,6 +514,14 @@ void main() {
 
     test('פריט יחיד נשאר על 0', () {
       expect(nextHighlightIndex(current: 0, delta: 1, total: 1), 0);
+    });
+
+    // ממצב "אין סימון" כל חץ מסמן את הראשונה; בלי זה חץ למטה היה מדלג שורה
+    // שלמה ומסמן את הקובייה החמישית.
+    test('ממצב ללא סימון כל חץ מסמן את הקובייה הראשונה', () {
+      expect(nextHighlightIndex(current: -1, delta: 1, total: 7), 0);
+      expect(nextHighlightIndex(current: -1, delta: 5, total: 7), 0);
+      expect(nextHighlightIndex(current: -1, delta: -5, total: 7), 0);
     });
   });
 
@@ -1466,6 +1493,96 @@ void main() {
 
       await openMenu(tester, 'לוח שנה');
       expect(_menuItemEnabled(tester, 'הזזה'), isFalse);
+    });
+
+    // שאילתה של פיסוק בלבד מתנרמלת לריקה ואינה מסננת דבר, ולכן אין סיבה
+    // להשבית את הסידור או לסמן קובייה.
+    testWidgets('שאילתת פיסוק בלבד אינה מצב חיפוש', (tester) async {
+      await pumpPanel(tester);
+      await tester.enterText(find.byType(TextField), '״');
+      await tester.pump();
+
+      expect(_selectedCardCount(tester), 0);
+      expect(
+        find.byType(ToolTile),
+        findsNWidgets(kBuiltInToolsCatalog.length + 2),
+      );
+      await openMenu(tester, 'לוח שנה');
+      expect(_menuItemEnabled(tester, 'הזזה'), isTrue);
+    });
+
+    testWidgets('חץ למטה ראשון מסמן את הקובייה הראשונה, לא את השורה הבאה', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+
+      expect(_selectedCardCount(tester), 1);
+      expect(_isCardSelected(tester, 'לוח שנה'), isTrue);
+    });
+
+    testWidgets('הפאנל מצייר את הסדר השמור', (tester) async {
+      await pumpPanel(
+        tester,
+        settings: SettingsState.initial().copyWith(
+          builtInToolsOrder: const [
+            'builtin.acronyms_dictionary',
+            'builtin.calendar',
+          ],
+        ),
+      );
+
+      final labels = tester
+          .widgetList<ToolTile>(find.byType(ToolTile))
+          .map((tile) => tile.entry.label)
+          .toList();
+      expect(labels.first, 'ראשי תיבות');
+      expect(labels[1], 'לוח שנה');
+    });
+
+    testWidgets('תוסף שהוסתר מהממשק ונשאר מוצמד מציג "הצג בממשק"', (
+      tester,
+    ) async {
+      final hiddenPinned = _pluginEntry(
+        'com.example.hidden',
+        'תוסף נסתר',
+      ).plugin!.copyWith(showInTools: false, pinnedToNavRail: true);
+      await pumpPanel(
+        tester,
+        pluginState: PluginSystemLoaded([hiddenPinned]),
+      );
+      await openMenu(tester, 'תוסף נסתר');
+
+      expect(find.text('הצג בממשק'), findsOneWidget);
+      expect(find.text('הסתר מהממשק'), findsNothing);
+    });
+
+    // ההזזה השנייה מגיעה לפני שה-bloc התיישר; בלי בסיס ממתין היא הייתה
+    // מחושבת מהסדר הישן ומוחקת את הראשונה.
+    testWidgets('שתי הזזות רצופות נערמות ואינן מבטלות זו את זו', (
+      tester,
+    ) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(tester, 'לוח שנה', 'גימטריה', beforeTarget: false);
+        await dragTileTo(tester, 'שמור וזכור', 'גימטריה', beforeTarget: false);
+
+        final orders = settingsBloc.recorded
+            .whereType<UpdateBuiltInToolsOrder>()
+            .map((event) => event.builtInToolsOrder)
+            .toList();
+        expect(orders, hasLength(2));
+        expect(
+          orders.last.indexOf('builtin.calendar'),
+          greaterThan(orders.last.indexOf('builtin.gematria')),
+          reason: 'ההזזה הראשונה חייבת לשרוד בסדר שהשנייה שולחת',
+        );
+        expect(
+          orders.last.indexOf('builtin.shamor_zachor'),
+          greaterThan(orders.last.indexOf('builtin.gematria')),
+        );
+      });
     });
 
     testWidgets('סידור מחדש אינו זורק וממשיך להציג את כל הכלים', (

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -15,6 +16,7 @@ import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/tabs/bloc/tabs_state.dart';
+import 'package:otzaria/tools/built_in_tools_catalog.dart';
 import 'package:otzaria/tools/tool_catalog_entry.dart';
 import 'package:otzaria/tools/view/tools_launcher_panel.dart';
 import 'package:otzaria/widgets/layout/app_card.dart';
@@ -136,6 +138,44 @@ Widget _launcherHost({
     ),
   ),
 );
+
+/// מציאת כפתור ⋯ של קובייה לפי התווית שכתובה בה.
+Finder _menuButtonOf(String label) => find.descendant(
+  of: find.ancestor(of: find.text(label), matching: find.byType(ToolTile)),
+  matching: find.byIcon(FluentIcons.more_vertical_24_regular),
+);
+
+bool _isCardSelected(WidgetTester tester, String label) => tester
+    .widget<AppCard>(
+      find.ancestor(of: find.text(label), matching: find.byType(AppCard)).first,
+    )
+    .selected;
+
+int _selectedCardCount(WidgetTester tester) => tester
+    .widgetList<AppCard>(find.byType(AppCard))
+    .where((card) => card.selected)
+    .length;
+
+/// מריץ גוף בדיקה כפלטפורמת שולחן עבודה. האיפוס חייב לקרות בתוך גוף הבדיקה,
+/// כי flutter_test מוודא שמשתני ה-debug נוקו לפני שה-tearDown רץ.
+Future<void> _asDesktop(Future<void> Function() body) async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
+}
+
+/// האם פריט התפריט הפתוח פעיל (פעולת הזזה בקצה הקבוצה מעומעמת).
+bool _menuItemEnabled(WidgetTester tester, String label) => tester
+    .widget<PopupMenuItem<VoidCallback>>(
+      find.ancestor(
+        of: find.text(label),
+        matching: find.byType(PopupMenuItem<VoidCallback>),
+      ),
+    )
+    .enabled;
 
 void main() {
   testWidgets('פתיחת משגר הכלים בתוך overlay אינה זורקת ParentDataWidget', (
@@ -464,11 +504,15 @@ void main() {
       bool isOpen = false,
       bool isHighlighted = false,
       VoidCallback? onTap,
+      List<ToolTileAction> actions = const [],
+      int movePulse = 0,
     }) => ToolTile(
       entry: entry ?? _entry('builtin.calendar', 'לוח שנה'),
       isOpen: isOpen,
       isHighlighted: isHighlighted,
       onTap: onTap ?? () {},
+      actions: actions,
+      movePulse: movePulse,
     );
 
     testWidgets('מציג את תווית הכלי', (tester) async {
@@ -636,18 +680,38 @@ void main() {
       expect(find.text('DEV'), findsOneWidget);
     });
 
-    testWidgets('Tooltip מציג את שם התוסף כשהוא שונה מהתווית', (tester) async {
+    // התווית כתובה בקובייה — טולטיפ ריחוף עליה היה כפילות מציקה.
+    testWidgets('אין טולטיפ ריחוף על הקובייה', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+      expect(find.byType(Tooltip), findsNothing);
+
       await tester.pumpWidget(
         _tileHost(
           buildTile(entry: _pluginEntry('com.example.x', 'מפה', name: 'Atlas')),
         ),
       );
-      expect(tester.widget<Tooltip>(find.byType(Tooltip)).message, 'Atlas');
+      expect(find.byType(Tooltip), findsNothing);
     });
 
-    testWidgets('Tooltip נופל לתווית כשאין תוסף', (tester) async {
-      await tester.pumpWidget(_tileHost(buildTile()));
-      expect(tester.widget<Tooltip>(find.byType(Tooltip)).message, 'לוח שנה');
+    // הטולטיפ היחיד שנשאר בקובייה הוא של כפתור הפעולות, כמו בספרייה.
+    testWidgets('הטולטיפ היחיד הוא של כפתור הפעולות', (tester) async {
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            actions: [
+              ToolTileAction(
+                icon: FluentIcons.eye_off_24_regular,
+                label: 'הסתר מהממשק',
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(
+        tester.widget<Tooltip>(find.byType(Tooltip)).message,
+        'אפשרויות נוספות',
+      );
     });
 
     testWidgets('סימון מקלדת מסמן את הכרטיס כנבחר', (tester) async {
@@ -656,6 +720,799 @@ void main() {
 
       await tester.pumpWidget(_tileHost(buildTile(isHighlighted: true)));
       expect(tester.widget<AppCard>(find.byType(AppCard)).selected, isTrue);
+    });
+
+    testWidgets('בלי פעולות אין כפתור ⋯', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+      expect(
+        find.byIcon(FluentIcons.more_vertical_24_regular),
+        findsNothing,
+      );
+    });
+
+    testWidgets('כפתור ⋯ מוצג כשיש פעולות ופותח אותן', (tester) async {
+      var hidden = 0;
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            actions: [
+              ToolTileAction(
+                icon: FluentIcons.eye_off_24_regular,
+                label: 'הסתר מהממשק',
+                onTap: () => hidden++,
+              ),
+            ],
+          ),
+          size: 140,
+        ),
+      );
+
+      await tester.tap(find.byIcon(FluentIcons.more_vertical_24_regular));
+      await tester.pumpAndSettle();
+      expect(find.text('הסתר מהממשק'), findsOneWidget);
+
+      await tester.tap(find.text('הסתר מהממשק'));
+      await tester.pumpAndSettle();
+      expect(hidden, 1);
+    });
+
+    // לחיצה על ⋯ אינה אמורה לפתוח את הכלי.
+    testWidgets('לחיצה על ⋯ אינה מפעילה את onTap של הקובייה', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            onTap: () => taps++,
+            actions: [
+              ToolTileAction(
+                icon: FluentIcons.eye_off_24_regular,
+                label: 'הסתר מהממשק',
+                onTap: () {},
+              ),
+            ],
+          ),
+          size: 140,
+        ),
+      );
+
+      await tester.tap(find.byIcon(FluentIcons.more_vertical_24_regular));
+      await tester.pumpAndSettle();
+      expect(taps, 0);
+    });
+
+    testWidgets('פעולה בלי onTap מוצגת מעומעמת ואינה נבחרת', (tester) async {
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            actions: const [
+              ToolTileAction(
+                icon: FluentIcons.arrow_left_24_regular,
+                label: 'הזז אחורה',
+                onTap: null,
+              ),
+            ],
+          ),
+          size: 140,
+        ),
+      );
+
+      await tester.tap(find.byIcon(FluentIcons.more_vertical_24_regular));
+      await tester.pumpAndSettle();
+      final item = tester.widget<PopupMenuItem<VoidCallback>>(
+        find.ancestor(
+          of: find.text('הזז אחורה'),
+          matching: find.byType(PopupMenuItem<VoidCallback>),
+        ),
+      );
+      expect(item.enabled, isFalse);
+    });
+
+    // מקום הכפתור נבחר כך שלא יתנגש בסימן "פתוח" שבפינה הנגדית.
+    testWidgets('כפתור ⋯ יושב בפינה הימנית-עליונה של הקובייה', (tester) async {
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            isOpen: true,
+            actions: [
+              ToolTileAction(
+                icon: FluentIcons.eye_off_24_regular,
+                label: 'הסתר מהממשק',
+                onTap: () {},
+              ),
+            ],
+          ),
+          size: 140,
+        ),
+      );
+
+      final tile = tester.getRect(find.byType(ToolTile));
+      final button = tester.getRect(
+        find.byIcon(FluentIcons.more_vertical_24_regular),
+      );
+      final openMark = tester.getRect(
+        find.byIcon(FluentIcons.checkmark_circle_16_filled),
+      );
+      expect(button.center.dx, greaterThan(tile.center.dx));
+      expect(button.center.dy, lessThan(tile.center.dy));
+      expect(
+        button.center.dx,
+        greaterThan(openMark.center.dx),
+        reason: 'סימן "פתוח" יושב בפינה הנגדית ואינו מתנגש בכפתור',
+      );
+    });
+
+    testWidgets('פעולה עם תת-פעולות נפתחת כתת-תפריט', (tester) async {
+      var moved = 0;
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            actions: [
+              ToolTileAction(
+                icon: FluentIcons.re_order_dots_vertical_24_regular,
+                label: 'הזזה',
+                onTap: null,
+                children: [
+                  ToolTileAction(
+                    icon: FluentIcons.arrow_left_24_regular,
+                    label: 'הזז אחורה',
+                    onTap: () => moved++,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          size: 140,
+        ),
+      );
+
+      await tester.tap(find.byIcon(FluentIcons.more_vertical_24_regular));
+      await tester.pumpAndSettle();
+      expect(find.text('הזזה'), findsOneWidget);
+      expect(find.text('הזז אחורה'), findsNothing);
+
+      await tester.tap(find.text('הזזה'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('הזז אחורה'));
+      await tester.pumpAndSettle();
+      expect(moved, 1);
+    });
+
+    testWidgets('תת-תפריט שכל פעולותיו מושבתות אינו נפתח', (tester) async {
+      await tester.pumpWidget(
+        _tileHost(
+          buildTile(
+            actions: const [
+              ToolTileAction(
+                icon: FluentIcons.re_order_dots_vertical_24_regular,
+                label: 'הזזה',
+                onTap: null,
+                children: [
+                  ToolTileAction(
+                    icon: FluentIcons.arrow_left_24_regular,
+                    label: 'הזז אחורה',
+                    onTap: null,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          size: 140,
+        ),
+      );
+
+      await tester.tap(find.byIcon(FluentIcons.more_vertical_24_regular));
+      await tester.pumpAndSettle();
+      expect(_menuItemEnabled(tester, 'הזזה'), isFalse);
+
+      // שורת תת-תפריט מושבתת עדיין נפתחת בלחיצה על ה-InkWell הפנימי שלה, ולכן
+      // היא מרונדרת כשורה רגילה מעומעמת — בלי תת-פעולות בכלל.
+      await tester.tap(find.text('הזזה'));
+      await tester.pumpAndSettle();
+      expect(find.text('הזז אחורה'), findsNothing);
+    });
+
+    testWidgets('פעימת הזזה אינה זורקת ומתייצבת', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+      await tester.pumpWidget(_tileHost(buildTile(movePulse: 1)));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(find.text('לוח שנה'), findsOneWidget);
+    });
+  });
+
+  group('פאנל הכלים — סימון, גלילה, פעולות וסידור', () {
+    late _RecordingSettingsBloc settingsBloc;
+    late _RecordingPluginSystemBloc pluginSystemBloc;
+    late _TestTabsBloc tabsBloc;
+    late List<ToolCatalogEntry> selected;
+
+    /// שני תוספים פעילים, כדי שתהיה גם קבוצת "תוספים" עם שכן להזזה.
+    List<InstalledPlugin> plugins() => [
+      _pluginEntry('com.example.a', 'תוסף א').plugin!,
+      _pluginEntry('com.example.b', 'תוסף ב').plugin!,
+    ];
+
+    Future<void> pumpPanel(
+      WidgetTester tester, {
+      SettingsState? settings,
+      PluginSystemState? pluginState,
+    }) async {
+      settingsBloc = _RecordingSettingsBloc(
+        settings ?? SettingsState.initial(),
+      );
+      pluginSystemBloc = _RecordingPluginSystemBloc(
+        pluginState ?? PluginSystemLoaded(plugins()),
+      );
+      tabsBloc = _TestTabsBloc(TabsState.initial());
+      selected = [];
+      addTearDown(() async {
+        await settingsBloc.close();
+        await pluginSystemBloc.close();
+        await tabsBloc.close();
+      });
+
+      await tester.pumpWidget(
+        _launcherHost(
+          settingsBloc: settingsBloc,
+          pluginSystemBloc: pluginSystemBloc,
+          tabsBloc: tabsBloc,
+          onToolSelected: selected.add,
+        ),
+      );
+      await tester.pump();
+    }
+
+    Future<void> openMenu(WidgetTester tester, String label) async {
+      await tester.tap(_menuButtonOf(label));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> tapMenuItem(WidgetTester tester, String label) async {
+      await tester.tap(find.text(label));
+      await tester.pumpAndSettle();
+    }
+
+    /// פותח את תפריט הקובייה ואת תת-תפריט "הזזה" שבתוכו.
+    Future<void> openMoveSubmenu(WidgetTester tester, String label) async {
+      await openMenu(tester, label);
+      await tester.tap(find.text('הזזה'));
+      await tester.pumpAndSettle();
+    }
+
+    // ── סימון מקלדת ─────────────────────────────────────────────────────────
+
+    testWidgets('בפתיחה אין קובייה מסומנת — לוח שנה לא נראה נבחר', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      expect(_selectedCardCount(tester), 0);
+      expect(_isCardSelected(tester, 'לוח שנה'), isFalse);
+    });
+
+    testWidgets('החץ הראשון מסמן את הקובייה הראשונה', (tester) async {
+      await pumpPanel(tester);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+
+      expect(_selectedCardCount(tester), 1);
+      expect(_isCardSelected(tester, 'לוח שנה'), isTrue);
+    });
+
+    testWidgets('חיפוש מסמן את התוצאה הראשונה', (tester) async {
+      await pumpPanel(tester);
+      await tester.enterText(find.byType(TextField), 'גימ');
+      await tester.pump();
+
+      expect(_selectedCardCount(tester), 1);
+      expect(_isCardSelected(tester, 'גימטריה'), isTrue);
+    });
+
+    testWidgets('ניקוי החיפוש מחזיר למצב ללא סימון', (tester) async {
+      await pumpPanel(tester);
+      await tester.enterText(find.byType(TextField), 'גימ');
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), '');
+      await tester.pump();
+
+      expect(_selectedCardCount(tester), 0);
+    });
+
+    testWidgets('Enter בלי סימון פותח את הכלי הראשון', (tester) async {
+      await pumpPanel(tester);
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(selected.single.toolId, 'builtin.calendar');
+    });
+
+    // ── פס הגלילה ───────────────────────────────────────────────────────────
+
+    testWidgets('הרשת שומרת מרווח בימין לפס הגלילה', (tester) async {
+      await pumpPanel(tester);
+      final listView = tester.widget<ListView>(find.byType(ListView));
+      expect(
+        listView.padding,
+        const EdgeInsets.only(right: kToolGridScrollbarGutter),
+      );
+    });
+
+    testWidgets('פס הגלילה מוצמד לימין בשולחן העבודה', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        // הרשת מכילה גם GridView-ים פנימיים, ולכל אחד נבנה פס משלו — כולם
+        // חייבים לשבת בימין, אחרת פס אחד היה מצטייר על הקוביות.
+        final scrollbars = tester.widgetList<Scrollbar>(
+          find.byType(Scrollbar),
+        );
+        expect(scrollbars, isNotEmpty);
+        expect(
+          scrollbars.every(
+            (bar) => bar.scrollbarOrientation == ScrollbarOrientation.right,
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    // ── תוכן תפריט ⋯ ────────────────────────────────────────────────────────
+
+    testWidgets('לכל קובייה יש כפתור ⋯', (tester) async {
+      await pumpPanel(tester);
+      expect(
+        find.byIcon(FluentIcons.more_vertical_24_regular),
+        findsNWidgets(kBuiltInToolsCatalog.length + 2),
+      );
+    });
+
+    testWidgets('תפריט כלי מובנה: הזזה, הצמדה והסתרה בלבד', (tester) async {
+      await pumpPanel(tester);
+      await openMenu(tester, 'גימטריה');
+
+      expect(find.text('הזזה'), findsOneWidget);
+      expect(find.text('הצמד לסרגל הניווט'), findsOneWidget);
+      expect(find.text('הסתר מהממשק'), findsOneWidget);
+      expect(find.text('ניהול הרשאות'), findsNothing);
+      expect(find.text('מחק תוסף'), findsNothing);
+      expect(find.text('השבת'), findsNothing);
+      // פעולות ההזזה עצמן חבויות בתת-תפריט ואינן מציפות את התפריט הראשי.
+      expect(find.text('הזז אחורה'), findsNothing);
+      expect(find.text('הזז לסוף'), findsNothing);
+    });
+
+    testWidgets('תת-תפריט "הזזה" מכיל את ארבע פעולות ההזזה', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'גימטריה');
+
+      expect(find.text('הזז אחורה'), findsOneWidget);
+      expect(find.text('הזז קדימה'), findsOneWidget);
+      expect(find.text('הזז לתחילה'), findsOneWidget);
+      expect(find.text('הזז לסוף'), findsOneWidget);
+    });
+
+    testWidgets('תפריט תוסף כולל את כל הפעולות שהיו לפני השינוי', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMenu(tester, 'תוסף א');
+
+      expect(find.text('ניהול הרשאות'), findsOneWidget);
+      expect(find.text('הצמד לסרגל הניווט'), findsOneWidget);
+      expect(find.text('הסתר מהממשק'), findsOneWidget);
+      expect(find.text('השבת'), findsOneWidget);
+      expect(find.text('מחק תוסף'), findsOneWidget);
+      expect(find.text('הזזה'), findsOneWidget);
+    });
+
+    testWidgets('תוסף שהוצמד לסרגל מציג "הסר מסרגל הניווט"', (tester) async {
+      final pinned = _pluginEntry(
+        'com.example.pinned',
+        'תוסף נעוץ',
+      ).plugin!.copyWith(pinnedToNavRail: true);
+      await pumpPanel(tester, pluginState: PluginSystemLoaded([pinned]));
+      await openMenu(tester, 'תוסף נעוץ');
+
+      expect(find.text('הסר מסרגל הניווט'), findsOneWidget);
+      expect(find.text('הצמד לסרגל הניווט'), findsNothing);
+    });
+
+    testWidgets('כלי מובנה שהוצמד לסרגל מציג "הסר מסרגל הניווט"', (
+      tester,
+    ) async {
+      await pumpPanel(
+        tester,
+        settings: SettingsState.initial().copyWith(
+          builtInToolsPinnedToNavRail: const {'builtin.gematria'},
+        ),
+      );
+      await openMenu(tester, 'גימטריה');
+
+      expect(find.text('הסר מסרגל הניווט'), findsOneWidget);
+    });
+
+    // בראש הקבוצה אין "אחורה" — הלחיצה על פריט מושבת אינה משנה סדר.
+    testWidgets('בראש הקבוצה "הזז אחורה" אינו עושה דבר', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'לוח שנה');
+      await tapMenuItem(tester, 'הזז אחורה');
+
+      expect(
+        settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
+        isEmpty,
+      );
+    });
+
+    testWidgets('בסוף הקבוצה "הזז קדימה" אינו עושה דבר', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'ראשי תיבות');
+      await tapMenuItem(tester, 'הזז קדימה');
+
+      expect(
+        settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
+        isEmpty,
+      );
+    });
+
+    // ── פעולות בפועל ────────────────────────────────────────────────────────
+
+    testWidgets('"הזז קדימה" על כלי מובנה שומר סדר חדש', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'לוח שנה');
+      await tapMenuItem(tester, 'הזז קדימה');
+
+      final event = settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>();
+      expect(event, hasLength(1));
+      expect(event.single.builtInToolsOrder.take(2), [
+        'builtin.shamor_zachor',
+        'builtin.calendar',
+      ]);
+      expect(
+        event.single.builtInToolsOrder.length,
+        kBuiltInToolsCatalog.length,
+        reason: 'הסדר שנשמר חייב להכיל את כל הכלים, אחרת ייווצרו מזהים חסרים',
+      );
+    });
+
+    testWidgets('"הזז אחורה" על כלי מובנה מקדים אותו לשכנו', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'הערות אישיות');
+      await tapMenuItem(tester, 'הזז אחורה');
+
+      final order = settingsBloc.recorded
+          .whereType<UpdateBuiltInToolsOrder>()
+          .single
+          .builtInToolsOrder;
+      expect(order.take(3), [
+        'builtin.calendar',
+        'builtin.notes',
+        'builtin.shamor_zachor',
+      ]);
+    });
+
+    // הזזה צעד-צעד לא מעשית למרחק גדול; "לתחילה"/"לסוף" קופצות בפעולה אחת.
+    testWidgets('"הזז לתחילה" מקדם את הכלי לראש הקבוצה בפעולה אחת', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'ראשי תיבות');
+      await tapMenuItem(tester, 'הזז לתחילה');
+
+      final order = settingsBloc.recorded
+          .whereType<UpdateBuiltInToolsOrder>()
+          .single
+          .builtInToolsOrder;
+      expect(order.first, 'builtin.acronyms_dictionary');
+      expect(order.length, kBuiltInToolsCatalog.length);
+    });
+
+    testWidgets('"הזז לסוף" מעביר את הכלי לסוף הקבוצה בפעולה אחת', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'לוח שנה');
+      await tapMenuItem(tester, 'הזז לסוף');
+
+      final order = settingsBloc.recorded
+          .whereType<UpdateBuiltInToolsOrder>()
+          .single
+          .builtInToolsOrder;
+      expect(order.last, 'builtin.calendar');
+      expect(order.length, kBuiltInToolsCatalog.length);
+    });
+
+    testWidgets('בראש הקבוצה "הזז לתחילה" אינו משנה סדר', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'לוח שנה');
+      await tapMenuItem(tester, 'הזז לתחילה');
+
+      expect(
+        settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
+        isEmpty,
+      );
+    });
+
+    testWidgets('"הזז לסוף" על תוסף נשאר בתוך קבוצת התוספים', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'תוסף א');
+      await tapMenuItem(tester, 'הזז לסוף');
+
+      final event = pluginSystemBloc.recorded
+          .whereType<ReorderPluginsRequested>()
+          .single;
+      expect(event.orderedPluginIds, ['com.example.b', 'com.example.a']);
+      expect(
+        settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
+        isEmpty,
+        reason: 'הזזת תוסף אינה נוגעת בסדר הכלים המובנים',
+      );
+    });
+
+    testWidgets('"הסתר מהממשק" על כלי מובנה מוסיף אותו למוסתרים', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMenu(tester, 'גימטריה');
+      await tapMenuItem(tester, 'הסתר מהממשק');
+
+      final event = settingsBloc.recorded
+          .whereType<UpdateHiddenBuiltInToolIds>()
+          .single;
+      expect(event.hiddenBuiltInToolIds, contains('builtin.gematria'));
+    });
+
+    testWidgets('"הצמד לסרגל הניווט" על כלי מובנה מעדכן את ההגדרה', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMenu(tester, 'גימטריה');
+      await tapMenuItem(tester, 'הצמד לסרגל הניווט');
+
+      final event = settingsBloc.recorded
+          .whereType<UpdateBuiltInToolsPinnedToNavRail>()
+          .single;
+      expect(event.builtInToolsPinnedToNavRail, {'builtin.gematria'});
+    });
+
+    testWidgets('"הזז קדימה" על תוסף משגר סידור תוספים', (tester) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'תוסף א');
+      await tapMenuItem(tester, 'הזז קדימה');
+
+      final event = pluginSystemBloc.recorded
+          .whereType<ReorderPluginsRequested>()
+          .single;
+      expect(event.orderedPluginIds, ['com.example.b', 'com.example.a']);
+    });
+
+    testWidgets('הסתרת תוסף משגרת SetPluginShowInToolsRequested', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMenu(tester, 'תוסף א');
+      await tapMenuItem(tester, 'הסתר מהממשק');
+
+      final event = pluginSystemBloc.recorded
+          .whereType<SetPluginShowInToolsRequested>()
+          .single;
+      expect(event.pluginId, 'com.example.a');
+      expect(event.showInTools, isFalse);
+    });
+
+    // ── גרירה לסידור ────────────────────────────────────────────────────────
+
+    /// לחיצה, גרירה ועזיבה. [beforeTarget] קובע לאיזה חצי של קוביית היעד
+    /// מגיעים — בכיוון RTL החצי הימני מציב לפניה והשמאלי אחריה.
+    Future<TestGesture> dragTileTo(
+      WidgetTester tester,
+      String from,
+      String to, {
+      required bool beforeTarget,
+      bool release = true,
+    }) async {
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text(from)),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+      final target = tester.getRect(
+        find.ancestor(of: find.text(to), matching: find.byType(ToolTile)),
+      );
+      final dx = beforeTarget ? target.width / 4 : -target.width / 4;
+      await gesture.moveTo(target.center + Offset(dx, 0));
+      await tester.pump();
+      if (release) {
+        await gesture.up();
+        await tester.pumpAndSettle();
+      }
+      return gesture;
+    }
+
+    testWidgets('גרירה לחצי הימני של היעד מציבה לפניו', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(tester, 'ראשי תיבות', 'גימטריה', beforeTarget: true);
+
+        final order = settingsBloc.recorded
+            .whereType<UpdateBuiltInToolsOrder>()
+            .single
+            .builtInToolsOrder;
+        expect(
+          order.indexOf('builtin.acronyms_dictionary'),
+          order.indexOf('builtin.gematria') - 1,
+        );
+      });
+    });
+
+    testWidgets('גרירה לחצי השמאלי של היעד מציבה אחריו', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(tester, 'לוח שנה', 'גימטריה', beforeTarget: false);
+
+        final order = settingsBloc.recorded
+            .whereType<UpdateBuiltInToolsOrder>()
+            .single
+            .builtInToolsOrder;
+        expect(
+          order.indexOf('builtin.calendar'),
+          order.indexOf('builtin.gematria') + 1,
+        );
+        expect(order.first, 'builtin.shamor_zachor');
+      });
+    });
+
+    // קו ההוספה הוא החיווי שהמשתמש רואה — היכן הקובייה תיפול.
+    testWidgets('בגרירה מוצג קו הוספה אחד בצד שאליו תיפול הקובייה', (
+      tester,
+    ) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        final gesture = await dragTileTo(
+          tester,
+          'לוח שנה',
+          'גימטריה',
+          beforeTarget: true,
+          release: false,
+        );
+
+        expect(find.byKey(kToolDropIndicatorKey), findsOneWidget);
+        final line = tester.getRect(find.byKey(kToolDropIndicatorKey));
+        final target = tester.getRect(
+          find.ancestor(
+            of: find.text('גימטריה'),
+            matching: find.byType(ToolTile),
+          ),
+        );
+        expect(
+          line.center.dx,
+          greaterThan(target.center.dx),
+          reason: 'ב-RTL "לפני" הוא הקצה הימני של קובייית היעד',
+        );
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+      });
+    });
+
+    testWidgets('בלי גרירה אין קו הוספה', (tester) async {
+      await pumpPanel(tester);
+      expect(find.byKey(kToolDropIndicatorKey), findsNothing);
+    });
+
+    testWidgets('גרירה למרחק גדול מגיעה למקום בפעולה אחת', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(
+          tester,
+          'לוח שנה',
+          'ראשי תיבות',
+          beforeTarget: false,
+        );
+
+        final order = settingsBloc.recorded
+            .whereType<UpdateBuiltInToolsOrder>()
+            .single
+            .builtInToolsOrder;
+        expect(order.last, 'builtin.calendar');
+      });
+    });
+
+    testWidgets('גרירת תוסף על תוסף מסדרת את התוספים', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(tester, 'תוסף א', 'תוסף ב', beforeTarget: false);
+
+        expect(
+          pluginSystemBloc.recorded
+              .whereType<ReorderPluginsRequested>()
+              .single
+              .orderedPluginIds,
+          ['com.example.b', 'com.example.a'],
+        );
+      });
+    });
+
+    testWidgets('גרירת כלי מובנה על תוסף אינה מסדרת דבר', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(tester, 'לוח שנה', 'תוסף א', beforeTarget: true);
+
+        expect(
+          settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
+          isEmpty,
+        );
+        expect(
+          pluginSystemBloc.recorded.whereType<ReorderPluginsRequested>(),
+          isEmpty,
+        );
+        expect(find.byKey(kToolDropIndicatorKey), findsNothing);
+      });
+    });
+
+    testWidgets('גרירה אינה פותחת את הכלי', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+        await dragTileTo(tester, 'לוח שנה', 'גימטריה', beforeTarget: false);
+        expect(selected, isEmpty);
+      });
+    });
+
+    // בחיפוש הקוביות מסוננות, ולכן "השכן" על המסך אינו השכן האמיתי בסדר.
+    testWidgets('בחיפוש פעיל הסידור מושבת', (tester) async {
+      await pumpPanel(tester);
+      await tester.enterText(find.byType(TextField), 'ו');
+      await tester.pump();
+
+      expect(find.byType(Draggable<ToolCatalogEntry>), findsNothing);
+      expect(find.byType(LongPressDraggable<ToolCatalogEntry>), findsNothing);
+
+      await openMenu(tester, 'לוח שנה');
+      expect(_menuItemEnabled(tester, 'הזזה'), isFalse);
+    });
+
+    testWidgets('סידור מחדש אינו זורק וממשיך להציג את כל הכלים', (
+      tester,
+    ) async {
+      await pumpPanel(tester);
+      await openMoveSubmenu(tester, 'לוח שנה');
+      await tapMenuItem(tester, 'הזז קדימה');
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byType(ToolTile),
+        findsNWidgets(kBuiltInToolsCatalog.length + 2),
+      );
+    });
+  });
+
+  group('canReorderBetween', () {
+    final builtInA = _entry('builtin.calendar', 'לוח שנה');
+    final builtInB = _entry('builtin.gematria', 'גימטריה');
+    final pluginA = _pluginEntry('com.example.a', 'תוסף א');
+    final pluginB = _pluginEntry('com.example.b', 'תוסף ב');
+    final leadingPlugin = _pluginEntry(
+      'com.example.lead',
+      'תוסף מקדים',
+      allowOrderBeforeBuiltIns: true,
+    );
+
+    test('שני כלים מובנים — מותר', () {
+      expect(canReorderBetween(builtInA, builtInB), isTrue);
+    });
+
+    test('שני תוספים באותה קבוצה — מותר', () {
+      expect(canReorderBetween(pluginA, pluginB), isTrue);
+    });
+
+    test('כלי מובנה ותוסף — אסור', () {
+      expect(canReorderBetween(builtInA, pluginA), isFalse);
+      expect(canReorderBetween(pluginA, builtInA), isFalse);
+    });
+
+    test('תוסף מקדים ותוסף רגיל בקבוצות שונות — אסור', () {
+      expect(canReorderBetween(leadingPlugin, pluginA), isFalse);
+    });
+
+    test('אותה רשומה — אסור', () {
+      expect(canReorderBetween(builtInA, builtInA), isFalse);
     });
   });
 }
@@ -693,6 +1550,44 @@ class _ToolsLauncherOverlayHarnessState
       ],
     );
   }
+}
+
+/// בלוק הגדרות שמתעד את האירועים שנשלחו אליו, בלי לשמור לדיסק.
+class _RecordingSettingsBloc extends Bloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {
+  _RecordingSettingsBloc(super.initialState) {
+    on<SettingsEvent>((event, emit) {});
+  }
+
+  final List<SettingsEvent> recorded = [];
+
+  @override
+  void add(SettingsEvent event) {
+    recorded.add(event);
+    super.add(event);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingPluginSystemBloc
+    extends Bloc<PluginSystemEvent, PluginSystemState>
+    implements PluginSystemBloc {
+  _RecordingPluginSystemBloc(super.initialState) {
+    on<PluginSystemEvent>((event, emit) {});
+  }
+
+  final List<PluginSystemEvent> recorded = [];
+
+  @override
+  void add(PluginSystemEvent event) {
+    recorded.add(event);
+    super.add(event);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>

--- a/test/unit/mocks/mock_settings_repository.mocks.dart
+++ b/test/unit/mocks/mock_settings_repository.mocks.dart
@@ -623,6 +623,18 @@ class MockSettingsRepository extends _i1.Mock
           as _i3.Future<void>);
 
   @override
+  _i3.Future<void> updateBuiltInToolsOrder(List<String>? value) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #updateBuiltInToolsOrder,
+              [value],
+            ),
+            returnValue: _i3.Future<void>.value(),
+            returnValueForMissingStub: _i3.Future<void>.value(),
+          )
+          as _i3.Future<void>);
+
+  @override
   _i3.Future<void> updateProtectedModeEnabled(bool? value) =>
       (super.noSuchMethod(
             Invocation.method(

--- a/test/utils/page_converter_cache_test.dart
+++ b/test/utils/page_converter_cache_test.dart
@@ -181,9 +181,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tempDir;
+  late Map<String, List<PdfOutlineNode>> outlinesByPath;
 
   setUp(() async {
     await Settings.init(cacheProvider: MemorySettingsCache());
+    outlinesByPath = {};
+    pdfAnchorsReaderForTesting = (pdfPath) async {
+      final outline = outlinesByPath[pdfPath];
+      if (outline == null) throw FileSystemException('PDF not found', pdfPath);
+      return collectPdfAnchors(outline);
+    };
     tempDir = await Directory.systemTemp.createTemp('page_converter_cache');
     final dbDir = Directory(p.join(tempDir.path, 'databases'));
     await dbDir.create(recursive: true);
@@ -206,7 +213,21 @@ void main() {
     addTearDown(() => AppPaths.debugOverrideDataRootPath(previousDataRoot));
     addTearDown(() => CacheDatabaseHolder.instance.close());
     addTearDown(() => LibraryProviderManager.instance.resetForTesting());
+    addTearDown(() => pdfAnchorsReaderForTesting = null);
   });
+
+  Future<void> writePdf(
+    String pdfPath, {
+    required List<({String title, int page})> bookmarks,
+  }) async {
+    outlinesByPath[pdfPath] = [
+      for (final bookmark in bookmarks)
+        _outlineNode(bookmark.title, bookmark.page),
+    ];
+    await File(pdfPath).writeAsBytes(
+      buildMinimalPdf(pageCount: 3, bookmarks: bookmarks),
+    );
+  }
 
   /// ספרייה עם מהדורת PDF אחת ומהדורות טקסט לפי [textTitles], וספק
   /// תוכן-עניינים רשום — בלעדיו `TextBook.tableOfContents` מחזיר רשימה ריקה.
@@ -352,9 +373,7 @@ void main() {
   group('מטמון העוגנים המתמיד (cache.db)', () {
     test('PDF עם סימניות — הרשומה נשמרת וההמרה מצליחה', () async {
       final pdfPath = p.join(tempDir.path, 'with-outline.pdf');
-      await File(pdfPath).writeAsBytes(
-        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
-      );
+      await writePdf(pdfPath, bookmarks: _pdfBookmarks);
       final books = seedLibrary(
         textTitles: const ['סוכה-מלא'],
         pdfPath: pdfPath,
@@ -374,9 +393,7 @@ void main() {
         // שתי כותרות טקסט מול אותו PDF: מפתח מפת-העמודים שונה, ולכן הקריאה
         // השנייה חוזרת למטמון המתמיד במקום להתקצר במטמון שבזיכרון.
         final pdfPath = p.join(tempDir.path, 'reused.pdf');
-        await File(pdfPath).writeAsBytes(
-          buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
-        );
+        await writePdf(pdfPath, bookmarks: _pdfBookmarks);
         final books = seedLibrary(
           textTitles: const ['יומא-א', 'יומא-ב'],
           pdfPath: pdfPath,
@@ -409,11 +426,9 @@ void main() {
     test('החלפת הקובץ פוסלת את הרשומה ומרעננת את העוגנים', () async {
       final pdfPath = p.join(tempDir.path, 'replaced.pdf');
       final file = File(pdfPath);
-      await file.writeAsBytes(
-        buildMinimalPdf(
-          pageCount: 3,
-          bookmarks: const [(title: 'דף ב.', page: 1)],
-        ),
+      await writePdf(
+        pdfPath,
+        bookmarks: const [(title: 'דף ב.', page: 1)],
       );
       final books = seedLibrary(
         textTitles: const ['נדרים-א', 'נדרים-ב'],
@@ -424,9 +439,7 @@ void main() {
       final before = await waitFor(() => anchorRow(pdfPath));
       expect(before!.decodeAnchors(), hasLength(1));
 
-      await file.writeAsBytes(
-        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
-      );
+      await writePdf(pdfPath, bookmarks: _pdfBookmarks);
 
       expect(await textToPdfPage(books.texts[1], 20, pdfBook: books.pdf), 2);
       final after = await waitFor(() async {
@@ -440,9 +453,7 @@ void main() {
     test('outline ריק מהטאב — הסימניות נקראות מהקובץ', () async {
       // ה-outline של הטאב נטען ברקע; לחיצה לפני שהגיע חייבת ליפול לקובץ.
       final pdfPath = p.join(tempDir.path, 'tab-outline-empty.pdf');
-      await File(pdfPath).writeAsBytes(
-        buildMinimalPdf(pageCount: 3, bookmarks: _pdfBookmarks),
-      );
+      await writePdf(pdfPath, bookmarks: _pdfBookmarks);
       final books = seedLibrary(
         textTitles: const ['גיטין-רקע'],
         pdfPath: pdfPath,


### PR DESCRIPTION
## מה בפנים

חזרת הפעולות שאבדו במעבר למשגר הקוביות, ותיקון ארבעה דברים שהציקו בו.

### תפריט פעולות לכל קובייה
כפתור ⋯ בפינה הימנית-עליונה של כל קובייה, עם כל מה שהיה בפאנל התוספים הקודם:
ניהול הרשאות, הצמדה/הסרה מסרגל הניווט, הסתרה מהממשק, השבתה, ומחיקת תוסף.
פעולות ההזזה מרוכזות בתת-תפריט "הזזה" (אחורה / קדימה / לתחילה / לסוף).

### סידור מחדש בלחיצה-גרירה-עזיבה
גוררים קובייה, וקו הוספה נצבע בקצה קוביית היעד לפי חצי הקובייה שהסמן נמצא בו —
כמו סידור לשוניות בדפדפן. סידור בין קבוצות חסום (כלי מובנה מול תוסף, ותוסף
שהורשה להקדים כלים מובנים מול תוסף רגיל), ובחיפוש פעיל הסידור מושבת כי הקוביות
מסוננות ו"השכן" שעל המסך אינו השכן האמיתי בסדר.

סדר הכלים המובנים נשמר בהגדרות (`key-builtin-tools-order`) ומשפיע גם על סדר
הכלים המוצמדים בסרגל הניווט. הבסיס הוא שדה `order` של הקטלוג, וכלי מובנה חדש
שאינו בסדר השמור נספח בסוף — כך שאף כלי אינו נעלם.

### תיקונים
- **הכלי הראשון נראה תמיד "נבחר"** — סימון המקלדת התחיל באינדקס 0. כעת אין סימון
  עד החץ הראשון; בחיפוש מסומנת התוצאה הראשונה, זו ש-Enter פותח.
- **פס הגלילה** של הרשת מוצמד לימין עם מרווח שמור, ואינו מצטייר על הקוביות.
- **טולטיפ הריחוף** על הקובייה הוסר — התווית כתובה בקובייה עצמה.
- **פאנל הכלים לא נסגר בניווט** — ה-scrim מכסה רק את אזור התוכן, ולכן לחיצה על
  "ספריה" השאירה אותו צף מעל המסך החדש. עכשיו כל מעבר מסך סוגר אותו, כולל
  מסלולים שאינם סרגל הניווט (קיצורי מקלדת, סימניות, קישור עמוק).

## בדיקות

`flutter analyze` נקי. נוספו 95 בדיקות למשגר, 25 לעזרי הסדר, ובדיקות לשכבת
ההגדרות ולסגירה בניווט:

```
flutter test test/tools/ test/settings/ test/navigation/ test/widgets/
05:25 +1522: All tests passed!
```

שתי בדיקות ב-`test/plugins/bridge/plugin_bridge_adapter_test.dart` (network.download)
נכשלות גם ב-`dev` נקי — לא קשורות לשינוי הזה.

🤖 Generated with [Claude Code](https://claude.com/claude-code)