### PR TITLE
תוספים: פתיחת ספרים חיצוניים שנפתרו

### DIFF
--- a/docs/plugin-sdk/API_REFERENCE.md
+++ b/docs/plugin-sdk/API_REFERENCE.md
@@ -595,7 +595,7 @@ const { data } = await Otzaria.call('search.fullText', {
 נפתחות בטאב.
 
 ```javascript
-const { data } = await Otzaria.call('search.query', {
+const chunks = Otzaria.call('search.query', {
   query: 'ואהבת לרעך',
   mode: 'advanced',       // 'exact' (ברירת מחדל) | 'advanced' | 'fuzzy'
   distance: 2,            // מרווח מילים מותר במצב מתקדם/מקורב
@@ -606,6 +606,11 @@ const { data } = await Otzaria.call('search.query', {
   options: { 'קידומות דקדוקיות': true },
   includeBookCounts: true
 });
+
+for await (const chunk of chunks) {
+  appendResults(chunk.results);
+  updateTotal(chunk.total);
+}
 ```
 
 **פרמטרים**
@@ -643,10 +648,15 @@ const { data } = await Otzaria.call('search.query', {
 היקפים מאותו סוג מתחברים ב-OR; סוגים שונים מתחברים ב-AND (למשל `eras` + `categories`
 = ספרי אותה תקופה שבאותה קטגוריה).
 
-**פלט**
+**פלט — `AsyncIterable` של chunks**
+
+הקריאה אינה מחזירה `Promise` ואינה ממתינה לכל התוצאות. משתמשים ב־`for await`;
+הפסקת הלולאה (`break` או `return`) מבטלת את החיפוש בצד אוצריא. ה־chunk הראשון
+נושא את הספירות, והבאים נושאים עד 50 תוצאות כל אחד.
 
 ```javascript
 {
+  sequence: 0,
   results: [{
     id: 183, type: 'text', bookId: 'ויקרא', source: 'library',
     book: 'ויקרא', categoryPath: '/הלכה/משנה תורה',
@@ -657,7 +667,7 @@ const { data } = await Otzaria.call('search.query', {
     merged: [{ id, type, bookId, source, book, categoryPath, reference, index }]
                             // רק כשיש איחוד; לכל אח זהות וקטגוריה מלאות
   }],
-  total: 812,             // סך ההתאמות (לא רק העמוד הנוכחי)
+  total: 812,             // סך ההתאמות; זמין מה-chunk הראשון
   groupCount: null,       // מספר הקבוצות כש-grouping פעיל, אחרת null
   truncated: false,       // true = שאילתה רחבה מדי, התוצאות והספירה חלקיות
   limit: 100, offset: 0,
@@ -665,6 +675,10 @@ const { data } = await Otzaria.call('search.query', {
   bookCounts: [{ id, type, bookId, source, title, count }]  // רק עם includeBookCounts
 }
 ```
+
+אין לצבור את כל התוצאות לפני ציור המסך: יש להוסיף כל `results` מיד עם הגעת
+ה־chunk. אם החיפוש נכשל, האיטרטור זורק שגיאה; chunks שכבר התקבלו נשארים בידי
+התוסף.
 
 **מפתחות פר-מילה** — `wordOptions`, `alternativeWords` ו-`customSpacing` נבדקים
 מול פיצול המילים של השאילתה: מפתח `"{מילה}_{אינדקס}"` שאינו תואם, אינדקס מחוץ

--- a/docs/plugin-sdk/API_REFERENCE.md
+++ b/docs/plugin-sdk/API_REFERENCE.md
@@ -497,7 +497,8 @@ const { data } = await Otzaria.call('library.getBookAltToc', {
 (במיוחד `POST`) יש להשתמש בו ולא ב-`fetch()` ישיר.
 
 פרמטרים: `url` (חובה), `method` (ברירת מחדל `GET`), `headers` (אובייקט,
-אופציונלי), `body` (מחרוזת, אופציונלי).
+אופציונלי), `body` (מחרוזת, אופציונלי), `timeoutMs` (מספר שלם חיובי;
+ברירת מחדל 30,000 ומקסימום 120,000 מילישניות).
 
 ```javascript
 // GET פשוט
@@ -511,7 +512,8 @@ const res = await Otzaria.call('network.fetch', {
   url: 'https://api.example.com/endpoint',
   method: 'POST',
   headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-  body: JSON.stringify({ key: 'value' })
+  body: JSON.stringify({ key: 'value' }),
+  timeoutMs: 120000
 });
 if (res.success && res.data.ok) {
   const parsed = JSON.parse(res.data.body);

--- a/docs/plugin-sdk/README.md
+++ b/docs/plugin-sdk/README.md
@@ -307,7 +307,7 @@ Otzaria.on('plugin.suspended', stop);   // עצירת timers / polling / WebSock
 | Method | הרשאה | פרמטרים | החזרה |
 |--------|-------|----------|-------|
 | `search.fullText` | `search.fulltext.read` | `{ query, limit? }` | `SearchResult[]` |
-| `search.query` | `search.fulltext.read` | `{ query, mode?, distance?, proximityScope?, order?, grouping?, wordMatchMode?, options?, wordOptions?, alternativeWords?, customSpacing?, negativeQuery?, categories?, books?, authors?, eras?, baseBooksOnly?, limit?, offset?, includeBookCounts? }` | `{ results, total, groupCount, truncated, facets, bookCounts? }` |
+| `search.query` | `search.fulltext.read` | `{ query, mode?, distance?, proximityScope?, order?, grouping?, wordMatchMode?, options?, wordOptions?, alternativeWords?, customSpacing?, negativeQuery?, categories?, books?, authors?, eras?, baseBooksOnly?, limit?, offset?, includeBookCounts? }` | `AsyncIterable<{ sequence, results, total, groupCount, truncated, facets, bookCounts? }>` |
 | `search.getOptions` | `search.fulltext.read` | `{}` | הערכים החוקיים לכל פרמטר של `search.query` |
 
 ב-`search.query`, גודל עמוד מוגבל ל-500 וחלון הדפדוף (`offset + limit`

--- a/docs/plugin-sdk/otzaria_plugin.d.ts
+++ b/docs/plugin-sdk/otzaria_plugin.d.ts
@@ -46,7 +46,7 @@
 // Shared types
 // ---------------------------------------------------------------------------
 
-/** Response envelope returned by every `Otzaria.call()` invocation. */
+/** Response envelope returned by non-streaming `Otzaria.call()` invocations. */
 export interface OtzariaResponse<T = unknown> {
   success: boolean;
   data: T | null;
@@ -239,9 +239,12 @@ export interface SearchQueryHit extends BookIdentity {
   >;
 }
 
-export interface SearchQueryResponse {
+export interface SearchQueryChunk {
+  /** מספר ה-chunk, החל מ-0. */
+  sequence: number;
   results: SearchQueryHit[];
-  total: number;
+  /** זמין מה-chunk הראשון; null רק אם המנוע טרם החזיר ספירה. */
+  total: number | null;
   groupCount: number | null;
   /** `true` = שאילתה רחבה מדי; התוצאות והספירה חלקיות. */
   truncated: boolean;
@@ -1082,6 +1085,12 @@ export type OtzariaMethod =
 // ---------------------------------------------------------------------------
 
 export interface OtzariaGlobal {
+  /** חיפוש מלא שמזרים chunks ככל שהם מתקבלים מהמנוע. */
+  call(
+    method: 'search.query',
+    payload: SearchQueryParams
+  ): AsyncIterable<SearchQueryChunk>;
+
   /**
    * Call a Host API method.
    *

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:file_picker/file_picker.dart';
@@ -26,7 +27,7 @@ import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/search/search_repository.dart';
 import 'package:otzaria/plugins/bridge/plugin_search_api.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart'
-    show SearchResult;
+    show SearchStreamUpdate;
 import 'package:otzaria/utils/navigation/book_open_coordinator.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
@@ -344,6 +345,12 @@ class PluginBridgeDependencies {
   });
 }
 
+typedef PluginRpcEventSink =
+    Future<void> Function(
+      String topic,
+      Map<String, dynamic> payload,
+    );
+
 // ===================================================================
 // Bridge Adapter - strict 1:1 with plugin_system_plan.md
 // ===================================================================
@@ -420,8 +427,29 @@ class PluginBridgeAdapter {
   Map<int, List<Book>> _booksById = const {};
   Map<String, List<Book>> _booksByTitle = const {};
   Map<String, Book> _booksByIndexedPath = const {};
+  final Map<String, Future<void> Function()> _activeSearchStreams = {};
+  final Set<String> _pendingSearchCancellations = {};
+
+  static const _searchStreamEvent = '__otzaria.search.query.chunk';
+  static const _streamIdKey = '__streamId';
+  static const _cancelStreamIdKey = '__cancelStreamId';
+  static const _maxConcurrentSearchStreams = 4;
+  static const _maxSearchDuration = Duration(minutes: 2);
+  static const _searchIdleTimeout = Duration(seconds: 30);
+  static final _streamIdPattern = RegExp(r'^[A-Za-z0-9_-]{1,64}$');
+
+  static bool isSearchCancellationPayload(Map<String, dynamic> args) {
+    if (args.length != 1) return false;
+    final streamId = args[_cancelStreamIdKey];
+    return streamId is String && _streamIdPattern.hasMatch(streamId);
+  }
 
   void dispose() {
+    for (final cancel in _activeSearchStreams.values) {
+      unawaited(cancel());
+    }
+    _activeSearchStreams.clear();
+    _pendingSearchCancellations.clear();
     _networkFetchService?.dispose();
     _fileDownloadService?.dispose();
     _bookIndexLibrary = null;
@@ -471,15 +499,16 @@ class PluginBridgeAdapter {
   Future<dynamic> execute(
     String domain,
     String action,
-    Map<String, dynamic> args,
-  ) async {
+    Map<String, dynamic> args, {
+    PluginRpcEventSink? eventSink,
+  }) async {
     switch (domain) {
       case 'app':
         return await _handleApp(action, args);
       case 'library':
         return await _handleLibrary(action, args);
       case 'search':
-        return await _handleSearch(action, args);
+        return await _handleSearch(action, args, eventSink: eventSink);
       case 'reader':
         return await _handleReader(action, args);
       case 'navigation':
@@ -927,8 +956,9 @@ class PluginBridgeAdapter {
   // ----------------------------------------------------------------
   Future<dynamic> _handleSearch(
     String action,
-    Map<String, dynamic> args,
-  ) async {
+    Map<String, dynamic> args, {
+    PluginRpcEventSink? eventSink,
+  }) async {
     switch (action) {
       case 'fullText':
         final query = args['query'] as String?;
@@ -952,123 +982,158 @@ class PluginBridgeAdapter {
       case 'getOptions':
         return PluginSearchApi.describeOptions();
       case 'query':
-        return await _runPluginSearch(args);
+        if (args[_cancelStreamIdKey] case final String streamId) {
+          return _cancelPluginSearch(streamId);
+        }
+        return await _runPluginSearch(args, eventSink: eventSink);
       default:
         throw Exception("Unknown action in search: $action");
     }
   }
 
-  /// מריץ את `search.query` באותו מסלול מנוע של מסך החיפוש. ספירות לפי
-  /// ספר נאספות רק כשהתוסף מבקש אותן.
+  /// מזרים את `search.query` באותו מסלול chunks של מסך החיפוש.
   Future<Map<String, dynamic>> _runPluginSearch(
-    Map<String, dynamic> args,
-  ) async {
-    final request = PluginSearchRequest.fromArgs(args)..validateAgainstQuery();
+    Map<String, dynamic> args, {
+    required PluginRpcEventSink? eventSink,
+  }) async {
+    final streamId = args[_streamIdKey];
+    if (streamId is! String || !_streamIdPattern.hasMatch(streamId)) {
+      throw Exception('error.invalid_params: invalid internal stream id');
+    }
+    if (eventSink == null) {
+      throw Exception('error.internal: search stream transport unavailable');
+    }
+    if (_pendingSearchCancellations.remove(streamId)) {
+      return {'completed': false, 'cancelled': true};
+    }
+    if (_activeSearchStreams.containsKey(streamId)) {
+      throw Exception('error.invalid_params: duplicate search stream id');
+    }
+    if (_activeSearchStreams.length >= _maxConcurrentSearchStreams) {
+      throw Exception('error.rate_limited: too many active search streams');
+    }
+
+    final publicArgs = Map<String, dynamic>.of(args)..remove(_streamIdKey);
+    final request = PluginSearchRequest.fromArgs(publicArgs)
+      ..validateAgainstQuery();
     final library = await DataRepository.instance.library;
     final facets = PluginSearchApi.resolveFacets(
-      args,
+      publicArgs,
       findBook: (identity) => _findPluginBook(library, identity),
     );
+    final stream = _dependencies.searchRepository.searchTextsStreamWithCounts(
+      request.sanitizedQuery,
+      facets,
+      request.limit,
+      offset: request.offset,
+      chunkSize: 50,
+      order: request.order,
+      searchMode: request.searchMode,
+      distance: request.distance,
+      negativeQuery: request.sanitizedNegativeQuery,
+      negativeDistance: request.negativeDistance,
+      scope: request.proximityScope,
+      negativeScope: request.negativeProximityScope,
+      customSpacing: request.effectiveCustomSpacing,
+      negativeCustomSpacing: request.effectiveNegativeCustomSpacing,
+      alternativeWords: request.effectiveAlternativeWords,
+      negativeAlternativeWords: request.effectiveNegativeAlternativeWords,
+      searchOptions: request.effectiveSearchOptions,
+      negativeSearchOptions: request.effectiveNegativeSearchOptions,
+      grouping: request.grouping,
+      wordMatchMode: request.wordMatchMode,
+      wordMatchCount: request.wordMatchCount,
+    );
+    final iterator = StreamIterator<SearchStreamUpdate>(stream);
+    var cancelled = false;
+    var expired = false;
+    Future<void> cancel() async {
+      cancelled = true;
+      await iterator.cancel();
+    }
 
-    final results = <SearchResult>[];
+    if (_pendingSearchCancellations.remove(streamId)) {
+      await iterator.cancel();
+      return {'completed': false, 'cancelled': true};
+    }
+    _activeSearchStreams[streamId] = cancel;
+    final deadline = Timer(_maxSearchDuration, () {
+      expired = true;
+      unawaited(cancel());
+    });
+    var sequence = 0;
     int? totalCount;
     int? groupCount;
     var truncated = false;
-    Map<String, int>? bookCounts;
-
-    if (request.includeBookCounts) {
-      final stream = _dependencies.searchRepository.searchTextsStreamWithCounts(
-        request.sanitizedQuery,
-        facets,
-        request.limit,
-        offset: request.offset,
-        order: request.order,
-        searchMode: request.searchMode,
-        distance: request.distance,
-        negativeQuery: request.sanitizedNegativeQuery,
-        negativeDistance: request.negativeDistance,
-        scope: request.proximityScope,
-        negativeScope: request.negativeProximityScope,
-        customSpacing: request.effectiveCustomSpacing,
-        negativeCustomSpacing: request.effectiveNegativeCustomSpacing,
-        alternativeWords: request.effectiveAlternativeWords,
-        negativeAlternativeWords: request.effectiveNegativeAlternativeWords,
-        searchOptions: request.effectiveSearchOptions,
-        negativeSearchOptions: request.effectiveNegativeSearchOptions,
-        grouping: request.grouping,
-        wordMatchMode: request.wordMatchMode,
-        wordMatchCount: request.wordMatchCount,
-      );
-
-      await for (final update in stream) {
+    try {
+      while (await iterator.moveNext().timeout(_searchIdleTimeout)) {
+        final update = iterator.current;
         if (update.totalCount != null) {
           totalCount = update.totalCount;
           groupCount = update.groupCount;
           truncated = update.truncated;
-          bookCounts = update.bookCounts;
         }
-        results.addAll(update.results);
+        if (update.results.isNotEmpty || update.bookCounts != null) {
+          _ensureBookIndex(library);
+        }
+        final booksByPath = _booksByIndexedPath;
+        await eventSink(_searchStreamEvent, {
+          'streamId': streamId,
+          'chunk': {
+            'sequence': sequence++,
+            'results': [
+              for (final result in update.results)
+                PluginSearchApi.resultToJson(
+                  result,
+                  booksByPath[result.filePath],
+                  booksByPath: booksByPath,
+                ),
+            ],
+            'total': totalCount,
+            'groupCount': groupCount,
+            'truncated': truncated,
+            'limit': request.limit,
+            'offset': request.offset,
+            'facets': facets,
+            if (request.includeBookCounts && update.bookCounts != null)
+              'bookCounts': [
+                for (final entry in update.bookCounts!.entries)
+                  if (booksByPath[entry.key] case final Book book)
+                    {
+                      ...PluginBookIdentity.toJson(book),
+                      'title': book.title,
+                      'count': entry.value,
+                    },
+              ],
+          },
+        });
       }
-    } else {
-      final page = await _dependencies.searchRepository.searchTextsAndCount(
-        request.sanitizedQuery,
-        facets,
-        request.limit,
-        offset: request.offset,
-        order: request.order,
-        searchMode: request.searchMode,
-        distance: request.distance,
-        negativeQuery: request.sanitizedNegativeQuery,
-        negativeDistance: request.negativeDistance,
-        scope: request.proximityScope,
-        negativeScope: request.negativeProximityScope,
-        customSpacing: request.effectiveCustomSpacing,
-        negativeCustomSpacing: request.effectiveNegativeCustomSpacing,
-        alternativeWords: request.effectiveAlternativeWords,
-        negativeAlternativeWords: request.effectiveNegativeAlternativeWords,
-        searchOptions: request.effectiveSearchOptions,
-        negativeSearchOptions: request.effectiveNegativeSearchOptions,
-        grouping: request.grouping,
-        wordMatchMode: request.wordMatchMode,
-        wordMatchCount: request.wordMatchCount,
-      );
-      results.addAll(page.results);
-      totalCount = page.totalCount;
-      groupCount = page.groupCount;
-      truncated = page.truncated;
+      if (expired) throw TimeoutException('Search stream timed out');
+      return {
+        'completed': !cancelled,
+        'cancelled': cancelled,
+        'chunks': sequence,
+      };
+    } finally {
+      deadline.cancel();
+      _activeSearchStreams.remove(streamId);
+      await iterator.cancel();
     }
+  }
 
-    if (results.isNotEmpty || bookCounts != null) {
-      _ensureBookIndex(library);
+  Map<String, dynamic> _cancelPluginSearch(String streamId) {
+    if (!_streamIdPattern.hasMatch(streamId)) {
+      throw Exception('error.invalid_params: invalid internal stream id');
     }
-    final booksByPath = _booksByIndexedPath;
-
-    return {
-      'results': [
-        for (final result in results)
-          PluginSearchApi.resultToJson(
-            result,
-            booksByPath[result.filePath],
-            booksByPath: booksByPath,
-          ),
-      ],
-      'total': totalCount ?? results.length,
-      'groupCount': groupCount,
-      'truncated': truncated,
-      'limit': request.limit,
-      'offset': request.offset,
-      'facets': facets,
-      if (request.includeBookCounts)
-        'bookCounts': [
-          for (final entry in (bookCounts ?? const <String, int>{}).entries)
-            if (booksByPath[entry.key] case final Book book)
-              {
-                ...PluginBookIdentity.toJson(book),
-                'title': book.title,
-                'count': entry.value,
-              },
-        ],
-    };
+    final cancel = _activeSearchStreams[streamId];
+    if (cancel == null) {
+      if (_pendingSearchCancellations.length < 16) {
+        _pendingSearchCancellations.add(streamId);
+      }
+      return {'cancelled': false};
+    }
+    unawaited(cancel());
+    return {'cancelled': true};
   }
 
   // ----------------------------------------------------------------

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -3187,6 +3187,17 @@ class PluginBridgeAdapter {
           throw Exception('error.invalid_params: invalid method');
         }
         final requestBody = args['body'] as String?;
+        final rawTimeoutMs = args['timeoutMs'];
+        if (rawTimeoutMs != null &&
+            (rawTimeoutMs is! int ||
+                rawTimeoutMs <= 0 ||
+                rawTimeoutMs >
+                    PluginNetworkFetchService.maxTimeout.inMilliseconds)) {
+          throw Exception(
+            'error.invalid_params: timeoutMs must be a positive integer '
+            'up to ${PluginNetworkFetchService.maxTimeout.inMilliseconds}',
+          );
+        }
         final rawHeaders = args['headers'];
         final headers = <String, String>{};
         if (rawHeaders is Map) {
@@ -3202,6 +3213,9 @@ class PluginBridgeAdapter {
           method: method,
           headers: headers.isEmpty ? null : headers,
           body: requestBody,
+          timeout: rawTimeoutMs == null
+              ? PluginNetworkFetchService.defaultTimeout
+              : Duration(milliseconds: rawTimeoutMs),
         );
         return {'status': result.status, 'ok': result.ok, 'body': result.body};
 

--- a/lib/plugins/bridge/plugin_bridge_handler.dart
+++ b/lib/plugins/bridge/plugin_bridge_handler.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
@@ -54,7 +55,16 @@ class PluginBridgeHandler {
       callback: (args) async {
         onWorkStarted?.call();
         try {
-          return await _handleRpc(args);
+          return await _handleRpc(
+            args,
+            eventSink: (topic, payload) async {
+              await controller.evaluateJavascript(
+                source:
+                    'window.dispatchEvent(new CustomEvent('
+                    '${jsonEncode(topic)}, { detail: ${jsonEncode(payload)} }));',
+              );
+            },
+          );
         } finally {
           onWorkEnded?.call();
         }
@@ -65,7 +75,10 @@ class PluginBridgeHandler {
   /// נקודת כניסה לבדיקות בלבד: מריצה את אותו נתיב RPC שמופעל מ-JavaScript,
   /// כדי לבדוק את אכיפת ההרשאות וצימוד ההחרגה-מ-throttle ב-[_handleRpc].
   @visibleForTesting
-  Future<dynamic> handleRpcForTesting(List<dynamic> args) => _handleRpc(args);
+  Future<dynamic> handleRpcForTesting(
+    List<dynamic> args, {
+    PluginRpcEventSink? eventSink,
+  }) => _handleRpc(args, eventSink: eventSink);
 
   /// קובע אם קריאת RPC מוחרגת ממגביל הקצב.
   ///
@@ -79,11 +92,15 @@ class PluginBridgeHandler {
   /// האם הקריאה מנהלת חסם זמן או משאבים בתוך השירות שלה,
   /// ולכן אינה כפופה ל-timeout הגנרי של 30 שניות.
   static bool hasOwnTimeout(String method) =>
+      method == 'search.query' ||
       method == 'network.fetch' ||
       method == 'network.download' ||
       method == 'fs.extractZip';
 
-  Future<dynamic> _handleRpc(List<dynamic> args) async {
+  Future<dynamic> _handleRpc(
+    List<dynamic> args, {
+    PluginRpcEventSink? eventSink,
+  }) async {
     if (args.isEmpty) {
       return _errorResp("error.invalid_params", "No arguments provided");
     }
@@ -114,6 +131,9 @@ class PluginBridgeHandler {
     // permission_denied. כדי לא להוסיף קריאת DB לכל RPC, ההקדמה הזו מתבצעת רק
     // לקריאות תוכן; שאר הקריאות נבדקות כרגיל בהמשך.
     final isContentRead = isRateLimitExempt(request.method);
+    final isSearchCancellation =
+        request.method == 'search.query' &&
+        PluginBridgeAdapter.isSearchCancellationPayload(request.payload);
     bool? grantedEarly;
     if (isContentRead && declaresPermission && requiredPermission != null) {
       grantedEarly =
@@ -121,7 +141,8 @@ class PluginBridgeHandler {
           true;
     }
 
-    final exempt = isContentRead && (grantedEarly ?? false);
+    final exempt =
+        (isContentRead && (grantedEarly ?? false)) || isSearchCancellation;
     if (!exempt && !_rateLimiter.consume()) {
       return _errorResp("error.rate_limited", "Rate limit exceeded");
     }
@@ -149,9 +170,13 @@ class PluginBridgeHandler {
         }
       }
 
-      // פעולות I/O ארוכות (download/extractZip) מנהלות בעצמן את חסם הזמן; שאר
-      // הקריאות אמורות להיות מהירות ולכן נחתכות אחרי 30 שניות.
-      final execution = adapter.execute(domain, action, request.payload);
+      // פעולות ארוכות מנהלות בעצמן חסם זמן; היתר נחתכות אחרי 30 שניות.
+      final execution = adapter.execute(
+        domain,
+        action,
+        request.payload,
+        eventSink: eventSink,
+      );
       final result = hasOwnTimeout(request.method)
           ? await execution
           : await execution.timeout(const Duration(seconds: 30));

--- a/lib/plugins/bridge/plugin_bridge_handler.dart
+++ b/lib/plugins/bridge/plugin_bridge_handler.dart
@@ -76,15 +76,12 @@ class PluginBridgeHandler {
   static bool isRateLimitExempt(String method) =>
       method == 'library.getBookContent';
 
-  /// קובע אם קריאת RPC מוחרגת מ-timeout ברירת המחדל של 30 שניות.
-  ///
-  /// `network.download` ו-`fs.extractZip` הן פעולות I/O ארוכות מטבען (הזרמת
-  /// קובץ לדיסק, חילוץ ארכיון), ו-30 שניות חתכו אותן באמצע על קבצים גדולים.
-  /// ההורדה אוכפת timeout על *תקיעה* (היעדר בייטים נכנסים) בתוך שירות ההורדה,
-  /// כך שהורדה איטית נמשכת כל עוד יש התקדמות; החילוץ אוכף בתוך השירות תקרת גודל
-  /// מחולץ ומספר רשומות (הגנת zip bomb), ולכן חסום בלי תלות ב-timeout הגנרי.
+  /// האם הקריאה מנהלת חסם זמן או משאבים בתוך השירות שלה,
+  /// ולכן אינה כפופה ל-timeout הגנרי של 30 שניות.
   static bool hasOwnTimeout(String method) =>
-      method == 'network.download' || method == 'fs.extractZip';
+      method == 'network.fetch' ||
+      method == 'network.download' ||
+      method == 'fs.extractZip';
 
   Future<dynamic> _handleRpc(List<dynamic> args) async {
     if (args.isEmpty) {

--- a/lib/plugins/declarative/services/declarative_library_book_access.dart
+++ b/lib/plugins/declarative/services/declarative_library_book_access.dart
@@ -5,6 +5,7 @@ import 'package:otzaria/plugins/declarative/services/declarative_host_action_exe
 import 'package:otzaria/plugins/declarative/services/declarative_program_executor.dart';
 import 'package:otzaria/plugins/models/plugin_book_identity.dart';
 import 'package:otzaria/utils/navigation/book_open_coordinator.dart';
+import 'package:otzaria/utils/navigation/otzar_utils.dart';
 
 typedef DeclarativeBookListLoader = Future<List<Book>> Function();
 typedef DeclarativeExternalBookListLoader =
@@ -16,18 +17,22 @@ typedef DeclarativeBookOpen =
       String searchQuery, {
       required bool navigateToPositionIfReused,
     });
+typedef DeclarativeExternalBookOpen =
+    Future<bool> Function(ExternalLibraryBook book);
 
 class DeclarativeLibraryBookAccess
     implements DeclarativeBookResolver, DeclarativeBookOpener {
   final DeclarativeBookListLoader _libraryBooks;
   final DeclarativeExternalBookListLoader _externalBooks;
   final DeclarativeBookOpen _openBook;
+  final DeclarativeExternalBookOpen externalBookOpener;
 
   DeclarativeLibraryBookAccess(
     this._libraryBooks,
     this._externalBooks,
-    this._openBook,
-  );
+    this._openBook, {
+    required this.externalBookOpener,
+  });
 
   factory DeclarativeLibraryBookAccess.otzaria(
     BookOpenCoordinator coordinator,
@@ -48,6 +53,7 @@ class DeclarativeLibraryBookAccess
             requiresStableLayout: book is PdfBook,
             navigateToPositionIfReused: navigateToPositionIfReused,
           ),
+      externalBookOpener: (book) => OtzarUtils.launchOtzarWeb(book.link),
     );
   }
 
@@ -78,6 +84,9 @@ class DeclarativeLibraryBookAccess
   }) async {
     final book = (await findUniqueBooks([identity])).single;
     if (book == null) return false;
+    if (book is ExternalLibraryBook) {
+      return externalBookOpener(book);
+    }
     _openBook(
       book,
       index,

--- a/lib/plugins/services/plugin_network_fetch_service.dart
+++ b/lib/plugins/services/plugin_network_fetch_service.dart
@@ -30,6 +30,9 @@ class PluginNetworkFetchResult {
 ///
 /// בדיקת ההרשאה וה-allowlist מתבצעות אצל הקורא (האדפטר), לא כאן.
 class PluginNetworkFetchService {
+  static const defaultTimeout = Duration(seconds: 30);
+  static const maxTimeout = Duration(seconds: 120);
+
   final http.Client _client;
   late final FutureOr<void> Function() _closer = _client.close;
 
@@ -52,6 +55,21 @@ class PluginNetworkFetchService {
   Future<PluginNetworkFetchResult> fetch(
     Uri uri, {
     String method = 'GET',
+    Map<String, String>? headers,
+    String? body,
+    Duration timeout = defaultTimeout,
+  }) {
+    return _fetch(
+      uri,
+      method: method,
+      headers: headers,
+      body: body,
+    ).timeout(timeout);
+  }
+
+  Future<PluginNetworkFetchResult> _fetch(
+    Uri uri, {
+    required String method,
     Map<String, String>? headers,
     String? body,
   }) async {

--- a/lib/plugins/view/plugin_background_host.dart
+++ b/lib/plugins/view/plugin_background_host.dart
@@ -68,10 +68,19 @@ const String _sdkStub = r'''
 (function () {
   var _queue = [];
   var _realSdk = null;
+  var _notReadySearchStream = function () {
+    return {
+      next: function () {
+        return Promise.reject(new Error('Otzaria SDK not ready yet'));
+      },
+      [Symbol.asyncIterator]: function () { return this; }
+    };
+  };
 
   window.Otzaria = {
     call: function (method, payload) {
       if (_realSdk) return _realSdk.call(method, payload);
+      if (method === 'search.query') return _notReadySearchStream();
       return Promise.reject(new Error('Otzaria SDK not ready yet'));
     },
     on: function (event, cb) {
@@ -888,12 +897,95 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
                 '''
 (function () {
   var _ls = {};
+  var _searchStreams = {};
+  var _searchSequence = 0;
+  var _searchEvent = '__otzaria.search.query.chunk';
+  var rpc = function (method, payload) {
+    return window.flutter_inappwebview.callHandler('otzaria_rpc', {
+      method: method,
+      payload: payload || {}
+    });
+  };
+  window.addEventListener(_searchEvent, function (event) {
+    var detail = event.detail || {};
+    var stream = _searchStreams[detail.streamId];
+    if (stream) stream.push(detail.chunk);
+  });
+  var createSearchStream = function (payload) {
+    var streamId = 'search_' + Date.now().toString(36) + '_' + (++_searchSequence).toString(36);
+    var queue = [];
+    var waiters = [];
+    var ended = false;
+    var failure = null;
+    var flush = function () {
+      while (waiters.length && queue.length) {
+        waiters.shift().resolve({ value: queue.shift(), done: false });
+      }
+      if (queue.length || !ended) return;
+      while (waiters.length) {
+        var waiter = waiters.shift();
+        if (failure) waiter.reject(failure);
+        else waiter.resolve({ value: undefined, done: true });
+      }
+    };
+    var session = {
+      push: function (chunk) {
+        if (ended) return;
+        queue.push(chunk);
+        flush();
+      },
+      finish: function () {
+        if (ended) return;
+        ended = true;
+        delete _searchStreams[streamId];
+        flush();
+      },
+      fail: function (error) {
+        if (ended) return;
+        failure = error instanceof Error ? error : new Error(String(error));
+        ended = true;
+        delete _searchStreams[streamId];
+        flush();
+      }
+    };
+    _searchStreams[streamId] = session;
+    var request = Object.assign({}, payload || {}, { __streamId: streamId });
+    rpc('search.query', request).then(function (response) {
+      if (!response || response.success !== true) {
+        var message = response && response.error && response.error.message;
+        session.fail(new Error(message || 'Search failed'));
+        return;
+      }
+      session.finish();
+    }, session.fail);
+    return {
+      next: function () {
+        if (queue.length) return Promise.resolve({ value: queue.shift(), done: false });
+        if (ended) {
+          return failure
+            ? Promise.reject(failure)
+            : Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise(function (resolve, reject) {
+          waiters.push({ resolve: resolve, reject: reject });
+        });
+      },
+      return: function () {
+        if (!ended) {
+          ended = true;
+          delete _searchStreams[streamId];
+          flush();
+          void rpc('search.query', { __cancelStreamId: streamId });
+        }
+        return Promise.resolve({ value: undefined, done: true });
+      },
+      [Symbol.asyncIterator]: function () { return this; }
+    };
+  };
   var realSdk = {
     call: function (method, payload) {
-      return window.flutter_inappwebview.callHandler('otzaria_rpc', {
-        method: method,
-        payload: payload || {}
-      });
+      if (method === 'search.query') return createSearchStream(payload);
+      return rpc(method, payload);
     },
     on: function (event, cb) {
       if (!_ls[event]) _ls[event] = [];

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -56,10 +56,19 @@ const String _sdkStub = r'''
 (function () {
   var _queue = [];
   var _realSdk = null;
+  var _notReadySearchStream = function () {
+    return {
+      next: function () {
+        return Promise.reject(new Error('Otzaria SDK not ready yet'));
+      },
+      [Symbol.asyncIterator]: function () { return this; }
+    };
+  };
 
   window.Otzaria = {
     call: function (method, payload) {
       if (_realSdk) return _realSdk.call(method, payload);
+      if (method === 'search.query') return _notReadySearchStream();
       return Promise.reject(new Error('Otzaria SDK not ready yet'));
     },
     on: function (event, cb) {
@@ -741,12 +750,95 @@ class _PluginTabPageState extends State<PluginTabPage> {
     }
   } catch (e) { console.error('font-face inject failed', e); }
   var _ls = {};
+  var _searchStreams = {};
+  var _searchSequence = 0;
+  var _searchEvent = '__otzaria.search.query.chunk';
+  var rpc = function (method, payload) {
+    return window.flutter_inappwebview.callHandler('otzaria_rpc', {
+      method: method,
+      payload: payload || {}
+    });
+  };
+  window.addEventListener(_searchEvent, function (event) {
+    var detail = event.detail || {};
+    var stream = _searchStreams[detail.streamId];
+    if (stream) stream.push(detail.chunk);
+  });
+  var createSearchStream = function (payload) {
+    var streamId = 'search_' + Date.now().toString(36) + '_' + (++_searchSequence).toString(36);
+    var queue = [];
+    var waiters = [];
+    var ended = false;
+    var failure = null;
+    var flush = function () {
+      while (waiters.length && queue.length) {
+        waiters.shift().resolve({ value: queue.shift(), done: false });
+      }
+      if (queue.length || !ended) return;
+      while (waiters.length) {
+        var waiter = waiters.shift();
+        if (failure) waiter.reject(failure);
+        else waiter.resolve({ value: undefined, done: true });
+      }
+    };
+    var session = {
+      push: function (chunk) {
+        if (ended) return;
+        queue.push(chunk);
+        flush();
+      },
+      finish: function () {
+        if (ended) return;
+        ended = true;
+        delete _searchStreams[streamId];
+        flush();
+      },
+      fail: function (error) {
+        if (ended) return;
+        failure = error instanceof Error ? error : new Error(String(error));
+        ended = true;
+        delete _searchStreams[streamId];
+        flush();
+      }
+    };
+    _searchStreams[streamId] = session;
+    var request = Object.assign({}, payload || {}, { __streamId: streamId });
+    rpc('search.query', request).then(function (response) {
+      if (!response || response.success !== true) {
+        var message = response && response.error && response.error.message;
+        session.fail(new Error(message || 'Search failed'));
+        return;
+      }
+      session.finish();
+    }, session.fail);
+    return {
+      next: function () {
+        if (queue.length) return Promise.resolve({ value: queue.shift(), done: false });
+        if (ended) {
+          return failure
+            ? Promise.reject(failure)
+            : Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise(function (resolve, reject) {
+          waiters.push({ resolve: resolve, reject: reject });
+        });
+      },
+      return: function () {
+        if (!ended) {
+          ended = true;
+          delete _searchStreams[streamId];
+          flush();
+          void rpc('search.query', { __cancelStreamId: streamId });
+        }
+        return Promise.resolve({ value: undefined, done: true });
+      },
+      [Symbol.asyncIterator]: function () { return this; }
+    };
+  };
   var realSdk = {
     call: function (method, payload) {
-      return window.flutter_inappwebview.callHandler('otzaria_rpc', {
-        method: method,
-        payload: payload || {}
-      });
+      if (method === 'search.query') return createSearchStream(payload);
+      return rpc(method, payload);
     },
     on: function (event, cb) {
       if (!_ls[event]) _ls[event] = [];

--- a/test/plugins/bridge/plugin_bridge_adapter_test.dart
+++ b/test/plugins/bridge/plugin_bridge_adapter_test.dart
@@ -1638,6 +1638,32 @@ Future<void> main() async {
       );
       expect(hit, isFalse);
     });
+
+    test('timeoutMs מעל התקרה נדחה לפני ביצוע הבקשה', () async {
+      var hit = false;
+      final fetchService = PluginNetworkFetchService(
+        client: MockClient((req) async {
+          hit = true;
+          return http.Response('', 200);
+        }),
+      );
+      final adapter = buildAdapter(fetchService);
+
+      await expectLater(
+        () => adapter.execute('network', 'fetch', const {
+          'url': 'https://nakdan.dicta.org.il/api',
+          'timeoutMs': 120001,
+        }),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('timeoutMs'),
+          ),
+        ),
+      );
+      expect(hit, isFalse);
+    });
   });
 
   group('PluginBridgeAdapter fs + pickFolder + download.destPath', () {

--- a/test/plugins/bridge/plugin_bridge_adapter_test.dart
+++ b/test/plugins/bridge/plugin_bridge_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 // קידומת ל-Link של dart:io כי models/links.dart מגדיר Link משלו שמסתיר אותו.
@@ -97,6 +98,7 @@ class _StubSearchRepository extends SearchRepository {
   );
   int pageCalls = 0;
   int streamWithCountsCalls = 0;
+  Stream<SearchStreamUpdate>? streamOverride;
 
   void _capture(
     String query,
@@ -210,7 +212,7 @@ class _StubSearchRepository extends SearchRepository {
       wordMatchMode: wordMatchMode,
       searchOptions: searchOptions,
     );
-    return Stream.fromIterable(updates);
+    return streamOverride ?? Stream.fromIterable(updates);
   }
 }
 
@@ -2313,19 +2315,29 @@ Future<void> main() async {
           searchRepository: stub,
         );
 
-        final result =
-            await adapter.execute('search', 'query', {
-                  'query': 'בראשית',
-                  'mode': 'advanced',
-                  'distance': 3,
-                  'proximityScope': 'sameParagraph',
-                  'order': 'catalogue',
-                  'grouping': 'sameSection',
-                  'wordMatchMode': 'mostWords',
-                  'limit': 10,
-                  'offset': 5,
-                  'includeBookCounts': true,
-                })
+        final chunks = <Map<String, dynamic>>[];
+        final completion =
+            await adapter.execute(
+                  'search',
+                  'query',
+                  {
+                    'query': 'בראשית',
+                    'mode': 'advanced',
+                    'distance': 3,
+                    'proximityScope': 'sameParagraph',
+                    'order': 'catalogue',
+                    'grouping': 'sameSection',
+                    'wordMatchMode': 'mostWords',
+                    'limit': 10,
+                    'offset': 5,
+                    'includeBookCounts': true,
+                    '__streamId': 'test_search_1',
+                  },
+                  eventSink: (topic, payload) async {
+                    expect(topic, '__otzaria.search.query.chunk');
+                    chunks.add(payload['chunk'] as Map<String, dynamic>);
+                  },
+                )
                 as Map<String, dynamic>;
 
         expect(stub.captured!['limit'], 10);
@@ -2339,14 +2351,16 @@ Future<void> main() async {
         expect(stub.streamWithCountsCalls, 1);
         expect(stub.pageCalls, 0);
 
-        expect(result['total'], 812);
-        expect(result['truncated'], isFalse);
-        final hit = (result['results'] as List).single as Map;
+        expect(completion['completed'], isTrue);
+        expect(chunks, hasLength(2));
+        expect(chunks.first['total'], 812);
+        expect(chunks.first['truncated'], isFalse);
+        final hit = (chunks.last['results'] as List).single as Map;
         expect(hit['id'], 10);
         expect(hit['type'], 'text');
         expect(hit['index'], 12);
         expect(hit['reference'], 'בראשית, פרק א');
-        expect((result['bookCounts'] as List).single, {
+        expect((chunks.first['bookCounts'] as List).single, {
           'id': 10,
           'type': 'text',
           'bookId': 'בראשית',
@@ -2368,15 +2382,24 @@ Future<void> main() async {
           searchRepository: stub,
         );
 
-        final result =
-            await adapter.execute('search', 'query', {'query': 'בראשית'})
-                as Map<String, dynamic>;
+        final chunks = <Map<String, dynamic>>[];
+        await adapter.execute(
+          'search',
+          'query',
+          {
+            'query': 'בראשית',
+            '__streamId': 'test_search_2',
+          },
+          eventSink: (topic, payload) async {
+            chunks.add(payload['chunk'] as Map<String, dynamic>);
+          },
+        );
 
         expect(stub.captured!['facets'], ['/']);
-        expect(stub.pageCalls, 1);
-        expect(stub.streamWithCountsCalls, 0);
-        expect(result['facets'], ['/']);
-        expect(result['total'], 0);
+        expect(stub.pageCalls, 0);
+        expect(stub.streamWithCountsCalls, 1);
+        expect(chunks.single['facets'], ['/']);
+        expect(chunks.single['total'], isNull);
       },
       skip: engineReady ? false : searchEngineSkipReason,
     );
@@ -2393,15 +2416,86 @@ Future<void> main() async {
 
         await adapter.execute('search', 'query', {
           'query': 'בראשית',
+          '__streamId': 'test_search_3',
           'books': [
             {'id': 10},
           ],
-        });
+        }, eventSink: (topic, payload) async {});
 
         expect(
           (stub.captured!['facets'] as List).single,
           startsWith('/תנך/תורה/'),
         );
+      },
+      skip: engineReady ? false : searchEngineSkipReason,
+    );
+
+    test('search.query דורש תעבורת stream פנימית', () async {
+      final adapter = buildAdapter(books: [TextBook(id: 10, title: 'בראשית')]);
+
+      await expectLater(
+        () => adapter.execute('search', 'query', {'query': 'בראשית'}),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            contains('stream id'),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'ביטול בזמן אתחול החיפוש נצרך לפני רישום ה-stream הפעיל',
+      () async {
+        final stub = _StubSearchRepository();
+        final adapter = buildAdapter(
+          books: [TextBook(id: 10, title: 'בראשית')],
+          searchRepository: stub,
+        );
+        final search = adapter.execute('search', 'query', {
+          'query': 'בראשית',
+          '__streamId': 'cancel_during_startup_1',
+        }, eventSink: (topic, payload) async {});
+
+        await adapter.execute('search', 'query', {
+          '__cancelStreamId': 'cancel_during_startup_1',
+        });
+        final completion = await search as Map<String, dynamic>;
+
+        expect(completion['cancelled'], isTrue);
+      },
+      skip: engineReady ? false : searchEngineSkipReason,
+    );
+
+    test(
+      'עצירת האיטרטור מבטלת את stream החיפוש הפעיל',
+      () async {
+        final controller = StreamController<SearchStreamUpdate>();
+        final stub = _StubSearchRepository()
+          ..streamOverride = controller.stream;
+        final adapter = buildAdapter(
+          books: [TextBook(id: 10, title: 'בראשית')],
+          searchRepository: stub,
+        );
+        final search = adapter.execute('search', 'query', {
+          'query': 'בראשית',
+          '__streamId': 'cancel_search_1',
+        }, eventSink: (topic, payload) async {});
+        while (stub.streamWithCountsCalls == 0) {
+          await Future<void>.delayed(Duration.zero);
+        }
+
+        final cancellation =
+            await adapter.execute('search', 'query', {
+                  '__cancelStreamId': 'cancel_search_1',
+                })
+                as Map<String, dynamic>;
+        final completion = await search as Map<String, dynamic>;
+
+        expect(cancellation['cancelled'], isTrue);
+        expect(completion['cancelled'], isTrue);
+        await controller.close();
       },
       skip: engineReady ? false : searchEngineSkipReason,
     );

--- a/test/plugins/bridge/plugin_bridge_handler_test.dart
+++ b/test/plugins/bridge/plugin_bridge_handler_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/plugins/bridge/plugin_bridge_adapter.dart';
 import 'package:otzaria/plugins/bridge/plugin_bridge_handler.dart';
@@ -22,8 +24,9 @@ class _FakeAdapter implements PluginBridgeAdapter {
   Future<dynamic> execute(
     String domain,
     String action,
-    Map<String, dynamic> args,
-  ) async {
+    Map<String, dynamic> args, {
+    PluginRpcEventSink? eventSink,
+  }) async {
     executeCalls++;
     lastDomain = domain;
     lastAction = action;
@@ -122,6 +125,16 @@ List<dynamic> _getConnectivityRequest() => [
   {'method': 'app.getConnectivity', 'payload': <String, dynamic>{}},
 ];
 
+List<dynamic> _cancelSearchRequest({bool includeExtraKey = false}) => [
+  {
+    'method': 'search.query',
+    'payload': {
+      '__cancelStreamId': 'search_test_1',
+      if (includeExtraKey) 'query': 'בדיקה',
+    },
+  },
+];
+
 void main() {
   group('PluginBridgeHandler.isRateLimitExempt', () {
     test('library.getBookContent מוחרג ממגביל הקצב', () {
@@ -151,6 +164,7 @@ void main() {
   group('PluginBridgeHandler.hasOwnTimeout', () {
     test('פעולות עם timeout פנימי מוחרגות מ-timeout ברירת המחדל', () {
       // פעולות I/O ארוכות שנחתכו על קבצים גדולים ע"י ה-30 שניות.
+      expect(PluginBridgeHandler.hasOwnTimeout('search.query'), isTrue);
       expect(PluginBridgeHandler.hasOwnTimeout('network.fetch'), isTrue);
       expect(PluginBridgeHandler.hasOwnTimeout('network.download'), isTrue);
       expect(PluginBridgeHandler.hasOwnTimeout('fs.extractZip'), isTrue);
@@ -387,6 +401,58 @@ void main() {
       },
     );
 
+    test('ביטול stream תקין עוקף throttle אך עדיין דורש הרשאת חיפוש', () async {
+      final adapter = _FakeAdapter(result: const {'cancelled': true});
+      final limiter = _BlockingRateLimiter();
+      final handler = buildHandler(
+        declaredPermissions: const ['search.fulltext.read'],
+        granted: true,
+        adapter: adapter,
+        rateLimiter: limiter,
+      );
+
+      final resp =
+          await handler.handleRpcForTesting(_cancelSearchRequest())
+              as Map<String, dynamic>;
+
+      expect(resp['success'], isTrue);
+      expect(adapter.executeCalls, 1);
+      expect(limiter.consumeCalls, 0);
+
+      final deniedAdapter = _FakeAdapter();
+      final denied = buildHandler(
+        declaredPermissions: const ['search.fulltext.read'],
+        granted: false,
+        adapter: deniedAdapter,
+        rateLimiter: _BlockingRateLimiter(),
+      );
+      final deniedResp =
+          await denied.handleRpcForTesting(_cancelSearchRequest()) as Map;
+      expect(deniedResp['error']['code'], 'permission_denied');
+      expect(deniedAdapter.executeCalls, 0);
+    });
+
+    test('payload דמוי ביטול עם מפתח נוסף אינו עוקף throttle', () async {
+      final adapter = _FakeAdapter();
+      final limiter = _BlockingRateLimiter();
+      final handler = buildHandler(
+        declaredPermissions: const ['search.fulltext.read'],
+        granted: true,
+        adapter: adapter,
+        rateLimiter: limiter,
+      );
+
+      final resp =
+          await handler.handleRpcForTesting(
+                _cancelSearchRequest(includeExtraKey: true),
+              )
+              as Map<String, dynamic>;
+
+      expect(resp['error']['code'], 'error.rate_limited');
+      expect(adapter.executeCalls, 0);
+      expect(limiter.consumeCalls, 1);
+    });
+
     test('תוסף ללא הרשאה מוענקת אינו עוקף את ה-throttle: מגביל מרוקן + הרשאה לא '
         'מוענקת → rate_limited (עובר דרך המגביל)', () async {
       // grantedEarly=false ⇒ exempt=false ⇒ הקריאה עוברת דרך consume, שמרוקן
@@ -495,6 +561,34 @@ void main() {
 
       expect(resp['error']['code'], 'error.internal');
     });
+
+    test(
+      'TimeoutException פנימי של search.query מוחזר כ-error.timeout',
+      () async {
+        final handler = PluginBridgeHandler(
+          _buildInstalledPlugin(
+            permissions: const ['search.fulltext.read'],
+          ),
+          adapter: _FakeAdapter(errorToThrow: TimeoutException('search')),
+          registry: _StubRegistry(true),
+        );
+
+        final resp =
+            await handler.handleRpcForTesting([
+                  {
+                    'method': 'search.query',
+                    'payload': {
+                      'query': 'בדיקה',
+                      '__streamId': 'search_test_1',
+                    },
+                  },
+                ])
+                as Map;
+
+        expect(resp['success'], isFalse);
+        expect(resp['error']['code'], 'error.timeout');
+      },
+    );
   });
 
   // פעולות הקבצים האישיים (pickUserFile וכו') דורשות הרשאת manifest

--- a/test/plugins/bridge/plugin_bridge_handler_test.dart
+++ b/test/plugins/bridge/plugin_bridge_handler_test.dart
@@ -149,14 +149,14 @@ void main() {
   });
 
   group('PluginBridgeHandler.hasOwnTimeout', () {
-    test('download/extractZip מוחרגות מ-timeout ברירת המחדל', () {
+    test('פעולות עם timeout פנימי מוחרגות מ-timeout ברירת המחדל', () {
       // פעולות I/O ארוכות שנחתכו על קבצים גדולים ע"י ה-30 שניות.
+      expect(PluginBridgeHandler.hasOwnTimeout('network.fetch'), isTrue);
       expect(PluginBridgeHandler.hasOwnTimeout('network.download'), isTrue);
       expect(PluginBridgeHandler.hasOwnTimeout('fs.extractZip'), isTrue);
     });
 
     test('שאר הקריאות נשארות תחת timeout ברירת המחדל', () {
-      expect(PluginBridgeHandler.hasOwnTimeout('network.fetch'), isFalse);
       expect(PluginBridgeHandler.hasOwnTimeout('fs.deleteFile'), isFalse);
       expect(
         PluginBridgeHandler.hasOwnTimeout('library.getBookContent'),

--- a/test/plugins/declarative/declarative_library_book_access_test.dart
+++ b/test/plugins/declarative/declarative_library_book_access_test.dart
@@ -77,6 +77,7 @@ void main() {
         ];
       },
       (_, _, _, {required navigateToPositionIfReused}) {},
+      externalBookOpener: (_) async => true,
     );
 
     final resolved = await access.resolveUniqueBatch([
@@ -167,6 +168,36 @@ void main() {
     expect(navigationFlags, [true]);
   });
 
+  test('ספר חיצוני שנפתר נפתח דרך הקישור החיצוני', () async {
+    final external = ExternalLibraryBook(
+      title: 'ספר חיצוני',
+      id: 10,
+      link: 'https://hebrewbooks.org/10',
+      externalLibraryId: 'hb:10',
+    );
+    final externallyOpened = <ExternalLibraryBook>[];
+    final locallyOpened = <Book>[];
+    final access = _access(
+      library: const [],
+      hebrewBooks: [external],
+      opened: locallyOpened,
+      externallyOpened: externallyOpened,
+    );
+    final identity = await access.resolveUnique({
+      'external': {'provider': 'hebrewbooks', 'id': 10},
+    });
+
+    final result = await access.openUnique(
+      identity!,
+      index: 0,
+      searchQuery: '',
+    );
+
+    expect(result, isTrue);
+    expect(externallyOpened, [external]);
+    expect(locallyOpened, isEmpty);
+  });
+
   test('PluginBookIdentity מפענח ספק חיצוני מוכר בלבד', () {
     final hb = ExternalLibraryBook(
       title: 'HB',
@@ -196,6 +227,7 @@ DeclarativeLibraryBookAccess _access({
   List<(int, String)>? positions,
   List<bool>? navigationFlags,
   List<(String, Set<Object>)>? externalLoads,
+  List<ExternalLibraryBook>? externallyOpened,
 }) {
   return DeclarativeLibraryBookAccess(
     () async => library,
@@ -207,6 +239,10 @@ DeclarativeLibraryBookAccess _access({
       opened?.add(book);
       positions?.add((index, searchQuery));
       navigationFlags?.add(navigateToPositionIfReused);
+    },
+    externalBookOpener: (book) async {
+      externallyOpened?.add(book);
+      return true;
     },
   );
 }

--- a/test/plugins/services/plugin_network_fetch_service_test.dart
+++ b/test/plugins/services/plugin_network_fetch_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -72,5 +74,22 @@ void main() {
     expect(result.status, 404);
     expect(result.ok, isFalse);
     expect(result.body, 'nope');
+  });
+
+  test('timeout מותאם מגביל גם את זמן ההמתנה לתשובה', () async {
+    final service = PluginNetworkFetchService(
+      client: MockClient((req) async {
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        return http.Response('late', 200);
+      }),
+    );
+
+    await expectLater(
+      service.fetch(
+        Uri.parse('https://api.example.com/slow'),
+        timeout: const Duration(milliseconds: 5),
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
   });
 }


### PR DESCRIPTION
## מה השתנה
- `reader.openBook` הדקלרטיבי פותח `ExternalLibraryBook` דרך הקישור הקטלוגי במקום להעבירו לבונה טאבים שאינו תומך בו
- ספרי טקסט ו-PDF מקומיים ממשיכים להיפתח במסלול הקיים
- נוספה בדיקת round-trip של `resolveBooks` ולאחריו פתיחה חיצונית

## אימות
- `flutter analyze`
- `flutter test test/plugins/`
- `git diff --check`