### PR TITLE
כלים: פאנל המשגר נסגר בלחיצה על מסגרת החלון

### DIFF
--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -108,6 +108,10 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
   // הבחירה נדחית לשחרור כדי שתחילת גרירה לא תחליף את התצוגה.
   OpenedTab? _pendingTabSelection;
 
+  // הטאב שהעכבר מעליו. שדה ולא משתנה מקומי ב-_buildTab: rebuild של ההורה היה
+  // מאפס אותו, וה-X שמוצג רק בריחוף היה נמחק מתחת לסמן לפני שהלחיצה נורית.
+  OpenedTab? _hoveredTab;
+
   /// המקש שמפעיל בחירה מרובה: Ctrl בכל הפלטפורמות, Command במק.
   bool get _isMultiSelectModifierPressed {
     final keyboard = HardwareKeyboard.instance;
@@ -756,7 +760,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         Settings.getValue<String>('key-shortcut-close-tab') ?? 'ctrl+w';
 
     bool isTabActive(int tabIndex) => tabIndex == state.currentTabIndex;
-    bool isTabHovered = false;
+    bool isTabHovered = identical(_hoveredTab, tab);
 
     // כותרת בשורה אחת שמוצגת מההתחלה (RTL: מימין) ונדהית רק בקצה הסוף, כמו
     // כרום. TextOverflow.fade/clip של פלאטר מציג בעברית את *סוף* הכותרת
@@ -1054,8 +1058,16 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         child: StatefulBuilder(
           builder: (context, setLocalState) {
             return MouseRegion(
-              onEnter: (_) => setLocalState(() => isTabHovered = true),
-              onExit: (_) => setLocalState(() => isTabHovered = false),
+              // setLocalState מצייר מחדש את הטאב הזה בלבד; השדה שומר את המצב
+              // כך שישרוד rebuild של שורת הטאבים.
+              onEnter: (_) => setLocalState(() {
+                isTabHovered = true;
+                _hoveredTab = tab;
+              }),
+              onExit: (_) => setLocalState(() {
+                isTabHovered = false;
+                if (identical(_hoveredTab, tab)) _hoveredTab = null;
+              }),
               child: buildTabAppearance(setLocalState),
             );
           },

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -2913,11 +2913,17 @@ class MainWindowScreenState extends State<MainWindowScreen>
                         Column(
                           children: [
                             if (!isImmersive)
-                              CustomTitleBar(
-                                onReadingSettingsPressed:
-                                    _toggleReadingSettingsPanel,
-                                isReadingSettingsPanelOpen:
-                                    _isReadingSettingsPanelOpen,
+                              // מסגרת החלון יושבת מעל ה-scrim של פאנל הכלים;
+                              // Listener פסיבי סוגר בלי לחטוף את הלחיצה.
+                              Listener(
+                                behavior: HitTestBehavior.translucent,
+                                onPointerDown: (_) => _closeToolsLauncher(),
+                                child: CustomTitleBar(
+                                  onReadingSettingsPressed:
+                                      _toggleReadingSettingsPanel,
+                                  isReadingSettingsPanelOpen:
+                                      _isReadingSettingsPanelOpen,
+                                ),
                               ),
                             Expanded(
                               child: OrientationBuilder(

--- a/test/navigation/custom_title_bar_test.dart
+++ b/test/navigation/custom_title_bar_test.dart
@@ -810,6 +810,78 @@ void main() {
       );
     });
 
+    testWidgets('ה-X של טאב צר תחת ריחוף שורד בנייה מחדש של שורת הטאבים', (
+      tester,
+    ) async {
+      // בטאב צר שאינו נבחר ה-X מוצג רק בריחוף. כשמצב הריחוף לא שרד בנייה מחדש
+      // של השורה, ה-IconButton נמחק מתחת לסמן ולחיצה עליו לא סגרה את הטאב.
+      final tabs = List.generate(10, (i) => _makeTextTab('ספר מספר $i'));
+      final tabsBloc = _TestTabsBloc(
+        TabsState(tabs: tabs, currentTabIndex: 0),
+      );
+      final navigationBloc = _TestNavigationBloc(
+        const NavigationState(currentScreen: Screen.reading),
+      );
+      final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+      final historyBloc = _TestHistoryBloc();
+
+      addTearDown(() async {
+        for (final t in tabs) {
+          t.dispose();
+        }
+        await tabsBloc.close();
+        await navigationBloc.close();
+        await settingsBloc.close();
+        await historyBloc.close();
+      });
+
+      await _setSurfaceSize(tester, const Size(900, 800));
+      await _pumpTitleBar(
+        tester,
+        tabsBloc: tabsBloc,
+        navigationBloc: navigationBloc,
+        settingsBloc: settingsBloc,
+        historyBloc: historyBloc,
+      );
+      await tester.pumpAndSettle();
+
+      final hoveredTab = find.ancestor(
+        of: find.text('ספר מספר 3'),
+        matching: find.byType(Tab),
+      );
+      final closeButton = find.descendant(
+        of: hoveredTab,
+        matching: find.byIcon(FluentIcons.dismiss_24_regular),
+      );
+      expect(closeButton, findsNothing, reason: 'בטאב צר לא-נבחר ה-X מוסתר');
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: tester.getCenter(hoveredTab));
+      addTearDown(gesture.removePointer);
+      await tester.pumpAndSettle();
+      expect(closeButton, findsOneWidget, reason: 'ריחוף חושף את ה-X');
+
+      // בנייה מחדש של השורה מסיבה חיצונית — כמו setState של המסך העוטף.
+      tester.element(find.byType(CustomTitleBar)).markNeedsBuild();
+      await tester.pumpAndSettle();
+
+      expect(
+        closeButton,
+        findsOneWidget,
+        reason: 'ה-X חייב להישאר תחת הסמן גם אחרי בנייה מחדש',
+      );
+      tester
+          .widget<IconButton>(
+            find.ancestor(of: closeButton, matching: find.byType(IconButton)),
+          )
+          .onPressed!();
+      await tester.pump();
+      expect(
+        tabsBloc.addedEvents.whereType<RemoveTab>().map((e) => e.tab),
+        contains(same(tabs[3])),
+      );
+    });
+
     testWidgets('בצפיפות הטאב הנבחר שומר רוחב מזערי וכפתור ה-X שלו נשאר', (
       tester,
     ) async {


### PR DESCRIPTION
## הבאג

פותחים את פאנל הכלים מסרגל הניווט, ואז לוחצים על כרטיסייה במסך "עיון" — הפאנל נשאר פתוח.

ה-scrim של `ContextOverlayPanel` פרוש רק על אזור התוכן, במכוון, כדי שסרגל הניווט יישאר לחיץ. שורת הכרטיסיות יושבת ב-`CustomTitleBar`, שהוא אח **מעל** ה-Stack הזה, ולכן הלחיצה לא מגיעה ל-scrim ואף מסלול אחר לא סוגר את הפאנל — מעבר כרטיסייה אינו מעבר מסך.

## התיקון

`Listener` פסיבי סביב `CustomTitleBar`:

```dart
Listener(
  behavior: HitTestBehavior.translucent,
  onPointerDown: (_) => _closeToolsLauncher(),
  child: CustomTitleBar(...),
)
```

`Listener` מקבל אירועי מצביע גולמיים ואינו נכנס ל-gesture arena, ולכן אינו חוטף את הלחיצה: גרירת החלון, לחיצה כפולה למקסום, בחירת כרטיסייה, כפתור ה-X, תפריט ההקשר וגרירת הסידור ממשיכים לעבוד. זה מכסה גם לחיצה על הכרטיסייה **הפעילה**, שלא מייצרת שינוי מצב כלשהו.

`translucent` ולא ברירת המחדל `deferToChild`: ברקע הריק של המסגרת ובאזור הריק של רצועת הכרטיסיות אף ילד אינו נפגע ב-hit-test, ולכן `deferToChild` היה משאיר שם פערים.

## מלכוד שהתגלה בדרך

`isTabHovered` היה משתנה מקומי ב-`_buildTab`, כך שכל בנייה מחדש של שורת הכרטיסיות איפסה אותו. בכרטיסייה צרה שאינה נבחרת ה-X מוצג **רק** בריחוף — ולכן ה-`IconButton` נמחק מתחת לסמן, מזהה ההקשה שלו נזרק, ו-`onPressed` לא נורה כלל.

ה-`setState` שבסגירת הפאנל הפך את זה לנגיש (פאנל פתוח + לחיצה על ה-X של כרטיסייה צרה מרוחפת → הפאנל נסגר, הכרטיסייה לא), אבל הבאג היה קיים גם קודם — כל בנייה מחדש של השורה, למשל בשינוי רוחב החלון, כבר העלימה את ה-X מתחת לסמן.

המצב עבר לשדה `_hoveredTab` ב-State, ששורד בנייה מחדש. ה-`setLocalState` נשאר, כך שריחוף ממשיך לצייר מחדש רק את הכרטיסייה עצמה ולא את כל השורה — בלי רגרסיית ביצועים.

## בדיקות

בדיקת רגרסיה חדשה ב-`test/navigation/custom_title_bar_test.dart`: כרטיסייה צרה, ריחוף, בנייה מחדש של השורה — ה-X חייב לשרוד והלחיצה עליו לשלוח `RemoveTab`. **אומת שהיא נופלת בלי התיקון** ועוברת איתו.

`flutter analyze` נקי ו-`flutter test test/navigation/` (120 בדיקות) עובר, מול בסיס `dev` העדכני.

## מה לא נכלל

לחיצה על **השטח הריק** בסרגל הניווט עדיין אינה סוגרת את הפאנל. אי אפשר לפתור זאת באותה עטיפה — `Listener` על הסרגל היה יורה גם על כפתור "כלים" עצמו, סוגר את הפאנל, ואז ה-tap היה פותח אותו מחדש. כל *פריט* בסרגל כבר סוגר כראוי.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
