### PR TITLE
תיקון: קו סימון החלונית הפעילה נעלם בתצוגה זו-לצד-זו

### DIFF
--- a/lib/tabs/view/split_pane_view.dart
+++ b/lib/tabs/view/split_pane_view.dart
@@ -24,9 +24,6 @@ const double _kDividerHandleLength = 40;
 /// עיגול פינות כרטיס החלונית.
 const double kPaneCardRadius = 10;
 
-/// סכום ה-flex בין שתי החלוניות.
-const int _kFlexResolution = 1000;
-
 /// כמה זז המפריד בכל הקשה על חץ.
 const double _kKeyboardNudge = 24;
 
@@ -121,15 +118,6 @@ class PaneCard extends StatelessWidget {
             ? Border.all(
                 color: AppSurfaces.paneCardBorder(cs, isActive: isActive),
               )
-            : null,
-        boxShadow: isSplit
-            ? [
-                BoxShadow(
-                  color: AppSurfaces.paneCardShadow(cs, isActive: isActive),
-                  blurRadius: isActive ? 10 : 6,
-                  offset: const Offset(0, 1),
-                ),
-              ]
             : null,
       ),
       child: ClipRRect(borderRadius: radius, child: child),
@@ -267,30 +255,37 @@ class _SplitNodeState extends State<_SplitNode> {
     return ValueListenableBuilder<double>(
       valueListenable: _ratioNotifier,
       builder: (context, ratio, _) {
-        // חלוקה ב-flex נמנעת מבניית תת-העץ בזמן layout.
-        final firstFlex = (ratio * _kFlexResolution).round().clamp(
-          1,
-          _kFlexResolution - 1,
-        );
+        return LayoutBuilder(
+          // גבול בין החלוניות על שבר פיקסל: חיתוך הכרטיס (hardEdge) מקצר את
+          // הרוחב לפיקסל שלם ומוחק את קו המסגרת של החלונית הפעילה.
+          builder: (context, constraints) {
+            final available = constraints.maxWidth - widget.thickness;
+            final firstWidth = available > 0
+                ? (available * ratio).roundToDouble().clamp(0.0, available)
+                : 0.0;
 
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(flex: firstFlex, child: firstChild),
-            _PaneDivider(
-              thickness: widget.thickness,
-              isTouch: widget.thickness == kPaneDividerThicknessTouch,
-              ratio: ratio,
-              increasedRatio: _ratioAfterNudge(towardFirst: false),
-              decreasedRatio: _ratioAfterNudge(towardFirst: true),
-              onDragStart: () => _dragging = true,
-              onDragUpdate: _onDragUpdate,
-              onDragEnd: _commit,
-              onReset: _resetRatio,
-              onNudge: (towardFirst) => _nudge(towardFirst: towardFirst),
-            ),
-            Expanded(flex: _kFlexResolution - firstFlex, child: secondChild),
-          ],
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // הילדים נבנים מחוץ ל-builder, ולכן פריסה מחדש אינה בונה
+                // מחדש את תצוגות הספרים.
+                SizedBox(width: firstWidth, child: firstChild),
+                _PaneDivider(
+                  thickness: widget.thickness,
+                  isTouch: widget.thickness == kPaneDividerThicknessTouch,
+                  ratio: ratio,
+                  increasedRatio: _ratioAfterNudge(towardFirst: false),
+                  decreasedRatio: _ratioAfterNudge(towardFirst: true),
+                  onDragStart: () => _dragging = true,
+                  onDragUpdate: _onDragUpdate,
+                  onDragEnd: _commit,
+                  onReset: _resetRatio,
+                  onNudge: (towardFirst) => _nudge(towardFirst: towardFirst),
+                ),
+                Expanded(child: secondChild),
+              ],
+            );
+          },
         );
       },
     );
