### PR TITLE
צורת הדף: בחירת מפרש לקטגוריה מתעדכנת בכל ספר גם כשאין "על" בשם

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -624,6 +624,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Combined view helpers (shouldShow…) | `test/text_book/view/combined_view/combined_book_screen_test.dart` |
 | TabbedCommentaryPanel tab switching / onTabChanged | `test/text_book/view/tabbed_commentary_panel_test.dart` |
 | Page shape commentary selection | `test/text_book/view/page_shape_commentary_selection_test.dart` |
+| התאמת מפרשי צורת הדף בין ספרים (היקף קטגוריה) | `test/text_book/view/page_shape/page_shape_category_commentator_matching_test.dart` |
 | חלונית הצד של צורת הדף (3 לשוניות) | `test/text_book/view/page_shape/page_shape_sidebar_tabs_test.dart` |
 | תפריט הקשר בצורת הדף (מפרשים / קטע היעד) | `test/text_book/view/page_shape/simple_text_viewer_context_menu_test.dart` |
 | תת-תפריט "מפרשים" המשותף + מדיניות הצגה | `test/text_book/utils/commentators_context_menu_test.dart` |

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -1587,6 +1587,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       bottomRightSelection: configuration['bottomRight'],
       availableCommentators: candidateCommentators,
       columnVisibility: columnVisibility,
