### PR TITLE
תיקון: היפוך כפול של חצי הניווט בשורה שבראש תפריט ה-"..."

### DIFF
--- a/lib/widgets/navigation/responsive_action_bar.dart
+++ b/lib/widgets/navigation/responsive_action_bar.dart
@@ -3,7 +3,6 @@ import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/widgets/widgets_exports.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
-import 'package:otzaria/widgets/misc/rtl_icon.dart';
 
 /// מחשב כמה כפתורי פעולה ניתן להציג בסרגל הקריאה לפי רוחב המסך.
 ///
@@ -356,14 +355,6 @@ class _MenuIconActionRow extends StatelessWidget {
   /// מסתמך על סכום הגבהים כדי לבחור כיוון פתיחה.
   static const double rowHeight = _buttonSize + 8;
 
-  static Widget _buildIcon(IconData? icon) {
-    if (icon == FluentIcons.chevron_left_24_regular ||
-        icon == FluentIcons.chevron_right_24_regular) {
-      return RtlIcon(icon!, size: _iconSize);
-    }
-    return Icon(icon, size: _iconSize);
-  }
-
   @override
   Widget build(BuildContext context) {
     assert(
@@ -380,7 +371,7 @@ class _MenuIconActionRow extends StatelessWidget {
             IconButton(
               onPressed: action.onPressed,
               tooltip: action.tooltip,
-              icon: _buildIcon(action.icon),
+              icon: Icon(action.icon, size: _iconSize),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(
                 minWidth: _buttonSize,

--- a/test/widgets/responsive_action_bar_test.dart
+++ b/test/widgets/responsive_action_bar_test.dart
@@ -236,18 +236,18 @@ void main() {
       }
     });
 
-    testWidgets('חצי הקטע מתהפכים ב-RTL כמו בסרגל הרגיל', (tester) async {
+    testWidgets('חצי הניווט נשארים כמו בסרגל הרגיל — היפוך יחיד ב-RTL', (
+      tester,
+    ) async {
       await pumpBar(tester, menuHeaderActions: navActions(onPressed: (_) {}));
       await openMenu(tester);
 
-      expect(
-        glyphIcon(tester, 'הקטע הקודם'),
-        FluentIcons.chevron_right_24_regular,
-      );
-      expect(
-        glyphIcon(tester, 'הקטע הבא'),
-        FluentIcons.chevron_left_24_regular,
-      );
+      // לאייקוני Fluent יש matchTextDirection:true — Icon כבר מהפך אותם ב-RTL.
+      // החלפה נוספת ל-IconData הנגדי מהפכת פעמיים ומחזירה לכיוון LTR.
+      for (final entry in navIcons.entries) {
+        expect(glyphIcon(tester, entry.key), entry.value);
+        expect(entry.value.matchTextDirection, isTrue);
+      }
     });
 
     testWidgets('השורה מופיעה מעל שאר פריטי התפריט', (tester) async {


### PR DESCRIPTION
## הבעיה

בתצוגה מפוצלת, בתפריט ה-"..." שבראש סרגל הקריאה, שורת ארבעת כפתורי הניווט הוצגה עם חצים סותרים: "הדף/פרק הקודם" ו-"הדף/פרק הבא" הצביעו לכיוון הנכון ל-RTL, אבל "הקטע הקודם" ו-"הקטע הבא" הצביעו הפוך.

## שורש הבעיה

לכל אייקוני ה-Fluent הרלוונטיים (`chevron_left/right_24_regular`, `arrow_previous/next_24_filled`) מוגדר `matchTextDirection: true`, ולכן ווידג'ט `Icon` של Flutter כבר מהפך אותם גאומטרית ב-RTL.

`_MenuIconActionRow` עטף את שני החצים ב-`RtlIcon`, שמחליף אותם ל-`IconData` הנגדי — ואז `Icon` היפך גם אותו. **היפוך כפול = ללא היפוך**, כלומר הצ'יבררונים נשארו בכיוון LTR בעוד שני החצים האחרים (שלא עברו `RtlIcon`) הוצגו נכון.

הוכנס ב-`a9320f5df`.

## התיקון

הוסרה הפונקציה `_buildIcon` והאייקונים חוזרים ל-`Icon(action.icon, size: _iconSize)` — בדיוק כמו במסלול הסרגל הרגיל (`BarButton.icon` עם `flipInRtl: false`), שם התצוגה תמיד הייתה תקינה.

## בדיקות

הבדיקה `'חצי הקטע מתהפכים ב-RTL כמו בסרגל הרגיל'` קיבעה את ההתנהגות השגויה — הוחלפה בבדיקה שמאמתת שהאייקון נשאר ה-`IconData` המקורי ושכל אייקוני הניווט מסומנים `matchTextDirection`.

```
flutter test test/widgets/responsive_action_bar_test.dart test/widgets/reader_nav_center_test.dart
→ All tests passed! (28)

dart analyze lib/widgets/navigation/responsive_action_bar.dart test/widgets/responsive_action_bar_test.dart
→ No issues found!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
