### PR TITLE
תיקון: התאמת תצוגת PDF לשינוי רוחב

### DIFF
--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -1351,7 +1351,13 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       },
       backgroundColor: _pdfViewerBgColor(),
       pageDropShadow: _pageDropShadow,
-      sizeDelegateProvider: PdfViewerSizeDelegateProviderLegacy(maxScale: 20),
+      sizeDelegateProvider: layoutMode.isBookView
+          ? const PdfViewerSizeDelegateProviderLegacy(maxScale: 20)
+          : const PdfViewerSizeDelegateProviderSmart(
+              maxScale: 20,
+              smartMaxScale: 20,
+              maxPagesVisible: 1,
+            ),
       maxImageBytesCachedOnMemory: pdfImageCacheBytesForPanes(
         widget.pdfPaneCount,
       ),
@@ -2021,10 +2027,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           // את סמן הגרירה עד לשחרור.
           if (_isInteractivePageTurn)
             Positioned.fill(
-              child: MouseRegion(
-                cursor: AppCursors.grabbing,
-                opaque: false,
-              ),
+              child: MouseRegion(cursor: AppCursors.grabbing, opaque: false),
             ),
         ],
       ),
@@ -3028,10 +3031,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       // Animation already in flight: queue this turn FIFO so it plays after
       // the current one finishes. Each click gets its own curl, in order.
       _pendingPageTurns.add(
-        _PendingBookPageTurn(
-          targetPage: targetPage,
-          direction: direction,
-        ),
+        _PendingBookPageTurn(targetPage: targetPage, direction: direction),
       );
       return;
     }
@@ -4311,9 +4311,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                             widget.tab.incomingSearchConfiguration,
                         onSearchResultNavigated: _ensureSearchTabIsActive,
                       )
