### PR TITLE
הוספת endpoint של EmailJS לרשימת ההיתר — תוספי הביוגרפיות

### DIFF
--- a/lib/plugins/models/plugin_network_allowlist.dart
+++ b/lib/plugins/models/plugin_network_allowlist.dart
@@ -80,6 +80,9 @@ const List<String> pluginNetworkAllowlist = <String>[
   'https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/wikishiva.zim',
   'https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/otzaria-wiki.zim',
   'https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/otzar-hasfarim.zim',
+
+  // תוספי הביוגרפיות (יאיר דניאל) — דיווח שגיאות תוכן מתוך התוסף
+  'https://api.emailjs.com/api/v1.0/email/send',
 ];
 
 /// דומייני ה-CDN שאליהם GitHub מפנה (redirect) בהורדת asset של release.

--- a/plugin_network_allowlist.txt
+++ b/plugin_network_allowlist.txt
@@ -67,3 +67,6 @@ https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/wiki
 https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/wikishiva.zim
 https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/otzaria-wiki.zim
 https://github.com/YairDaniel11/otzaria-zim-plugin/releases/download/v0.5.0/otzar-hasfarim.zim
+
+# תוספי הביוגרפיות (יאיר דניאל) — דיווח שגיאות תוכן מתוך התוסף
+https://api.emailjs.com/api/v1.0/email/send


### PR DESCRIPTION
## הבקשה

הוספת כתובת אחת לרשימת ההיתר לגישת רשת של תוספים:

```
https://api.emailjs.com/api/v1.0/email/send
```

## התוספים המבקשים

| שם | `id` במניפסט |
|---|---|
| ביוגרפיות | `com.otzaria.biographies-tannaim-amoraim` |
| ביוגרפיות+ | `com.otzaria.biographies-plus` |

שניהם מאת יאיר דניאל, ומשתמשים באותו endpoint.

## למה זה נחוץ

התוספים הם אנציקלופדיית תנאים ואמוראים / דמויות מקראיות. בכל ערך יש כפתור
"דיווח על שגיאה בתוכן", שמאפשר למשתמש לדווח על טעות עובדתית בערך מסוים
(תאריך, שיוך משפחתי, מראה מקום שגוי וכד'). הדיווח נשלח למחבר התוסף דרך
EmailJS.

## אילו נתונים עוברים

בגוף הבקשה נשלחים אך ורק:

- שם הערך שעליו דווח והטקסט השגוי שבו
- תיאור השגיאה שהמשתמש הקליד
- כתובת מייל לחזרה — רק אם המשתמש מילא אותה מרצונו

לא נשלחים נתוני ספרייה, היסטוריית קריאה, הערות אישיות או מידע מזהה כלשהו
שהמשתמש לא הקליד בעצמו.

## הערות

- הכתובת היא הנתיב המדויק והמלא של ה-endpoint, לא הדומיין הכללי —
  `https://api.emailjs.com` לבדו **אינו** מבוקש.
- עודכנו שני הקבצים כנדרש: `plugin_network_allowlist.txt` והרשימה המקומפלת
  `lib/plugins/models/plugin_network_allowlist.dart`, כדי ש-
  `plugin_network_allowlist_branch_sync_test.dart` יעבור.
- לאחר המיזוג התוספים יעברו מקריאת `fetch()` ישירה ל-`network.fetch`, כך
  שהגישה תעבור דרך מנגנון האישור של אוצריא כמתועד ב-API_REFERENCE.
