### PR TITLE
מרווח שורות מדויק בעיון בספר — קיבוע גובה השורה

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -720,6 +720,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Smooth mouse-wheel scrolling | `test/widgets/smooth_wheel_scroll_test.dart` |
 | Smart text render settings | `test/widgets/smart_text/render_settings_test.dart` |
 | Smart text ↔ plugin section sync gate | `test/widgets/smart_text/smart_text_section_sync_gate_test.dart` |
+| קיבוע מדויק של גובה השורה (סימוני הערות, `<big>`) בשלושת מסלולי הרינדור | `test/widgets/smart_text/exact_line_height_test.dart` |
 | Work/indexing status overlays | `test/widgets/work_status_overlay_test.dart`, `…indexing_status_overlay_test.dart` |
 | App dropdown/search menu | `test/widgets/app_dropdown_field_test.dart`, `…app_search_menu_test.dart` |
 | Search pane base | `test/widgets/search_pane_base_test.dart` |

--- a/lib/text_book/view/widgets/continuous_reading_paragraph.dart
+++ b/lib/text_book/view/widgets/continuous_reading_paragraph.dart
@@ -7,6 +7,7 @@ import 'package:otzaria/text_book/utils/link_anchor_variants.dart';
 import 'package:otzaria/text_book/utils/link_preview_utils.dart';
 import 'package:otzaria/plugins/services/plugin_highlight_renderer.dart';
 import 'package:otzaria/plugins/view/plugin_highlight_frame_overlay.dart';
+import 'package:otzaria/widgets/smart_text/exact_line_height.dart';
 import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
 
 /// תגובה ללחיצה על קישור inline בתוך פסקה של מצב טקסט רציף.
@@ -196,7 +197,11 @@ class _ContinuousReadingParagraphState
     final textSpan = TextSpan(style: widget.baseStyle, children: spans);
     // justify אינו מותח שורה אחרונה, ולכן גם לא פסקה בת שורה חזותית אחת.
     // מדידה מוקדמת של מספר השורות = layout שני על כל הפסקה, ומייקרת גלילה.
-    final text = Text.rich(textSpan, textAlign: widget.textAlign);
+    final text = Text.rich(
+      textSpan,
+      textAlign: widget.textAlign,
+      strutStyle: exactLineHeightStrut(widget.baseStyle, textSpan),
+    );
     if (frameRanges.isEmpty) return text;
     return PluginHighlightFrameOverlay(ranges: frameRanges, child: text);
   }

--- a/lib/widgets/misc/link_context_menu_entry.dart
+++ b/lib/widgets/misc/link_context_menu_entry.dart
@@ -5,6 +5,7 @@ import 'package:otzaria/settings/services/nikud_display_service.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/widgets/misc/app_popup_menu.dart';
+import 'package:otzaria/widgets/smart_text/exact_line_height.dart';
 import 'package:otzaria/widgets/smart_text/smart_text.dart';
 
 /// בונה פריט תפריט הקשר עבור קישור בודד בתת-תפריט "קישורים".
