### PR TITLE
תיקון 2 באגים

### DIFF
--- a/lib/core/messages/common_messages.dart
+++ b/lib/core/messages/common_messages.dart
@@ -43,6 +43,19 @@ abstract class CommonMessages {
   static String openedBookAtHeader(String bookTitle, String header) =>
       'פתח ספר: $bookTitle - $header';
 
+  static String openedBookAtPartialHeader(
+    String bookTitle,
+    String reachedHeader,
+    String missingHeader,
+  ) =>
+      'פתח ספר: $bookTitle - $reachedHeader. '
+      'הכותרת "$missingHeader" לא נמצאה';
+
+  static String navigatedToPartialHeader(
+    String reachedHeader,
+    String missingHeader,
+  ) => 'נווט ל: $reachedHeader. הכותרת "$missingHeader" לא נמצאה';
+
   static String cannotOpenBook(String bookTitle) =>
       'לא ניתן לפתוח את הספר: $bookTitle';
 

--- a/lib/utils/text/html_link_handler.dart
+++ b/lib/utils/text/html_link_handler.dart
@@ -343,16 +343,16 @@ class HtmlLinkHandler {
         }
       }
 
-      // הרמה שלא נמצאה בעץ עשויה להופיע בגוף הספר בלי תגית כותרת.
-      final fromContent = await _findHeaderInContent(
-        book,
-        hierarchical.missingSegment!,
-      );
-      if (fromContent != null) {
-        return HeaderPathResult(
-          index: fromContent,
-          reachedHeader: hierarchical.missingSegment,
-        );
+      // חיפוש בגוף הספר אינו יכול לשמור על ענף ההורה, ולכן הוא בטוח רק
+      // כשבקישור יש כותרת אחת.
+      if (segments.length == 1) {
+        final fromContent = await _findHeaderInContent(book, segments.single);
+        if (fromContent != null) {
+          return HeaderPathResult(
+            index: fromContent,
+            reachedHeader: segments.single,
+          );
+        }
       }
 
       return hierarchical;

--- a/lib/utils/text/html_link_handler.dart
+++ b/lib/utils/text/html_link_handler.dart
@@ -99,17 +99,24 @@ class HtmlLinkHandler {
     return title;
   }
 
+  /// מפצל את חלק הכותרות של הקישור לרמות, ומסיר רמות ריקות.
+  static List<String> _headerSegments(String raw) => [
+    for (final part in raw.split('#')) _safeDecode(part).trim(),
+  ]..removeWhere((segment) => segment.isEmpty);
+
   /// מטפל בלחיצה על קישור HTML
   ///
   /// הפונקציה מפרשת קישורים בפורמטים הבאים:
-  /// - book://שם_הסxxxxxxxxח ספר בתחילת הספר
+  /// - book://שם_הספר - פותח ספר בתחילתו
   /// - book://שם_הספר#כותרת - פותח ספר ומנווט לכותרת ספציפית
-  /// - #כותרת - מנווט לכותרת באותו ספר
+  /// - book://שם_הספר#כותרת#תת-כותרת#... - נתיב היררכי בעץ תוכן העניינים
+  /// - #כותרת (וכן #כותרת#תת-כותרת) - מנווט לכותרת באותו ספר
   /// - otzaria://inline-link?path={path}&index={index}&ref={ref} - קישור מבוסס תווים
   ///
   /// דוגמאות:
   /// - <a href="book://ברכות">ברכות</a>
   /// - <a href="book://ברכות#דף ב">ברכות דף ב</a>
+  /// - <a href="book://בית יוסף#אורח חיים#סימן א">בית יוסף או"ח סימן א</a>
   /// - <a href="#דף ג">דף ג</a>
   static Future<bool> handleLink(
     BuildContext context,
@@ -125,41 +132,23 @@ class HtmlLinkHandler {
 
       // בדיקה אם זה קישור פנימי לכותרת באותו ספר
       if (url.startsWith('#')) {
-        final headerName = _safeDecode(url.substring(1));
-        await _navigateToHeader(context, headerName);
+        await _navigateToHeader(context, _headerSegments(url.substring(1)));
         return true;
       }
 
       // בדיקה אם זה קישור לספר
       if (url.startsWith('book://')) {
         final bookUrl = url.substring(7); // הסרת "book://"
-
-        String bookTitle;
-        String? headerName;
-
-        // בדיקה אם יש כותרת ספציפית
-        if (bookUrl.contains('#')) {
-          final parts = bookUrl.split('#');
-          bookTitle = _safeDecode(parts[0]);
-
-          // טיפול במבנה תלמודי: ספר#דף#צד
-          if (parts.length >= 2) {
-            if (parts.length == 3) {
-              // מבנה מלא: ספר#דף#צד
-              headerName = _safeDecode('${parts[1]} ${parts[2]}');
-            } else {
-              // מבנה רגיל: ספר#כותרת
-              headerName = _safeDecode(parts[1]);
-            }
-          }
-        } else {
-          bookTitle = _safeDecode(bookUrl);
-        }
+        final separatorIndex = bookUrl.indexOf('#');
 
         await _openBookWithHeader(
           context,
-          bookTitle,
-          headerName,
+          _safeDecode(
+            separatorIndex < 0 ? bookUrl : bookUrl.substring(0, separatorIndex),
+          ),
+          separatorIndex < 0
+              ? const <String>[]
+              : _headerSegments(bookUrl.substring(separatorIndex + 1)),
           openBookCallback,
         );
         return true;
@@ -183,8 +172,9 @@ class HtmlLinkHandler {
   /// מנווט לכותרת באותו ספר הנוכחי
   static Future<void> _navigateToHeader(
     BuildContext context,
-    String headerName,
+    List<String> segments,
   ) async {
+    final headerName = segments.join(', ');
     try {
       // נקבל את הספר הנוכחי מה-BLoC
       final textBookBloc = context.read<TextBookBloc>();
@@ -197,26 +187,33 @@ class HtmlLinkHandler {
       // חיפוש הכותרת בתוכן הספציפי
       final viewportExtent =
           context.size?.height ?? MediaQuery.sizeOf(context).height;
-      final index = await _findHeaderIndex(state.book, headerName);
+      final resolved = await _findHeaderPath(state.book, segments);
 
-      if (index != null) {
+      if (resolved.index != null) {
         // ניווט לאינדקס שנמצא
         await scrollToSourceLine(
           scrollController: state.scrollController,
           scrollOffsetController: state.scrollOffsetController,
           positionsListener: state.positionsListener,
           segments: state.readingSegments,
-          lineIndex: index,
+          lineIndex: resolved.index!,
           viewportExtent: viewportExtent,
           duration: const Duration(milliseconds: 250),
           curve: Curves.ease,
         );
 
         if (context.mounted) {
-          UiSnack.show(CommonMessages.navigatedToHeader(headerName));
+          UiSnack.show(
+            resolved.missingSegment == null
+                ? CommonMessages.navigatedToHeader(headerName)
+                : CommonMessages.navigatedToPartialHeader(
+                    resolved.reachedHeader ?? headerName,
+                    resolved.missingSegment!,
+                  ),
+          );
         }
       } else {
-        throw Exception('לא נמצאה הכותרת: $headerName');
+        throw Exception('לא נמצאה הכותרת: ${resolved.missingSegment}');
       }
     } catch (e) {
       debugPrint('שגיאה בניווט לכותרת: $e');
@@ -227,11 +224,11 @@ class HtmlLinkHandler {
     }
   }
 
-  /// פותח ספר ומנווט לכותרת ספציפית (אם צוינה)
+  /// פותח ספר ומנווט לנתיב הכותרות שצוין (אם צוין)
   static Future<void> _openBookWithHeader(
     BuildContext context,
     String bookTitle,
-    String? headerName,
+    List<String> segments,
     Function(TextBookTab) openBookCallback,
   ) async {
     try {
@@ -266,27 +263,14 @@ class HtmlLinkHandler {
       }
 
       final book = foundBook;
-      int startIndex = 0;
-
-      // אם צוינה כותרת, נחפש את האינדקס שלה
-      if (headerName != null && headerName.isNotEmpty) {
-        final headerIndex = await _findHeaderIndex(book, headerName);
-        if (headerIndex != null) {
-          startIndex = headerIndex;
-        } else {
-          // אם לא נמצאה הכותרת, נציג אזהרה אבל עדיין נפתח את הספר
-          if (context.mounted) {
-            UiSnack.show(
-              CommonMessages.headerNotFoundOpeningStart(headerName, bookTitle),
-            );
-          }
-        }
-      }
+      final resolved = segments.isEmpty
+          ? const HeaderPathResult()
+          : await _findHeaderPath(book, segments);
 
       // פתיחת הספר
       final tab = TextBookTab(
         book: book,
-        index: startIndex,
+        index: resolved.index ?? 0,
         openLeftPane:
             (Settings.getValue<bool>('key-pin-sidebar') ?? false) ||
             (Settings.getValue<bool>('key-default-sidebar-open') ?? false),
@@ -294,8 +278,28 @@ class HtmlLinkHandler {
 
       openBookCallback(tab);
 
-      if (context.mounted && headerName != null && headerName.isNotEmpty) {
+      if (!context.mounted || segments.isEmpty) return;
+
+      // הודעה אחת בלבד, שמשקפת לאן הקישור הגיע בפועל: הצלחה מלאה, נחיתה על
+      // רמה חלקית, או כישלון שפתח את תחילת הספר.
+      final headerName = segments.join(', ');
+      if (resolved.missingSegment == null) {
         UiSnack.show(CommonMessages.openedBookAtHeader(bookTitle, headerName));
+      } else if (resolved.index != null) {
+        UiSnack.show(
+          CommonMessages.openedBookAtPartialHeader(
+            bookTitle,
+            resolved.reachedHeader ?? headerName,
+            resolved.missingSegment!,
+          ),
+        );
+      } else {
+        UiSnack.show(
+          CommonMessages.headerNotFoundOpeningStart(
+            resolved.missingSegment!,
+            bookTitle,
+          ),
+        );
       }
     } catch (e) {
       debugPrint('שגיאה בפתיחת ספר: $e');
@@ -306,63 +310,140 @@ class HtmlLinkHandler {
     }
   }
 
-  /// מחפש את האינדקס של כותרת בספר
-  static Future<int?> _findHeaderIndex(TextBook book, String headerName) async {
+  /// מפענח נתיב כותרות בספר.
+  ///
+  /// [segments] - רמות הכותרות לפי הסדר, למשל ['אורח חיים', 'סימן א'].
+  /// מחזיר [HeaderPathResult] עם האינדקס העמוק שנמצא והרמה הראשונה שלא נמצאה.
+  @visibleForTesting
+  static HeaderPathResult resolveHeaderPath(
+    List<TocEntry> roots,
+    List<String> segments,
+  ) => _resolveHeaderPath(roots, segments);
+
+  static Future<HeaderPathResult> _findHeaderPath(
+    TextBook book,
+    List<String> segments,
+  ) async {
+    if (segments.isEmpty) return const HeaderPathResult();
+
     try {
-      // קבלת תוכן הספציפי
       final tableOfContents = await book.tableOfContents;
+      final hierarchical = _resolveHeaderPath(tableOfContents, segments);
+      if (hierarchical.missingSegment == null) return hierarchical;
 
-      // חיפוש בתוכן העניינים - קודם חיפוש מדויק
-      for (final entry in tableOfContents) {
-        if (isHeaderMatch(entry.text, headerName)) {
-          return entry.index;
+      // תאימות לאחור: קישור בן שתי רמות שנכתב לפני התמיכה בנתיב היררכי התייחס
+      // לכותרת אחת שמורכבת משתיהן עם רווח (מבנה "דף ב" + "עמוד א" בגמרא).
+      if (segments.length == 2) {
+        final joined = segments.join(' ');
+        final legacyIndex =
+            _findSingleHeader(tableOfContents, joined) ??
+            await _findHeaderInContent(book, joined);
+        if (legacyIndex != null) {
+          return HeaderPathResult(index: legacyIndex, reachedHeader: joined);
         }
       }
 
-      // אם לא נמצא, ננסה לחפש רק לפי מספר הדף (בלי עמוד)
-      // זה עוזר כשהקישור כולל עמוד שלא קיים בתוכן העניינים
-      final pageOnlyMatch = _extractPageNumber(headerName);
-      if (pageOnlyMatch != null) {
-        for (final entry in tableOfContents) {
-          final entryPageMatch = _extractPageNumber(entry.text);
-          if (entryPageMatch != null && entryPageMatch == pageOnlyMatch) {
-            return entry.index;
-          }
-        }
+      // הרמה שלא נמצאה בעץ עשויה להופיע בגוף הספר בלי תגית כותרת.
+      final fromContent = await _findHeaderInContent(
+        book,
+        hierarchical.missingSegment!,
+      );
+      if (fromContent != null) {
+        return HeaderPathResult(
+          index: fromContent,
+          reachedHeader: hierarchical.missingSegment,
+        );
       }
 
-      // אם לא נמצא בתוכן העניינים, נחפש בתוכן הספר עצמו
-      final content = await book.text;
-      final lines = content.split('\n');
-
-      // חיפוש מדויק
-      for (int i = 0; i < lines.length; i++) {
-        final line = lines[i];
-        final cleanLine = line.replaceAll(RegExp(r'<[^>]*>'), '').trim();
-
-        if (isHeaderMatch(cleanLine, headerName)) {
-          return i;
-        }
-      }
-
-      // חיפוש לפי דף בלבד
-      if (pageOnlyMatch != null) {
-        for (int i = 0; i < lines.length; i++) {
-          final line = lines[i];
-          final cleanLine = line.replaceAll(RegExp(r'<[^>]*>'), '').trim();
-          final linePageMatch = _extractPageNumber(cleanLine);
-
-          if (linePageMatch != null && linePageMatch == pageOnlyMatch) {
-            return i;
-          }
-        }
-      }
-
-      return null;
+      return hierarchical;
     } catch (e) {
       debugPrint('שגיאה בחיפוש כותרת: $e');
-      return null;
+      return const HeaderPathResult();
     }
+  }
+
+  /// הולך במורד עץ תוכן העניינים לפי [segments], רמה אחר רמה.
+  static HeaderPathResult _resolveHeaderPath(
+    List<TocEntry> roots,
+    List<String> segments,
+  ) {
+    var candidates = roots;
+    int? deepestIndex;
+    String? reachedHeader;
+
+    for (final segment in segments) {
+      final match = _matchInSubtree(candidates, segment);
+      if (match == null) {
+        return HeaderPathResult(
+          index: deepestIndex,
+          reachedHeader: reachedHeader,
+          missingSegment: segment,
+        );
+      }
+      deepestIndex = match.index;
+      reachedHeader = match.text;
+      candidates = match.children;
+    }
+
+    return HeaderPathResult(index: deepestIndex, reachedHeader: reachedHeader);
+  }
+
+  /// מאתר כותרת בין [candidates], ואם אינה שם - בכל תת-העץ שמתחתיהם.
+  /// החיפוש בתת-העץ מאפשר לקישור לדלג על רמות ביניים שכותב הקישור לא הכיר,
+  /// וההתאמה המדויקת מבטיחה שלא יקפוץ לענף אחר.
+  static TocEntry? _matchInSubtree(List<TocEntry> candidates, String segment) {
+    for (final entry in candidates) {
+      if (isHeaderMatch(entry.text, segment)) return entry;
+    }
+    for (final entry in flattenToc(candidates)) {
+      if (isHeaderMatch(entry.text, segment)) return entry;
+    }
+    return null;
+  }
+
+  /// מחפש כותרת יחידה בכל עץ תוכן העניינים, כולל התאמה לפי מספר דף בלבד.
+  static int? _findSingleHeader(List<TocEntry> roots, String headerName) {
+    final entries = flattenToc(roots);
+    for (final entry in entries) {
+      if (isHeaderMatch(entry.text, headerName)) return entry.index;
+    }
+
+    // אם לא נמצא, ננסה לחפש רק לפי מספר הדף (בלי עמוד)
+    // זה עוזר כשהקישור כולל עמוד שלא קיים בתוכן העניינים
+    final pageOnlyMatch = _extractPageNumber(headerName);
+    if (pageOnlyMatch == null) return null;
+    for (final entry in entries) {
+      if (_extractPageNumber(entry.text) == pageOnlyMatch) return entry.index;
+    }
+    return null;
+  }
+
+  /// מחפש כותרת בשורות הספר עצמן, כשאינה מופיעה בתוכן העניינים.
+  static Future<int?> _findHeaderInContent(
+    TextBook book,
+    String headerName,
+  ) async {
+    final content = await book.text;
+    final lines = content.split('\n');
+    final tagPattern = RegExp(r'<[^>]*>');
+
+    for (int i = 0; i < lines.length; i++) {
+      if (isHeaderMatch(
+        lines[i].replaceAll(tagPattern, '').trim(),
+        headerName,
+      )) {
+        return i;
+      }
+    }
+
+    // חיפוש לפי דף בלבד
+    final pageOnlyMatch = _extractPageNumber(headerName);
+    if (pageOnlyMatch == null) return null;
+    for (int i = 0; i < lines.length; i++) {
+      final cleanLine = lines[i].replaceAll(tagPattern, '').trim();
+      if (_extractPageNumber(cleanLine) == pageOnlyMatch) return i;
+    }
+    return null;
   }
 
   /// מחלץ את מספר הדף מכותרת (למשל "דף כג א" -> "כג")
@@ -392,4 +473,17 @@ class HtmlLinkHandler {
     final cleanHeader = headerName.trim().replaceAll(RegExp(r'\s+'), '');
     return cleanText == cleanHeader;
   }
+}
+
+/// תוצאת פענוח נתיב כותרות בקישור.
+///
+/// [index] - שורת היעד שנמצאה (null כשאף רמה לא נמצאה).
+/// [reachedHeader] - טקסט הכותרת העמוקה שאליה הגענו.
+/// [missingSegment] - הרמה הראשונה שלא נמצאה; null כשכל הנתיב נמצא.
+class HeaderPathResult {
+  final int? index;
+  final String? reachedHeader;
+  final String? missingSegment;
+
+  const HeaderPathResult({this.index, this.reachedHeader, this.missingSegment});
 }

--- a/lib/utils/text/text_manipulation.dart
+++ b/lib/utils/text/text_manipulation.dart
@@ -1065,6 +1065,17 @@ String formatTextWithParentheses(String text) {
   int i = 0;
 
   while (i < text.length) {
+    // תגי HTML עוברים כמכלול - אחרת סוגריים בתוך attribute (למשל
+    // style="color:rgb(0,0,0)") נעטפים ב-<small> וההגדרה נהרסת.
+    if (text[i] == '<') {
+      final tagEnd = text.indexOf('>', i);
+      if (tagEnd != -1) {
+        result.write(text.substring(i, tagEnd + 1));
+        i = tagEnd + 1;
+        continue;
+      }
+    }
+
     if (text[i] == '(') {
       // מחפשים את הסוגר הסוגר המתאים
       int openCount = 1;
@@ -1073,6 +1084,13 @@ String formatTextWithParentheses(String text) {
 
       // בודקים אם יש סוגר פותח נוסף בפנים
       while (j < text.length && openCount > 0) {
+        if (text[j] == '<') {
+          final tagEnd = text.indexOf('>', j);
+          if (tagEnd != -1) {
+            j = tagEnd + 1;
+            continue;
+          }
+        }
         if (text[j] == '(') {
           if (innerOpenIndex == -1) {
             innerOpenIndex = j; // שומרים את המיקום של הסוגר הפנימי הראשון

--- a/lib/utils/text/text_manipulation.dart
+++ b/lib/utils/text/text_manipulation.dart
@@ -1068,7 +1068,7 @@ String formatTextWithParentheses(String text) {
     // תגי HTML עוברים כמכלול - אחרת סוגריים בתוך attribute (למשל
     // style="color:rgb(0,0,0)") נעטפים ב-<small> וההגדרה נהרסת.
     if (text[i] == '<') {
-      final tagEnd = text.indexOf('>', i);
+      final tagEnd = _htmlTagEnd(text, i);
       if (tagEnd != -1) {
         result.write(text.substring(i, tagEnd + 1));
         i = tagEnd + 1;
@@ -1085,7 +1085,7 @@ String formatTextWithParentheses(String text) {
       // בודקים אם יש סוגר פותח נוסף בפנים
       while (j < text.length && openCount > 0) {
         if (text[j] == '<') {
-          final tagEnd = text.indexOf('>', j);
+          final tagEnd = _htmlTagEnd(text, j);
           if (tagEnd != -1) {
             j = tagEnd + 1;
             continue;
@@ -1131,6 +1131,36 @@ String formatTextWithParentheses(String text) {
   }
 
   return result.toString();
+}
+
+int _htmlTagEnd(String text, int start) {
+  if (text.startsWith('<!--', start)) {
+    final commentEnd = text.indexOf('-->', start + 4);
+    return commentEnd == -1 ? -1 : commentEnd + 2;
+  }
+
+  if (start + 1 >= text.length) return -1;
+  final first = text[start + 1];
+  final firstCode = first.codeUnitAt(0);
+  final startsWithLetter =
+      (firstCode >= 65 && firstCode <= 90) ||
+      (firstCode >= 97 && firstCode <= 122);
+  if (!startsWithLetter && first != '!' && first != '/' && first != '?') {
+    return -1;
+  }
+
+  String? quote;
+  for (var i = start + 1; i < text.length; i++) {
+    final char = text[i];
+    if (quote != null) {
+      if (char == quote) quote = null;
+    } else if (char == '"' || char == "'") {
+      quote = char;
+    } else if (char == '>') {
+      return i;
+    }
+  }
+  return -1;
 }
 
 String replaceHolyNames(String s) {

--- a/test/utils/html_link_handler_test.dart
+++ b/test/utils/html_link_handler_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/utils/text/html_link_handler.dart';
+
+/// בונה עץ תוכן עניינים לפי מפרט מקונן: {טקסט: {טקסט-בן: ...}}.
+List<TocEntry> _buildToc(
+  Map<String, dynamic> spec, {
+  int level = 1,
+  TocEntry? parent,
+  List<int>? counter,
+}) {
+  final index = counter ?? [0];
+  final entries = <TocEntry>[];
+  for (final key in spec.keys) {
+    index[0]++;
+    final entry = TocEntry(
+      text: key,
+      index: index[0],
+      level: level,
+      parent: parent,
+    );
+    final children = spec[key];
+    if (children is Map<String, dynamic>) {
+      entry.children = _buildToc(
+        children,
+        level: level + 1,
+        parent: entry,
+        counter: index,
+      );
+    }
+    entries.add(entry);
+  }
+  return entries;
+}
+
+void main() {
+  group('isHeaderMatch', () {
+    test('התאמה מדויקת אחרי נרמול רווחים', () {
+      expect(HtmlLinkHandler.isHeaderMatch('סימן   א', 'סימן א'), isTrue);
+    });
+
+    test('אין התאמת substring', () {
+      expect(HtmlLinkHandler.isHeaderMatch('סימן א', 'סימן'), isFalse);
+    });
+  });
+
+  group('resolveHeaderPath', () {
+    final toc = _buildToc({
+      'אורח חיים': {
+        'סימן א': {'סעיף קטן יג': {}, 'סעיף קטן יד': {}},
+        'סימן ב': {},
+      },
+      'יורה דעה': {'סימן פט': {}},
+    });
+
+    test('רמה אחת - מחזיר את השורש', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, ['יורה דעה']);
+      expect(result.missingSegment, isNull);
+      expect(result.reachedHeader, 'יורה דעה');
+      expect(result.index, isNotNull);
+    });
+
+    test('נתיב בן שלוש רמות - מגיע לרמה העמוקה', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, [
+        'אורח חיים',
+        'סימן א',
+        'סעיף קטן יג',
+      ]);
+      expect(result.missingSegment, isNull);
+      expect(result.reachedHeader, 'סעיף קטן יג');
+    });
+
+    test('שתי רמות עמוקות נבדלות זו מזו', () {
+      final first = HtmlLinkHandler.resolveHeaderPath(toc, [
+        'אורח חיים',
+        'סימן א',
+        'סעיף קטן יג',
+      ]);
+      final second = HtmlLinkHandler.resolveHeaderPath(toc, [
+        'אורח חיים',
+        'סימן א',
+        'סעיף קטן יד',
+      ]);
+      expect(first.index, isNot(second.index));
+    });
+
+    test('רמה חסרה באמצע - מדלג עליה ומוצא בתת-העץ', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, [
+        'אורח חיים',
+        'סעיף קטן יג',
+      ]);
+      expect(result.missingSegment, isNull);
+      expect(result.reachedHeader, 'סעיף קטן יג');
+    });
+
+    test('רמה שאינה קיימת - מחזיר נחיתה חלקית ומדווח מה חסר', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, [
+        'אורח חיים',
+        'סימן א',
+        'סעיף קטן צט',
+      ]);
+      expect(result.missingSegment, 'סעיף קטן צט');
+      expect(result.reachedHeader, 'סימן א');
+      expect(result.index, isNotNull);
+    });
+
+    test('הרמה הראשונה אינה קיימת - אין אינדקס בכלל', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, ['חושן משפט']);
+      expect(result.missingSegment, 'חושן משפט');
+      expect(result.index, isNull);
+      expect(result.reachedHeader, isNull);
+    });
+
+    test('נתיב אינו קופץ לענף אחר - סימן פט אינו תחת אורח חיים', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, [
+        'אורח חיים',
+        'סימן פט',
+      ]);
+      expect(result.missingSegment, 'סימן פט');
+      expect(result.reachedHeader, 'אורח חיים');
+    });
+
+    test('נתיב ריק - אין תוצאה ואין כותרת חסרה', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, const []);
+      expect(result.index, isNull);
+      expect(result.missingSegment, isNull);
+    });
+
+    test('כותרת עמוקה שנכתבה כרמה אחת בלבד נמצאת', () {
+      final result = HtmlLinkHandler.resolveHeaderPath(toc, ['סימן ב']);
+      expect(result.missingSegment, isNull);
+      expect(result.reachedHeader, 'סימן ב');
+    });
+  });
+}

--- a/test/utils/text_manipulation_test.dart
+++ b/test/utils/text_manipulation_test.dart
@@ -992,6 +992,26 @@ Future<void> main() async {
       expect(formatTextWithParentheses(input), input);
     });
 
+    test('סוגריים בתג עם סוגר זוויתי במאפיין אינם נעטפים', () {
+      const input = '<span title="> (א)">טקסט</span>';
+      expect(formatTextWithParentheses(input), input);
+    });
+
+    test('סוגריים אחרי סימני השוואה אינם נחשבים תג HTML', () {
+      expect(
+        formatTextWithParentheses('א < (ב) > ג'),
+        'א < <small>(ב)</small> > ג',
+      );
+    });
+
+    test('סוגריים בתגובת HTML אינם נעטפים', () {
+      const input = '<!-- (הערה) --> אמר (רש"י)';
+      expect(
+        formatTextWithParentheses(input),
+        '<!-- (הערה) --> אמר <small>(רש"י)</small>',
+      );
+    });
+
     test('סוגריים בטקסט נעטפים גם כשלתג שעוטף אותם יש סוגריים ב-style', () {
       expect(
         formatTextWithParentheses(

--- a/test/utils/text_manipulation_test.dart
+++ b/test/utils/text_manipulation_test.dart
@@ -955,4 +955,69 @@ Future<void> main() async {
     },
     skip: engineReady ? false : searchEngineSkipReason,
   );
+
+  group('formatTextWithParentheses', () {
+    test('עוטף טקסט בסוגריים ב-small', () {
+      expect(
+        formatTextWithParentheses('אמר (רש"י) שם'),
+        'אמר <small>(רש"י)</small> שם',
+      );
+    });
+
+    test('סוגריים מקוננים - רק הפנימיים נעטפים', () {
+      expect(
+        formatTextWithParentheses('א (ב (ג) ד) ה'),
+        'א (ב <small>(ג)</small> ד) ה',
+      );
+    });
+
+    test('סוגר פותח בלי סוגר סוגר נשאר כפי שהוא', () {
+      expect(formatTextWithParentheses('אמר (רש"י שם'), 'אמר (רש"י שם');
+    });
+
+    test('סוגריים ב-style אינם נעטפים - rgb', () {
+      const input = '<span style="color:rgb(200,30,30);">אדום</span>';
+      expect(formatTextWithParentheses(input), input);
+    });
+
+    test('סוגריים ב-style אינם נעטפים - rgba ו-hsl', () {
+      const rgba = '<span style="background-color:rgba(255,0,0,0.2);">א</span>';
+      const hsl = '<span style="color:hsl(120,60%,35%);">ב</span>';
+      expect(formatTextWithParentheses(rgba), rgba);
+      expect(formatTextWithParentheses(hsl), hsl);
+    });
+
+    test('סוגריים ב-href אינם נעטפים', () {
+      const input = '<a href="otzaria://inline-link?ref=בראשית (א)">כאן</a>';
+      expect(formatTextWithParentheses(input), input);
+    });
+
+    test('סוגריים בטקסט נעטפים גם כשלתג שעוטף אותם יש סוגריים ב-style', () {
+      expect(
+        formatTextWithParentheses(
+          '<span style="color:rgb(1,2,3);">אמר (רש"י) שם</span>',
+        ),
+        '<span style="color:rgb(1,2,3);">אמר <small>(רש"י)</small> שם</span>',
+      );
+    });
+
+    test('תג בתוך הסוגריים אינו מפריע לזיהוי הסוגר הסוגר', () {
+      expect(
+        formatTextWithParentheses('(אמר <b>רש"י</b>) שם'),
+        '<small>(אמר <b>רש"י</b>)</small> שם',
+      );
+    });
+
+    test('סוגר סוגר שנמצא רק בתוך תג אינו נחשב סוגר', () {
+      const input = '(אמר <span style="color:rgb(1,2,3);">רש"י</span> שם';
+      expect(formatTextWithParentheses(input), input);
+    });
+
+    test('סימן קטן-מ בודד בלי תג אינו בולע את השורה', () {
+      expect(
+        formatTextWithParentheses('א < ב (ג) ד'),
+        'א < ב <small>(ג)</small> ד',
+      );
+    });
+  });
 }


### PR DESCRIPTION

תיקון באגים בהוספת תגי הקטנה ובהצגת קישורים לספרים אחרים כולל הודעות מפורטות

## קישורים:

לפני כן, שתי הסולמיות לא היו היררכיה, אלא **חיבור־ברווח** למחרוזת אחת. עכשיו זה עץ אמיתי:

`<a href="book://בית יוסף#אורח חיים#סימן א#סעיף קטן יג">שלוש רמות</a>`

בנוסף: לפני כן, כשהכותרת לא נמצאת, הקוד מציג אזהרה ומיד אחריה הודעת הצלחה שדוחקת אותה — לכן ראית "נפתח בסימן י" בזמן שנפתח בתחילת הספר.


זה מעניין: הקוד מטפל ב־2 סולמיות, אבל לא כהיררכיה. ב־[html_link_handler.dart:146-153](lib/utils/text/html_link_handler.dart#L146-L153):


```
if (parts.length == 3) {
  headerName = _safeDecode('${parts[1]} ${parts[2]}');   // ← מחבר ברווח!
} else {
  headerName = _safeDecode(parts[1]);                     // ← השאר נזרק
}

```
שתי הסולמיות **אינן** שתי רמות כותרת. הן מתחברות למחרוזת **אחת** עם רווח, ואז מחפשים כותרת שהטקסט שלה הוא בדיוק `"דף ב עמוד א"`. כלומר זה נועד לספרים שבהם הכותרת עצמה כתובה כך.

ולכן — כמו שאמרת — אם במאגר הכותרת היא `דף ב:` או `דף ב.`, המבנה הזה **מזיק ולא מועיל:** `book://ברכות#דף ב#עמוד א` יחפש `"דף ב עמוד א"` ולא ימצא כלום, בזמן ש־`book://ברכות#דף ב:` בסולמית אחת עובד. זה מסביר למה בפועל תמיד עבדה לך רק סולמית אחת.

המשמעות לתיקון: אין כאן תמיכה היררכית שצריך לשמר, אלא **מקרה קצה יחיד** (`חיבור-ברווח` לשתי מחרוזות) שצריך להשאיר כ־fallback לאחור, ומעליו לבנות את ההליכה האמיתית בעץ. זה בדיוק מה שהסוכן מתכנן כרגע — כולל השאלה מה לעשות כשרמה באמצע הנתיב לא נמצאת.


קישור עם כמה סולמיות — כן, יש הגבלה: סולמית אחת בלבד. [html_link_handler.dart:141](lib/utils/text/html_link_handler.dart#L1411) מטפל רק ב־`parts.length == 3` (מבנה גמרא), וכל אורך אחר נופל ל־`parts[1]` — השאר נזרק בשקט.

הבנתי במהלך הבדיקה שהחיפוש הקודם היה גרוע עוד יותר ממה שחשבתי — `book.tableOfContents` מחזיר **רק את שורשי העץ**, כך שכותרת מקוננת נמצאה עד היום רק בטעות, דרך ה־fallback שסורק את שורות הספר.

### מה שהתיקון עושה ([html_link_handler.dart](lib\utils\text\html_link_handler.dart)):

**הליכה בעץ** רמה אחר רמה. כל רמה נחפשת רק בתוך תת־העץ של קודמתה, כך שאין קפיצה לענף אחר בעל שם דומה.
**דילוג על רמות ביניים** — אם לא ציינת רמה, מחפש בכל תת־העץ שמתחת. ההתאמה המדויקת של `isHeaderMatch` מגנה מטעויות.
**תאימות לאחור** — אם ההליכה ההיררכית לא הצליחה במלואה ויש בדיוק שתי רמות, מנסה את הצורה הישנה (חיבור ברווח). כך קישורי גמרא קיימים לא נשברים.
**ההודעה השקרית תוקנה**. עכשיו יש הודעה אחת שמשקפת את המצב: הצלחה מלאה / נחיתה חלקית עם שם הרמה החסרה / כישלון מלא. שתי הודעות חדשות ב־`CommonMessages`.
11 טסטים חדשים ב־[test/utils/html_link_handler_test.dart](test/utils/html_link_handler_test.dart) — לא היו טסטים לקובץ הזה בכלל.

## תגי הקטנה שמוזרקים אוטומטית.

הערכים: **rgb/rgba/hsl לא עובדים** — זה באג באוצריא. `formatTextWithParentheses` ב־[text_manipulation.dart:1061](lib/utils/text/text_manipulation.dart#L1061) סורק את השורה כטקסט חופשי ועוטף כל סוגריים ב־`<small>` — כולל סוגריים בתוך `style`.

 מדדתי:
```
IN : <span style="color:rgb(200,30,30);">
OUT: <span style="color:rgb<small>(200,30,30)</small>;">
```


הפתרון היה כבר בקובץ עצמו: `removePunctuation` פותר את אותה בעיה בדיוק עם דגל `inTag`, ויש שם הערה שמסבירה את זה. יישמתי את אותו דפוס ב־[text_manipulation.dart:1067](lib/utils/text/text_manipulation.dart#L1067) — 18 שורות, כולל דילוג על תגים גם בסריקה הפנימית של הסוגר הסוגר.

10 טסטים חדשים ב־[text_manipulation_test.dart](test/utils/text_manipulation_test.dart), כולל: `rgb`/`rgba`/`hsl` ב־style, סוגריים ב־`href` (זה נשבר גם קודם), ומקרה מעורב — תג עם `rgb()` ב־style שעוטף טקסט בסוגריים שכן צריך להיעטף.