+      commentedBookTitle: state.book.title,
     );
 
     _cachedPageShapeTargetBookTitlesKey = cacheKey;

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -336,6 +336,7 @@ class _PageShapeScreenState extends State<PageShapeScreen> {
       commentators = _resolveCommentatorNames(
         config,
         state.availableCommentators,
+        state.book.title,
       );
     } else {
       // אין הגדרה שמורה בכלל - השתמש בברירות מחדל
@@ -366,12 +367,14 @@ class _PageShapeScreenState extends State<PageShapeScreen> {
   Map<String, String?> _resolveCommentatorNames(
     Map<String, String?> config,
     List<String> availableCommentators,
+    String bookTitle,
   ) {
     return Map.fromEntries(
       config.entries.map((entry) {
         final resolved = resolvePageShapeCommentatorSelection(
           selection: entry.value,
           availableCommentators: availableCommentators,
+          commentedBookTitle: bookTitle,
         );
         return MapEntry(entry.key, resolved);
       }),
@@ -391,6 +394,7 @@ class _PageShapeScreenState extends State<PageShapeScreen> {
         _bottomCommentator,
         _bottomRightCommentator,
       ],
+      commentedBookTitle: state.book.title,
     );
   }
 
@@ -491,6 +495,7 @@ class _PageShapeScreenState extends State<PageShapeScreen> {
       final resolvedSingle = resolvePageShapeCommentatorSelection(
         selection: _rightCommentator,
         availableCommentators: selectableCommentators,
+        commentedBookTitle: state.book.title,
       );
       if (resolvedSingle == null) {
         return _buildEmptyColumnContent(
@@ -2073,6 +2078,20 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       }
 
       if (!mounted) return;
+
+      // מפרש שאינו מקושר לספר הנוכחי שייך לספר אחר, ו-BookLocator היה טוען
+      // אותו לפי שמו ומציג את הספר הזר. ההגדרה השמורה נשארת על כנה.
+      if (state is TextBookLoaded &&
+          state.availableCommentators.isNotEmpty &&
+          !state.availableCommentators.contains(widget.commentatorName)) {
+        _notifyCommentaryLoadFailed();
+        setState(() {
+          _reportBook = null;
+          _content = null;
+          _isLoading = false;
+        });
+        return;
+      }
 
       if (state is TextBookLoaded) {
         // סינון קישורים לפי שם המפרש ולפי סוג הקישור (COMMENTARY/TARGUM)

--- a/lib/text_book/view/page_shape/page_shape_settings_panel.dart
+++ b/lib/text_book/view/page_shape/page_shape_settings_panel.dart
@@ -134,6 +134,7 @@ class _PageShapeSettingsPanelState extends State<PageShapeSettingsPanel> {
       _rightSingleCommentator = resolvePageShapeSingleCommentatorSelection(
         selection: widget.currentRight,
         availableCommentators: widget.availableCommentators,
+        commentedBookTitle: widget.bookTitle,
       );
       _bottomCommentator = widget.currentBottom;
       _bottomRightCommentator = widget.currentBottomRight;

--- a/lib/text_book/view/page_shape/utils/page_shape_commentary_selection.dart
+++ b/lib/text_book/view/page_shape/utils/page_shape_commentary_selection.dart
@@ -31,11 +31,54 @@ bool isPageShapeMultipleCommentatorsMode(String? value) {
       isPageShapeMultiCommentatorsValue(value);
 }
 
+/// מחזיר את שם המפרש בלי שם הספר שהוא מפרש.
+/// "רמב"ן על ברכות" → "רמב"ן"; "יכין מקואות" עם [commentedBookTitle]
+/// "משנה מקואות" → "יכין". יש משפחות מפרשים שאינן כוללות "על" בשם.
+String? pageShapeCommentatorBaseName(
+  String? fullName, {
+  String? commentedBookTitle,
+}) {
+  if (fullName == null) return null;
+
+  final onIndex = fullName.indexOf(' על ');
+  if (onIndex > 0) {
+    return fullName.substring(0, onIndex).trim();
+  }
+
+  if (commentedBookTitle == null || commentedBookTitle.isEmpty) {
+    return fullName;
+  }
+
+  final nameWords = _splitWords(fullName);
+  final bookWords = _splitWords(commentedBookTitle);
+
+  // שם שכולו שם הספר אינו נושא חלק-מפרש שאפשר לבודד.
+  if (nameWords.join(' ') == bookWords.join(' ')) return fullName;
+
+  var shared = 0;
+  while (shared < nameWords.length - 1 &&
+      shared < bookWords.length &&
+      nameWords[nameWords.length - 1 - shared] ==
+          bookWords[bookWords.length - 1 - shared]) {
+    shared++;
+  }
+
+  if (shared == 0) return fullName;
+  return nameWords.take(nameWords.length - shared).join(' ');
+}
+
+List<String> _splitWords(String value) =>
+    value.split(RegExp(r'\s+')).where((word) => word.isNotEmpty).toList();
+
 /// מחפש את שם המפרש המלא מתוך רשימת המפרשים הזמינים.
+///
+/// [commentedBookTitle] מאפשר להתאים גם בחירה ישנה שנשמרה עם שם ספר אחר צרוב
+/// בתוכה ("יכין מקואות" בזמן קריאה במסכת נדה).
 String? findMatchingPageShapeCommentator(
   String? selection,
-  List<String> availableCommentators,
-) {
+  List<String> availableCommentators, {
+  String? commentedBookTitle,
+}) {
   if (selection == null) {
     return null;
   }
@@ -53,7 +96,43 @@ String? findMatchingPageShapeCommentator(
     }
   }
 
-  return null;
+  return _matchByCommentatorBase(
+    selection,
+    availableCommentators,
+    commentedBookTitle,
+  );
+}
+
+/// מתאים בחירה ישנה למפרש שחלק-המפרש שלו הוא מילות הפתיחה של הבחירה.
+/// דורש גבול-מילה מלא, ובוחר את ההתאמה הארוכה ביותר, כדי ש"תוספות רבי עקיבא
+/// איגר" לא ייקלט כ"תוספות יום טוב".
+String? _matchByCommentatorBase(
+  String selection,
+  List<String> availableCommentators,
+  String? commentedBookTitle,
+) {
+  if (commentedBookTitle == null || commentedBookTitle.isEmpty) {
+    return null;
+  }
+
+  String? best;
+  var bestLength = 0;
+
+  for (final commentator in availableCommentators) {
+    final base = pageShapeCommentatorBaseName(
+      commentator,
+      commentedBookTitle: commentedBookTitle,
+    );
+    if (base == null || base == commentator || base.length <= bestLength) {
+      continue;
+    }
+    if (selection.startsWith('$base ')) {
+      best = commentator;
+      bestLength = base.length;
+    }
+  }
+
+  return best;
 }
 
 List<String> _decodeMultiCommentators(String value) {
@@ -114,6 +193,7 @@ List<String> decodePageShapeCommentatorsSelection(String? value) {
 String? resolvePageShapeCommentatorSelection({
   required String? selection,
   required List<String> availableCommentators,
+  String? commentedBookTitle,
 }) {
   if (selection == null ||
       isPageShapeRemainingCommentatorsValue(selection) ||
@@ -122,7 +202,11 @@ String? resolvePageShapeCommentatorSelection({
   }
 
   if (!isPageShapeMultiCommentatorsValue(selection)) {
-    return findMatchingPageShapeCommentator(selection, availableCommentators) ??
+    return findMatchingPageShapeCommentator(
+          selection,
+          availableCommentators,
+          commentedBookTitle: commentedBookTitle,
+        ) ??
         selection;
   }
 
@@ -132,6 +216,7 @@ String? resolvePageShapeCommentatorSelection({
     final match = findMatchingPageShapeCommentator(
       commentator,
       availableCommentators,
+      commentedBookTitle: commentedBookTitle,
     );
     if (match != null && seen.add(match)) {
       resolved.add(match);
@@ -152,6 +237,7 @@ String? resolvePageShapeCommentatorSelection({
 String? resolvePageShapeSingleCommentatorSelection({
   required String? selection,
   required List<String> availableCommentators,
+  String? commentedBookTitle,
 }) {
   if (selection == null ||
       isPageShapeRemainingCommentatorsValue(selection) ||
@@ -160,7 +246,11 @@ String? resolvePageShapeSingleCommentatorSelection({
   }
 
   if (!isPageShapeMultiCommentatorsValue(selection)) {
-    return findMatchingPageShapeCommentator(selection, availableCommentators) ??
+    return findMatchingPageShapeCommentator(
+          selection,
+          availableCommentators,
+          commentedBookTitle: commentedBookTitle,
+        ) ??
         selection;
   }
 
@@ -168,6 +258,7 @@ String? resolvePageShapeSingleCommentatorSelection({
     final match = findMatchingPageShapeCommentator(
       commentator,
       availableCommentators,
+      commentedBookTitle: commentedBookTitle,
     );
     if (match != null) {
       return match;
@@ -182,10 +273,12 @@ List<String> resolvePageShapeSelectedCommentators({
   required String? selection,
   required List<String> availableCommentators,
   Iterable<String?> excludedCommentators = const [],
+  String? commentedBookTitle,
 }) {
   final normalizedSelection = resolvePageShapeCommentatorSelection(
     selection: selection,
     availableCommentators: availableCommentators,
+    commentedBookTitle: commentedBookTitle,
   );
 
   if (normalizedSelection == null) {
@@ -211,10 +304,12 @@ List<String> resolvePageShapeSelectedCommentators({
 String? _resolvePageShapeSingleCommentator({
   required String? selection,
   required List<String> availableCommentators,
+  String? commentedBookTitle,
 }) {
   final resolved = resolvePageShapeCommentatorSelection(
     selection: selection,
     availableCommentators: availableCommentators,
+    commentedBookTitle: commentedBookTitle,
   );
 
   if (resolved == null ||
@@ -243,18 +338,22 @@ List<String> resolvePageShapeDisplayedCommentators({
     'right': true,
     'bottom': true,
   },
+  String? commentedBookTitle,
 }) {
   final resolvedLeft = _resolvePageShapeSingleCommentator(
     selection: leftSelection,
     availableCommentators: availableCommentators,
+    commentedBookTitle: commentedBookTitle,
   );
   final resolvedBottom = _resolvePageShapeSingleCommentator(
     selection: bottomSelection,
     availableCommentators: availableCommentators,
+    commentedBookTitle: commentedBookTitle,
   );
   final resolvedBottomRight = _resolvePageShapeSingleCommentator(
     selection: bottomRightSelection,
     availableCommentators: availableCommentators,
+    commentedBookTitle: commentedBookTitle,
   );
 
   final excludedForRightPane = [
@@ -273,6 +372,7 @@ List<String> resolvePageShapeDisplayedCommentators({
           selection: rightSelection,
           availableCommentators: rightSelectableCommentators,
           excludedCommentators: excludedForRightPane,
+          commentedBookTitle: commentedBookTitle,
         );
 
   final displayedCommentators = <String>[];

--- a/lib/text_book/view/page_shape/utils/page_shape_settings_manager.dart
+++ b/lib/text_book/view/page_shape/utils/page_shape_settings_manager.dart
@@ -85,20 +85,17 @@ class PageShapeSettingsManager {
     return null;
   }
 
-  /// חילוץ שם בסיסי של מפרש (בלי "על X")
+  /// חילוץ שם בסיסי של מפרש (בלי שם הספר המפורש)
   /// למשל: "רמב"ן על ברכות" → "רמב"ן"
-  /// למשל: "השגות הראב"ד על משנה תורה, הלכות דעות" → "השגות הראב"ד"
-  static String? extractBaseCommentatorName(String? fullName) {
-    if (fullName == null) return null;
-
-    // מחפשים "על " ולוקחים את מה שלפניו
-    final onIndex = fullName.indexOf(' על ');
-    if (onIndex > 0) {
-      return fullName.substring(0, onIndex).trim();
-    }
-
-    // אם אין "על", מחזירים את השם כמו שהוא
-    return fullName;
+  /// למשל: "יכין מקואות" עם [commentedBookTitle] "משנה מקואות" → "יכין"
+  static String? extractBaseCommentatorName(
+    String? fullName, {
+    String? commentedBookTitle,
+  }) {
+    return pageShapeCommentatorBaseName(
+      fullName,
+      commentedBookTitle: commentedBookTitle,
+    );
   }
 
   // ==================== גודל גופן (גלובלי בלבד) ====================
@@ -281,9 +278,14 @@ class PageShapeSettingsManager {
         return MapEntry(
           key,
           encodePageShapeCommentatorsSelection(
-            decodePageShapeCommentatorsSelection(
-              value,
-            ).map(extractBaseCommentatorName).whereType<String>(),
+            decodePageShapeCommentatorsSelection(value)
+                .map(
+                  (name) => extractBaseCommentatorName(
+                    name,
+                    commentedBookTitle: bookTitle,
+                  ),
+                )
+                .whereType<String>(),
             forceMultipleMode: isPageShapeMultipleCommentatorsMode(value),
           ),
         );

--- a/test/text_book/view/page_shape/page_shape_category_commentator_matching_test.dart
+++ b/test/text_book/view/page_shape/page_shape_category_commentator_matching_test.dart
@@ -1,0 +1,652 @@
+// התאמת מפרשים בין ספרים בהגדרות צורת הדף בהיקף קטגוריה.
+//
+// יש משפחות מפרשים ששמן "<מפרש> <שם הספר>" בלי "על" — "יכין מקואות",
+// "ריף בבא מציעא", "רלבג שיר השירים", "באר היטב אורח חיים", "תרגום קהלת".
+
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/text_book/view/page_shape/utils/page_shape_commentary_selection.dart';
+import 'package:otzaria/text_book/view/page_shape/utils/page_shape_settings_manager.dart';
+
+import '../../../test_helpers/memory_cache_provider.dart';
+
+/// המפרשים הזמינים במסכת נדה שבמשנה, בשמות כפי שהם בספרייה.
+const _mishnaNidaCommentators = [
+  'ברטנורא על משנה נדה',
+  'תוספות יום טוב על משנה נדה',
+  'עיקר תוספות יום טוב על משנה נדה',
+  'תוספות רבי עקיבא איגר על משנה נדה',
+  'מלאכת שלמה על משנה נדה',
+  'רמבם על משנה נדה',
+  'יכין נדה',
+  'בועז על משנה נדה',
+];
+
+const _mishnaMikvaotCommentators = [
+  'ברטנורא על משנה מקואות',
+  'תוספות יום טוב על משנה מקואות',
+  'יכין מקואות',
+  'בועז על משנה מקואות',
+];
+
+/// שומר בחירת מפרש בהיקף קטגוריה ומחזיר את השם שהותאם לספר אחר בקטגוריה.
+Future<String?> _reresolveInOtherBook({
+  required String category,
+  required String savedFromBookTitle,
+  required String savedCommentator,
+  required String otherBookTitle,
+  required String otherBookCategories,
+  required List<String> otherBookCommentators,
+}) async {
+  await PageShapeSettingsManager.saveConfiguration(
+    savedFromBookTitle,
+    {
+      'left': savedCommentator,
+      'right': null,
+      'bottom': null,
+      'bottomRight': null,
+    },
+    saveToCategory: category,
+  );
+
+  final config = PageShapeSettingsManager.loadConfiguration(
+    otherBookTitle,
+    heCategories: otherBookCategories,
+  );
+
+  return resolvePageShapeCommentatorSelection(
+    selection: config?['left'],
+    availableCommentators: otherBookCommentators,
+    commentedBookTitle: otherBookTitle,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  group('extractBaseCommentatorName — שמות שכוללים "על"', () {
+    test('מחזיר את הקידומת שלפני "על"', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'ברטנורא על משנה נדה',
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'ברטנורא',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'תוספות רבי עקיבא איגר על משנה טהרות',
+          commentedBookTitle: 'משנה טהרות',
+        ),
+        'תוספות רבי עקיבא איגר',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'רשי על סנהדרין',
+          commentedBookTitle: 'סנהדרין',
+        ),
+        'רשי',
+      );
+    });
+
+    test('שם ספר מורכב אחרי "על" אינו משפיע על הקידומת', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'אור שמח על משנה תורה, הלכות ציצית',
+          commentedBookTitle: 'משנה תורה, הלכות ציצית',
+        ),
+        'אור שמח',
+      );
+    });
+
+    test('"על" גובר גם בלי שם ספר נתון', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName('רמבן על ברכות'),
+        'רמבן',
+      );
+    });
+  });
+
+  group('extractBaseCommentatorName — שמות בלי "על"', () {
+    test('מסיר את שם המסכת של המשנה', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'יכין מקואות',
+          commentedBookTitle: 'משנה מקואות',
+        ),
+        'יכין',
+      );
+    });
+
+    test('מסיר שם מסכת בן שתי מילים', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'יכין טבול יום',
+          commentedBookTitle: 'משנה טבול יום',
+        ),
+        'יכין',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'ריף בבא מציעא',
+          commentedBookTitle: 'בבא מציעא',
+        ),
+        'ריף',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'ריף עבודה זרה',
+          commentedBookTitle: 'עבודה זרה',
+        ),
+        'ריף',
+      );
+    });
+
+    test('מסיר שם ספר בתנ"ך', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'רלבג שיר השירים',
+          commentedBookTitle: 'שיר השירים',
+        ),
+        'רלבג',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'תרגום קהלת',
+          commentedBookTitle: 'קהלת',
+        ),
+        'תרגום',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'תרגום דברי הימים ב',
+          commentedBookTitle: 'דברי הימים ב',
+        ),
+        'תרגום',
+      );
+    });
+
+    test('מסיר חלק משם הספר כשהמפרש נושא רק את הסיומת', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'באר היטב אורח חיים',
+          commentedBookTitle: 'שולחן ערוך אורח חיים',
+        ),
+        'באר היטב',
+      );
+    });
+  });
+
+  group('extractBaseCommentatorName — מקרי קצה', () {
+    test('null מוחזר כ-null', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          null,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        isNull,
+      );
+    });
+
+    test('מפרש שאינו נושא את שם הספר נשאר שלם', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'משנה ברורה',
+          commentedBookTitle: 'שולחן ערוך אורח חיים',
+        ),
+        'משנה ברורה',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'ביאור הלכה',
+          commentedBookTitle: 'שולחן ערוך אורח חיים',
+        ),
+        'ביאור הלכה',
+      );
+    });
+
+    test('בלי שם ספר נתון השם נשאר שלם', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName('יכין מקואות'),
+        'יכין מקואות',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'יכין מקואות',
+          commentedBookTitle: '',
+        ),
+        'יכין מקואות',
+      );
+    });
+
+    test('שם זהה לחלוטין לשם הספר אינו מתרוקן', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'משנה נדה',
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'משנה נדה',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'נדה',
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'נדה',
+      );
+    });
+
+    test('רווחים כפולים אינם מונעים את ההסרה', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'יכין  מקואות',
+          commentedBookTitle: 'משנה   מקואות',
+        ),
+        'יכין',
+      );
+    });
+
+    test('התאמה חלקית של מילה אינה נחשבת', () {
+      // "מקוואות" אינה "מקואות" — אין מילה משותפת ולכן אין הסרה.
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'יכין מקואות',
+          commentedBookTitle: 'משנה מקוואות',
+        ),
+        'יכין מקואות',
+      );
+    });
+  });
+
+  group('findMatchingPageShapeCommentator — התאמה לספר הנוכחי', () {
+    test('שם בסיס חדש מותאם למסכת הנוכחית', () {
+      expect(
+        findMatchingPageShapeCommentator('יכין', _mishnaNidaCommentators),
+        'יכין נדה',
+      );
+      expect(
+        findMatchingPageShapeCommentator('ברטנורא', _mishnaNidaCommentators),
+        'ברטנורא על משנה נדה',
+      );
+    });
+
+    test('הגדרה ישנה עם שם מסכת אחרת מותאמת לפי חלק-המפרש', () {
+      expect(
+        findMatchingPageShapeCommentator(
+          'יכין מקואות',
+          _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'יכין נדה',
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'ריף בבא מציעא',
+          const ['רשי על שבת', 'ריף שבת', 'תוספות על שבת'],
+          commentedBookTitle: 'שבת',
+        ),
+        'ריף שבת',
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'רלבג שיר השירים',
+          const ['רלבג אסתר', 'אבן עזרא על אסתר'],
+          commentedBookTitle: 'אסתר',
+        ),
+        'רלבג אסתר',
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'ברטנורא על משנה מקואות',
+          _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'ברטנורא על משנה נדה',
+      );
+    });
+
+    test('בלי שם הספר הנוכחי אין ריפוי של הגדרה ישנה', () {
+      expect(
+        findMatchingPageShapeCommentator(
+          'יכין מקואות',
+          _mishnaNidaCommentators,
+        ),
+        isNull,
+      );
+    });
+
+    test('הקידומת הארוכה ביותר גוברת על קידומת קצרה יותר', () {
+      expect(
+        findMatchingPageShapeCommentator(
+          'תוספות יום טוב על משנה פרה',
+          _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'תוספות יום טוב על משנה נדה',
+      );
+    });
+
+    test('משפחות שחולקות קידומת אינן מתבלבלות', () {
+      expect(
+        findMatchingPageShapeCommentator(
+          'עיקר תוספות יום טוב',
+          _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'עיקר תוספות יום טוב על משנה נדה',
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'תוספות רבי עקיבא איגר',
+          _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'תוספות רבי עקיבא איגר על משנה נדה',
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'רמבם',
+          _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'רמבם על משנה נדה',
+      );
+    });
+
+    test('מפרש חסר אינו מוחלף במפרש של מחבר אחר', () {
+      // רגרסיה: התאמה לפי מילות פתיחה משותפות החזירה כאן "תוספות יום טוב".
+      expect(
+        findMatchingPageShapeCommentator(
+          'תוספות רבי עקיבא איגר',
+          const ['ברטנורא על משנה עדיות', 'תוספות יום טוב על משנה עדיות'],
+          commentedBookTitle: 'משנה עדיות',
+        ),
+        isNull,
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'עיקר תוספות יום טוב',
+          const ['ברטנורא על משנה עדיות', 'תוספות יום טוב על משנה עדיות'],
+          commentedBookTitle: 'משנה עדיות',
+        ),
+        isNull,
+      );
+    });
+
+    test('שכבה חסרה של אותו מחבר נופלת חזרה לפירושו בספר הנוכחי', () {
+      expect(
+        findMatchingPageShapeCommentator(
+          'מלבים באור המילות',
+          const ['מלבים על רות', 'אבן עזרא על רות'],
+          commentedBookTitle: 'רות',
+        ),
+        'מלבים על רות',
+      );
+    });
+
+    test('מפרש שאין לו מקבילה בספר הנוכחי אינו מותאם', () {
+      expect(
+        findMatchingPageShapeCommentator(
+          'מלאכת שלמה על משנה נדה',
+          const ['רשי על בראשית', 'רמבן על בראשית'],
+          commentedBookTitle: 'בראשית',
+        ),
+        isNull,
+      );
+      expect(
+        findMatchingPageShapeCommentator(
+          'יכין מקואות',
+          const [],
+          commentedBookTitle: 'משנה נדה',
+        ),
+        isNull,
+      );
+    });
+
+    test('null אינו מותאם', () {
+      expect(
+        findMatchingPageShapeCommentator(null, _mishnaNidaCommentators),
+        isNull,
+      );
+    });
+  });
+
+  group('resolvePageShapeCommentatorSelection', () {
+    test('ערכי sentinel עוברים כמות שהם', () {
+      expect(
+        resolvePageShapeCommentatorSelection(
+          selection: pageShapeRemainingCommentatorsValue,
+          availableCommentators: _mishnaNidaCommentators,
+        ),
+        pageShapeRemainingCommentatorsValue,
+      );
+      expect(
+        resolvePageShapeCommentatorSelection(
+          selection: pageShapeMultipleCommentatorsModeValue,
+          availableCommentators: _mishnaNidaCommentators,
+        ),
+        isNull,
+      );
+    });
+
+    test('בחירה מרובה שנשמרה במסכת אחרת מותאמת כולה', () {
+      final encoded = encodePageShapeCommentatorsSelection(
+        const ['יכין מקואות', 'ברטנורא על משנה מקואות'],
+        forceMultipleMode: true,
+      );
+
+      final resolved = resolvePageShapeCommentatorSelection(
+        selection: encoded,
+        availableCommentators: _mishnaNidaCommentators,
+        commentedBookTitle: 'משנה נדה',
+      );
+
+      expect(
+        decodePageShapeCommentatorsSelection(resolved),
+        ['יכין נדה', 'ברטנורא על משנה נדה'],
+      );
+    });
+
+    test('בחירה מרובה מסוננת לפי מה שקיים בספר הנוכחי', () {
+      final encoded = encodePageShapeCommentatorsSelection(
+        const ['יכין מקואות', 'מפרש שלא קיים כאן'],
+        forceMultipleMode: true,
+      );
+
+      expect(
+        resolvePageShapeSelectedCommentators(
+          selection: encoded,
+          availableCommentators: _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        ['יכין נדה'],
+      );
+    });
+
+    test('שדה בחירה בודדת מציג את השם המותאם למסכת הנוכחית', () {
+      expect(
+        resolvePageShapeSingleCommentatorSelection(
+          selection: 'יכין מקואות',
+          availableCommentators: _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'יכין נדה',
+      );
+    });
+  });
+
+  group('מסלול מלא: שמירה לקטגוריה וטעינה בספר אחר', () {
+    test('יכין — משנה', () async {
+      final resolved = await _reresolveInOtherBook(
+        category: 'משנה',
+        savedFromBookTitle: 'משנה מקואות',
+        savedCommentator: 'יכין מקואות',
+        otherBookTitle: 'משנה נדה',
+        otherBookCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+        otherBookCommentators: _mishnaNidaCommentators,
+      );
+      expect(resolved, 'יכין נדה');
+    });
+
+    test('ברטנורא — משנה (שם עם "על")', () async {
+      final resolved = await _reresolveInOtherBook(
+        category: 'משנה',
+        savedFromBookTitle: 'משנה מקואות',
+        savedCommentator: 'ברטנורא על משנה מקואות',
+        otherBookTitle: 'משנה נדה',
+        otherBookCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+        otherBookCommentators: _mishnaNidaCommentators,
+      );
+      expect(resolved, 'ברטנורא על משנה נדה');
+    });
+
+    test('רי"ף — תלמוד', () async {
+      final resolved = await _reresolveInOtherBook(
+        category: 'בבלי',
+        savedFromBookTitle: 'בבא מציעא',
+        savedCommentator: 'ריף בבא מציעא',
+        otherBookTitle: 'שבת',
+        otherBookCategories: 'אוצריא, תלמוד, בבלי, סדר מועד',
+        otherBookCommentators: const ['רשי על שבת', 'ריף שבת'],
+      );
+      expect(resolved, 'ריף שבת');
+    });
+
+    test('רלב"ג — תנ"ך', () async {
+      final resolved = await _reresolveInOtherBook(
+        category: 'כתובים',
+        savedFromBookTitle: 'שיר השירים',
+        savedCommentator: 'רלבג שיר השירים',
+        otherBookTitle: 'אסתר',
+        otherBookCategories: 'אוצריא, תנ"ך, כתובים, אסתר',
+        otherBookCommentators: const ['רלבג אסתר', 'אבן עזרא על אסתר'],
+      );
+      expect(resolved, 'רלבג אסתר');
+    });
+
+    test('באר היטב — שולחן ערוך', () async {
+      final resolved = await _reresolveInOtherBook(
+        category: 'שולחן ערוך',
+        savedFromBookTitle: 'שולחן ערוך אורח חיים',
+        savedCommentator: 'באר היטב אורח חיים',
+        otherBookTitle: 'שולחן ערוך יורה דעה',
+        otherBookCategories: 'הלכה, שולחן ערוך, יורה דעה',
+        otherBookCommentators: const [
+          'באר היטב יורה דעה',
+          'שך על שולחן ערוך יורה דעה',
+        ],
+      );
+      expect(resolved, 'באר היטב יורה דעה');
+    });
+
+    test('בחירה מרובה נשמרת ומותאמת בספר אחר', () async {
+      await PageShapeSettingsManager.saveConfiguration(
+        'משנה מקואות',
+        {
+          'left': null,
+          'right': encodePageShapeCommentatorsSelection(
+            const ['יכין מקואות', 'ברטנורא על משנה מקואות'],
+            forceMultipleMode: true,
+          ),
+          'bottom': null,
+          'bottomRight': null,
+        },
+        saveToCategory: 'משנה',
+      );
+
+      final config = PageShapeSettingsManager.loadConfiguration(
+        'משנה נדה',
+        heCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+      );
+
+      expect(
+        decodePageShapeCommentatorsSelection(config?['right']),
+        ['יכין', 'ברטנורא'],
+        reason: 'בהיקף קטגוריה נשמרים שמות הבסיס בלבד',
+      );
+      expect(
+        resolvePageShapeSelectedCommentators(
+          selection: config?['right'],
+          availableCommentators: _mishnaNidaCommentators,
+          commentedBookTitle: 'משנה נדה',
+        ),
+        ['יכין נדה', 'ברטנורא על משנה נדה'],
+      );
+    });
+
+    test('מפרש שאינו קיים בספר האחר נשמר ואינו מוחלף במפרש זר', () async {
+      const otherBookCommentators = ['ברטנורא על משנה נדה'];
+      final resolved = await _reresolveInOtherBook(
+        category: 'משנה',
+        savedFromBookTitle: 'משנה מקואות',
+        savedCommentator: 'מלאכת שלמה על משנה מקואות',
+        otherBookTitle: 'משנה נדה',
+        otherBookCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+        otherBookCommentators: otherBookCommentators,
+      );
+
+      // ההגדרה נשמרת כדי שלא תימחק משאר ספרי הקטגוריה, אבל היא אינה מפרש
+      // של הספר הזה ולכן החלונית לא תטען אותה.
+      expect(resolved, 'מלאכת שלמה');
+      expect(otherBookCommentators.contains(resolved), isFalse);
+    });
+  });
+
+  group('היקף ספר בודד — השם המלא נשמר כמות שהוא', () {
+    test('שמירה לספר אינה מקצרת את שם המפרש', () async {
+      await PageShapeSettingsManager.saveConfiguration(
+        'משנה מקואות',
+        const {
+          'left': 'יכין מקואות',
+          'right': null,
+          'bottom': null,
+          'bottomRight': null,
+        },
+      );
+
+      final config = PageShapeSettingsManager.loadConfiguration(
+        'משנה מקואות',
+      );
+      expect(config?['left'], 'יכין מקואות');
+      expect(
+        resolvePageShapeCommentatorSelection(
+          selection: config?['left'],
+          availableCommentators: _mishnaMikvaotCommentators,
+        ),
+        'יכין מקואות',
+      );
+    });
+
+    test('הגדרת ספר גוברת על הגדרת הקטגוריה', () async {
+      await PageShapeSettingsManager.saveConfiguration(
+        'משנה מקואות',
+        const {
+          'left': 'יכין מקואות',
+          'right': null,
+          'bottom': null,
+          'bottomRight': null,
+        },
+        saveToCategory: 'משנה',
+      );
+      await PageShapeSettingsManager.saveConfiguration(
+        'משנה נדה',
+        const {
+          'left': 'בועז על משנה נדה',
+          'right': null,
+          'bottom': null,
+          'bottomRight': null,
+        },
+      );
+
+      final config = PageShapeSettingsManager.loadConfiguration(
+        'משנה נדה',
+        heCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+      );
+      expect(config?['left'], 'בועז על משנה נדה');
+    });
+  });
+}

--- a/test/text_book/view/page_shape/page_shape_screen_settings_test.dart
+++ b/test/text_book/view/page_shape/page_shape_screen_settings_test.dart
@@ -208,6 +208,144 @@ void main() {
     expect(settingsPane(tester).isOpen, isFalse);
   });
 
