### PR TITLE
תיקון: גרירת המפריד כיווצה ספר לרצועה ולכדה את פוקוס המקלדת

### DIFF
--- a/lib/tabs/view/pane_drop_geometry.dart
+++ b/lib/tabs/view/pane_drop_geometry.dart
@@ -5,6 +5,21 @@ import 'package:flutter/foundation.dart';
 /// המקום המזערי שחייב להישאר לכל חלונית — בפיצול ובגרירת המפריד כאחד.
 const double kMinPaneExtent = 140;
 
+/// חלקה המזערי של חלונית מהמקום הפנוי. רצפת [kMinPaneExtent] לבדה כמעט אינה
+/// מגבילה במסך רחב, ושם אפשר היה לכווץ ספר לרצועה.
+const double kMinPaneRatio = 0.2;
+
+/// היחס המזערי לחלונית כשיש [availableExtent] פיקסלים פנויים — הגדולה מבין
+/// שתי הרצפות, ולעולם לא מעל מחצית.
+double minPaneRatioFor(double availableExtent) {
+  if (availableExtent <= 0) return kMinPaneRatio;
+  final pixelFloor = kMinPaneExtent / availableExtent;
+  return (pixelFloor > kMinPaneRatio ? pixelFloor : kMinPaneRatio).clamp(
+    0.0,
+    0.5,
+  );
+}
+
 /// עובי רצועת המפריד בעכבר.
 const double kPaneDividerThickness = 12;
 