-                    : const Center(
-                        child: CircularProgressIndicator(),
-                      ),
+                    : const Center(child: CircularProgressIndicator()),
               ),
               ValueListenableBuilder(
                 valueListenable: widget.tab.documentRef,
@@ -5544,12 +5542,7 @@ class _BookPageTurnBackgroundPainter extends CustomPainter {
       canvas.clipPath(revealedPath);
       canvas.drawImageRect(
         target,
-        Rect.fromLTWH(
-          0,
-          0,
-          target.width.toDouble(),
-          target.height.toDouble(),
-        ),
+        Rect.fromLTWH(0, 0, target.width.toDouble(), target.height.toDouble()),
         destRect,
         Paint(),
       );
@@ -5798,9 +5791,7 @@ class _BookPageTurnPainter extends CustomPainter {
             begin: fadeLeft ? Alignment.centerRight : Alignment.centerLeft,
             end: fadeLeft ? Alignment.centerLeft : Alignment.centerRight,
             colors: [
-              shadowColor.withValues(
-                alpha: baseAlpha * geometry.shadeStrength,
-              ),
+              shadowColor.withValues(alpha: baseAlpha * geometry.shadeStrength),
               shadowColor.withValues(alpha: 0.0),
             ],
           ).createShader(shadowRect),
@@ -5992,10 +5983,7 @@ class _BookViewTurnButton extends StatelessWidget {
 /// resolver so the underlying pdfrx InteractiveViewer can claim it and zoom
 /// at the correct focal point (cursor position) instead of the viewport center.
 class _PdfScrollOnlyListener extends SingleChildRenderObjectWidget {
-  const _PdfScrollOnlyListener({
-    required this.onPointerSignal,
-    super.child,
-  });
+  const _PdfScrollOnlyListener({required this.onPointerSignal, super.child});
 
   final void Function(PointerSignalEvent) onPointerSignal;
 
@@ -6013,9 +6001,8 @@ class _PdfScrollOnlyListener extends SingleChildRenderObjectWidget {
 }
 
 class _RenderPdfScrollOnlyListener extends RenderProxyBoxWithHitTestBehavior {
-  _RenderPdfScrollOnlyListener({
-    required this._onPointerSignal,
-  }) : super(behavior: HitTestBehavior.translucent);
+  _RenderPdfScrollOnlyListener({required this._onPointerSignal})
+    : super(behavior: HitTestBehavior.translucent);
 
   void Function(PointerSignalEvent) _onPointerSignal;
 

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -138,6 +138,20 @@ int pdfImageCacheBytesForPanes(int pdfPaneCount) {
       : perPane;
 }
 
+/// מחזיר את מדיניות שינוי גודל ה-PDF לפי מצב התצוגה.
+@visibleForTesting
+PdfViewerSizeDelegateProvider pdfSizeDelegateProviderForLayoutMode(
+  PdfLayoutMode layoutMode,
+) {
+  return layoutMode.isBookView
+      ? const PdfViewerSizeDelegateProviderLegacy(maxScale: 20)
+      : const PdfViewerSizeDelegateProviderSmart(
+          maxScale: 20,
+          smartMaxScale: 20,
+          maxPagesVisible: 1,
+        );
+}
+
 class PdfBookScreen extends StatefulWidget {
   final PdfBookTab tab;
   final bool isInCombinedView;
@@ -1351,13 +1365,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       },
       backgroundColor: _pdfViewerBgColor(),
       pageDropShadow: _pageDropShadow,
-      sizeDelegateProvider: layoutMode.isBookView
-          ? const PdfViewerSizeDelegateProviderLegacy(maxScale: 20)
-          : const PdfViewerSizeDelegateProviderSmart(
-              maxScale: 20,
-              smartMaxScale: 20,
-              maxPagesVisible: 1,
-            ),
+      sizeDelegateProvider: pdfSizeDelegateProviderForLayoutMode(layoutMode),
       maxImageBytesCachedOnMemory: pdfImageCacheBytesForPanes(
         widget.pdfPaneCount,
       ),

--- a/test/pdf_book/pdf_viewer_resize_test.dart
+++ b/test/pdf_book/pdf_viewer_resize_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/pdf_book/view/pdf_book_screen.dart';
+import 'package:otzaria/widgets/layout/dual_adaptive_reader_pane.dart';
+import 'package:otzaria/settings/services/per_book_settings_service.dart'
+    show PdfLayoutMode;
+import 'package:pdfrx/pdfrx.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          pathProviderChannel,
+          (call) async => switch (call.method) {
+            'getTemporaryDirectory' => '/tmp/otzaria-pdfrx-test',
+            _ => null,
+          },
+        );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+  });
+
+  Future<PdfDocument> openTestDocument(WidgetTester tester) async {
+    final document = await tester.runAsync(() async {
+      final source = pw.Document();
+      source.addPage(
+        pw.Page(
+          build: (context) => pw.SizedBox(),
+        ),
+      );
+      final bytes = await source.save();
+      return PdfDocument.openData(
+        bytes,
+        sourceName: 'pdf-viewer-resize-test.pdf',
+        useProgressiveLoading: false,
+      );
+    });
+    return document!;
+  }
+
+  Future<void> waitForViewer(
+    WidgetTester tester,
+    PdfViewerController controller,
+  ) async {
+    var hasLayout = false;
+    for (var i = 0; i < 30 && !hasLayout; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
+      );
+      if (controller.isReady) {
+        try {
+          controller.viewSize;
+          hasLayout = true;
+        } catch (_) {
+          // pdfrx exposes isReady slightly before the first layout frame.
+        }
+      }
+    }
+    expect(hasLayout, isTrue);
+  }
+
+  Widget buildHost({
+    required PdfDocument document,
+    required PdfViewerController controller,
+    required double width,
+    required bool showRightPane,
+    required ValueChanged<bool> onShowRightPaneChanged,
+  }) {
+    return MaterialApp(
+      home: Directionality(
+        textDirection: TextDirection.rtl,
+        child: SizedBox(
+          width: width,
+          height: 700,
+          child: DualAdaptiveReaderPane(
+            mainContent: PdfViewer(
+              PdfDocumentRefDirect(document),
+              controller: controller,
+              params: const PdfViewerParams(
+                sizeDelegateProvider: PdfViewerSizeDelegateProviderSmart(
+                  maxScale: 20,
+                  smartMaxScale: 20,
+                  maxPagesVisible: 1,
+                ),
+                behaviorControlParams: PdfViewerBehaviorControlParams(
+                  trailingPageLoadingDelay: Duration.zero,
+                ),
+              ),
+            ),
+            showLeftPane: false,
+            leftPaneContent: const SizedBox.shrink(),
+            leftPaneWidth: 220,
+            leftMinPaneWidth: 180,
+            onCloseLeftPane: () {},
+            showRightPane: showRightPane,
+            rightPaneContent: const SizedBox.shrink(),
+            rightPaneWidth: 240,
+            rightMinPaneWidth: 180,
+            onCloseRightPane: () => onShowRightPaneChanged(false),
+            minMainContentWidth: 500,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('PDF shrinks when a wide side pane opens', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1400, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final document = await openTestDocument(tester);
+    addTearDown(document.dispose);
+    final controller = PdfViewerController();
+    var showRightPane = false;
+    late ValueChanged<bool> setShowRightPane;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setShowRightPane = (value) => setState(() {
+            showRightPane = value;
+          });
+          return buildHost(
+            document: document,
+            controller: controller,
+            width: 1400,
+            showRightPane: showRightPane,
+            onShowRightPaneChanged: setShowRightPane,
+          );
+        },
+      ),
+    );
+    await waitForViewer(tester, controller);
+
+    final initialWidth = controller.viewSize.width;
+    final initialZoom = controller.value.zoom;
+    setShowRightPane(true);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(controller.viewSize.width, lessThan(initialWidth));
+    expect(controller.value.zoom, lessThan(initialZoom));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 200));
+  });
+
+  test('PDF layout modes select the intended resize policies', () {
+    expect(
+      pdfSizeDelegateProviderForLayoutMode(PdfLayoutMode.regularView),
+      isA<PdfViewerSizeDelegateProviderSmart>(),
+    );
+    expect(
+      pdfSizeDelegateProviderForLayoutMode(PdfLayoutMode.bookView),
+      isA<PdfViewerSizeDelegateProviderLegacy>(),
+    );
+  });
+
+  testWidgets('PDF does not resize when a narrow side pane overlays it', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(620, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final document = await openTestDocument(tester);
+    addTearDown(document.dispose);
+    final controller = PdfViewerController();
+    var showRightPane = false;
+    late ValueChanged<bool> setShowRightPane;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setShowRightPane = (value) => setState(() {
+            showRightPane = value;
+          });
+          return buildHost(
+            document: document,
+            controller: controller,
+            width: 620,
+            showRightPane: showRightPane,
+            onShowRightPaneChanged: setShowRightPane,
+          );
+        },
+      ),
+    );
+    await waitForViewer(tester, controller);
+
+    final initialWidth = controller.viewSize.width;
+    final initialZoom = controller.value.zoom;
+    setShowRightPane(true);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(controller.viewSize.width, closeTo(initialWidth, 0.1));
+    expect(controller.value.zoom, closeTo(initialZoom, 0.01));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 200));
+  });
+}


### PR DESCRIPTION
תיקון תצוגת PDF בעת הקטנת רוחב אזור הקריאה, בין השאר בפתיחת חלונית המפרשים ובהצגת שני ספרים זה לצד זה.

בתצוגה הרגילה נעשה שימוש ב-PdfViewerSizeDelegateProviderSmart, כדי לשמור על התאמה לרוחב בעת שינוי גודל ה-viewport. תצוגת הספר ממשיכה להשתמש במנגנון Legacy בשל נרמול המטריצה ואנימציות הדפדוף המותאמות שלה.

בדיקות:
- flutter analyze lib/pdf_book/view/pdf_book_screen.dart
- No issues found

לא נמצא פתרון להצגת PDF בתצוגת ספר, לכאו' לא כדאי להגדיר הגדרה דומה כי זה יצא בגודל לא קריא
אולי צריך להגדיר שמרוחב מסוים גם תצוגת ספר תציג רגיל @Y-PLONI 