+  testWidgets('בחירת קטגוריה שנשמרה עם שם מסכת אחרת מתעדכנת למסכת הנוכחית', (
+    tester,
+  ) async {
+    // "יכין מקואות" — משפחת מפרשים שאין ב שמה "על" — נשמרה כפי שהיא בהגדרת
+    // הקטגוריה, וכל מסכת אחרת הציגה את היכין של המסכת הראשונה.
+    await PageShapeSettingsManager.saveConfiguration(
+      'משנה מקואות',
+      const {
+        'left': 'יכין מקואות',
+        'right': null,
+        'bottom': null,
+        'bottomRight': null,
+      },
+      saveToCategory: 'משנה',
+    );
+
+    final openSettingsNotifier = ValueNotifier<int>(0);
+    addTearDown(openSettingsNotifier.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(
+              value: _TestTextBookBloc(
+                _loadedState(
+                  book: TextBook(
+                    title: 'משנה נדה',
+                    heCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+                  ),
+                  availableCommentators: const [
+                    'ברטנורא על משנה נדה',
+                    'יכין נדה',
+                  ],
+                ),
+              ),
+            ),
+            BlocProvider<PersonalNotesBloc>.value(
+              value: _TestPersonalNotesBloc(
+                const PersonalNotesState(
+                  isLoading: false,
+                  bookId: 'משנה נדה',
+                  locatedNotes: [],
+                  missingNotes: [],
+                  errorMessage: null,
+                  filteredLocatedNotes: [],
+                  filteredMissingNotes: [],
+                ),
+              ),
+            ),
+            BlocProvider<SettingsBloc>.value(
+              value: _TestSettingsBloc(SettingsState.initial()),
+            ),
+          ],
+          child: PageShapeScreen(
+            openBookCallback: (_) {},
+            openSettingsNotifier: openSettingsNotifier,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    openSettingsNotifier.value++;
+    await tester.pump();
+    await tester.pump();
+
+    final panel = tester.widget<PageShapeSettingsPanel>(
+      find.byType(PageShapeSettingsPanel),
+    );
+    expect(panel.currentLeft, 'יכין נדה');
+  });
+
+  testWidgets('מפרש שאינו קיים בספר הנוכחי אינו נמחק מההגדרה', (tester) async {
+    // איפוס הבחירה ל-null היה נשמר חזרה מהפאנל ומוחק את המפרש מכל הקטגוריה.
+    await PageShapeSettingsManager.saveConfiguration(
+      'משנה נדה',
+      const {
+        'left': 'מלאכת שלמה על משנה מקואות',
+        'right': null,
+        'bottom': null,
+        'bottomRight': null,
+      },
+    );
+
+    final openSettingsNotifier = ValueNotifier<int>(0);
+    addTearDown(openSettingsNotifier.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(
+              value: _TestTextBookBloc(
+                _loadedState(
+                  book: TextBook(title: 'משנה נדה'),
+                  availableCommentators: const ['ברטנורא על משנה נדה'],
+                ),
+              ),
+            ),
+            BlocProvider<PersonalNotesBloc>.value(
+              value: _TestPersonalNotesBloc(
+                const PersonalNotesState(
+                  isLoading: false,
+                  bookId: 'משנה נדה',
+                  locatedNotes: [],
+                  missingNotes: [],
+                  errorMessage: null,
+                  filteredLocatedNotes: [],
+                  filteredMissingNotes: [],
+                ),
+              ),
+            ),
+            BlocProvider<SettingsBloc>.value(
+              value: _TestSettingsBloc(SettingsState.initial()),
+            ),
+          ],
+          child: PageShapeScreen(
+            openBookCallback: (_) {},
+            openSettingsNotifier: openSettingsNotifier,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    openSettingsNotifier.value++;
+    await tester.pump();
+    await tester.pump();
+
+    final panel = tester.widget<PageShapeSettingsPanel>(
+      find.byType(PageShapeSettingsPanel),
+    );
+    expect(panel.currentLeft, 'מלאכת שלמה על משנה מקואות');
+  });
+
   testWidgets('כשל טעינת מפרש תחתון אינו שומר הסתרה גלובלית', (tester) async {
     const missingCommentator = 'מפרש בדיקה שלא קיים במאגר';
 
@@ -271,9 +409,10 @@ void main() {
 
 TextBookLoaded _loadedState({
   List<String> availableCommentators = const ['רש"י על ספר בדיקה'],
+  TextBook? book,
 }) {
   return TextBookLoaded(
-    book: TextBook(title: 'ספר בדיקה'),
+    book: book ?? TextBook(title: 'ספר בדיקה'),
     showLeftPane: false,
     content: const ['שורה א'],
     fontSize: 18,

--- a/test/text_book/view/page_shape/page_shape_settings_manager_category_test.dart
+++ b/test/text_book/view/page_shape/page_shape_settings_manager_category_test.dart
@@ -61,6 +61,94 @@ void main() {
     });
   });
 
+  group('extractBaseCommentatorName מפריד את שם הספר משם המפרש', () {
+    test('שם עם "על" — הקידומת היא שם המפרש', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'ברטנורא על משנה נדה',
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'ברטנורא',
+      );
+    });
+
+    test('שם בלי "על" — שם המסכת מוסר לפי שם הספר הנקרא', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'יכין מקואות',
+          commentedBookTitle: 'משנה מקואות',
+        ),
+        'יכין',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'ריף בבא מציעא',
+          commentedBookTitle: 'בבא מציעא',
+        ),
+        'ריף',
+      );
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'באר היטב אורח חיים',
+          commentedBookTitle: 'שולחן ערוך אורח חיים',
+        ),
+        'באר היטב',
+      );
+    });
+
+    test('מפרש שאינו נושא את שם הספר נשאר כמות שהוא', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'משנה ברורה',
+          commentedBookTitle: 'שולחן ערוך אורח חיים',
+        ),
+        'משנה ברורה',
+      );
+    });
+
+    test('שם שכולו זהה לשם הספר אינו מתרוקן', () {
+      expect(
+        PageShapeSettingsManager.extractBaseCommentatorName(
+          'נדה',
+          commentedBookTitle: 'משנה נדה',
+        ),
+        'נדה',
+      );
+    });
+  });
+
+  test(
+    'רגרסיה: "יכין" נשמר לקטגוריה בלי שם המסכת ולכן מתעדכן במסכת אחרת',
+    () async {
+      // ספרי "יכין" נקראים "יכין <מסכת>" — בלי "על".
+      const mikvaotCategories = 'אוצריא, משנה, סדר טהרות, מקואות';
+
+      await PageShapeSettingsManager.saveConfiguration(
+        'משנה מקואות',
+        const {
+          'left': 'יכין מקואות',
+          'right': null,
+          'bottom': null,
+          'bottomRight': null,
+        },
+        saveToCategory: 'משנה',
+      );
+
+      final nidaConfig = PageShapeSettingsManager.loadConfiguration(
+        'משנה נדה',
+        heCategories: 'אוצריא, משנה, סדר טהרות, נדה',
+      );
+      expect(nidaConfig?['left'], 'יכין');
+
+      // גם בספר המקורי הבחירה נשארת תקפה.
+      final mikvaotConfig = PageShapeSettingsManager.loadConfiguration(
+        'משנה מקואות',
+        heCategories: mikvaotCategories,
+      );
+      expect(mikvaotConfig?['left'], 'יכין');
+    },
+  );
+
   test(
     'רגרסיה: שמירת מפרש לקטגוריה של ספר אחד לא מדליפה לספר אחר תחת קטגוריית-אב משותפת',
     () async {


### PR DESCRIPTION
## הבאג

בצורת הדף, בוחרים מפרש בהיקף **"קטגוריה"**, פותחים מסכת אחרת — והחלונית ממשיכה להציג את המפרש של המסכת הראשונה. דווח על "יכין" במשניות: בוחרים יכין לכל הקטגוריה, פותחים מסכת אחרת, ורואים את היכין של המסכת הקודמת.

## שורש הבעיה

הגדרה בהיקף קטגוריה נשמרת עם **שם הבסיס** של המפרש, כדי שתותאם מחדש לשם המלא בכל ספר. `PageShapeSettingsManager.extractBaseCommentatorName` חילץ את שם הבסיס לפי המחרוזת `' על '` בלבד:

- `ברטנורא על משנה נדה` → `ברטנורא` ✅
- `יכין מקואות` → `יכין מקואות` ❌ — שם המסכת נשמר בהגדרה

ואז שלושה דברים הצטרפו:

1. `resolvePageShapeCommentatorSelection` נופל חזרה על `findMatchingPageShapeCommentator(...) ?? selection` — בהיעדר התאמה מוחזר השם הזר.
2. `_CommentaryPane._loadCommentary` טוען ספר לפי שמו דרך `BookLocator.locateBook`, בלי תלות בקישורי הספר הנוכחי.
3. ספר בשם הזה באמת קיים — ולכן הוא נטען והוצג.

## היקף — לא רק "יכין"

סריקה של `all_metadata.json` (7,445 ספרים) מעלה את משפחות המפרשים ששמן `<מפרש> <שם הספר>` בלי "על":

| משפחה | היקף | דוגמה |
|---|---|---|
| **יכין** (משנה) | 63/63 | `יכין מקואות` |
| **רי"ף** (תלמוד) | 42 | `ריף בבא מציעא` |
| **תרגום** (תנ"ך) | 7 | `תרגום קהלת` |
| **רלב"ג** (תנ"ך) | 4 | `רלבג שיר השירים` |
| **באר היטב** (הלכה) | 4 | `באר היטב אורח חיים` |
| **תרגום ירושלמי**, **מחוקקי יהודה** | 2-3 | `מחוקקי יהודה קרני אור` |

במשנה יכין הוא היחיד מבין 29 משפחות המפרשים — כל השאר כוללות "על", ולכן דווקא בו נתקלים.

## התיקון

**1. חילוץ שם הבסיס לפי שם הספר הנקרא** (`pageShapeCommentatorBaseName`)

כלל ה-"על" נשמר; כשאין "על", מוסרות מסוף שם המפרש המילים המשותפות עם שם הספר:

```
יכין מקואות  /  משנה מקואות   → יכין
ריף בבא מציעא  /  בבא מציעא   → ריף
באר היטב אורח חיים  /  שולחן ערוך אורח חיים → באר היטב
משנה ברורה  /  שולחן ערוך אורח חיים → משנה ברורה   (אין מילה משותפת — אין שינוי)
```

**2. התאמה לפי חלק-המפרש, לריפוי הגדרות שכבר נשמרו**

בהיעדר התאמה ישירה, כל מועמד מנורמל באותה דרך ומושווה למילות הפתיחה של הבחירה השמורה. `יכין מקואות` בספר `משנה נדה` מוצא את `יכין נדה`, בלי שהמשתמש יבחר מחדש.

ההתאמה דורשת **גבול-מילה מלא** ובוחרת את הבסיס **הארוך ביותר**, כדי שלא תיווצר החלפה בין מחברים:

- `תוספות רבי עקיבא איגר` **אינו** מתאים ל-`תוספות יום טוב על משנה נדה`
- `עיקר תוספות יום טוב` **אינו** מתאים ל-`תוספות יום טוב על משנה נדה`

**3. חלונית המפרש אינה טוענת ספר זר**

מפרש שאינו ב-`availableCommentators` של הספר הנוכחי מפעיל את מסלול `onLoadFailed` הקיים (הסתרה ללא שמירה). ההגדרה השמורה **נשארת על כנה** — אחרת איפוסה היה נשמר חזרה מפאנל ההגדרות ומוחק את המפרש מכל ספרי הקטגוריה.

## בדיקות

קובץ חדש `test/text_book/view/page_shape/page_shape_category_commentator_matching_test.dart` — 32 בדיקות: חילוץ שם בסיס לכל משפחות השמות שבטבלה, מקרי קצה (רווחים כפולים, שם זהה לשם הספר, בלי שם ספר), התאמה חוצת-ספרים, מניעת החלפה בין מחברים, בחירה מרובה, ומסלול שמירה→טעינה מלא לכל משפחה.

הורחבו גם `page_shape_settings_manager_category_test.dart` ו-`page_shape_screen_settings_test.dart`.

- `flutter test test/text_book/` — 1259 עוברות
- `flutter analyze` — נקי
- אומת שהבדיקות החדשות נכשלות ללא התיקון

🤖 Generated with [Claude Code](https://claude.com/claude-code)