@@ -433,23 +428,20 @@ class _PaneDividerState extends State<_PaneDivider> {
             child: SizedBox(
               width: widget.thickness,
               child: Center(
-                child: AnimatedOpacity(
+                // דהייה בצבע ולא ב-AnimatedOpacity: אטימות חיה הופכת את המפריד
+                // ל-repaint boundary, ומסגרת החלונית שמצוירת אחריו נעלמת.
+                child: AnimatedContainer(
                   duration: const Duration(milliseconds: 140),
                   curve: Curves.easeOut,
-                  opacity: active ? 1 : 0,
-                  child: SizedBox(
-                    width: _kDividerHandleThickness,
-                    height: _kDividerHandleLength,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: AppSurfaces.paneDividerHandle(
-                          colorScheme,
-                          isActive: active,
-                        ),
-                        borderRadius: BorderRadius.circular(
-                          _kDividerHandleThickness / 2,
-                        ),
-                      ),
+                  width: _kDividerHandleThickness,
+                  height: _kDividerHandleLength,
+                  decoration: BoxDecoration(
+                    color: AppSurfaces.paneDividerHandle(
+                      colorScheme,
+                      isActive: active,
+                    ),
+                    borderRadius: BorderRadius.circular(
+                      _kDividerHandleThickness / 2,
                     ),
                   ),
                 ),

--- a/lib/theme/app_surfaces.dart
+++ b/lib/theme/app_surfaces.dart
@@ -108,13 +108,10 @@ class AppSurfaces {
       ? cs.primary.withValues(alpha: 0.55)
       : cs.outlineVariant.withValues(alpha: 0.35);
 
-  /// צל כרטיס החלונית — מרים אותה מעל הרקע בלי קו מפריד.
-  static Color paneCardShadow(ColorScheme cs, {required bool isActive}) =>
-      cs.shadow.withValues(alpha: isActive ? 0.16 : 0.08);
-
   /// ידית המפריד בין חלוניות — נראית רק בהצבעה, בגרירה או בפוקוס.
+  /// ההיעלמות היא באלפא של אותו גוון, כדי שהדהייה תהיה שקיפות בלבד.
   static Color paneDividerHandle(ColorScheme cs, {required bool isActive}) =>
-      isActive ? cs.primary : Colors.transparent;
+      isActive ? cs.primary : cs.primary.withValues(alpha: 0);
 
   /// רקע רצועת [PanelOpenHandle] — מתפוגג מעט במצב רגיל, אטום יותר ב-hover.
   static Color panelOpenHandle(ColorScheme cs, {required bool isHovering}) =>

--- a/test/tabs/view/split_pane_view_test.dart
+++ b/test/tabs/view/split_pane_view_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/tabs/models/combined_tab.dart';
@@ -133,6 +134,57 @@ void main() {
       final narrow = tester.getSize(find.text('צרה')).width;
       expect(wide, greaterThan(narrow * 2));
     });
+
+    // הכרטיס עטוף בחיתוך מרובע בגודלו: צל היה נחתך לאורך הצדדים הישרים,
+    // ונשאר רק ככתם מרובע בכל פינה עגולה.
+    testWidgets('כרטיס החלונית אינו מצייר צל', (tester) async {
+      for (final isActive in [true, false]) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PaneCard(
+              isActive: isActive,
+              isSplit: true,
+              child: const SizedBox(),
+            ),
+          ),
+        );
+
+        final decoration =
+            tester
+                    .widget<AnimatedContainer>(find.byType(AnimatedContainer))
+                    .decoration!
+                as BoxDecoration;
+        expect(decoration.boxShadow, isNull, reason: 'isActive=$isActive');
+      }
+    });
+
+    // גבול בין החלוניות על שבר פיקסל: חיתוך הכרטיס מקצר את הרוחב לפיקסל שלם
+    // ומוחק את קו המסגרת של החלונית הפעילה.
+    testWidgets('גבול החלוניות נופל על פיקסל שלם', (tester) async {
+      addTearDown(tester.view.reset);
+
+      for (final width in [1600.0, 1601.0, 1287.0]) {
+        for (final ratio in [0.5, 0.4237, 0.618]) {
+          tester.view.physicalSize = Size(width, 900);
+          tester.view.devicePixelRatio = 1.0;
+
+          final right = _LeafTab('ימין');
+          final left = _LeafTab('שמאל');
+          await tester.pumpWidget(
+            _host(
+              CombinedTab(rightTab: right, leftTab: left, splitRatio: ratio),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final leftRect = tester.getRect(find.byKey(GlobalObjectKey(left)));
+          final rightRect = tester.getRect(find.byKey(GlobalObjectKey(right)));
+          final reason = 'רוחב $width ויחס $ratio';
+          expect(leftRect.right % 1, 0, reason: reason);
+          expect(rightRect.left % 1, 0, reason: reason);
+        }
+      }
+    });
   });
 
   group('שוליי תוכן', () {
@@ -242,6 +294,36 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(reportedRatio, 0.5);
+    });
+
+    // המפריד מצויר בין החלוניות: שכבת ציור חדשה בהצבעה מפצלת את הרסטר,
+    // ומסגרת הפיקסל של החלונית שמצוירת אחריו נעלמת עד שהעכבר מתרחק.
+    testWidgets('הצבעה על המפריד אינה מוסיפה שכבות ציור', (tester) async {
+      final root = CombinedTab(
+        rightTab: _LeafTab('ימין'),
+        leftTab: _LeafTab('שמאל'),
+      );
+      await tester.pumpWidget(_host(root));
+      await tester.pumpAndSettle();
+
+      final layersBefore = tester.layers.length;
+      final handle = find.descendant(
+        of: find.byType(MouseRegion).last,
+        matching: find.byType(AnimatedContainer),
+      );
+      BoxDecoration decoration() =>
+          tester.widget<AnimatedContainer>(handle).decoration! as BoxDecoration;
+      expect(decoration().color!.a, 0);
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(find.byType(MouseRegion).last));
+      await tester.pumpAndSettle();
+
+      // הידית נראית עכשיו — ובכל זאת מספר השכבות לא גדל.
+      expect(decoration().color!.a, greaterThan(0));
+      expect(tester.layers.length, layersBefore);
     });
   });
 