--- a/lib/tabs/view/split_pane_view.dart
+++ b/lib/tabs/view/split_pane_view.dart
@@ -192,7 +192,8 @@ class _SplitNodeState extends State<_SplitNode> {
     final minRatio = minPaneRatioFor(availableExtent);
     // אין לשנות יחס כשאין מקום לשתי חלוניות קריאות.
     if (minRatio >= 0.5) return;
-    _ratioNotifier.value = (_ratio + delta / availableExtent).clamp(
+    final effectiveRatio = _ratio.clamp(minRatio, 1 - minRatio);
+    _ratioNotifier.value = (effectiveRatio + delta / availableExtent).clamp(
       minRatio,
       1 - minRatio,
     );
@@ -381,6 +382,7 @@ class _PaneDividerState extends State<_PaneDivider> {
     // הגרירה אינה תובעת פוקוס: הוא היה נשאר על המפריד גם אחריה, והחצים
     // ו-Home היו מזיזים אותו במקום לגלול את הספר.
     void handleDragStart(DragStartDetails _) {
+      _focusNode.unfocus();
       _setDragging(true);
       widget.onDragStart();
     }

--- a/lib/tabs/view/split_pane_view.dart
+++ b/lib/tabs/view/split_pane_view.dart
@@ -10,6 +10,8 @@ import 'package:otzaria/widgets/layout/split_pane_content_inset.dart';
 
 export 'pane_drop_geometry.dart'
     show
+        kMinPaneExtent,
+        kMinPaneRatio,
         kPaneCardMargin,
         kPaneDividerThickness,
         kPaneDividerThicknessTouch,
@@ -187,8 +189,7 @@ class _SplitNodeState extends State<_SplitNode> {
     final availableExtent = _availableExtent;
     if (availableExtent == null) return;
 
-    // הגבול בפיקסלים שומר על חלונית קריאה בכל רוחב מסך.
-    final minRatio = (kMinPaneExtent / availableExtent).clamp(0.0, 0.5);
+    final minRatio = minPaneRatioFor(availableExtent);
     // אין לשנות יחס כשאין מקום לשתי חלוניות קריאות.
     if (minRatio >= 0.5) return;
     _ratioNotifier.value = (_ratio + delta / availableExtent).clamp(
@@ -215,14 +216,19 @@ class _SplitNodeState extends State<_SplitNode> {
     _commitDebounce = Timer(_kKeyboardCommitDelay, _commit);
   }
 
-  /// היחס שיושג בהזזה אחת, לדיווח לקורא מסך.
-  double _ratioAfterNudge({required bool towardFirst}) {
-    final extent = _availableExtent;
-    if (extent == null) return _ratio;
-    final minRatio = (kMinPaneExtent / extent).clamp(0.0, 0.5);
-    if (minRatio >= 0.5) return _ratio;
+  /// היחס שיושג בהזזה אחת מ-[from], לדיווח לקורא מסך.
+  /// [extent] מגיע מה-layout ולא מ-[_availableExtent], שאין לו מידה בבנייה
+  /// הראשונה — ואז המחוון היה מדווח יחס שלא ניתן להגיע אליו.
+  double _ratioAfterNudge(
+    double extent,
+    double from, {
+    required bool towardFirst,
+  }) {
+    if (extent <= 0) return from;
+    final minRatio = minPaneRatioFor(extent);
+    if (minRatio >= 0.5) return from;
     final delta = (towardFirst ? -_kKeyboardNudge : _kKeyboardNudge) / extent;
-    return (_ratio + delta).clamp(minRatio, 1 - minRatio);
+    return (from + delta).clamp(minRatio, 1 - minRatio);
   }
 
   void _commit() {
@@ -260,8 +266,14 @@ class _SplitNodeState extends State<_SplitNode> {
           // הרוחב לפיקסל שלם ומוחק את קו המסגרת של החלונית הפעילה.
           builder: (context, constraints) {
             final available = constraints.maxWidth - widget.thickness;
+            // גם יחס שנשמר לפני הרצפה היחסית לא יצייר רצועה במקום חלונית.
+            final minRatio = minPaneRatioFor(available);
+            final effectiveRatio = ratio.clamp(minRatio, 1 - minRatio);
             final firstWidth = available > 0
-                ? (available * ratio).roundToDouble().clamp(0.0, available)
+                ? (available * effectiveRatio).roundToDouble().clamp(
+                    0.0,
+                    available,
+                  )
                 : 0.0;
 
             return Row(
@@ -273,9 +285,18 @@ class _SplitNodeState extends State<_SplitNode> {
                 _PaneDivider(
                   thickness: widget.thickness,
                   isTouch: widget.thickness == kPaneDividerThicknessTouch,
-                  ratio: ratio,
-                  increasedRatio: _ratioAfterNudge(towardFirst: false),
-                  decreasedRatio: _ratioAfterNudge(towardFirst: true),
+                  // המחוון מדווח את היחס המצויר, לא יחס שמור שנחסם ברצפה.
+                  ratio: effectiveRatio,
+                  increasedRatio: _ratioAfterNudge(
+                    available,
+                    effectiveRatio,
+                    towardFirst: false,
+                  ),
+                  decreasedRatio: _ratioAfterNudge(
+                    available,
+                    effectiveRatio,
+                    towardFirst: true,
+                  ),
                   onDragStart: () => _dragging = true,
                   onDragUpdate: _onDragUpdate,
                   onDragEnd: _commit,
@@ -357,10 +378,10 @@ class _PaneDividerState extends State<_PaneDivider> {
     final colorScheme = Theme.of(context).colorScheme;
     final active = _hovering || _dragging || _focused;
 
+    // הגרירה אינה תובעת פוקוס: הוא היה נשאר על המפריד גם אחריה, והחצים
+    // ו-Home היו מזיזים אותו במקום לגלול את הספר.
     void handleDragStart(DragStartDetails _) {
       _setDragging(true);
-      // החצים ממשיכים לשלוט במפריד שנגרר.
-      _focusNode.requestFocus();
       widget.onDragStart();
     }
 

--- a/test/tabs/view/pane_divider_input_test.dart
+++ b/test/tabs/view/pane_divider_input_test.dart
@@ -302,6 +302,41 @@ void main() {
     });
   });
 
+  group('פוקוס מקלדת', () {
+    Finder dividerFocus() => find
+        .ancestor(of: _horizontalDivider, matching: find.byType(Focus))
+        .first;
+
+    testWidgets('גרירה בעכבר אינה משאירה את הפוקוס על המפריד', (tester) async {
+      final root = horizontal();
+      await tester.pumpWidget(host(root));
+
+      await tester.drag(
+        _horizontalDivider,
+        const Offset(-40, 0),
+        warnIfMissed: false,
+      );
+      await tester.pumpAndSettle();
+
+      // פוקוס תקוע על המפריד היה גורם לחצים ול-Home להזיז אותו במקום לגלול.
+      expect(tester.widget<Focus>(dividerFocus()).focusNode!.hasFocus, isFalse);
+      expect(root.splitRatio, greaterThan(0.5), reason: 'הגרירה עצמה עבדה');
+    });
+
+    testWidgets('המפריד עדיין ניתן למיקוד ולשליטה במקלדת', (tester) async {
+      final root = horizontal();
+      double? reported;
+      await tester.pumpWidget(
+        host(root, onRatioChanged: (ratio) => reported = ratio),
+      );
+
+      await pressKey(tester, _horizontalDivider, LogicalKeyboardKey.arrowLeft);
+
+      expect(tester.widget<Focus>(dividerFocus()).focusNode!.hasFocus, isTrue);
+      expect(reported, greaterThan(0.5));
+    });
+  });
+
   group('מגע', () {
     testWidgets('לחיצה ארוכה מאפסת את היחס', (tester) async {
       final root = horizontal(ratio: 0.75);
@@ -358,6 +393,41 @@ void main() {
       expect(semantics.properties.value, '40%');
       expect(semantics.properties.onIncrease, isNotNull);
       expect(semantics.properties.onDecrease, isNotNull);
+    });
+
+    testWidgets('ערכי ההזזה נכונים כבר בבנייה הראשונה', (tester) async {
+      // בבנייה הראשונה אין עדיין מידה ל-RenderBox; ערכי המחוון חייבים
+      // להיגזר מה-layout, אחרת הם מדווחים יחס שלא ניתן להגיע אליו.
+      await tester.pumpWidget(host(horizontal(ratio: 0.4)));
+
+      final semantics = tester.widget<Semantics>(_horizontalDivider);
+      expect(semantics.properties.increasedValue, isNot('40%'));
+      expect(semantics.properties.decreasedValue, isNot('40%'));
+    });
+
+    testWidgets('יחס שמור מתחת לרצפה מדווח כערך המצויר', (tester) async {
+      // יחס כזה נשמר בטאבים בתקופה שבה הרצפה הייתה בפיקסלים בלבד.
+      await tester.pumpWidget(host(horizontal(ratio: 0.03)));
+
+      final semantics = tester.widget<Semantics>(_horizontalDivider);
+      expect(semantics.properties.value, '20%');
+      expect(semantics.properties.decreasedValue, '20%');
+    });
+
+    testWidgets('המחוון אינו מדווח ערך מעבר לרצפה', (tester) async {
+      await tester.pumpWidget(host(horizontal()));
+
+      for (var i = 0; i < 40; i++) {
+        await pressKey(
+          tester,
+          _horizontalDivider,
+          LogicalKeyboardKey.arrowLeft,
+        );
+      }
+
+      final semantics = tester.widget<Semantics>(_horizontalDivider);
+      expect(semantics.properties.value, '80%');
+      expect(semantics.properties.increasedValue, '80%');
     });
 
     testWidgets('onIncrease ו-onDecrease מזיזים את המפריד', (tester) async {

--- a/test/tabs/view/pane_divider_input_test.dart
+++ b/test/tabs/view/pane_divider_input_test.dart
@@ -311,6 +311,9 @@ void main() {
       final root = horizontal();
       await tester.pumpWidget(host(root));
 
+      tester.widget<Focus>(dividerFocus()).focusNode!.requestFocus();
+      await tester.pump();
+
       await tester.drag(
         _horizontalDivider,
         const Offset(-40, 0),
@@ -334,6 +337,18 @@ void main() {
 
       expect(tester.widget<Focus>(dividerFocus()).focusNode!.hasFocus, isTrue);
       expect(reported, greaterThan(0.5));
+    });
+
+    testWidgets('הזזה ראשונה מנרמלת יחס ישן שנשמר מתחת לרצפה', (tester) async {
+      final root = horizontal(ratio: 0.03);
+      double? reported;
+      await tester.pumpWidget(
+        host(root, onRatioChanged: (ratio) => reported = ratio),
+      );
+
+      await pressKey(tester, _horizontalDivider, LogicalKeyboardKey.arrowLeft);
+
+      expect(reported, greaterThan(kMinPaneRatio));
     });
   });
 

--- a/test/tabs/view/pane_drop_geometry_test.dart
+++ b/test/tabs/view/pane_drop_geometry_test.dart
@@ -81,6 +81,61 @@ void main() {
     });
   });
 
+  group('הרצפה של חלונית בגרירת המפריד', () {
+    test('במסך רחב הרצפה היחסית גוברת על זו שבפיקסלים', () {
+      // 140 פיקסלים מתוך 2400 הם פחות מ-6% — רצועה, לא חלונית.
+      expect(minPaneRatioFor(2400), kMinPaneRatio);
+      expect(minPaneRatioFor(1920), kMinPaneRatio);
+      expect(minPaneRatioFor(kMinPaneExtent / kMinPaneRatio), kMinPaneRatio);
+    });
+
+    test('במסך צר הרצפה בפיקסלים גוברת על היחסית', () {
+      expect(minPaneRatioFor(500), closeTo(kMinPaneExtent / 500, 1e-9));
+      expect(minPaneRatioFor(400), closeTo(kMinPaneExtent / 400, 1e-9));
+      expect(minPaneRatioFor(500), greaterThan(kMinPaneRatio));
+    });
+
+    test('הרצפה לעולם אינה עולה על מחצית', () {
+      for (final extent in [0.0, 1.0, 100.0, 200.0, 279.0, 280.0]) {
+        expect(minPaneRatioFor(extent), lessThanOrEqualTo(0.5));
+      }
+      expect(minPaneRatioFor(200), 0.5);
+    });
+
+    test('רוחב לא חוקי אינו מפיל ומחזיר את הרצפה היחסית', () {
+      expect(minPaneRatioFor(0), kMinPaneRatio);
+      expect(minPaneRatioFor(-10), kMinPaneRatio);
+    });
+
+    test('הרצפה משאירה תמיד מקום לשתי חלוניות', () {
+      for (final extent in [300.0, 700.0, 1280.0, 1920.0, 3840.0]) {
+        final min = minPaneRatioFor(extent);
+        expect(min, lessThanOrEqualTo(1 - min));
+        expect(extent * min, greaterThanOrEqualTo(0));
+      }
+    });
+
+    test('מעל סף הפיצול הרצפה נותנת חלונית קריאה', () {
+      // סף הפיצול מבטיח 140 לכל חלונית; הרצפה לא תיתן פחות מכך.
+      for (final extent in [300.0, 800.0, 1600.0, 2560.0]) {
+        expect(
+          extent * minPaneRatioFor(extent),
+          greaterThanOrEqualTo(kMinPaneExtent - 0.001),
+        );
+      }
+    });
+
+    test('הרצפה עולה מונוטונית ככל שהמסך צר יותר', () {
+      final widths = [3840.0, 2560.0, 1920.0, 1280.0, 800.0, 500.0, 400.0];
+      for (var i = 1; i < widths.length; i++) {
+        expect(
+          minPaneRatioFor(widths[i]),
+          greaterThanOrEqualTo(minPaneRatioFor(widths[i - 1])),
+        );
+      }
+    });
+  });
+
   group('תצוגה מקדימה', () {
     test('ב-RTL החלונית הראשונה מסומנת בחצי הימני', () {
       final rect = previewRectFor(

--- a/test/tabs/view/split_pane_view_test.dart
+++ b/test/tabs/view/split_pane_view_test.dart
@@ -48,12 +48,13 @@ Widget _host(
   OpenedTab root, {
   ValueChanged<double>? onRatioChanged,
   Widget Function(OpenedTab)? paneBuilder,
+  TextDirection textDirection = TextDirection.rtl,
 }) {
   return MaterialApp(
     // עובי המפריד תלוי בפלטפורמה (רחב יותר במגע); כאן נבדקת התנהגות העכבר.
     theme: ThemeData(platform: TargetPlatform.windows),
     home: Directionality(
-      textDirection: TextDirection.rtl,
+      textDirection: textDirection,
       child: Scaffold(
         body: SplitPaneView(
           root: root,
@@ -324,6 +325,183 @@ void main() {
       // הידית נראית עכשיו — ובכל זאת מספר השכבות לא גדל.
       expect(decoration().color!.a, greaterThan(0));
       expect(tester.layers.length, layersBefore);
+    });
+  });
+
+  // רגרסיה: הרצפה הייתה בפיקסלים בלבד (140), ובמסך רחב היא כמעט לא הגבילה —
+  // אפשר היה לגרור ספר אחד על כמעט כל הרוחב ולהשאיר לשני רצועה.
+  group('רצפת החלונית בגרירה', () {
+    /// מקבע רוחב מסך לוגי לבדיקה.
+    void useScreenWidth(WidgetTester tester, double width) {
+      tester.view.physicalSize = Size(width, 1000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+    }
+
+    CombinedTab twoPanes({double ratio = 0.5}) => CombinedTab(
+      rightTab: _LeafTab('ימין'),
+      leftTab: _LeafTab('שמאל'),
+      splitRatio: ratio,
+    );
+
+    double paneWidth(WidgetTester tester, String title) =>
+        tester.getSize(find.text(title)).width;
+
+    Future<void> dragDivider(WidgetTester tester, double dx) async {
+      await tester.drag(
+        find.byType(MouseRegion).last,
+        Offset(dx, 0),
+        warnIfMissed: false,
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('במסך רחב גרירה קיצונית משאירה חמישית לחלונית', (tester) async {
+      useScreenWidth(tester, 2400);
+      final root = twoPanes();
+      double? reported;
+      await tester.pumpWidget(_host(root, onRatioChanged: (r) => reported = r));
+
+      await dragDivider(tester, 5000);
+
+      expect(reported, closeTo(kMinPaneRatio, 1e-6));
+      final right = paneWidth(tester, 'ימין');
+      final left = paneWidth(tester, 'שמאל');
+      expect(right / (right + left), closeTo(kMinPaneRatio, 0.005));
+      // הרצפה בפיקסלים לבדה הייתה מתירה כאן פחות מ-6%.
+      expect(right, greaterThan(kMinPaneExtent * 3));
+    });
+
+    testWidgets('הרצפה חלה גם בכיוון ההפוך', (tester) async {
+      useScreenWidth(tester, 2400);
+      final root = twoPanes();
+      double? reported;
+      await tester.pumpWidget(_host(root, onRatioChanged: (r) => reported = r));
+
+      await dragDivider(tester, -5000);
+
+      expect(reported, closeTo(1 - kMinPaneRatio, 1e-6));
+      final right = paneWidth(tester, 'ימין');
+      final left = paneWidth(tester, 'שמאל');
+      expect(left / (right + left), closeTo(kMinPaneRatio, 0.005));
+    });
+
+    testWidgets('ב-LTR הרצפה זהה ובשני הכיוונים', (tester) async {
+      useScreenWidth(tester, 2400);
+      for (final dx in [5000.0, -5000.0]) {
+        final root = twoPanes();
+        double? reported;
+        await tester.pumpWidget(
+          _host(
+            root,
+            onRatioChanged: (r) => reported = r,
+            textDirection: TextDirection.ltr,
+          ),
+        );
+
+        await dragDivider(tester, dx);
+
+        expect(reported, inInclusiveRange(kMinPaneRatio, 1 - kMinPaneRatio));
+        expect(
+          paneWidth(tester, 'ימין') + paneWidth(tester, 'שמאל'),
+          greaterThan(0),
+        );
+      }
+    });
+
+    testWidgets('במסך צר הרצפה בפיקסלים היא שגוברת', (tester) async {
+      useScreenWidth(tester, 700);
+      final root = twoPanes();
+      double? reported;
+      await tester.pumpWidget(_host(root, onRatioChanged: (r) => reported = r));
+
+      await dragDivider(tester, 5000);
+
+      // 20% מ-700 קטן מ-140, ולכן כאן הרצפה בפיקסלים היא הקובעת.
+      expect(reported, greaterThan(kMinPaneRatio));
+      expect(
+        paneWidth(tester, 'ימין'),
+        greaterThanOrEqualTo(kMinPaneExtent - 1),
+      );
+    });
+
+    testWidgets('יחס קיצוני שנשמר בעבר מצויר לפי הרצפה', (tester) async {
+      useScreenWidth(tester, 2400);
+      // יחס כזה נשמר בטאבים לפני שהוחזרה הרצפה היחסית.
+      await tester.pumpWidget(_host(twoPanes(ratio: 0.03)));
+      await tester.pumpAndSettle();
+
+      final right = paneWidth(tester, 'ימין');
+      final left = paneWidth(tester, 'שמאל');
+      expect(right / (right + left), closeTo(kMinPaneRatio, 0.005));
+    });
+
+    testWidgets('גרירות חוזרות אינן צוברות חריגה מהרצפה', (tester) async {
+      useScreenWidth(tester, 2400);
+      final root = twoPanes();
+      final reported = <double>[];
+      await tester.pumpWidget(
+        _host(root, onRatioChanged: reported.add),
+      );
+
+      for (var i = 0; i < 8; i++) {
+        await dragDivider(tester, 900);
+      }
+
+      expect(reported, isNotEmpty);
+      for (final ratio in reported) {
+        expect(ratio, inInclusiveRange(kMinPaneRatio, 1 - kMinPaneRatio));
+      }
+      expect(root.splitRatio, closeTo(kMinPaneRatio, 1e-6));
+    });
+
+    testWidgets('שתי החלוניות והמפריד ממלאים בדיוק את הרוחב', (tester) async {
+      useScreenWidth(tester, 2400);
+      for (final ratio in [0.03, 0.2, 0.5, 0.8, 0.97]) {
+        await tester.pumpWidget(_host(twoPanes(ratio: ratio)));
+        await tester.pumpAndSettle();
+
+        final total =
+            paneWidth(tester, 'ימין') +
+            paneWidth(tester, 'שמאל') +
+            tester.getSize(find.byType(MouseRegion).last).width;
+        // שוליי כרטיס החלונית משני צדי השורה.
+        expect(total, closeTo(2400 - kPaneCardMargin * 2, 1.0));
+      }
+    });
+
+    testWidgets('איפוס בלחיצה כפולה מחזיר לחצי גם מיחס קיצוני', (tester) async {
+      useScreenWidth(tester, 2400);
+      final root = twoPanes(ratio: 0.03);
+      double? reported;
+      await tester.pumpWidget(_host(root, onRatioChanged: (r) => reported = r));
+
+      await tester.tap(find.byType(MouseRegion).last, warnIfMissed: false);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.byType(MouseRegion).last, warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(reported, 0.5);
+      expect(
+        paneWidth(tester, 'ימין'),
+        closeTo(paneWidth(tester, 'שמאל'), 2.0),
+      );
+    });
+
+    testWidgets('מסך צר מדי לשתי חלוניות אינו מפיל ואינו משנה יחס', (
+      tester,
+    ) async {
+      useScreenWidth(tester, 260);
+      final root = twoPanes();
+      var reports = 0;
+      await tester.pumpWidget(_host(root, onRatioChanged: (_) => reports++));
+
+      await dragDivider(tester, 400);
+
+      // הרצפה מגיעה למחצית — אין יחס חוקי לשנות אליו.
+      expect(root.splitRatio, 0.5);
+      expect(reports, lessThanOrEqualTo(1));
+      expect(tester.takeException(), isNull);
     });
   });
 


### PR DESCRIPTION
## הבעיה

בתצוגה "זה לצד זה" אפשר היה לגרור את המפריד ולכווץ ספר אחד כמעט לגמרי לטובת השני, עד שנשארה ממנו רצועה דקה. בנוסף, אחרי גרירת המפריד בעכבר המקלדת נתקעה עליו.

## שורש הבעיה

### 1. הרצפה של גרירת המפריד

לפני #683 הגרירה הייתה מוגבלת ביחס — אף חלונית לא ירדה מתחת לחמישית מהרוחב:

```dart
_splitRatio = (_splitRatio + ratioDelta).clamp(0.2, 0.8);
```

ב-#683 ההגבלה הוחלפה ברצפה בפיקסלים בלבד:

```dart
final minRatio = (kMinPaneExtent / availableExtent).clamp(0.0, 0.5);  // kMinPaneExtent = 140
```

140 פיקסלים הם 20% במסך צר, אבל **7% במסך 1920** ופחות מזה במסך רחב יותר — כלומר במסכים שבהם התצוגה המפוצלת שימושית, ההגבלה כמעט לא קיימת.

### 2. המפריד לכד את פוקוס המקלדת

הגרירה תבעה פוקוס (`_focusNode.requestFocus()` ב-`onDragStart`) ולא שחררה אותו בסיום. אחרי גרירה בעכבר, החצים הזיזו את המפריד במקום לגלול את הספר, ו-Home איפס את הפיצול במקום לקפוץ לתחילת הספר. לפני #683 המפריד לא נגע בפוקוס כלל.

### 3. המחוון דיווח יחס שלא ניתן להגיע אליו

`_ratioAfterNudge` שאב את הרוחב מ-`context.findRenderObject()`, שאין לו מידה בבנייה הראשונה. לכן `increasedValue`/`decreasedValue` דיווחו לקורא המסך את היחס הנוכחי במקום את יעד ההזזה.

## התיקון

`kMinPaneRatio = 0.2` חוזר כרצפה יחסית, לצד רצפת הפיקסלים הקיימת. `minPaneRatioFor()` מחזירה את הגדולה מבין השתיים — היחסית קובעת במסך רחב, זו שבפיקסלים במסך צר, שבו 20% קטנים מ-140px. הרצפה נאכפת בשלושת המסלולים: גרירה, חצי מקלדת, וחישוב הרוחב המצויר — האחרון כדי שגם יחס קיצוני שכבר נשמר אצל משתמש לא ייפתח כרצועה.

הגרירה כבר לא תובעת פוקוס, ו-`_ratioAfterNudge` מקבלת את הרוחב מה-layout.

## בדיקות

18 בדיקות חדשות:

| קובץ | כיסוי |
|---|---|
| `pane_drop_geometry_test.dart` | הרצפה בשני המשטרים, גבול המחצית, רוחב לא חוקי, מונוטוניות, ועקביות מול סף הפיצול |
| `split_pane_view_test.dart` | גרירה קיצונית בשני הכיוונים במסך 2400, LTR, מסך צר, יחס קיצוני שנשמר, גרירות חוזרות, סכום הרוחבים בחמישה יחסים, איפוס, ומסך צר מדי לשתי חלוניות |
| `pane_divider_input_test.dart` | הפוקוס משתחרר אחרי גרירה אך המפריד עדיין נשלט במקלדת, וערכי המחוון נכונים כבר בבנייה הראשונה |

`flutter analyze` נקי; כל הבדיקות תחת `test/tabs/` עוברות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