@@ -236,17 +237,23 @@ class _LinkHoverPreviewContentState extends State<LinkHoverPreviewContent> {
                         if (removePunctuation) {
                           measureText = utils.removePunctuation(measureText);
                         }
+                        final measureStyle = TextStyle(
+                          fontSize: fontSize,
+                          fontFamily: settingsState.commentatorsFontFamily,
+                          height: lineHeight,
+                          fontWeight: settingsState.commentatorsFontBold
+                              ? FontWeight.bold
+                              : null,
+                        );
+                        final measureSpan = TextSpan(
+                          text: measureText,
+                          style: measureStyle,
+                        );
                         final painter = TextPainter(
-                          text: TextSpan(
-                            text: measureText,
-                            style: TextStyle(
-                              fontSize: fontSize,
-                              fontFamily: settingsState.commentatorsFontFamily,
-                              height: lineHeight,
-                              fontWeight: settingsState.commentatorsFontBold
-                                  ? FontWeight.bold
-                                  : null,
-                            ),
+                          text: measureSpan,
+                          strutStyle: exactLineHeightStrut(
+                            measureStyle,
+                            measureSpan,
                           ),
                           textDirection: TextDirection.rtl,
                           maxLines: null,

--- a/lib/widgets/smart_text/exact_line_height.dart
+++ b/lib/widgets/smart_text/exact_line_height.dart
@@ -1,0 +1,52 @@
+/// קיבוע גובה השורה לגובה שהטקסט הראשי מכתיב.
+///
+/// מנוע הטקסט קובע את גובה כל שורה לפי ה-ascent/descent הגדולים ביותר מבין
+/// ריצות-הטקסט שבה. די לכן בריצה אחת שונה כדי למתוח את השורה כולה ולשבור את
+/// אחידות המרווח — מילה ב-`<big>` (סימוני "גמ׳" ו"מתני׳" בתלמוד), או ספרת
+/// superscript של סימון הערה, שאין לה גליף באף אחד מגופני האפליקציה ולכן
+/// נפתרת לגופן מערכת שיחסי ה-ascent/descent שלו אחרים.
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
+
+/// [StrutStyle] שמקבע כל שורה לגובה `fontSize × height` של [baseStyle] — הגובה
+/// של שורה שכל תוכנה בגופן הבסיס (המנוע מעגל אותו לפיקסל שלם, אותו עיגול בכל
+/// השורות).
+///
+/// מחזיר null כשאסור לקבע: ווידג'ט inline (שגובהו אמיתי ולא מטריקה של גופן), או
+/// ריצה שגדולה מ-`<big>` או מתיבת השורה עצמה — כותרת בתוך שורה, וגם `<big>`
+/// במרווח שורות צפוף, באמת צריכות יותר מקום, וקיבוע היה מפיל אותן על השורה
+/// שמעליה.
+StrutStyle? exactLineHeightStrut(TextStyle baseStyle, InlineSpan content) {
+  final fontSize = baseStyle.fontSize;
+  final lineHeight = baseStyle.height;
+  if (fontSize == null || lineHeight == null) return null;
+  final maxRunFontSize = fontSize * math.min(kHtmlLargerFontScale, lineHeight);
+  if (!_fitsLineBox(content, maxRunFontSize)) return null;
+
+  return StrutStyle.fromTextStyle(
+    baseStyle,
+    // חלוקת ה-leading חייבת להיות מפורשת ולא בירושה: בחלוקה proportional
+    // המנוע מחלק את הגובה המבוקש גם על ה-lineGap של הגופן אך אינו מוסיף אותו
+    // לתיבת השורה, וה-strut יוצא נמוך מ-fontSize×height.
+    leadingDistribution: TextLeadingDistribution.even,
+    forceStrutHeight: true,
+  );
+}
+
+/// רקורסיה ידנית ולא `visitChildren`: זה מדלג על ספאן שאין לו `text`, ולכן
+/// ספאן-אב שנושא את הגופן הגדול היה חומק מהבדיקה.
+bool _fitsLineBox(InlineSpan content, double maxRunFontSize) {
+  if (content is! TextSpan) return false;
+  final fontSize = content.style?.fontSize;
+  if (fontSize != null && fontSize > maxRunFontSize + _epsilon) return false;
+  for (final child in content.children ?? const <InlineSpan>[]) {
+    if (!_fitsLineBox(child, maxRunFontSize)) return false;
+  }
+  return true;
+}
+
+const double _epsilon = 0.01;

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -10,6 +10,7 @@ import 'package:otzaria/text_book/utils/link_preview_utils.dart';
 import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/utils/text/html_link_handler.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
+import 'package:otzaria/widgets/smart_text/exact_line_height.dart';
 import 'package:otzaria/widgets/smart_text/render_settings.dart';
 import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
 import 'package:otzaria/widgets/smart_text/text_renderer_service.dart';
@@ -48,7 +49,8 @@ class SmartTextWidget extends StatelessWidget {
   final void Function(String url)? onAnchorTap;
 
   /// callback לריחוף מעל עוגן-מילה — מקבל את ה-URL ואת מיקום הסמן הגלובלי.
-  /// כשמסופק, סמני העוגן מרונדרים כווידג'ט inline (ל-fwfh אין hover על <a>).
+  /// כשמסופק, onEnter/onExit מוזרקים ל-TextSpan של הסמן (ל-fwfh אין hover על
+  /// `<a>`), והסמן נשאר ספאן טקסט.
   final void Function(String url, Offset globalPosition)? onAnchorHover;
 
   /// callback ליציאת הסמן מעוגן-מילה.
@@ -209,6 +211,7 @@ class SmartTextWidget extends StatelessWidget {
             child: Text.rich(
               simpleSpan,
               style: textStyle,
+              strutStyle: exactLineHeightStrut(textStyle, simpleSpan),
               textAlign: settings.justifyText
                   ? TextAlign.justify
                   : TextAlign.right,
@@ -255,17 +258,22 @@ class SmartTextWidget extends StatelessWidget {
           if (headingWeight != null) {
             return {'font-weight': headingWeight};
           }
-          // הסמנים מוקטנים אך נשארים על קו הבסיס: הגבהה ב-fwfh אפשרית רק דרך
-          // vertical-align, שבונה WidgetSpan — וזה מחזיר את היפוך הסדר ב-RTL.
           if (element.localName == 'span' &&
               element.classes.contains('footnote-marker-number')) {
-            return {'font-size': '0.75em', 'font-style': 'italic'};
+            return {
+              'font-size': '0.75em',
+              'font-style': 'italic',
+              'position': 'relative',
+              'top': '-0.55em',
+            };
           }
           if (element.localName == 'a' &&
               element.classes.contains('book-note-marker')) {
             return {
               'font-size': '0.75em',
               'font-style': 'italic',
+              'position': 'relative',
+              'top': '-0.55em',
               'color': anchorColorCss,
               'text-decoration': 'none',
             };
@@ -276,12 +284,14 @@ class SmartTextWidget extends StatelessWidget {
               element.classes.contains('numbered-note-marker')) {
             return {'color': anchorLinkColorCss, 'text-decoration': 'none'};
           }
-          // סמן-אות של מפרש (עוגן-נקודה): אות קטנה בצבע ה-primary, עם
+          // סמן-אות של מפרש (עוגן-נקודה): אות קטנה מורמת בצבע ה-primary, עם
           // וריאנט טיפוגרפי קבוע לכל מפרש (ראו anchorStyleIndexByCommentator).
           if ((element.localName == 'span' || element.localName == 'a') &&
               element.classes.contains('link-anchor')) {
             final style = <String, String>{
               'font-size': '${kLinkAnchorMarkerScale}em',
+              'position': 'relative',
+              'top': '-0.55em',
               'white-space': 'nowrap',
               'color': anchorLinkColorCss,
               'text-decoration': 'none',
@@ -356,11 +366,12 @@ class SmartTextWidget extends StatelessWidget {
   }
 }
 
-/// WidgetFactory ל-fwfh עם שתי אחריות:
+/// WidgetFactory ל-fwfh עם שלוש אחריות:
 /// 1. בולד אמיתי לגופן משתנה — מזריק FontVariation('wght') לספאנים מודגשים.
 /// 2. ריחוף על עוגני-מילה — fwfh בונה recognizer לכל `<a>`; זוכרים אילו
 ///    recognizers שייכים ל-href של עוגן, וכשה-TextSpan נבנה מזריקים
 ///    onEnter/onExit לצד ה-recognizer הקיים.
+/// 3. קיבוע גובה השורה — ראו [buildText].
 class _SmartTextWidgetFactory extends WidgetFactory {
   final void Function(String url, Offset globalPosition)? onAnchorHover;
   final void Function(String url)? onAnchorHoverExit;
@@ -379,6 +390,62 @@ class _SmartTextWidgetFactory extends WidgetFactory {
       _previewHrefByRecognizer[recognizer] = href;
     }
     return recognizer;
+  }
+
+  /// ה-RichText של fwfh נבנה בלי strut ואין פרמטר להעביר אחד מבחוץ, לכן
+  /// בונים מחדש את מה ש-fwfh בנה עם [exactLineHeightStrut]. מבנה אחר מהצפוי
+  /// (גרסת fwfh חדשה) פשוט נשאר כפי שהוא — בלי קיבוע.
+  @override
+  Widget? buildText(
+    BuildTree tree,
+    InheritedProperties resolved,
+    InlineSpan text,
+  ) {
+    final built = super.buildText(tree, resolved, text);
+    final strutStyle = exactLineHeightStrut(resolved.prepareTextStyle(), text);
+    if (strutStyle == null || built is! Builder) {
+      return built;
+    }
+
+    return Builder(
+      builder: (context) {
+        final child = built.builder(context);
+        if (child is RichText) {
+          return _withStrutStyle(child, strutStyle);
+        }
+        if (child is MouseRegion && child.child is RichText) {
+          return MouseRegion(
+            onEnter: child.onEnter,
+            onExit: child.onExit,
+            onHover: child.onHover,
+            cursor: child.cursor,
+            opaque: child.opaque,
+            hitTestBehavior: child.hitTestBehavior,
+            child: _withStrutStyle(child.child! as RichText, strutStyle),
+          );
+        }
+        return child;
+      },
+    );
+  }
+
+  static RichText _withStrutStyle(RichText source, StrutStyle strutStyle) {
+    return RichText(
+      key: source.key,
+      text: source.text,
+      textAlign: source.textAlign,
+      textDirection: source.textDirection,
+      softWrap: source.softWrap,
+      overflow: source.overflow,
+      textScaler: source.textScaler,
+      maxLines: source.maxLines,
+      locale: source.locale,
+      strutStyle: strutStyle,
+      textWidthBasis: source.textWidthBasis,
+      textHeightBehavior: source.textHeightBehavior,
+      selectionRegistrar: source.selectionRegistrar,
+      selectionColor: source.selectionColor,
+    );
   }
 
   @override

--- a/test/widgets/smart_text/exact_line_height_test.dart
+++ b/test/widgets/smart_text/exact_line_height_test.dart
@@ -58,6 +58,9 @@ TextSpan _withForeignRun(TextStyle base) => TextSpan(
   ],
 );
 
+TextSpan _withSuperscriptRun(TextStyle base) =>
+    TextSpan(text: 'ויאמר ¹² אל העם', style: base);
+
 /// שורה שבתוכה מילה ב-`<big>` — הסימון "גמ׳" בתלמוד.
 TextSpan _withBigRun(TextStyle base) => TextSpan(
   style: base,
@@ -91,6 +94,20 @@ void main() {
         _paragraphHeight(_withForeignRun(base)),
         greaterThan(_paragraphHeight(_plain(base))),
       );
+    });
+
+    test('ספרות עיליות נשארות בגובה שורה קבוע', () {
+      for (final family in _fontFiles.keys) {
+        final base = TextStyle(fontFamily: family, fontSize: 18, height: 1.5);
+        final content = _withSuperscriptRun(base);
+        final strutStyle = exactLineHeightStrut(base, content);
+        expect(strutStyle, isNotNull, reason: family);
+        expect(
+          _paragraphHeight(content, strutStyle: strutStyle),
+          _paragraphHeight(_plain(base)),
+          reason: family,
+        );
+      }
     });
 
     test('עם קיבוע — גובה השורה זהה לשורה שכולה בגופן הבסיס', () {

--- a/test/widgets/smart_text/exact_line_height_test.dart
+++ b/test/widgets/smart_text/exact_line_height_test.dart
@@ -1,0 +1,374 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+import 'package:otzaria/text_book/view/widgets/continuous_reading_paragraph.dart';
+import 'package:otzaria/widgets/smart_text/exact_line_height.dart';
+import 'package:otzaria/widgets/smart_text/render_settings.dart';
+import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
+import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
+
+/// גופני האפליקציה נטענים מהדיסק: מטריקות ה-ascent/descent האמיתיות שלהם הן
+/// כל הסיפור כאן, וגופן הבדיקה של flutter_test אינו מייצג אותן.
+const _fontFiles = {
+  'FrankRuhlCLM': 'fonts/FrankRuehlCLM-Medium.ttf',
+  'TaameyDavidCLM': 'fonts/TaameyDavidCLM-Medium.ttf',
+  'KeterYG': 'fonts/KeterYG-Medium.ttf',
+  'Tinos': 'fonts/Tinos-Regular.ttf',
+  // עומד כאן במקום גופן ה-fallback של המערכת, שאליו נופלות ספרות superscript
+  // (אין להן גליף באף גופן עברי באפליקציה).
+  'Rubik': 'fonts/Rubik-VariableFont_wght.ttf',
+};
+
+Future<void> _loadFonts() async {
+  for (final entry in _fontFiles.entries) {
+    final bytes = await File(entry.value).readAsBytes();
+    await (FontLoader(
+      entry.key,
+    )..addFont(Future.value(ByteData.sublistView(bytes)))).load();
+  }
+}
+
+double _paragraphHeight(InlineSpan span, {StrutStyle? strutStyle}) {
+  final painter = TextPainter(
+    text: span,
+    textDirection: TextDirection.rtl,
+    strutStyle: strutStyle,
+  )..layout(maxWidth: 2000);
+  final height = painter.height;
+  painter.dispose();
+  return height;
+}
+
+TextSpan _plain(TextStyle base) =>
+    TextSpan(text: 'ויאמר משה אל העם', style: base);
+
+/// שורה שבתוכה ריצה בגופן אחר — כמו סימון הערה שנפתר לגופן מערכת.
+TextSpan _withForeignRun(TextStyle base) => TextSpan(
+  style: base,
+  children: const [
+    TextSpan(text: 'ויאמר משה '),
+    TextSpan(
+      text: '1',
+      style: TextStyle(fontFamily: 'Rubik'),
+    ),
+    const TextSpan(text: ' אל העם'),
+  ],
+);
+
+/// שורה שבתוכה מילה ב-`<big>` — הסימון "גמ׳" בתלמוד.
+TextSpan _withBigRun(TextStyle base) => TextSpan(
+  style: base,
+  children: [
+    TextSpan(
+      text: 'גמ׳ ',
+      style: TextStyle(fontSize: base.fontSize! * kHtmlLargerFontScale),
+    ),
+    const TextSpan(text: 'תנא היכא קאי'),
+  ],
+);
+
+Widget _wrap(Widget child) => MaterialApp(
+  home: Directionality(
+    textDirection: TextDirection.rtl,
+    child: Scaffold(body: child),
+  ),
+);
+
+void main() {
+  setUpAll(_loadFonts);
+
+  group('exactLineHeightStrut', () {
+    test('בלי קיבוע — ריצה בגופן אחר מגדילה את גובה השורה', () {
+      const base = TextStyle(
+        fontFamily: 'TaameyDavidCLM',
+        fontSize: 18,
+        height: 1.5,
+      );
+      expect(
+        _paragraphHeight(_withForeignRun(base)),
+        greaterThan(_paragraphHeight(_plain(base))),
+      );
+    });
+
+    test('עם קיבוע — גובה השורה זהה לשורה שכולה בגופן הבסיס', () {
+      for (final family in _fontFiles.keys) {
+        for (final fontSize in [16.0, 18.0, 22.0]) {
+          for (final lineHeight in [1.0, 1.5, 2.2]) {
+            final base = TextStyle(
+              fontFamily: family,
+              fontSize: fontSize,
+              height: lineHeight,
+            );
+            final content = _withForeignRun(base);
+            final strutStyle = exactLineHeightStrut(base, content);
+            expect(strutStyle, isNotNull);
+            expect(
+              _paragraphHeight(content, strutStyle: strutStyle),
+              _paragraphHeight(_plain(base)),
+              reason: '$family $fontSize/$lineHeight',
+            );
+          }
+        }
+      }
+    });
+
+    // הסימון "גמ׳" בתלמוד הוא <big><strong>, ולכן השורה שבה הוא יושב גבוהה
+    // מהשורות סביבה — זו הדוגמה שהמשתמש דיווח עליה.
+    test('מילה ב-<big> נכנסת לתיבת השורה — מקובעת לגובה הרגיל', () {
+      for (final family in _fontFiles.keys) {
+        final base = TextStyle(fontFamily: family, fontSize: 18, height: 1.5);
+        final withBig = _withBigRun(base);
+        expect(
+          _paragraphHeight(withBig),
+          greaterThan(_paragraphHeight(_plain(base))),
+          reason: family,
+        );
+        expect(
+          _paragraphHeight(
+            withBig,
+            strutStyle: exactLineHeightStrut(base, withBig),
+          ),
+          _paragraphHeight(_plain(base)),
+          reason: family,
+        );
+      }
+    });
+
+    test('ריצה גדולה מ-<big> אינה מקובעת — כותרת בשורה צריכה מקום', () {
+      const base = TextStyle(
+        fontFamily: 'FrankRuhlCLM',
+        fontSize: 18,
+        height: 1.5,
+      );
+      final withHuge = TextSpan(
+        style: base,
+        children: const [
+          TextSpan(text: 'כותרת', style: TextStyle(fontSize: 36)),
+          TextSpan(text: ' והמשך'),
+        ],
+      );
+      expect(exactLineHeightStrut(base, withHuge), isNull);
+    });
+
+    // במרווח צפוף אין בתיבת השורה מקום לגליפים של ריצה מוגדלת, וקיבוע היה
+    // מפיל אותם על השורה שמעליה (נמדד: חפיפה של 1–3px במרווח 1.0–1.1).
+    test('<big> אינו מקובע כשמרווח השורות צפוף מהגדלת הגופן', () {
+      for (final lineHeight in [1.0, 1.1]) {
+        final base = TextStyle(
+          fontFamily: 'FrankRuhlCLM',
+          fontSize: 18,
+          height: lineHeight,
+        );
+        expect(
+          exactLineHeightStrut(base, _withBigRun(base)),
+          isNull,
+          reason: 'מרווח $lineHeight',
+        );
+      }
+    });
+
+    // רגרסיה: TextSpan.visitChildren מדלג על ספאן בלי text, ולכן בדיקת הגדלים
+    // חייבת לרדת בעץ בעצמה — אחרת ספאן-אב שנושא את הגופן הגדול חומק ממנה.
+    test('גופן גדול על ספאן-אב (בלי text משלו) נתפס', () {
+      const base = TextStyle(
+        fontFamily: 'FrankRuhlCLM',
+        fontSize: 18,
+        height: 1.5,
+      );
+      final nested = TextSpan(
+        style: base,
+        children: const [
+          TextSpan(
+            style: TextStyle(fontSize: 54),
+            children: [TextSpan(text: 'כותרת ענקית')],
+          ),
+        ],
+      );
+      expect(exactLineHeightStrut(base, nested), isNull);
+    });
+
+    test('ווידג\'ט inline אינו מקובע', () {
+      const base = TextStyle(
+        fontFamily: 'FrankRuhlCLM',
+        fontSize: 18,
+        height: 1.5,
+      );
+      final withWidget = TextSpan(
+        style: base,
+        children: const [
+          TextSpan(text: 'ויאמר '),
+          WidgetSpan(child: SizedBox(width: 10, height: 40)),
+        ],
+      );
+      expect(exactLineHeightStrut(base, withWidget), isNull);
+    });
+
+    test('בלי גודל גופן או גובה שורה אין מה לקבע', () {
+      const noSize = TextStyle(fontFamily: 'FrankRuhlCLM', height: 1.5);
+      const noHeight = TextStyle(fontFamily: 'FrankRuhlCLM', fontSize: 18);
+      expect(exactLineHeightStrut(noSize, _plain(noSize)), isNull);
+      expect(exactLineHeightStrut(noHeight, _plain(noHeight)), isNull);
+    });
+  });
+
+  group('מסלולי הרינדור מקבעים את גובה השורה', () {
+    testWidgets('המסלול המהיר של SmartTextWidget', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: 'ויאמר משה אל העם',
+            settings: RenderSettings(
+              fontSize: 18,
+              fontFamily: 'FrankRuhlCLM',
+              lineHeight: 1.5,
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(richText.strutStyle?.forceStrutHeight, isTrue);
+    });
+
+    testWidgets('מסלול ה-HtmlWidget', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const SmartTextWidget(
+            text: 'טקסט <span class="link-anchor">א</span> ועוד',
+            settings: RenderSettings(
+              fontSize: 18,
+              fontFamily: 'FrankRuhlCLM',
+              lineHeight: 1.5,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HtmlWidget), findsOneWidget);
+      final richText = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .firstWhere((widget) => widget.text.toPlainText().contains('ועוד'));
+      expect(richText.strutStyle?.forceStrutHeight, isTrue);
+    });
+
+    // רגרסיה מקצה לקצה על צורת הטקסט בתלמוד, בשני המסלולים: `<big><strong>`
+    // לבדו נשאר במסלול המהיר, ותוספת סמן-עוגן מעבירה את השורה ל-HtmlWidget.
+    for (final withAnchor in [false, true]) {
+      final anchor = withAnchor ? ' <span class="link-anchor">א</span>' : '';
+      testWidgets(
+        'שורת "גמ׳" בגובה של שורה רגילה'
+        '${withAnchor ? ' (מסלול HtmlWidget)' : ''}',
+        (tester) async {
+          const settings = RenderSettings(
+            fontSize: 18,
+            fontFamily: 'FrankRuhlCLM',
+            lineHeight: 1.5,
+          );
+          await tester.pumpWidget(
+            _wrap(
+              SizedBox(
+                width: 600,
+                child: Column(
+                  children: [
+                    SmartTextWidget(
+                      text:
+                          '<big><strong>גמ׳</strong></big> תנא היכא קאי$anchor',
+                      settings: settings,
+                    ),
+                    SmartTextWidget(
+                      text: 'תנא היכא קאי$anchor',
+                      settings: settings,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            find.byType(HtmlWidget),
+            withAnchor ? findsNWidgets(2) : findsNothing,
+          );
+          final heights = tester
+              .widgetList<RichText>(find.byType(RichText))
+              .where((widget) => widget.text.toPlainText().contains('היכא'))
+              .map((widget) => tester.getSize(find.byWidget(widget)).height)
+              .toList();
+          expect(heights, hasLength(2));
+          expect(heights.first, heights.last);
+        },
+      );
+    }
+
+    testWidgets('פסקה במצב קריאה רציפה', (tester) async {
+      const base = TextStyle(
+        fontFamily: 'FrankRuhlCLM',
+        fontSize: 18,
+        height: 1.5,
+      );
+      await tester.pumpWidget(
+        _wrap(
+          ContinuousReadingParagraph(
+            lines: const [
+              ContinuousReadingParagraphLine(
+                lineIndex: 0,
+                text: 'ויאמר משה אל העם',
+                htmlText: 'ויאמר משה אל העם',
+                style: base,
+              ),
+            ],
+            baseStyle: base,
+            onLineTap: (_) {},
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(richText.strutStyle?.forceStrutHeight, isTrue);
+    });
+
+    testWidgets('פסקה רציפה עם סימון גמ׳ — גובה הפסקה כפולה של גובה השורה', (
+      tester,
+    ) async {
+      const base = TextStyle(
+        fontFamily: 'FrankRuhlCLM',
+        fontSize: 18,
+        height: 1.5,
+      );
+      const html =
+          '<big><strong>גמ׳</strong></big> תנא היכא קאי דקתני מאימתי '
+          'ותו מאי שנא דתני בערבית ברישא לתני בשחרית ברישא';
+      await tester.pumpWidget(
+        _wrap(
+          SizedBox(
+            width: 240,
+            child: ContinuousReadingParagraph(
+              lines: const [
+                ContinuousReadingParagraphLine(
+                  lineIndex: 0,
+                  text: html,
+                  htmlText: html,
+                  style: base,
+                ),
+              ],
+              baseStyle: base,
+              onLineTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // גובה השורה הנקייה כפי שהמנוע מעגל אותו — ולא 18×1.5 — כדי שהבדיקה
+      // תמדוד אחידות ולא תיפול על עיגול לפיקסל שלם.
+      final lineBox = _paragraphHeight(_plain(base));
+      final height = tester.getSize(find.byType(RichText)).height;
+      expect(height, greaterThan(lineBox));
+      expect(height % lineBox, 0);
+    });
+  });
+}

--- a/test/widgets/smart_text/exact_line_height_test.dart
+++ b/test/widgets/smart_text/exact_line_height_test.dart
@@ -54,7 +54,7 @@ TextSpan _withForeignRun(TextStyle base) => TextSpan(
       text: '1',
       style: TextStyle(fontFamily: 'Rubik'),
     ),
-    const TextSpan(text: ' אל העם'),
+    TextSpan(text: ' אל העם'),
   ],
 );
 


### PR DESCRIPTION
## הבעיה

מרווח השורות בעיון בספר אינו אחיד: שורה בודדת בתוך פסקה גבוהה בכמה פיקסלים מהשורות סביבה. הכי בולט בתצוגה הרציפה, שבה כל הפסקה היא בלוק אחד ולכן שורה חורגת צובטת את העין.

הסיבה: מנוע הטקסט קובע את גובה כל שורה לפי ה-`ascent`/`descent` הגדולים ביותר מבין ריצות-הטקסט שבה, ולכל גופן יחס `ascent`/`descent` משלו. די לכן בריצה אחת שונה כדי למתוח את השורה כולה:

| הגורם | דוגמה | המידה |
|---|---|---|
| מילה ב-`<big>` | הסימונים `<big><strong>גמ׳</strong></big>` ו-`מתני׳` בתלמוד | 27px → 32px (פרנק-רוהל, 18/1.5) |
| ספרת superscript של סימון הערה | `<sup>1</sup>` → `¹` | 27px → 28px |

לספרות העיליות (`¹²³`) אין גליף **באף אחד** מגופני האפליקציה (נבדק בטבלאות ה-cmap של כל הקבצים ב-`fonts/`), ולכן הן נפתרות לגופן מערכת שיחסי המטריקות שלו אחרים. בגופן "דוד" השורה נמתחת מ-27px ל-31px, ובמרווח 2.2 מ-40px ל-48px.

## התיקון

`exactLineHeightStrut` (חדש, `lib/widgets/smart_text/exact_line_height.dart`) מחזיר `StrutStyle` שמקבע כל שורה לגובה `fontSize × height` של הטקסט הראשי — הגובה שיש לשורה שכל תוכנה בגופן הבסיס (המנוע מעגל אותו לפיקסל שלם, אותו עיגול בכל השורות, ולכן האחידות נשמרת).

שתי נקודות עדינות:

- **`leadingDistribution: even` מפורש.** בחלוקת `proportional` המנוע מחלק את הגובה המבוקש גם על ה-`lineGap` של הגופן אך אינו מוסיף אותו לתיבת השורה, וה-strut יוצא נמוך מהמבוקש (בפרנק-רוהל: 25px במקום 27px). תופעת לוואי: חלוקה שווה של ה-leading ממרכזת את הטקסט בתיבת השורה, ולכן הטקסט זז עד 4px בתוך התיבה (במרווח 2.2) — הזזה זהה בכל השורות, גובה התיבה לא משתנה, והמרכוז יוצא סימטרי במקום 5.03px מעל / 1.73px מתחת.
- **הקיבוע מושהה** כשיש בשורה ווידג'ט inline, ריצה גדולה מ-`<big>`, או `<big>` במרווח שורות צפוף מהגדלת הגופן (`height < 6/5`) — שם באמת אין מקום, ומדידת דיו ברסטריזציה הראתה שקיבוע היה מייצר חפיפה של 1–3px עם השורה שמעליה. מ-1.2 ומעלה יש 1–3px אוויר, ובברירת המחדל 1.5 יש 6–8px.

מוחל בשלושת מסלולי הרינדור, כדי שהתנהגות זהה בכולם:

1. המסלול המהיר של `SmartTextWidget` (`Text.rich`).
2. מסלול `HtmlWidget` — ל-fwfh אין פרמטר strut ואין דרך להעביר לו אחד, לכן `buildText` בונה מחדש את ה-`RichText` שהוא בנה בתוספת ה-strut (עם נפילה חזרה למימוש של fwfh כשאין מה לקבע).
3. הפסקה של הקריאה הרציפה (`ContinuousReadingParagraph`).

## בדיקות

`test/widgets/smart_text/exact_line_height_test.dart` — טוען את גופני האפליקציה מהדיסק (גופן הבדיקה של `flutter_test` אינו מייצג את המטריקות האמיתיות, שהן כל הסיפור כאן) ומאמת:

- שורה עם ריצה בגופן אחר או מילה ב-`<big>` **גבוהה** מהשורה הנקייה — כלומר הבאג מתועד.
- עם הקיבוע הגובה **זהה** לשורה הנקייה: ריצה בגופן אחר על 5 גופנים × 3 גדלים × 3 מרווחי שורה, ו-`<big>` על 5 הגופנים.
- אינם מקובעים: ריצה גדולה מ-`<big>`, `<big>` במרווח 1.0–1.1, ווידג'ט inline, וגופן גדול שיושב על ספאן-אב בלי `text` משלו (`TextSpan.visitChildren` מדלג על ספאן כזה, ולכן הבדיקה יורדת בעץ בעצמה).
- שלושת מסלולי הרינדור מקבלים strut, כולל שורת `<big><strong>גמ׳</strong></big>` מקצה-לקצה — במסלול המהיר וגם במסלול `HtmlWidget` — שגובהה שווה לשורה רגילה, ופסקה רציפה שגובהה כפולה שלמה של גובה השורה.

הבדיקות רגישות למוטציות: ביטול התיקון מפיל 7 מ-14, הסרת `forceStrutHeight` מפילה 7, הסרת `leadingDistribution: even` מפילה 2, והסרת ה-strut מכל אחד משלושת אתרי הרינדור נתפסת בנפרד.

`flutter analyze` נקי, ו-`flutter test test/widgets/ test/text_book/` עובר.

## מה נשאר בכוונה מחוץ לתיקון

- `<sup>` **חשוף** שאינו סימון הערה (ייבוא Word) — fwfh מממש אותו כ-`WidgetSpan` דרך `vertical-align: super`, ולכן השורה שלו נשארת גבוהה (נמדד 33px). לא רגרסיה, ונדיר: שני סוגי הסמנים הנפוצים (מספרי ואות עברית) כן מתוקנים.
- `HtmlWidget` שמחוץ ל-`SmartTextWidget` — התצוגה המקדימה בעורך (`preview_renderer.dart`) ודיאלוג גרסאות הספר — אינו מקבל `factoryBuilder` ולכן גם לא strut. שווה השוואה לקורא בהמשך.
- מדידת הגובה ב-`link_context_menu_entry.dart` נעשית ב-`TextPainter` בלי strut (להחלטה על "…"), ולכן עשויה לסטות בשורה אחת. המדידה שם ממילא מקורבת.
- הספרות העיליות של סימוני ההערות עדיין מרונדרות בגופן מערכת (אין להן גליף בגופני האפליקציה) — המרווח תוקן, אך הטיפוגרפיה שלהן שונה משאר הטקסט. אפשר לאחד אותן עם סמני-האות של המפרשים בהמשך.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