### PR DESCRIPTION
## הבעיה

בתצוגה זו-לצד-זו, קו סימון החלונית הפעילה (מסגרת של פיקסל אחד) נעלם כשהעכבר עבר בקרבת המפריד — תמיד בחלונית השמאלית ותמיד בקצה הפונה למרכז. לעיתים הקו לא חזר עד לחיצה מחדש בחלונית. בנוסף, בכל פינה עגולה של כרטיס חלונית הופיע כתם אפור מרובע.

## הגורמים

שלושה גורמים נפרדים שפגעו כולם באותו קו:

**1. שכבת ציור של ידית המפריד.** הידית הייתה עטופה ב-`AnimatedOpacity`. ב-`RenderAnimatedOpacityMixin` הערך `isRepaintBoundary` נגזר מ-`_alpha > 0`, כלומר הרנדר הופך ל-repaint boundary בדיוק כשהידית נראית. המפריד מצויר **בין** שתי החלוניות, ולכן החלונית שמצוירת אחריו עברה לשכבת רסטר נפרדת בכל הצבעה. מכאן גם האסימטריה: החלונית הימנית מצוירת לפני המפריד ולא נפגעה.

מספר שכבות הציור לפני התיקון ואחריו, בהצבעה על המפריד:

| מצב | לפני | אחרי |
|---|---|---|
| בלי הצבעה | `pictures=2 opacity=0` | `pictures=2 opacity=0` |
| העכבר על המפריד | `pictures=4 opacity=1` | `pictures=2 opacity=0` |

הדהייה עוברת לצבע הידית (`AnimatedContainer`), שממילא שקוף כשאינה פעילה — כך שהמראה זהה בלי יצירת שכבה.

**2. גבול בין החלוניות על שבר פיקסל.** הרוחב חולק ב-`flex`, ולכן הגבול נפל על שבר. ה-`ClipRect` שעוטף כל חלונית הוא `Clip.hardEdge` ומקצר את החיתוך לפיקסל שלם, כך שנחתך מהקו בדיוק גודל השבר — ובשבר קרוב ל-1 הקו נעלם כמעט לגמרי. זה גם הסבר ה"לפעמים": התוצאה נגזרת מרוחב החלון ומיחס הפיצול.

מדידת עמודות הפיקסלים בקצה החלונית (יחס 0.4237, רוחב 1600):

```
לפני:  edge=914.232  frac=0.232   913: c2b4da   914: ece6ed   ← 77% מהקו, השאר נחתך
אחרי:  edge=915.000  frac=0.000   914: ab9bcd                 ← הצבע המלא
```

הרוחב מחושב עכשיו מעוגל לפיקסל שלם. הילדים ממשיכים להיבנות מחוץ ל-builder, ולכן חלוקה מחדש אינה בונה מחדש את תצוגות הספרים (מכוסה בבדיקה קיימת).

**3. צל שנחתך בריבוע.** ל-`PaneCard` היה `boxShadow` בתוך אותו `ClipRect` מרובע בגודל הכרטיס. לאורך הצדדים הישרים הצל נמצא מחוץ לקופסה ולכן נחתך כליל, ומה שנשאר ממנו היה הדיו שבתוך הפינות — חתוך בקו חד. כלומר הצל לא תפקד כצל, והביטוי היחיד שלו היה הכתם האפור המרובע בכל פינה. הצל הוסר, ואיתו `AppSurfaces.paneCardShadow` שלא היה בשימוש נוסף.

## בדיקות

נוספו ל-`test/tabs/view/split_pane_view_test.dart`:

- הצבעה על המפריד אינה מוסיפה שכבות ציור (ומאמתת שהידית באמת נראית באותו רגע)
- גבול החלוניות נופל על פיקסל שלם — בשלושה רוחבי חלון (1600 / 1601 / 1287) ושלושה יחסי פיצול (0.5 / 0.4237 / 0.618)
- כרטיס החלונית אינו מצייר צל

`flutter analyze` נקי, וכל 356 הבדיקות ב-`test/tabs` עוברות.

## הערה

הקו מיושר לפיקסל שלם בתצוגה של 100%. בסקיילינג של 125% השוליים הקבועים של הכרטיס (3px) הופכים ל-3.75 פיקסלי מסך, ואז הקו יוצא רך ומפוזר על שתי עמודות — אבל אינו נחתך ואינו נעלם.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
