### PR TITLE
כלים: קוביות המשגר כסמל תוכנה — אייקון גדול, כתב קטן, 4 בשורה

### DIFF
--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -89,9 +89,9 @@ List<ToolCatalogEntry> orderedToolEntries(List<ToolCatalogEntry> entries) => [
   for (final group in groupToolEntries(entries)) ...group.entries,
 ];
 
-/// רוחב היעד לקובייה.
+/// רוחב היעד לקובייה — ברוחב הפאנל שבברירת מחדל נכנסות ארבע קוביות בשורה.
 @visibleForTesting
-const double kToolTileTargetWidth = 104;
+const double kToolTileTargetWidth = 88;
 
 /// המרווח בקצה ימין שמפנה מקום לפס הגלילה, כדי שלא יעלה על הקוביות.
 @visibleForTesting
@@ -1005,7 +1005,7 @@ class _ToolDragFeedback extends StatelessWidget {
 
 /// קובייה בודדת ברשת הכלים.
 class ToolTile extends StatelessWidget {
-  static const double maxIconSize = 48;
+  static const double maxIconSize = 40;
   static const double minIconSize = 20;
   static const double menuButtonSize = 26;
 
@@ -1095,7 +1095,7 @@ class ToolTile extends StatelessWidget {
             if (actions.isNotEmpty)
               PositionedDirectional(
                 top: 0,
-                start: 0,
+                end: 0,
                 child: _buildMenuButton(cs),
               ),
             if (entry.isDevelopment)
@@ -1107,7 +1107,7 @@ class ToolTile extends StatelessWidget {
             if (isOpen)
               PositionedDirectional(
                 top: 4,
-                end: 4,
+                start: 4,
                 child: Icon(
                   FluentIcons.checkmark_circle_16_filled,
                   size: 12,

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -1005,9 +1005,24 @@ class _ToolDragFeedback extends StatelessWidget {
 
 /// קובייה בודדת ברשת הכלים.
 class ToolTile extends StatelessWidget {
-  static const double iconBoxSize = 32;
-  static const double iconSize = 16;
+  static const double maxIconSize = 48;
+  static const double minIconSize = 20;
   static const double menuButtonSize = 26;
+
+  /// התווית קטנה ובשתי שורות, כדי שרוב הקובייה תישאר לאייקון.
+  static const double labelFontSize = 11;
+  static const double labelLineHeight = 1.2;
+  static const double labelBlockHeight = labelFontSize * labelLineHeight * 2;
+
+  /// גודל האייקון לגובה הפנוי בקובייה: כל מה שנשאר אחרי שתי שורות התווית.
+  /// כך פאנל מצומצם מקטין את האייקון במקום לחתוך את הכתב.
+  static double iconSizeFor(double availableHeight) {
+    if (!availableHeight.isFinite) return maxIconSize;
+    return (availableHeight - AppTokens.spaceXS - labelBlockHeight).clamp(
+      minIconSize,
+      maxIconSize,
+    );
+  }
 
   final ToolCatalogEntry entry;
   final bool isOpen;
@@ -1043,39 +1058,37 @@ class ToolTile extends StatelessWidget {
       child: AppCard(
         onTap: onTap,
         selected: isHighlighted,
+        // הקובייה יושבת ישירות על משטח הפאנל, כמו סמל תוכנה בשולחן העבודה.
+        transparent: true,
         child: Stack(
           children: [
             // האייקון והכותרת ממורכזים כגוש אחד.
             Center(
               child: Padding(
                 padding: const EdgeInsets.all(AppTokens.spaceXS),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Container(
-                      width: iconBoxSize,
-                      height: iconBoxSize,
-                      decoration: BoxDecoration(
-                        color: cs.secondaryContainer,
-                        borderRadius: AppTokens.borderRadiusAll,
-                      ),
-                      child: Center(child: _buildIcon(cs)),
-                    ),
-                    const SizedBox(height: AppTokens.spaceXS),
-                    Flexible(
-                      child: Text(
-                        entry.label,
-                        textAlign: TextAlign.center,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: cs.onSurface,
+                child: LayoutBuilder(
+                  builder: (context, constraints) => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      _buildIcon(cs, iconSizeFor(constraints.maxHeight)),
+                      const SizedBox(height: AppTokens.spaceXS),
+                      Flexible(
+                        child: Text(
+                          entry.label,
+                          textAlign: TextAlign.center,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontSize: labelFontSize,
+                            height: labelLineHeight,
+                            fontWeight: FontWeight.w600,
+                            color: cs.onSurface,
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -1174,15 +1187,15 @@ class ToolTile extends StatelessWidget {
     );
   }
 
-  Widget _buildIcon(ColorScheme cs) {
+  Widget _buildIcon(ColorScheme cs, double iconSize) {
     if (entry.imageIcon != null) {
       return ImageIcon(
         AssetImage(entry.imageIcon!),
         size: iconSize,
-        color: cs.onSecondaryContainer,
+        color: cs.primary,
       );
     }
-    return Icon(entry.icon, size: iconSize, color: cs.onSecondaryContainer);
+    return Icon(entry.icon, size: iconSize, color: cs.primary);
   }
 }
 

--- a/lib/widgets/layout/app_card.dart
+++ b/lib/widgets/layout/app_card.dart
@@ -16,6 +16,7 @@ class AppCard extends StatelessWidget {
     this.margin,
     this.padding,
     this.selected = false,
+    this.transparent = false,
   }) : children = null;
 
   /// כרטיס מקטע עם מספר שורות — רווח 1.5px בין שורות.
@@ -27,7 +28,8 @@ class AppCard extends StatelessWidget {
     this.selected = false,
   }) : child = null,
        onTap = null,
-       focusNode = null;
+       focusNode = null,
+       transparent = false;
 
   /// הרווח הקבוע בין שורות במקטע כרטיס.
   static const double sectionSpacing = 1.5;
@@ -41,6 +43,10 @@ class AppCard extends StatelessWidget {
 
   /// מוסיף overlay של secondaryContainer מעל הכרטיס
   final bool selected;
+
+  /// רקע שקוף — הכרטיס נטמע במשטח שמאחוריו, ונשארים ממנו רק התוכן,
+  /// הריחוף וסימון הבחירה.
+  final bool transparent;
 
   /// Divider חיצוני בצבע עקבי עם המפריד הפנימי של [AppCard.section].
   ///
@@ -78,9 +84,13 @@ class AppCard extends StatelessWidget {
       content = _withSelected(context, content);
     }
 
+    final background = transparent
+        ? Colors.transparent
+        : AppSurfaces.card(context);
+
     if (onTap != null) {
       return Material(
-        color: AppSurfaces.card(context),
+        color: background,
         surfaceTintColor: Colors.transparent,
         borderRadius: resolvedRadius,
         clipBehavior: Clip.antiAlias,
@@ -95,7 +105,7 @@ class AppCard extends StatelessWidget {
     }
 
     return Material(
-      color: AppSurfaces.card(context),
+      color: background,
       borderRadius: resolvedRadius,
       clipBehavior: Clip.antiAlias,
       child: content,

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -17,6 +17,7 @@ import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/tabs/bloc/tabs_state.dart';
+import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/tools/built_in_tools_catalog.dart';
 import 'package:otzaria/tools/tool_catalog_entry.dart';
 import 'package:otzaria/tools/view/tools_launcher_panel.dart';
@@ -548,50 +549,70 @@ void main() {
       expect(find.text('לוח שנה'), findsOneWidget);
     });
 
-    testWidgets('בנוי מעל AppCard — אותו כרטיס כמו בספרייה', (tester) async {
+    // הקובייה יושבת ישירות על משטח הפאנל — בלי כרטיס לבן סביב האייקון והכתב.
+    testWidgets('בנויה מעל AppCard שקוף — בלי רקע כרטיס', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
       expect(find.byType(AppCard), findsOneWidget);
-    });
+      expect(tester.widget<AppCard>(find.byType(AppCard)).transparent, isTrue);
 
-    testWidgets('האייקון יושב בריבוע 32 והוא בגודל 16', (tester) async {
-      await tester.pumpWidget(_tileHost(buildTile()));
-
-      final iconBox = tester.getSize(
-        find.ancestor(
-          of: find.byIcon(FluentIcons.calendar_24_regular),
-          matching: find.byType(Container),
+      final material = tester.widget<Material>(
+        find.descendant(
+          of: find.byType(AppCard),
+          matching: find.byType(Material),
         ),
       );
-      expect(iconBox, const Size(ToolTile.iconBoxSize, ToolTile.iconBoxSize));
+      expect(material.color, Colors.transparent);
+    });
+
+    // סדר גודל של סמל תוכנה: האייקון תופס את המקום שנשאר אחרי התווית.
+    testWidgets('האייקון גדול ותופס את המקום שנשאר אחרי התווית', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
 
       final icon = tester.widget<Icon>(
         find.byIcon(FluentIcons.calendar_24_regular),
       );
-      expect(icon.size, ToolTile.iconSize);
+      expect(icon.size, ToolTile.iconSizeFor(100 - AppTokens.spaceXS * 2));
+      expect(icon.size, ToolTile.maxIconSize);
     });
 
-    testWidgets('צבעי הריבוע והאייקון נלקחים מ-secondaryContainer', (
-      tester,
-    ) async {
+    // בפאנל מצומצם האייקון מתכווץ, אחרת שתי שורות התווית נחתכות.
+    testWidgets('קובייה קטנה מקבלת אייקון קטן ללא חריגת פריסה', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile(), size: 70));
+      expect(tester.takeException(), isNull);
+
+      final icon = tester.widget<Icon>(
+        find.byIcon(FluentIcons.calendar_24_regular),
+      );
+      expect(icon.size, lessThan(ToolTile.maxIconSize));
+      expect(icon.size, greaterThanOrEqualTo(ToolTile.minIconSize));
+    });
+
+    // התווית קטנה מברירת המחדל של bodySmall, כדי לפנות מקום לאייקון.
+    testWidgets('תווית הקובייה בגודל 11', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+      final label = tester.widget<Text>(find.text('לוח שנה'));
+      expect(label.style?.fontSize, ToolTile.labelFontSize);
+    });
+
+    // האייקון עומד על רקע הכרטיס עצמו — בלי מעטפת מרובעת סביבו.
+    testWidgets('האייקון בצבע primary ובלי מעטפת מרובעת', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
       final context = tester.element(find.byType(ToolTile));
       final cs = Theme.of(context).colorScheme;
 
-      final container = tester.widget<Container>(
+      final icon = tester.widget<Icon>(
+        find.byIcon(FluentIcons.calendar_24_regular),
+      );
+      expect(icon.color, cs.primary);
+      expect(
         find.ancestor(
           of: find.byIcon(FluentIcons.calendar_24_regular),
           matching: find.byType(Container),
         ),
+        findsNothing,
       );
-      expect(
-        (container.decoration as BoxDecoration).color,
-        cs.secondaryContainer,
-      );
-
-      final icon = tester.widget<Icon>(
-        find.byIcon(FluentIcons.calendar_24_regular),
-      );
-      expect(icon.color, cs.onSecondaryContainer);
     });
 
     testWidgets('האייקון והטקסט ממורכזים אופקית בקובייה', (tester) async {
@@ -613,10 +634,7 @@ void main() {
 
       final tileCenter = tester.getCenter(find.byType(ToolTile));
       final iconBoxRect = tester.getRect(
-        find.ancestor(
-          of: find.byIcon(FluentIcons.calendar_24_regular),
-          matching: find.byType(Container),
-        ),
+        find.byIcon(FluentIcons.calendar_24_regular),
       );
       final textRect = tester.getRect(find.text('לוח שנה'));
 
@@ -651,7 +669,7 @@ void main() {
       );
       expect(find.byType(ImageIcon), findsOneWidget);
       final imageIcon = tester.widget<ImageIcon>(find.byType(ImageIcon));
-      expect(imageIcon.size, ToolTile.iconSize);
+      expect(imageIcon.size, ToolTile.iconSizeFor(100 - AppTokens.spaceXS * 2));
     });
 
     testWidgets('לחיצה מפעילה את onTap', (tester) async {

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -111,18 +111,23 @@ Widget _tileHost(ToolTile tile, {double size = 100}) => MaterialApp(
   ),
 );
 
+/// רוחב התוכן בפאנל שבברירת מחדל: `ContextOverlayPanel` ברוחב 400, פחות
+/// `contentPadding` של 16 מכל צד.
+const double _kDefaultPanelContentWidth = 368;
+
 Widget _launcherHost({
   required SettingsBloc settingsBloc,
   required PluginSystemBloc pluginSystemBloc,
   required TabsBloc tabsBloc,
   required ValueChanged<ToolCatalogEntry> onToolSelected,
+  double width = 520,
 }) => MaterialApp(
   theme: ThemeData(colorSchemeSeed: Colors.blue),
   home: Directionality(
     textDirection: TextDirection.rtl,
     child: Scaffold(
       body: SizedBox(
-        width: 520,
+        width: width,
         height: 600,
         child: MultiBlocProvider(
           providers: [
@@ -564,10 +569,8 @@ void main() {
       expect(material.color, Colors.transparent);
     });
 
-    // סדר גודל של סמל תוכנה: האייקון תופס את המקום שנשאר אחרי התווית.
-    testWidgets('האייקון גדול ותופס את המקום שנשאר אחרי התווית', (
-      tester,
-    ) async {
+    // סדר גודל של סמל תוכנה: בקובייה רגילה האייקון מגיע לגודלו המרבי.
+    testWidgets('האייקון מגיע לגודל המרבי בקובייה רגילה', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
 
       final icon = tester.widget<Icon>(
@@ -854,7 +857,7 @@ void main() {
     });
 
     // מקום הכפתור נבחר כך שלא יתנגש בסימן "פתוח" שבפינה הנגדית.
-    testWidgets('כפתור ⋯ יושב בפינה הימנית-עליונה של הקובייה', (tester) async {
+    testWidgets('כפתור ⋯ יושב בפינה השמאלית-עליונה של הקובייה', (tester) async {
       await tester.pumpWidget(
         _tileHost(
           buildTile(
@@ -878,11 +881,11 @@ void main() {
       final openMark = tester.getRect(
         find.byIcon(FluentIcons.checkmark_circle_16_filled),
       );
-      expect(button.center.dx, greaterThan(tile.center.dx));
+      expect(button.center.dx, lessThan(tile.center.dx));
       expect(button.center.dy, lessThan(tile.center.dy));
       expect(
         button.center.dx,
-        greaterThan(openMark.center.dx),
+        lessThan(openMark.center.dx),
         reason: 'סימן "פתוח" יושב בפינה הנגדית ואינו מתנגש בכפתור',
       );
     });
@@ -983,6 +986,7 @@ void main() {
       WidgetTester tester, {
       SettingsState? settings,
       PluginSystemState? pluginState,
+      double width = 520,
     }) async {
       settingsBloc = _RecordingSettingsBloc(
         settings ?? SettingsState.initial(),
@@ -1004,6 +1008,7 @@ void main() {
           pluginSystemBloc: pluginSystemBloc,
           tabsBloc: tabsBloc,
           onToolSelected: selected.add,
+          width: width,
         ),
       );
       await tester.pump();
@@ -1080,6 +1085,32 @@ void main() {
       expect(
         listView.padding,
         const EdgeInsets.only(right: kToolGridScrollbarGutter),
+      );
+    });
+
+    // ברוחב הפאנל שבברירת מחדל נכנסות ארבע קוביות בשורה, והאייקון הגדול
+    // עדיין נכנס בהן בשלמותו יחד עם שתי שורות התווית.
+    testWidgets('ברוחב הפאנל שבברירת מחדל — 4 קוביות בשורה', (tester) async {
+      await pumpPanel(tester, width: _kDefaultPanelContentWidth);
+      expect(tester.takeException(), isNull);
+
+      for (final grid in tester.widgetList<GridView>(find.byType(GridView))) {
+        final delegate =
+            grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+        expect(delegate.crossAxisCount, 4);
+      }
+
+      final tileHeight = tester.getSize(find.byType(ToolTile).first).height;
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byType(ToolTile).first,
+          matching: find.byIcon(FluentIcons.calendar_24_regular),
+        ),
+      );
+      expect(icon.size, ToolTile.maxIconSize);
+      expect(
+        ToolTile.maxIconSize + AppTokens.spaceXS + ToolTile.labelBlockHeight,
+        lessThan(tileHeight - AppTokens.spaceXS * 2),
       );
     });
 

--- a/test/widgets/app_card_test.dart
+++ b/test/widgets/app_card_test.dart
@@ -88,6 +88,26 @@ void main() {
     );
   });
 
+  testWidgets('AppCard transparent drops the card background', (tester) async {
+    final key = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AppCard(
+            key: key,
+            transparent: true,
+            onTap: () {},
+            child: const SizedBox(),
+          ),
+        ),
+      ),
+    );
+    final material = tester.widget<Material>(
+      find.descendant(of: find.byKey(key), matching: find.byType(Material)),
+    );
+    expect(material.color, Colors.transparent);
+  });
+
   // --- AppCard.section ---
 
   testWidgets('AppCard.section renders all children', (tester) async {


### PR DESCRIPTION
הקוביות בפאנל "כלים ותוספים" נראות כעת כמו סמל תוכנה בשולחן העבודה: אייקון גדול, כיתוב קטן מתחתיו, בלי מסגרת סביבם.

## מה השתנה

| | לפני | אחרי |
|---|---|---|
| גודל האייקון | 16px | עד 40px, לפי הגובה הפנוי בקובייה |
| מעטפת סביב האייקון | ריבוע `secondaryContainer` | אין |
| רקע הקובייה | כרטיס (`AppSurfaces.card`) | שקוף — משטח הפאנל |
| גודל התווית | 12px | 11px, גובה שורה 1.2 |
| צבע האייקון | `onSecondaryContainer` | `primary` |
| קוביות בשורה, ברוחב הפאנל שבברירת מחדל | 3 | 4 |
| כפתור ⋯ | פינה ימנית-עליונה | פינה שמאלית-עליונה |
| סימן "כלי פתוח" | פינה שמאלית-עליונה | פינה ימנית-עליונה |

## שלוש החלטות שכדאי לשים אליהן לב בסקירה

**גודל האייקון מחושב ולא קבוע.** רוחב הפאנל נגרר על ידי המשתמש עד 200px, ואז הקוביות מתכווצות ל-~73px. אייקון קבוע היה חותך את שורת התווית השנייה. `ToolTile.iconSizeFor` נותן לאייקון את מה שנשאר אחרי שתי שורות הכיתוב, מוגבל בין 20 ל-40 — כך שבפאנל צר האייקון מתכווץ במקום שהכתב ייחתך.

**40px הוא הגדול ביותר שנכנס בקובייה של ארבע-בשורה.** ברוחב הפאנל שבברירת מחדל הקובייה יוצאת 82.5×82.5, הפנוי בתוכה 74.5, והגוש (אייקון + רווח + שתי שורות כיתוב) הוא 70.4.

**`AppCard` קיבל דגל `transparent`.** הקובייה עדיין צריכה את הפינות המעוגלות, אפקט הריחוף, ה-ripple וסימון הבחירה של ניווט המקלדת — כלומר את כל `AppCard` פחות הצבע. במקום לשכפל את המבנה בקובץ הכלים, הדגל מחליף את רקע הכרטיס ב-`Colors.transparent`. כך מסלול צבעי האינטראקציה נשאר במקום אחד ולא נוצר override מקומי מחוץ ל-`lib/theme/`.

סימן "כלי פתוח" הועבר לפינה הנגדית מפני שהוא ישב בשמאל-למעלה, בדיוק במקום שאליו עבר כפתור ⋯; בלי ההזזה השניים היו מתנגשים. תג ה-DEV נשאר בימין-למטה.

## בדיקות

`dart analyze` נקי. 122 טסטים עוברים ב-`test/tools/tools_launcher_panel_test.dart` ו-`test/widgets/app_card_test.dart`, ובהם חדשים:

- `ברוחב הפאנל שבברירת מחדל — 4 קוביות בשורה` — מרנדר את הפאנל ברוחב התוכן האמיתי (368px: `ContextOverlayPanel` ברוחב 400 פחות `contentPadding` 16 מכל צד) ומאמת גם את `crossAxisCount` בכל מקטעי הרשת, וגם שהאייקון בגודלו המרבי עם שתי שורות התווית נכנס בגובה הקובייה בפועל
- האייקון מגיע לגודלו המרבי בקובייה רגילה, ומתכווץ בקובייה של 70px בלי חריגת פריסה
- התווית בגודל 11
- אין `Container` עוטף את האייקון, והאייקון בצבע `primary`
- ה-`AppCard` של הקובייה שקוף, ו-`AppCard(transparent: true)` מפיל את רקע הכרטיס
- כפתור ⋯ בפינה השמאלית-עליונה, וסימן "פתוח" בפינה הנגדית

🤖 Generated with [Claude Code](https://claude.com/claude-code)
