### PR TITLE
ניקוד ופיסוק: החרגת התנ"ך אינה חלה על מפרשיו

### DIFF
--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -602,7 +602,6 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     _pdfViewFocusNode.canRequestFocus = _isActivePane(
       context.read<TabsBloc>().state,
     );
-    _resolveIsTanachBook();
     _pageTurnController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 500),
@@ -3587,20 +3586,6 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   bool _isJumping = false; // flag לציון שאנחנו בתהליך קפיצה
   bool _linksLoading = true; // true עד שטעינת הקישורים מסתיימת
 
-  /// האם הספר שייך לתנ"ך — קובע את החרגות הניקוד/פיסוק על תוכן המפרשים,
-  /// בדיוק כמו בכרטיסיית הטקסט.
-  bool _isTanachBook = false;
-
-  Future<void> _resolveIsTanachBook() async {
-    final isTanach = await FileSystemData.instance.isTanachBook(
-      widget.tab.book.title,
-      categoryId: widget.tab.book.categoryId,
-      fileType: widget.tab.book.fileType,
-    );
-    if (!mounted || isTanach == _isTanachBook) return;
-    setState(() => _isTanachBook = isTanach);
-  }
-
   // מסלול חלון-הקישורים (ספרי מסד): tab.links מחזיק רק חלון שורות סביב
   // המיקום הנוכחי ומתרענן בדפדוף — ראה PdfLinksWindowPolicy.
   TextBook? _linksTextBook; // לא-null רק כשמסלול החלון פעיל
@@ -4385,14 +4370,15 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       tab: widget.tab,
       linksCount: widget.tab.links.length,
       linksLoading: _linksLoading,
+      // המפרשים אינם תנ"ך, ולכן החרגת הניקוד של התנ"ך אינה חלה עליהם.
       removeNikud: shouldRemoveNikudForBook(
         defaultRemoveNikud: settingsState.defaultRemoveNikud,
         removeNikudFromTanach: settingsState.removeNikudFromTanach,
-        isTanach: _isTanachBook,
+        isTanach: false,
       ),
       removePunctuation: shouldRemovePunctuationForBook(
         defaultRemovePunctuation: settingsState.defaultRemovePunctuation,
-        isTanach: _isTanachBook,
+        isTanach: false,
       ),
       openBookCallback: (tab) =>
           openPreparedTab(context, tab, insertAdjacent: true),

--- a/lib/pdf_book/view/pdf_commentators_tab_screen.dart
+++ b/lib/pdf_book/view/pdf_commentators_tab_screen.dart
@@ -33,8 +33,6 @@ import 'package:otzaria/text_book/utils/commentator_group_builder.dart';
 import 'package:otzaria/text_book/view/page_shape/utils/default_commentators.dart';
 import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
 import 'package:otzaria/settings/settings_exports.dart';
-import 'package:otzaria/settings/services/nikud_display_service.dart';
-import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart';
 import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
 import 'package:otzaria/widgets/layout/split_pane_content_inset.dart';
@@ -107,46 +105,20 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
   /// משקף את מצב "הכל מורחב" מתוך PdfCommentaryPanel (לכפתור כיווץ/הרחבה בסרגל).
   final _allExpandedInChild = ValueNotifier<bool>(true);
 
-  /// הסרת ניקוד/פיסוק מהמפרשים (כמו בכרטיסיית הטקסט). חייב להיות מאותחל
-  /// מהגדרת התצוגה של המשתמש, אחרת מוצג ניקוד למי שכיבה אותו.
+  /// מאותחל מהגדרת התצוגה, אחרת מוצג ניקוד למי שכיבה אותו. החרגות התנ"ך
+  /// אינן חלות כאן: תוכן הכרטיסייה הוא מפרשים, ואינו תנ"ך.
   late bool _removeNikud;
   late bool _removePunctuation;
 
-  /// החרגות התנ"ך על הניקוד/פיסוק נפתרות אסינכרונית, ולכן הן מוחלות על הערך
-  /// ההתחלתי ברגע שהסיווג מגיע — כל עוד המשתמש לא שינה אותו בסרגל.
-  bool _displayFlagsTouchedByUser = false;
-
   void _toggleRemoveNikud() {
     setState(() {
-      _displayFlagsTouchedByUser = true;
       _removeNikud = !_removeNikud;
     });
   }
 
   void _toggleRemovePunctuation() {
     setState(() {
-      _displayFlagsTouchedByUser = true;
       _removePunctuation = !_removePunctuation;
-    });
-  }
-
-  Future<void> _resolveIsTanachBook(SettingsState settings) async {
-    final isTanach = await FileSystemData.instance.isTanachBook(
-      widget.tab.sourceTab.book.title,
-      categoryId: widget.tab.sourceTab.book.categoryId,
-      fileType: widget.tab.sourceTab.book.fileType,
-    );
-    if (!mounted || !isTanach || _displayFlagsTouchedByUser) return;
-    setState(() {
-      _removeNikud = shouldRemoveNikudForBook(
-        defaultRemoveNikud: settings.defaultRemoveNikud,
-        removeNikudFromTanach: settings.removeNikudFromTanach,
-        isTanach: true,
-      );
-      _removePunctuation = shouldRemovePunctuationForBook(
-        defaultRemovePunctuation: settings.defaultRemovePunctuation,
-        isTanach: true,
-      );
     });
   }
 
@@ -159,7 +131,6 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
     final settings = context.read<SettingsBloc>().state;
     _removeNikud = settings.defaultRemoveNikud;
     _removePunctuation = settings.defaultRemovePunctuation;
-    _resolveIsTanachBook(settings);
     _navTabController = TabController(length: 3, vsync: this);
     _navTabController.addListener(_handleTabChanged);
     _initHeadings();

--- a/lib/settings/engine/settings_bloc.dart
+++ b/lib/settings/engine/settings_bloc.dart
@@ -636,6 +636,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       PerBookSettings.cleanupRedundantSettings(
         defaultFontSize: state.fontSize,
         defaultRemoveNikud: state.defaultRemoveNikud,
+        removeNikudFromTanach: state.removeNikudFromTanach,
         defaultRemovePunctuation: state.defaultRemovePunctuation,
         defaultShowSplitView:
             Settings.getValue<bool>('key-splited-view') ?? true,

--- a/lib/settings/services/nikud_display_service.dart
+++ b/lib/settings/services/nikud_display_service.dart
@@ -14,6 +14,16 @@ bool shouldRemoveNikudForBook({
   return defaultRemoveNikud && (removeNikudFromTanach || !isTanach);
 }
 
+/// מחזיר האם הספר פטור מהסרת ניקוד רק בזכות היותו תנ"ך (הגדרת "הצג ניקוד
+/// בתנ"ך"). פטור כזה אינו חל על המפרשים והקישורים שלו — הם אינם תנ"ך.
+bool isNikudExemptByTanach({
+  required bool defaultRemoveNikud,
+  required bool removeNikudFromTanach,
+  required bool isTanach,
+}) {
+  return defaultRemoveNikud && !removeNikudFromTanach && isTanach;
+}
+
 /// מחזיר האם יש להסיר פיסוק עבור ספר נתון. הסרת פיסוק אינה חלה על תנ"ך
 /// (הכפתור מוסתר שם), ולכן ההחרגה היא חלק מהחוזה ולא מהמסך.
 bool shouldRemovePunctuationForBook({
@@ -21,6 +31,15 @@ bool shouldRemovePunctuationForBook({
   required bool isTanach,
 }) {
   return defaultRemovePunctuation && !isTanach;
+}
+
+/// מחזיר האם הספר פטור מהסרת פיסוק רק בזכות היותו תנ"ך. פטור כזה אינו חל על
+/// המפרשים והקישורים שלו — הם אינם תנ"ך.
+bool isPunctuationExemptByTanach({
+  required bool defaultRemovePunctuation,
+  required bool isTanach,
+}) {
+  return defaultRemovePunctuation && isTanach;
 }
 
 /// מחזיר האם שינוי מצב ההגדרות מחייב טעינה מחדש של ספר פתוח.

--- a/lib/settings/services/per_book_settings_service.dart
+++ b/lib/settings/services/per_book_settings_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/services/nikud_display_service.dart';
 
 /// מחלקה לניהול הגדרות פר-ספר
 class PerBookSettings {
@@ -128,12 +129,12 @@ class PerBookSettings {
           (Settings.getValue<double>('key-font-size') ?? 25.0)) {
         cleaned.remove('fontSize');
       }
-      if (cleaned['removeNikud'] ==
-          (Settings.getValue<bool>('key-default-nikud') ?? false)) {
-        cleaned.remove('removeNikud');
-      }
-      _removeRedundantPunctuationFields(
+      _removeRedundantDisplayFields(
         cleaned,
+        defaultRemoveNikud:
+            Settings.getValue<bool>('key-default-nikud') ?? false,
+        removeNikudFromTanach:
+            Settings.getValue<bool>('key-remove-nikud-tanach') ?? false,
         defaultRemovePunctuation:
             Settings.getValue<bool>('key-default-remove-punctuation') ?? false,
       );
@@ -151,20 +152,36 @@ class PerBookSettings {
     }
   }
 
-  /// מסיר override של פיסוק ששווה לברירת המחדל האפקטיבית של הספר.
-  /// בתנ"ך (דגל isTanach שנשמר לצד ה-override) הסרת פיסוק אינה חלה —
-  /// ברירת המחדל האפקטיבית בו תמיד false, ללא תלות בהגדרה הגלובלית.
-  static void _removeRedundantPunctuationFields(
+  /// מסיר override של ניקוד/פיסוק ששווה לברירת המחדל האפקטיבית של הספר.
+  /// החרגות התנ"ך נגזרות מדגל isTanach שנשמר לצד ה-override.
+  static void _removeRedundantDisplayFields(
     Map<String, dynamic> cleaned, {
+    required bool defaultRemoveNikud,
+    required bool removeNikudFromTanach,
     required bool defaultRemovePunctuation,
   }) {
-    final effectiveDefault =
-        defaultRemovePunctuation && cleaned['isTanach'] != true;
-    if (cleaned['removePunctuation'] == effectiveDefault) {
+    final isTanach = cleaned['isTanach'] == true;
+
+    final effectiveNikud = shouldRemoveNikudForBook(
+      defaultRemoveNikud: defaultRemoveNikud,
+      removeNikudFromTanach: removeNikudFromTanach,
+      isTanach: isTanach,
+    );
+    if (cleaned['removeNikud'] == effectiveNikud) {
+      cleaned.remove('removeNikud');
+    }
+
+    final effectivePunctuation = shouldRemovePunctuationForBook(
+      defaultRemovePunctuation: defaultRemovePunctuation,
+      isTanach: isTanach,
+    );
+    if (cleaned['removePunctuation'] == effectivePunctuation) {
       cleaned.remove('removePunctuation');
     }
-    // הדגל הוא לוויין של ה-override; בלעדיו אין לו משמעות.
-    if (!cleaned.containsKey('removePunctuation')) {
+
+    // הדגל הוא לוויין של ה-overrides; בלעדיהם אין לו משמעות.
+    if (!cleaned.containsKey('removePunctuation') &&
+        !cleaned.containsKey('removeNikud')) {
       cleaned.remove('isTanach');
     }
   }
@@ -296,6 +313,7 @@ class PerBookSettings {
     required double defaultFontSize,
     required bool defaultRemoveNikud,
     required bool defaultShowSplitView,
+    bool removeNikudFromTanach = false,
     bool defaultRemovePunctuation = false,
     bool defaultContinuousReadingMode = false,
   }) async {
@@ -337,11 +355,10 @@ class PerBookSettings {
             if (cleaned['fontSize'] == defaultFontSize) {
               cleaned.remove('fontSize');
             }
-            if (cleaned['removeNikud'] == defaultRemoveNikud) {
-              cleaned.remove('removeNikud');
-            }
-            _removeRedundantPunctuationFields(
+            _removeRedundantDisplayFields(
               cleaned,
+              defaultRemoveNikud: defaultRemoveNikud,
+              removeNikudFromTanach: removeNikudFromTanach,
               defaultRemovePunctuation: defaultRemovePunctuation,
             );
             if (cleaned['commentatorsBelow'] == !defaultShowSplitView) {

--- a/lib/settings/tabs/design_settings_tab.dart
+++ b/lib/settings/tabs/design_settings_tab.dart
@@ -502,6 +502,8 @@ class DesignSettingsTab extends StatelessWidget {
                                 defaultFontSize: settingsBloc.state.fontSize,
                                 defaultRemoveNikud:
                                     settingsBloc.state.defaultRemoveNikud,
+                                removeNikudFromTanach:
+                                    settingsBloc.state.removeNikudFromTanach,
                                 defaultRemovePunctuation:
                                     settingsBloc.state.defaultRemovePunctuation,
                                 defaultShowSplitView: value,

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -815,10 +815,19 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         removeNikudFromTanach: removeNikudFromTanach,
         isTanach: isTanach,
       );
+      final nikudExemptByTanach = isNikudExemptByTanach(
+        defaultRemoveNikud: defaultRemoveNikud,
+        removeNikudFromTanach: removeNikudFromTanach,
+        isTanach: isTanach,
+      );
       // הסרת פיסוק אינה חלה על תנ"ך (הכפתור מוסתר שם).
-      final defaultRemovePunctuation =
-          !isTanach &&
-          (Settings.getValue<bool>('key-default-remove-punctuation') ?? false);
+      final globalRemovePunctuation =
+          Settings.getValue<bool>('key-default-remove-punctuation') ?? false;
+      final defaultRemovePunctuation = !isTanach && globalRemovePunctuation;
+      final punctuationExemptByTanach = isPunctuationExemptByTanach(
+        defaultRemovePunctuation: globalRemovePunctuation,
+        isTanach: isTanach,
+      );
 
       // מצב הרצף שומר את הערך הנוכחי רק כש-preserveContinuousReadingMode=true.
       // הלוגיקה הזו מנופית ל-`resolvePreservedContinuousReadingMode` כדי
@@ -956,6 +965,8 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
             ? preservedRemovePunctuation
             : defaultRemovePunctuation,
         isTanach: isTanach,
+        nikudExemptByTanach: nikudExemptByTanach,
+        punctuationExemptByTanach: punctuationExemptByTanach,
         supportsContinuousReadingMode: supportsContinuousReading,
         continuousReadingMode: effectiveContinuousReading,
         readingSegments: readingSegments,
@@ -1302,6 +1313,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       emit(
         currentState.copyWith(
           removeNikud: event.remove,
+          nikudExemptByTanach: event.applyToCommentaries ? false : null,
           selectedIndex: currentState.selectedIndex,
         ),
       );
@@ -1317,6 +1329,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       emit(
         currentState.copyWith(
           removePunctuation: event.remove,
+          punctuationExemptByTanach: event.applyToCommentaries ? false : null,
           selectedIndex: currentState.selectedIndex,
         ),
       );

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -169,6 +169,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     on<UpdateLinkTypeFilter>(_onUpdateLinkTypeFilter);
     on<ToggleNikud>(_onToggleNikud);
     on<TogglePunctuation>(_onTogglePunctuation);
+    on<ResetCommentaryDisplayOverrides>(_onResetCommentaryDisplayOverrides);
     on<ToggleContinuousReadingMode>(_onToggleContinuousReadingMode);
     on<UpdateVisibleIndecies>(_onUpdateVisibleIndecies);
     on<UpdateSelectedIndex>(_onUpdateSelectedIndex);
@@ -619,6 +620,8 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     List<CommentatorGroup> existingCommentatorGroups = const [];
     bool? preservedRemoveNikud;
     bool? preservedRemovePunctuation;
+    bool? preservedCommentaryRemoveNikudOverride;
+    bool? preservedCommentaryRemovePunctuationOverride;
     bool? preservedPinLeftPane;
 
     if (state is TextBookLoaded && event.preserveState) {
@@ -641,6 +644,10 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       existingCommentatorGroups = currentState.commentatorGroups;
       preservedRemoveNikud = currentState.removeNikud;
       preservedRemovePunctuation = currentState.removePunctuation;
+      preservedCommentaryRemoveNikudOverride =
+          currentState.commentaryRemoveNikudOverride;
+      preservedCommentaryRemovePunctuationOverride =
+          currentState.commentaryRemovePunctuationOverride;
       preservedPinLeftPane = currentState.pinLeftPane;
       pinpointHighlightIndex = currentState.pinpointHighlightIndex;
       pinpointHighlightText = currentState.pinpointHighlightText;
@@ -967,6 +974,9 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         isTanach: isTanach,
         nikudExemptByTanach: nikudExemptByTanach,
         punctuationExemptByTanach: punctuationExemptByTanach,
+        commentaryRemoveNikudOverride: preservedCommentaryRemoveNikudOverride,
+        commentaryRemovePunctuationOverride:
+            preservedCommentaryRemovePunctuationOverride,
         supportsContinuousReadingMode: supportsContinuousReading,
         continuousReadingMode: effectiveContinuousReading,
         readingSegments: readingSegments,
@@ -1311,11 +1321,15 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     if (state is TextBookLoaded) {
       final currentState = state as TextBookLoaded;
       emit(
-        currentState.copyWith(
-          removeNikud: event.remove,
-          nikudExemptByTanach: event.applyToCommentaries ? false : null,
-          selectedIndex: currentState.selectedIndex,
-        ),
+        event.applyToCommentaries
+            ? currentState.copyWith(
+                commentaryRemoveNikudOverride: event.remove,
+                selectedIndex: currentState.selectedIndex,
+              )
+            : currentState.copyWith(
+                removeNikud: event.remove,
+                selectedIndex: currentState.selectedIndex,
+              ),
       );
     }
   }
@@ -1327,13 +1341,36 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     if (state is TextBookLoaded) {
       final currentState = state as TextBookLoaded;
       emit(
-        currentState.copyWith(
-          removePunctuation: event.remove,
-          punctuationExemptByTanach: event.applyToCommentaries ? false : null,
-          selectedIndex: currentState.selectedIndex,
-        ),
+        event.applyToCommentaries
+            ? currentState.copyWith(
+                commentaryRemovePunctuationOverride: event.remove,
+                selectedIndex: currentState.selectedIndex,
+              )
+            : currentState.copyWith(
+                removePunctuation: event.remove,
+                selectedIndex: currentState.selectedIndex,
+              ),
       );
     }
+  }
+
+  void _onResetCommentaryDisplayOverrides(
+    ResetCommentaryDisplayOverrides event,
+    Emitter<TextBookState> emit,
+  ) {
+    final currentState = state;
+    if (currentState is! TextBookLoaded ||
+        (currentState.commentaryRemoveNikudOverride == null &&
+            currentState.commentaryRemovePunctuationOverride == null)) {
+      return;
+    }
+    emit(
+      currentState.copyWith(
+        clearCommentaryRemoveNikudOverride: true,
+        clearCommentaryRemovePunctuationOverride: true,
+        selectedIndex: currentState.selectedIndex,
+      ),
+    );
   }
 
   void _onToggleContinuousReadingMode(

--- a/lib/text_book/bloc/text_book_event.dart
+++ b/lib/text_book/bloc/text_book_event.dart
@@ -155,8 +155,7 @@ class UpdateLinkTypeFilter extends TextBookEvent {
 class ToggleNikud extends TextBookEvent {
   final bool remove;
 
-  /// מבטל את הפטור שהתנ"ך מקבל מהגדרת "הצג ניקוד בתנ"ך", כך שההחלפה חלה גם
-  /// על המפרשים. נדרש בכרטיסיית המפרשים, שבה אין טקסט ראשי לשלוט בו.
+  /// מחיל את ההחלפה זמנית על המפרשים בלבד, בלי לשנות את הטקסט הראשי.
   final bool applyToCommentaries;
 
   const ToggleNikud(this.remove, {this.applyToCommentaries = false});
@@ -168,14 +167,21 @@ class ToggleNikud extends TextBookEvent {
 class TogglePunctuation extends TextBookEvent {
   final bool remove;
 
-  /// כמו ב-[ToggleNikud]: מבטל את הפטור שהתנ"ך מקבל, כך שההחלפה חלה גם על
-  /// המפרשים.
+  /// כמו ב-[ToggleNikud]: מחיל את ההחלפה זמנית על המפרשים בלבד.
   final bool applyToCommentaries;
 
   const TogglePunctuation(this.remove, {this.applyToCommentaries = false});
 
   @override
   List<Object?> get props => [remove, applyToCommentaries];
+}
+
+/// מאפס את העקיפות הזמניות של כרטיסיית המפרשים בסגירתה.
+class ResetCommentaryDisplayOverrides extends TextBookEvent {
+  const ResetCommentaryDisplayOverrides();
+
+  @override
+  List<Object?> get props => [];
 }
 
 class UpdateVisibleIndecies extends TextBookEvent {

--- a/lib/text_book/bloc/text_book_event.dart
+++ b/lib/text_book/bloc/text_book_event.dart
@@ -155,19 +155,27 @@ class UpdateLinkTypeFilter extends TextBookEvent {
 class ToggleNikud extends TextBookEvent {
   final bool remove;
 
-  const ToggleNikud(this.remove);
+  /// מבטל את הפטור שהתנ"ך מקבל מהגדרת "הצג ניקוד בתנ"ך", כך שההחלפה חלה גם
+  /// על המפרשים. נדרש בכרטיסיית המפרשים, שבה אין טקסט ראשי לשלוט בו.
+  final bool applyToCommentaries;
+
+  const ToggleNikud(this.remove, {this.applyToCommentaries = false});
 
   @override
-  List<Object?> get props => [remove];
+  List<Object?> get props => [remove, applyToCommentaries];
 }
 
 class TogglePunctuation extends TextBookEvent {
   final bool remove;
 
-  const TogglePunctuation(this.remove);
+  /// כמו ב-[ToggleNikud]: מבטל את הפטור שהתנ"ך מקבל, כך שההחלפה חלה גם על
+  /// המפרשים.
+  final bool applyToCommentaries;
+
+  const TogglePunctuation(this.remove, {this.applyToCommentaries = false});
 
   @override
-  List<Object?> get props => [remove];
+  List<Object?> get props => [remove, applyToCommentaries];
 }
 
 class UpdateVisibleIndecies extends TextBookEvent {

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -195,6 +195,12 @@ class TextBookLoaded extends TextBookState {
   /// האם הספר קיבל פיסוק רק בזכות היותו תנ"ך.
   /// ראה [commentaryRemovePunctuation].
   final bool punctuationExemptByTanach;
+
+  /// עקיפת ניקוד זמנית לכרטיסיית המפרשים בלבד.
+  final bool? commentaryRemoveNikudOverride;
+
+  /// עקיפת פיסוק זמנית לכרטיסיית המפרשים בלבד.
+  final bool? commentaryRemovePunctuationOverride;
   final bool supportsContinuousReadingMode;
   final bool continuousReadingMode;
 
@@ -284,6 +290,8 @@ class TextBookLoaded extends TextBookState {
     this.isTanach = false,
     this.nikudExemptByTanach = false,
     this.punctuationExemptByTanach = false,
+    this.commentaryRemoveNikudOverride,
+    this.commentaryRemovePunctuationOverride,
     this.supportsContinuousReadingMode = false,
     this.continuousReadingMode = false,
     this.readingSegments = const [],
@@ -369,14 +377,14 @@ class TextBookLoaded extends TextBookState {
     );
   }
 
-  /// מצב הניקוד שחל על המפרשים, הקישורים והתצוגות המקדימות. הם אינם תנ"ך,
-  /// ולכן פטור התנ"ך אינו חל עליהם — אך הסתרה יזומה בסרגל כן.
-  bool get commentaryRemoveNikud => removeNikud || nikudExemptByTanach;
+  /// מצב הניקוד שחל על המפרשים, הקישורים והתצוגות המקדימות.
+  bool get commentaryRemoveNikud =>
+      commentaryRemoveNikudOverride ?? (removeNikud || nikudExemptByTanach);
 
-  /// מצב הפיסוק שחל על המפרשים, הקישורים והתצוגות המקדימות של הספר, באותו
-  /// היגיון של [commentaryRemoveNikud].
+  /// מצב הפיסוק שחל על המפרשים, הקישורים והתצוגות המקדימות של הספר.
   bool get commentaryRemovePunctuation =>
-      removePunctuation || punctuationExemptByTanach;
+      commentaryRemovePunctuationOverride ??
+      (removePunctuation || punctuationExemptByTanach);
 
   TextBookLoaded copyWith({
     TextBook? book,
@@ -401,6 +409,10 @@ class TextBookLoaded extends TextBookState {
     bool? isTanach,
     bool? nikudExemptByTanach,
     bool? punctuationExemptByTanach,
+    bool? commentaryRemoveNikudOverride,
+    bool? commentaryRemovePunctuationOverride,
+    bool clearCommentaryRemoveNikudOverride = false,
+    bool clearCommentaryRemovePunctuationOverride = false,
     bool? supportsContinuousReadingMode,
     bool? continuousReadingMode,
     List<ReadingSegment>? readingSegments,
@@ -470,6 +482,15 @@ class TextBookLoaded extends TextBookState {
       nikudExemptByTanach: nikudExemptByTanach ?? this.nikudExemptByTanach,
       punctuationExemptByTanach:
           punctuationExemptByTanach ?? this.punctuationExemptByTanach,
+      commentaryRemoveNikudOverride: clearCommentaryRemoveNikudOverride
+          ? null
+          : (commentaryRemoveNikudOverride ??
+                this.commentaryRemoveNikudOverride),
+      commentaryRemovePunctuationOverride:
+          clearCommentaryRemovePunctuationOverride
+          ? null
+          : (commentaryRemovePunctuationOverride ??
+                this.commentaryRemovePunctuationOverride),
       supportsContinuousReadingMode:
           supportsContinuousReadingMode ?? this.supportsContinuousReadingMode,
       continuousReadingMode:
@@ -581,6 +602,8 @@ class TextBookLoaded extends TextBookState {
     isTanach,
     nikudExemptByTanach,
     punctuationExemptByTanach,
+    commentaryRemoveNikudOverride,
+    commentaryRemovePunctuationOverride,
     supportsContinuousReadingMode,
     continuousReadingMode,
     readingSegments.length,

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -187,6 +187,14 @@ class TextBookLoaded extends TextBookState {
   final bool removeNikud;
   final bool removePunctuation;
   final bool isTanach;
+
+  /// האם הספר קיבל ניקוד רק בזכות היותו תנ"ך ("הצג ניקוד בתנ"ך").
+  /// ראה [commentaryRemoveNikud].
+  final bool nikudExemptByTanach;
+
+  /// האם הספר קיבל פיסוק רק בזכות היותו תנ"ך.
+  /// ראה [commentaryRemovePunctuation].
+  final bool punctuationExemptByTanach;
   final bool supportsContinuousReadingMode;
   final bool continuousReadingMode;
 
@@ -274,6 +282,8 @@ class TextBookLoaded extends TextBookState {
     required this.removeNikud,
     this.removePunctuation = false,
     this.isTanach = false,
+    this.nikudExemptByTanach = false,
+    this.punctuationExemptByTanach = false,
     this.supportsContinuousReadingMode = false,
     this.continuousReadingMode = false,
     this.readingSegments = const [],
@@ -359,6 +369,15 @@ class TextBookLoaded extends TextBookState {
     );
   }
 
+  /// מצב הניקוד שחל על המפרשים, הקישורים והתצוגות המקדימות. הם אינם תנ"ך,
+  /// ולכן פטור התנ"ך אינו חל עליהם — אך הסתרה יזומה בסרגל כן.
+  bool get commentaryRemoveNikud => removeNikud || nikudExemptByTanach;
+
+  /// מצב הפיסוק שחל על המפרשים, הקישורים והתצוגות המקדימות של הספר, באותו
+  /// היגיון של [commentaryRemoveNikud].
+  bool get commentaryRemovePunctuation =>
+      removePunctuation || punctuationExemptByTanach;
+
   TextBookLoaded copyWith({
     TextBook? book,
     List<String>? content,
@@ -380,6 +399,8 @@ class TextBookLoaded extends TextBookState {
     bool? removeNikud,
     bool? removePunctuation,
     bool? isTanach,
+    bool? nikudExemptByTanach,
+    bool? punctuationExemptByTanach,
     bool? supportsContinuousReadingMode,
     bool? continuousReadingMode,
     List<ReadingSegment>? readingSegments,
@@ -446,6 +467,9 @@ class TextBookLoaded extends TextBookState {
       removeNikud: removeNikud ?? this.removeNikud,
       removePunctuation: removePunctuation ?? this.removePunctuation,
       isTanach: isTanach ?? this.isTanach,
+      nikudExemptByTanach: nikudExemptByTanach ?? this.nikudExemptByTanach,
+      punctuationExemptByTanach:
+          punctuationExemptByTanach ?? this.punctuationExemptByTanach,
       supportsContinuousReadingMode:
           supportsContinuousReadingMode ?? this.supportsContinuousReadingMode,
       continuousReadingMode:
@@ -555,6 +579,8 @@ class TextBookLoaded extends TextBookState {
     removeNikud,
     removePunctuation,
     isTanach,
+    nikudExemptByTanach,
+    punctuationExemptByTanach,
     supportsContinuousReadingMode,
     continuousReadingMode,
     readingSegments.length,

--- a/lib/text_book/utils/per_book_display_settings.dart
+++ b/lib/text_book/utils/per_book_display_settings.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/settings/services/nikud_display_service.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart';
 import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -24,9 +25,17 @@ Future<void> savePerBookDisplaySettings(
   }
 
   final defaultFontSize = settingsBloc.state.fontSize;
-  final defaultRemoveNikud = settingsBloc.state.defaultRemoveNikud;
-  final defaultRemovePunctuation =
-      settingsBloc.state.defaultRemovePunctuation && !state.isTanach;
+  // ברירות המחדל האפקטיביות של הספר, כולל החרגות התנ"ך — אחרת בחירה שסוטה
+  // מההחרגה נחשבת "כמו ברירת המחדל" ולא נשמרת.
+  final defaultRemoveNikud = shouldRemoveNikudForBook(
+    defaultRemoveNikud: settingsBloc.state.defaultRemoveNikud,
+    removeNikudFromTanach: settingsBloc.state.removeNikudFromTanach,
+    isTanach: state.isTanach,
+  );
+  final defaultRemovePunctuation = shouldRemovePunctuationForBook(
+    defaultRemovePunctuation: settingsBloc.state.defaultRemovePunctuation,
+    isTanach: state.isTanach,
+  );
   final defaultShowSplitView =
       Settings.getValue<bool>('key-splited-view') ?? true;
   final defaultContinuousReading =
@@ -60,9 +69,11 @@ Future<void> savePerBookDisplaySettings(
           ? null
           : removePunctuation;
     }
-    // דגל התנ"ך נשמר רק כלוויין של override פיסוק — הניקוי התקופתי משתמש בו
-    // לחישוב ברירת המחדל האפקטיבית של הספר (בתנ"ך היא תמיד false).
-    final bool? newIsTanach = (newRemovePunctuation != null && state.isTanach)
+    // דגל התנ"ך נשמר כלוויין של override ניקוד/פיסוק — הניקוי התקופתי משתמש
+    // בו לחישוב ברירת המחדל האפקטיבית של הספר, שבתנ"ך מוחרגת.
+    final bool? newIsTanach =
+        ((newRemovePunctuation != null || newRemoveNikud != null) &&
+            state.isTanach)
         ? true
         : null;
 

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -471,8 +471,8 @@ class _CombinedViewState extends State<CombinedView> {
       link: link,
       globalPosition: globalPosition,
       hoverMode: hoverMode,
-      removeNikud: loaded?.removeNikud,
-      removePunctuation: loaded?.removePunctuation,
+      removeNikud: loaded?.commentaryRemoveNikud,
+      removePunctuation: loaded?.commentaryRemovePunctuation,
       onOpen: () => _openLinkTarget(link),
       onDismissed: activeAnchor == null
           ? null
@@ -1129,8 +1129,8 @@ class _CombinedViewState extends State<CombinedView> {
       ...paragraphLinks.map(
         (link) => buildLinkContextMenuEntry(
           link: link,
-          removeNikud: state.removeNikud,
-          removePunctuation: state.removePunctuation,
+          removeNikud: state.commentaryRemoveNikud,
+          removePunctuation: state.commentaryRemovePunctuation,
           onTap: () async {
             final tab = await buildLinkTargetTab(link);
             if (_disposed || !mounted) return;
@@ -1219,8 +1219,8 @@ class _CombinedViewState extends State<CombinedView> {
         final entry = _siblingController.buildEntry(
           lineIndex: paragraphIndex,
           sourceLink: sourceLink,
-          removeNikud: state.removeNikud,
-          removePunctuation: state.removePunctuation,
+          removeNikud: state.commentaryRemoveNikud,
+          removePunctuation: state.commentaryRemovePunctuation,
           onNavigate: (link) async {
             final tab = await buildLinkTargetTab(link);
             if (_disposed || !mounted) return;

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -613,7 +613,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
         bookId: bookTitle,
         documentTitle: bookTitle,
         prebuiltBlocks: blocks,
-        removeNikud: blocState.removeNikud,
+        removeNikud: blocState.commentaryRemoveNikud,
         removeTaamim: removeTaamim,
       ),
     );
@@ -1154,9 +1154,9 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
 
     final blocState = context.read<TextBookBloc>().state;
     final removePunctuation =
-        blocState is TextBookLoaded && blocState.removePunctuation;
-    // מצב הניקוד של הטאב חל על כל המפרשים, ללא רזולוציה פר-יעד.
-    final removeNikud = blocState is TextBookLoaded && blocState.removeNikud;
+        blocState is TextBookLoaded && blocState.commentaryRemovePunctuation;
+    final removeNikud =
+        blocState is TextBookLoaded && blocState.commentaryRemoveNikud;
     final wantSnippets = widget.externalSearchSnippetsNotifier != null;
 
     for (final link in links) {
@@ -1316,8 +1316,8 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
       isExpanded: isExpanded,
       fontSize: widget.fontSize,
       openBookCallback: widget.openBookCallback,
-      removeNikud: state.removeNikud,
-      removePunctuation: state.removePunctuation,
+      removeNikud: state.commentaryRemoveNikud,
+      removePunctuation: state.commentaryRemovePunctuation,
       showSearch: widget.showSearch,
       searchQueryListenable: _searchQueryNotifier,
       currentSearchIndexListenable: _currentSearchIndexNotifier,
@@ -1453,7 +1453,10 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
             !setEquals(previous.selectedIndices, current.selectedIndices) ||
             previous.fontSize != current.fontSize ||
             previous.removeNikud != current.removeNikud ||
-            previous.removePunctuation != current.removePunctuation;
+            previous.commentaryRemoveNikud != current.commentaryRemoveNikud ||
+            previous.removePunctuation != current.removePunctuation ||
+            previous.commentaryRemovePunctuation !=
+                current.commentaryRemovePunctuation;
       },
       loadingWidget: const Center(),
       builder: (context, state) {

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -8,7 +8,6 @@ import 'package:otzaria/shortcuts/shortcut_helper.dart';
 import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/text_book/utils/commentary_type_filter.dart';
 import 'package:otzaria/text_book/utils/commentator_group_builder.dart';
-import 'package:otzaria/text_book/utils/per_book_display_settings.dart';
 import 'package:otzaria/text_book/utils/toc_unit_label.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -286,16 +285,24 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
     navExpandedChapter: _navExpandedChapter,
   );
 
-  void _toggleAndSaveNikud(BuildContext context, TextBookLoaded state) {
-    final newValue = !state.removeNikud;
-    context.read<TextBookBloc>().add(ToggleNikud(newValue));
-    savePerBookDisplaySettings(context, state, removeNikud: newValue);
+  /// הכפתורים שולטים במצב המפרשים. הבחירה אינה נשמרת פר-ספר — קובץ ההגדרות
+  /// משותף עם כרטיסיית הטקסט, ושמירה כאן הייתה דורסת את הטקסט הראשי שם.
+  void _toggleCommentaryNikud(BuildContext context, TextBookLoaded state) {
+    context.read<TextBookBloc>().add(
+      ToggleNikud(!state.commentaryRemoveNikud, applyToCommentaries: true),
+    );
   }
 
-  void _toggleAndSavePunctuation(BuildContext context, TextBookLoaded state) {
-    final newValue = !state.removePunctuation;
-    context.read<TextBookBloc>().add(TogglePunctuation(newValue));
-    savePerBookDisplaySettings(context, state, removePunctuation: newValue);
+  void _toggleCommentaryPunctuation(
+    BuildContext context,
+    TextBookLoaded state,
+  ) {
+    context.read<TextBookBloc>().add(
+      TogglePunctuation(
+        !state.commentaryRemovePunctuation,
+        applyToCommentaries: true,
+      ),
+    );
   }
 
   /// מחיל מצב חדש שחושב ע"י אחד הרדוסרים הטהורים (ראה [reduceChevronTap]
@@ -657,7 +664,10 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
                     prev.links != curr.links ||
                     prev.availableCommentators != curr.availableCommentators ||
                     prev.removeNikud != curr.removeNikud ||
-                    prev.removePunctuation != curr.removePunctuation;
+                    prev.commentaryRemoveNikud != curr.commentaryRemoveNikud ||
+                    prev.removePunctuation != curr.removePunctuation ||
+                    prev.commentaryRemovePunctuation !=
+                        curr.commentaryRemovePunctuation;
               }
               return true;
             },
@@ -1033,38 +1043,43 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
               // ניקוד
               ActionButtonData(
                 widget: BarButton.icon(
-                  tooltip: state.removeNikud ? 'הצג ניקוד' : 'הסתר ניקוד',
-                  icon: state.removeNikud
+                  tooltip: state.commentaryRemoveNikud
+                      ? 'הצג ניקוד'
+                      : 'הסתר ניקוד',
+                  icon: state.commentaryRemoveNikud
                       ? OtzariaIcons.alef_with_score_24_regular
                       : OtzariaIcons.alef_deletion_24_regular,
                   compact: context.read<SettingsBloc>().state.compactMenuMode,
-                  onPressed: () => _toggleAndSaveNikud(context, state),
+                  onPressed: () => _toggleCommentaryNikud(context, state),
                 ),
-                icon: state.removeNikud
+                icon: state.commentaryRemoveNikud
                     ? OtzariaIcons.alef_with_score_24_regular
                     : OtzariaIcons.alef_deletion_24_regular,
-                tooltip: state.removeNikud ? 'הצג ניקוד' : 'הסתר ניקוד',
-                onPressed: () => _toggleAndSaveNikud(context, state),
+                tooltip: state.commentaryRemoveNikud
+                    ? 'הצג ניקוד'
+                    : 'הסתר ניקוד',
+                onPressed: () => _toggleCommentaryNikud(context, state),
               ),
-              // פיסוק (רק אם לא תנ"ך)
-              if (!state.isTanach)
-                ActionButtonData(
-                  widget: BarButton.icon(
-                    tooltip: state.removePunctuation
-                        ? 'הצג פיסוק'
-                        : 'הסתר פיסוק',
-                    icon: state.removePunctuation
-                        ? OtzariaIcons.alef_with_punctuation_24_regular
-                        : OtzariaIcons.alef_with_eraser_24_regular,
-                    compact: context.read<SettingsBloc>().state.compactMenuMode,
-                    onPressed: () => _toggleAndSavePunctuation(context, state),
-                  ),
-                  icon: state.removePunctuation
+              // פיסוק — מוצג גם בתנ"ך, כי התוכן כאן הוא מפרשים
+              ActionButtonData(
+                widget: BarButton.icon(
+                  tooltip: state.commentaryRemovePunctuation
+                      ? 'הצג פיסוק'
+                      : 'הסתר פיסוק',
+                  icon: state.commentaryRemovePunctuation
                       ? OtzariaIcons.alef_with_punctuation_24_regular
                       : OtzariaIcons.alef_with_eraser_24_regular,
-                  tooltip: state.removePunctuation ? 'הצג פיסוק' : 'הסתר פיסוק',
-                  onPressed: () => _toggleAndSavePunctuation(context, state),
+                  compact: context.read<SettingsBloc>().state.compactMenuMode,
+                  onPressed: () => _toggleCommentaryPunctuation(context, state),
                 ),
+                icon: state.commentaryRemovePunctuation
+                    ? OtzariaIcons.alef_with_punctuation_24_regular
+                    : OtzariaIcons.alef_with_eraser_24_regular,
+                tooltip: state.commentaryRemovePunctuation
+                    ? 'הצג פיסוק'
+                    : 'הסתר פיסוק',
+                onPressed: () => _toggleCommentaryPunctuation(context, state),
+              ),
               // הדפסת המפרשים המוצגים
               ActionButtonData(
                 widget: BarButton.icon(

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -453,6 +453,9 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
 
   @override
   void dispose() {
+    if (!widget.tab.bloc.isClosed) {
+      widget.tab.bloc.add(const ResetCommentaryDisplayOverrides());
+    }
     FocusRepository().unregisterTabContentFocusRequester(widget.tab);
     _navTabController.dispose();
     _typeSelection.dispose();

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -543,8 +543,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         link: link,
         globalPosition: globalPosition,
         hoverMode: true,
-        removeNikud: state.removeNikud,
-        removePunctuation: state.removePunctuation,
+        removeNikud: state.commentaryRemoveNikud,
+        removePunctuation: state.commentaryRemovePunctuation,
         onOpen: () => _openAnchorTarget(link),
       );
     });
@@ -634,8 +634,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         link: link,
         globalPosition: globalPosition,
         hoverMode: true,
-        removeNikud: state.removeNikud,
-        removePunctuation: state.removePunctuation,
+        removeNikud: state.commentaryRemoveNikud,
+        removePunctuation: state.commentaryRemovePunctuation,
         onOpen: () => _openAnchorTarget(link),
         onDismissed: anchor == null ? null : () => _setActiveAnchor(null, null),
       );
@@ -1177,6 +1177,16 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     return segmentIndexForLine(state.readingSegments, lineIndex);
   }
 
+  /// מצב הניקוד של הטור. טור מפרש אינו תנ"ך, ולכן חל עליו מצב המפרשים
+  /// ולא הפטור שהתנ"ך מקבל מהגדרת "הצג ניקוד בתנ"ך".
+  bool _removeNikud(TextBookLoaded state) =>
+      widget.isMainText ? state.removeNikud : state.commentaryRemoveNikud;
+
+  /// מצב הפיסוק של הטור, באותו היגיון של [_removeNikud].
+  bool _removePunctuation(TextBookLoaded state) => widget.isMainText
+      ? state.removePunctuation
+      : state.commentaryRemovePunctuation;
+
   RenderSettings _selectionRenderSettings({
     required TextBookLoaded state,
     required SettingsState settingsState,
@@ -1184,7 +1194,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
   }) {
     return RenderSettings(
       removeNikud: removeNikud,
-      removePunctuation: state.removePunctuation,
+      removePunctuation: _removePunctuation(state),
       removeTeamim: !settingsState.showTeamim,
       replaceHolyNames: settingsState.replaceHolyNames,
       searchText: widget.isMainText ? state.searchText : '',
@@ -1256,8 +1266,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     }
 
     final settingsState = context.read<SettingsBloc>().state;
-    // מצב הניקוד של הטאב חל גם על טורי המפרשים (isMainText=false).
-    final removeNikud = textBookState.removeNikud;
+    final removeNikud = _removeNikud(textBookState);
     final sourceIndices = _selectionSourceIndices();
     final renderSettings = _selectionRenderSettings(
       state: textBookState,
@@ -1597,8 +1606,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         sortedLinks.map(
           (link) => buildLinkContextMenuEntry(
             link: link,
-            removeNikud: state.removeNikud,
-            removePunctuation: state.removePunctuation,
+            removeNikud: state.commentaryRemoveNikud,
+            removePunctuation: state.commentaryRemovePunctuation,
             onTap: () async {
               final tab = await buildLinkTargetTab(link);
               if (!mounted) return;
@@ -1727,8 +1736,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       final siblingEntry = _siblingController!.buildEntry(
         lineIndex: index,
         sourceLink: sourceLink,
-        removeNikud: state.removeNikud,
-        removePunctuation: state.removePunctuation,
+        removeNikud: state.commentaryRemoveNikud,
+        removePunctuation: state.commentaryRemovePunctuation,
         onNavigate: (link) async {
           final tab = await buildLinkTargetTab(link);
           if (!mounted) return;
@@ -1804,7 +1813,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         final selectionSettings = _selectionRenderSettings(
           state: state,
           settingsState: menuContext.read<SettingsBloc>().state,
-          removeNikud: state.removeNikud,
+          removeNikud: _removeNikud(state),
         );
         final renderedLine = renderSelectionLine(
           rawText: widget.content[sectionIndex],
@@ -1898,14 +1907,14 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       service.buildCommentariesEntry(
         link: targetLink,
         onNavigate: navigate,
-        removeNikud: state.removeNikud,
-        removePunctuation: state.removePunctuation,
+        removeNikud: state.commentaryRemoveNikud,
+        removePunctuation: state.commentaryRemovePunctuation,
       ),
       service.buildLinksEntry(
         link: targetLink,
         onNavigate: navigate,
-        removeNikud: state.removeNikud,
-        removePunctuation: state.removePunctuation,
+        removeNikud: state.commentaryRemoveNikud,
+        removePunctuation: state.commentaryRemovePunctuation,
       ),
     ];
   }
@@ -2142,9 +2151,9 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     final settingsState = context.read<SettingsBloc>().state;
     final textBookState = context.read<TextBookBloc>().state;
 
-    // ההעתקה משקפת את התצוגה: מצב הניקוד של הטאב חל גם על טורי המפרשים.
+    // ההעתקה משקפת את התצוגה, ולכן עוברת באותו מסלול ניקוד.
     final removeNikud =
-        textBookState is TextBookLoaded && textBookState.removeNikud;
+        textBookState is TextBookLoaded && _removeNikud(textBookState);
     final processedText = removeNikud ? utils.removeVolwels(text) : text;
 
     final plainText = utils.stripHtmlIfNeeded(processedText);
@@ -2741,8 +2750,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
                   highlightSourceText: widget.isMainText ? data : null,
                   widgetKey: ValueKey('html_simple_text_$primaryLineIndex'),
                   settings: RenderSettings(
-                    removeNikud: state.removeNikud,
-                    removePunctuation: state.removePunctuation,
+                    removeNikud: _removeNikud(state),
+                    removePunctuation: _removePunctuation(state),
                     removeTeamim: !settingsState.showTeamim,
                     replaceHolyNames: settingsState.replaceHolyNames,
                     searchText: searchText,
@@ -3017,8 +3026,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         : SearchMode.exact;
 
     final renderSettings = RenderSettings(
-      removeNikud: state.removeNikud,
-      removePunctuation: state.removePunctuation,
+      removeNikud: _removeNikud(state),
+      removePunctuation: _removePunctuation(state),
       removeTeamim: !settingsState.showTeamim,
       replaceHolyNames: settingsState.replaceHolyNames,
       searchText: searchText,

--- a/lib/text_book/view/selected_line_links_view.dart
+++ b/lib/text_book/view/selected_line_links_view.dart
@@ -52,8 +52,9 @@ class SelectedLineLinksView extends StatelessWidget {
             !identical(previous.links, current.links) ||
             previous.selectedLinkTypes != current.selectedLinkTypes ||
             previous.fontSize != current.fontSize ||
-            previous.removeNikud != current.removeNikud ||
-            previous.removePunctuation != current.removePunctuation;
+            previous.commentaryRemoveNikud != current.commentaryRemoveNikud ||
+            previous.commentaryRemovePunctuation !=
+                current.commentaryRemovePunctuation;
       },
       builder: (context, state) {
         return LinksListView(
@@ -65,8 +66,8 @@ class SelectedLineLinksView extends StatelessWidget {
               context.read<TextBookBloc>().add(UpdateLinkTypeFilter(types)),
           openBookCallback: openBookCallback,
           fontSize: fontSize,
-          removeNikud: state.removeNikud,
-          removePunctuation: state.removePunctuation,
+          removeNikud: state.commentaryRemoveNikud,
+          removePunctuation: state.commentaryRemovePunctuation,
           selectionSyncController: selectionSyncController,
         );
       },

--- a/test/settings/nikud_display_service_test.dart
+++ b/test/settings/nikud_display_service_test.dart
@@ -38,6 +38,84 @@ void main() {
     });
   });
 
+  group('isNikudExemptByTanach', () {
+    test('returns true for Tanach when only Tanach keeps nikud', () {
+      expect(
+        isNikudExemptByTanach(
+          defaultRemoveNikud: true,
+          removeNikudFromTanach: false,
+          isTanach: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for a non-Tanach book', () {
+      expect(
+        isNikudExemptByTanach(
+          defaultRemoveNikud: true,
+          removeNikudFromTanach: false,
+          isTanach: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when hide-all is enabled', () {
+      expect(
+        isNikudExemptByTanach(
+          defaultRemoveNikud: true,
+          removeNikudFromTanach: true,
+          isTanach: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when nikud is always shown', () {
+      expect(
+        isNikudExemptByTanach(
+          defaultRemoveNikud: false,
+          removeNikudFromTanach: false,
+          isTanach: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('isPunctuationExemptByTanach', () {
+    test('returns true for Tanach when punctuation removal is on', () {
+      expect(
+        isPunctuationExemptByTanach(
+          defaultRemovePunctuation: true,
+          isTanach: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for a non-Tanach book', () {
+      expect(
+        isPunctuationExemptByTanach(
+          defaultRemovePunctuation: true,
+          isTanach: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when punctuation removal is off', () {
+      expect(
+        isPunctuationExemptByTanach(
+          defaultRemovePunctuation: false,
+          isTanach: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('shouldReloadForNikudSettingsChange', () {
     test('returns true when removeNikudFromTanach changes', () {
       final previous = SettingsState.initial().copyWith(

--- a/test/settings/per_book_settings_test.dart
+++ b/test/settings/per_book_settings_test.dart
@@ -314,9 +314,12 @@ void main() {
     Future<void> runCleanup({
       bool defaultContinuous = false,
       bool defaultRemovePunctuation = false,
+      bool defaultRemoveNikud = false,
+      bool removeNikudFromTanach = false,
     }) => PerBookSettings.cleanupRedundantSettings(
       defaultFontSize: 16,
-      defaultRemoveNikud: false,
+      defaultRemoveNikud: defaultRemoveNikud,
+      removeNikudFromTanach: removeNikudFromTanach,
       defaultRemovePunctuation: defaultRemovePunctuation,
       defaultShowSplitView: true,
       defaultContinuousReadingMode: defaultContinuous,
@@ -359,6 +362,61 @@ void main() {
       await runCleanup(defaultContinuous: true);
       expect(await PerBookSettings.loadSettings(key), isNull);
     });
+
+    test(
+      'override ניקוד של תנ"ך שורד את "הצג ניקוד בתנ"ך" (דגל isTanach)',
+      () async {
+        // בתנ"ך במצב "הצג ניקוד בתנ"ך" הברירה האפקטיבית היא false, ולכן
+        // override של true הוא בחירה אמיתית של המשתמש וחייב לשרוד.
+        const key = 'o__20__ישעיה';
+        await PerBookSettings.saveSettings(key, {
+          'removeNikud': true,
+          'isTanach': true,
+        });
+
+        await runCleanup(defaultRemoveNikud: true);
+
+        final json = await PerBookSettings.loadSettings(key);
+        expect(json?['removeNikud'], isTrue);
+        expect(json?['isTanach'], isTrue);
+      },
+    );
+
+    test('בתנ"ך removeNikud=false מיותר במצב "הצג ניקוד בתנ"ך"', () async {
+      const key = 'o__21__ירמיה';
+      await PerBookSettings.saveSettings(key, {
+        'removeNikud': false,
+        'isTanach': true,
+      });
+
+      await runCleanup(defaultRemoveNikud: true);
+
+      expect(await PerBookSettings.loadSettings(key), isNull);
+    });
+
+    test('במצב "אל תציג ניקוד" גם בתנ"ך override של true מיותר', () async {
+      const key = 'o__22__יחזקאל';
+      await PerBookSettings.saveSettings(key, {
+        'removeNikud': true,
+        'isTanach': true,
+      });
+
+      await runCleanup(defaultRemoveNikud: true, removeNikudFromTanach: true);
+
+      expect(await PerBookSettings.loadSettings(key), isNull);
+    });
+
+    test(
+      'בספר שאינו תנ"ך override ניקוד נמחק כשהוא שווה לברירת המחדל',
+      () async {
+        const key = 'o__23__ברכות';
+        await PerBookSettings.saveSettings(key, {'removeNikud': true});
+
+        await runCleanup(defaultRemoveNikud: true);
+
+        expect(await PerBookSettings.loadSettings(key), isNull);
+      },
+    );
 
     test('removePunctuation ששונה מברירת המחדל הגלובלית נשמר', () async {
       const key = 'o__4__במדבר';

--- a/test/text_book/bloc/commentary_display_flags_test.dart
+++ b/test/text_book/bloc/commentary_display_flags_test.dart
@@ -59,15 +59,15 @@ void main() {
       expect(state.copyWith(removeNikud: false).commentaryRemoveNikud, isFalse);
     });
 
-    test('ביטול הפטור (כפתור כרטיסיית המפרשים) מחזיר ניקוד למפרשים', () {
+    test('עקיפת המפרשים מחזירה ניקוד בלי לשנות את ספר התנ״ך', () {
       final state = _load(nikud: NikudMode.tanachOnly, isTanach: true);
 
-      final cleared = state.copyWith(
-        removeNikud: false,
-        nikudExemptByTanach: false,
+      final showingCommentaries = state.copyWith(
+        commentaryRemoveNikudOverride: false,
       );
 
-      expect(cleared.commentaryRemoveNikud, isFalse);
+      expect(showingCommentaries.removeNikud, isFalse);
+      expect(showingCommentaries.commentaryRemoveNikud, isFalse);
     });
   });
 
@@ -116,15 +116,15 @@ void main() {
       expect(state.commentaryRemovePunctuation, isFalse);
     });
 
-    test('ביטול הפטור מחזיר פיסוק למפרשים', () {
+    test('עקיפת המפרשים מחזירה פיסוק בלי לשנות את ספר התנ״ך', () {
       final state = _load(removePunctuation: true, isTanach: true);
 
-      final cleared = state.copyWith(
-        removePunctuation: false,
-        punctuationExemptByTanach: false,
+      final showingCommentaries = state.copyWith(
+        commentaryRemovePunctuationOverride: false,
       );
 
-      expect(cleared.commentaryRemovePunctuation, isFalse);
+      expect(showingCommentaries.removePunctuation, isFalse);
+      expect(showingCommentaries.commentaryRemovePunctuation, isFalse);
     });
   });
 

--- a/test/text_book/bloc/commentary_display_flags_test.dart
+++ b/test/text_book/bloc/commentary_display_flags_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/services/nikud_display_service.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+/// טבלת האמת של הניקוד והפיסוק: מה חל על הספר עצמו ומה על מפרשיו. מגן על
+/// הרגרסיה שבה "הצג ניקוד בתנ״ך" הותירה ניקוד גם במפרשים, שאינם תנ״ך.
+void main() {
+  group('ניקוד — הצג תמיד', () {
+    test('התנ״ך והמפרשים מנוקדים', () {
+      final state = _load(nikud: NikudMode.always, isTanach: true);
+
+      expect(state.removeNikud, isFalse);
+      expect(state.commentaryRemoveNikud, isFalse);
+    });
+
+    test('הסתרה יזומה בסרגל חלה גם על המפרשים', () {
+      final state = _load(nikud: NikudMode.always, isTanach: true);
+
+      expect(state.copyWith(removeNikud: true).commentaryRemoveNikud, isTrue);
+    });
+
+    test('גם בספר שאינו תנ"ך אין פטור, והכל מנוקד', () {
+      final state = _load(nikud: NikudMode.always, isTanach: false);
+
+      expect(state.removeNikud, isFalse);
+      expect(state.nikudExemptByTanach, isFalse);
+      expect(state.commentaryRemoveNikud, isFalse);
+    });
+  });
+
+  group('ניקוד — הצג בתנ״ך בלבד', () {
+    test('התנ״ך מנוקד אבל מפרשיו אינם', () {
+      final state = _load(nikud: NikudMode.tanachOnly, isTanach: true);
+
+      expect(state.removeNikud, isFalse);
+      expect(state.commentaryRemoveNikud, isTrue);
+    });
+
+    test('בספר שאינו תנ״ך גם הספר וגם המפרשים ללא ניקוד', () {
+      final state = _load(nikud: NikudMode.tanachOnly, isTanach: false);
+
+      expect(state.removeNikud, isTrue);
+      expect(state.commentaryRemoveNikud, isTrue);
+    });
+
+    test('הצגה יזומה בסרגל התנ״ך אינה מחזירה ניקוד למפרשים', () {
+      // בחירת המשתמש: הכפתור בסרגל ספר התנ״ך שולט בתנ״ך בלבד.
+      final state = _load(nikud: NikudMode.tanachOnly, isTanach: true);
+
+      expect(state.copyWith(removeNikud: true).commentaryRemoveNikud, isTrue);
+      expect(state.copyWith(removeNikud: false).commentaryRemoveNikud, isTrue);
+    });
+
+    test('בספר שאינו תנ״ך הצגה יזומה כן מחזירה ניקוד למפרשים', () {
+      final state = _load(nikud: NikudMode.tanachOnly, isTanach: false);
+
+      expect(state.copyWith(removeNikud: false).commentaryRemoveNikud, isFalse);
+    });
+
+    test('ביטול הפטור (כפתור כרטיסיית המפרשים) מחזיר ניקוד למפרשים', () {
+      final state = _load(nikud: NikudMode.tanachOnly, isTanach: true);
+
+      final cleared = state.copyWith(
+        removeNikud: false,
+        nikudExemptByTanach: false,
+      );
+
+      expect(cleared.commentaryRemoveNikud, isFalse);
+    });
+  });
+
+  group('ניקוד — אל תציג', () {
+    test('התנ״ך והמפרשים ללא ניקוד', () {
+      final state = _load(nikud: NikudMode.never, isTanach: true);
+
+      expect(state.removeNikud, isTrue);
+      expect(state.commentaryRemoveNikud, isTrue);
+    });
+
+    test('הצגה יזומה בסרגל מחזירה ניקוד לתנ״ך ולמפרשים', () {
+      // אין כאן פטור-תנ״ך, ולכן ההחלפה היזומה חלה על שניהם.
+      final state = _load(nikud: NikudMode.never, isTanach: true);
+
+      expect(state.copyWith(removeNikud: false).commentaryRemoveNikud, isFalse);
+    });
+  });
+
+  group('פיסוק', () {
+    test('בתנ״ך הפיסוק נשמר בספר אך מוסר מהמפרשים', () {
+      final state = _load(removePunctuation: true, isTanach: true);
+
+      expect(state.removePunctuation, isFalse);
+      expect(state.commentaryRemovePunctuation, isTrue);
+    });
+
+    test('בספר שאינו תנ״ך הפיסוק מוסר משניהם', () {
+      final state = _load(removePunctuation: true, isTanach: false);
+
+      expect(state.removePunctuation, isTrue);
+      expect(state.commentaryRemovePunctuation, isTrue);
+    });
+
+    test('כשההגדרה כבויה הפיסוק נשמר בשניהם', () {
+      final state = _load(removePunctuation: false, isTanach: true);
+
+      expect(state.removePunctuation, isFalse);
+      expect(state.commentaryRemovePunctuation, isFalse);
+    });
+
+    test('כשההגדרה כבויה ובספר שאינו תנ"ך אין פטור', () {
+      final state = _load(removePunctuation: false, isTanach: false);
+
+      expect(state.punctuationExemptByTanach, isFalse);
+      expect(state.commentaryRemovePunctuation, isFalse);
+    });
+
+    test('ביטול הפטור מחזיר פיסוק למפרשים', () {
+      final state = _load(removePunctuation: true, isTanach: true);
+
+      final cleared = state.copyWith(
+        removePunctuation: false,
+        punctuationExemptByTanach: false,
+      );
+
+      expect(cleared.commentaryRemovePunctuation, isFalse);
+    });
+  });
+
+  group('הדגלים נכללים בהשוואת ה-state', () {
+    test('שינוי פטור הניקוד מייצר state שונה', () {
+      expect(
+        _load(nikud: NikudMode.tanachOnly, isTanach: true),
+        isNot(equals(_load(nikud: NikudMode.tanachOnly, isTanach: false))),
+      );
+    });
+
+    test('שינוי פטור הפיסוק מייצר state שונה', () {
+      final exempt = _load(removePunctuation: true, isTanach: true);
+
+      expect(
+        exempt,
+        isNot(equals(exempt.copyWith(punctuationExemptByTanach: false))),
+      );
+    });
+  });
+}
+
+/// שלושת מצבי הגדרת הניקוד כפי שהם מוצגים במסך ההגדרות.
+enum NikudMode { always, tanachOnly, never }
+
+/// בונה state כפי שה-bloc מחשב אותו בטעינת ספר, מאותן פונקציות טהורות
+/// שה-bloc עצמו משתמש בהן.
+TextBookLoaded _load({
+  NikudMode nikud = NikudMode.always,
+  bool removePunctuation = false,
+  required bool isTanach,
+}) {
+  final defaultRemoveNikud = nikud != NikudMode.always;
+  final removeNikudFromTanach = nikud == NikudMode.never;
+
+  return TextBookLoaded(
+    book: TextBook(title: 'ספר בדיקה'),
+    showLeftPane: false,
+    content: const ['שורה א'],
+    fontSize: 18,
+    showSplitView: false,
+    activeCommentators: const [],
+    commentatorGroups: const [],
+    availableCommentators: const [],
+    links: const [],
+    linksByLine: const {},
+    tableOfContents: const [],
+    isTanach: isTanach,
+    removeNikud: shouldRemoveNikudForBook(
+      defaultRemoveNikud: defaultRemoveNikud,
+      removeNikudFromTanach: removeNikudFromTanach,
+      isTanach: isTanach,
+    ),
+    nikudExemptByTanach: isNikudExemptByTanach(
+      defaultRemoveNikud: defaultRemoveNikud,
+      removeNikudFromTanach: removeNikudFromTanach,
+      isTanach: isTanach,
+    ),
+    removePunctuation: shouldRemovePunctuationForBook(
+      defaultRemovePunctuation: removePunctuation,
+      isTanach: isTanach,
+    ),
+    punctuationExemptByTanach: isPunctuationExemptByTanach(
+      defaultRemovePunctuation: removePunctuation,
+      isTanach: isTanach,
+    ),
+    visibleIndices: const [0],
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+}

--- a/test/text_book/bloc/text_book_bloc_test.dart
+++ b/test/text_book/bloc/text_book_bloc_test.dart
@@ -896,6 +896,48 @@ void main() {
     );
 
     test(
+      'LoadContent(preserveState:true) שומר עקיפות תצוגה של מפרשים',
+      () async {
+        final repository = _FakeTextBookRepository();
+        final bloc = _createBloc(
+          repository: repository,
+          showPageShapeView: false,
+        );
+
+        bloc.add(
+          const LoadContent(
+            fontSize: 20,
+            showSplitView: false,
+            removeNikud: false,
+            loadCommentators: false,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        bloc.add(const ToggleNikud(false, applyToCommentaries: true));
+        bloc.add(const TogglePunctuation(false, applyToCommentaries: true));
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        bloc.add(
+          const LoadContent(
+            fontSize: 20,
+            showSplitView: false,
+            removeNikud: false,
+            preserveState: true,
+            loadCommentators: false,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final state = bloc.state as TextBookLoaded;
+        expect(state.commentaryRemoveNikudOverride, isFalse);
+        expect(state.commentaryRemovePunctuationOverride, isFalse);
+
+        await bloc.close();
+      },
+    );
+
+    test(
       'LoadContent(preserveRemoveNikud:false) מחיל ניקוד חדש מה-Settings',
       () async {
         final repository = _FakeTextBookRepository();

--- a/test/text_book/bloc/text_book_state_test.dart
+++ b/test/text_book/bloc/text_book_state_test.dart
@@ -116,6 +116,13 @@ void main() {
         isNot(equals(_loadedState())),
       );
     });
+
+    test('changes when the commentary nikud override changes', () {
+      expect(
+        _loadedState(commentaryRemoveNikudOverride: false),
+        isNot(equals(_loadedState())),
+      );
+    });
   });
 
   group('commentaryRemoveNikud', () {
@@ -140,19 +147,18 @@ void main() {
       expect(state.copyWith(removeNikud: false).commentaryRemoveNikud, isTrue);
     });
 
-    test('shows nikud once the exemption is cleared', () {
-      // מסלול הכפתור בכרטיסיית המפרשים: ToggleNikud(applyToCommentaries: true).
+    test('commentary override does not change the main book', () {
       final state = _loadedState(
-        removeNikud: true,
+        removeNikud: false,
         nikudExemptByTanach: true,
       );
 
-      final cleared = state.copyWith(
-        removeNikud: false,
-        nikudExemptByTanach: false,
+      final showingCommentaries = state.copyWith(
+        commentaryRemoveNikudOverride: false,
       );
 
-      expect(cleared.commentaryRemoveNikud, isFalse);
+      expect(showingCommentaries.removeNikud, isFalse);
+      expect(showingCommentaries.commentaryRemoveNikud, isFalse);
     });
 
     test('follows the tab when no exemption applies', () {
@@ -178,6 +184,7 @@ TextBookLoaded _loadedState({
   String? heCategories,
   bool removeNikud = false,
   bool nikudExemptByTanach = false,
+  bool? commentaryRemoveNikudOverride,
 }) {
   return TextBookLoaded(
     book: TextBook(title: 'ספר בדיקה', heCategories: heCategories),
@@ -196,6 +203,7 @@ TextBookLoaded _loadedState({
     tableOfContents: const [],
     removeNikud: removeNikud,
     nikudExemptByTanach: nikudExemptByTanach,
+    commentaryRemoveNikudOverride: commentaryRemoveNikudOverride,
     visibleIndices: const [0],
     selectedIndices: selectedIndices,
     pinLeftPane: false,

--- a/test/text_book/bloc/text_book_state_test.dart
+++ b/test/text_book/bloc/text_book_state_test.dart
@@ -109,6 +109,59 @@ void main() {
 
       expect(beforeEnrich, isNot(equals(afterEnrich)));
     });
+
+    test('changes when the Tanach nikud exemption changes', () {
+      expect(
+        _loadedState(nikudExemptByTanach: true),
+        isNot(equals(_loadedState())),
+      );
+    });
+  });
+
+  group('commentaryRemoveNikud', () {
+    test('hides nikud in commentaries of a Tanach book showing nikud', () {
+      // הבאג: "הצג ניקוד בתנ״ך" הותיר ניקוד גם במפרשי התנ״ך.
+      final state = _loadedState(
+        removeNikud: false,
+        nikudExemptByTanach: true,
+      );
+
+      expect(state.removeNikud, isFalse);
+      expect(state.commentaryRemoveNikud, isTrue);
+    });
+
+    test('keeps the exemption when the toolbar re-shows nikud', () {
+      final state = _loadedState(
+        removeNikud: false,
+        nikudExemptByTanach: true,
+      );
+
+      expect(state.copyWith(removeNikud: true).commentaryRemoveNikud, isTrue);
+      expect(state.copyWith(removeNikud: false).commentaryRemoveNikud, isTrue);
+    });
+
+    test('shows nikud once the exemption is cleared', () {
+      // מסלול הכפתור בכרטיסיית המפרשים: ToggleNikud(applyToCommentaries: true).
+      final state = _loadedState(
+        removeNikud: true,
+        nikudExemptByTanach: true,
+      );
+
+      final cleared = state.copyWith(
+        removeNikud: false,
+        nikudExemptByTanach: false,
+      );
+
+      expect(cleared.commentaryRemoveNikud, isFalse);
+    });
+
+    test('follows the tab when no exemption applies', () {
+      final showing = _loadedState(removeNikud: false);
+      final hiding = _loadedState(removeNikud: true);
+
+      expect(showing.commentaryRemoveNikud, isFalse);
+      expect(hiding.commentaryRemoveNikud, isTrue);
+    });
   });
 }
 
@@ -123,6 +176,8 @@ TextBookLoaded _loadedState({
   Set<int> selectedIndices = const {},
   Set<String> selectedLinkTypes = const {},
   String? heCategories,
+  bool removeNikud = false,
+  bool nikudExemptByTanach = false,
 }) {
   return TextBookLoaded(
     book: TextBook(title: 'ספר בדיקה', heCategories: heCategories),
@@ -139,7 +194,8 @@ TextBookLoaded _loadedState({
     selectedLinkTypes: selectedLinkTypes,
     linksByLine: const {},
     tableOfContents: const [],
-    removeNikud: false,
+    removeNikud: removeNikud,
+    nikudExemptByTanach: nikudExemptByTanach,
     visibleIndices: const [0],
     selectedIndices: selectedIndices,
     pinLeftPane: false,

--- a/test/text_book/bloc/toggle_display_flags_test.dart
+++ b/test/text_book/bloc/toggle_display_flags_test.dart
@@ -14,8 +14,7 @@ class _FakeTextBookRepository extends TextBookRepository {
   _FakeTextBookRepository() : super(fileSystem: FileSystemData.instance);
 }
 
-/// ההחלפה היזומה בסרגל: בכרטיסיית הטקסט היא חלה על הספר בלבד, ובכרטיסיית
-/// המפרשים (`applyToCommentaries`) היא מבטלת את פטור התנ״ך וחלה על המפרשים.
+/// ההחלפה היזומה בכרטיסיית המפרשים חלה על המפרשים בלבד.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -82,26 +81,37 @@ void main() {
   );
 
   blocTest<TextBookBloc, TextBookState>(
-    'ToggleNikud עם applyToCommentaries מבטל את הפטור ומחזיר ניקוד למפרשים',
+    'ToggleNikud עם applyToCommentaries מחזיר ניקוד למפרשים בלבד',
     build: () => bloc,
     seed: () => seed(nikudExemptByTanach: true),
     act: (bloc) =>
         bloc.add(const ToggleNikud(false, applyToCommentaries: true)),
     expect: () => [
       isA<TextBookLoaded>()
-          .having((s) => s.nikudExemptByTanach, 'הפטור', isFalse)
+          .having((s) => s.removeNikud, 'הספר', isFalse)
+          .having((s) => s.nikudExemptByTanach, 'הפטור', isTrue)
+          .having(
+            (s) => s.commentaryRemoveNikudOverride,
+            'עקיפת המפרשים',
+            isFalse,
+          )
           .having((s) => s.commentaryRemoveNikud, 'המפרשים', isFalse),
     ],
   );
 
   blocTest<TextBookBloc, TextBookState>(
-    'ToggleNikud(true) עם applyToCommentaries מסתיר ניקוד בשניהם',
+    'ToggleNikud(true) עם applyToCommentaries מסתיר ניקוד במפרשים בלבד',
     build: () => bloc,
     seed: () => seed(nikudExemptByTanach: true),
     act: (bloc) => bloc.add(const ToggleNikud(true, applyToCommentaries: true)),
     expect: () => [
       isA<TextBookLoaded>()
-          .having((s) => s.removeNikud, 'removeNikud', isTrue)
+          .having((s) => s.removeNikud, 'הספר', isFalse)
+          .having(
+            (s) => s.commentaryRemoveNikudOverride,
+            'עקיפת המפרשים',
+            isTrue,
+          )
           .having((s) => s.commentaryRemoveNikud, 'המפרשים', isTrue),
     ],
   );
@@ -119,15 +129,68 @@ void main() {
   );
 
   blocTest<TextBookBloc, TextBookState>(
-    'TogglePunctuation עם applyToCommentaries מחזיר פיסוק למפרשים',
+    'TogglePunctuation עם applyToCommentaries מחזיר פיסוק למפרשים בלבד',
     build: () => bloc,
     seed: () => seed(punctuationExemptByTanach: true),
     act: (bloc) =>
         bloc.add(const TogglePunctuation(false, applyToCommentaries: true)),
     expect: () => [
       isA<TextBookLoaded>()
-          .having((s) => s.punctuationExemptByTanach, 'הפטור', isFalse)
+          .having((s) => s.removePunctuation, 'הספר', isFalse)
+          .having((s) => s.punctuationExemptByTanach, 'הפטור', isTrue)
+          .having(
+            (s) => s.commentaryRemovePunctuationOverride,
+            'עקיפת המפרשים',
+            isFalse,
+          )
           .having((s) => s.commentaryRemovePunctuation, 'המפרשים', isFalse),
+    ],
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'TogglePunctuation(true) עם applyToCommentaries מסתיר פיסוק במפרשים בלבד',
+    build: () => bloc,
+    seed: () => seed(punctuationExemptByTanach: true),
+    act: (bloc) =>
+        bloc.add(const TogglePunctuation(true, applyToCommentaries: true)),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having((s) => s.removePunctuation, 'הספר', isFalse)
+          .having(
+            (s) => s.commentaryRemovePunctuationOverride,
+            'עקיפת המפרשים',
+            isTrue,
+          )
+          .having((s) => s.commentaryRemovePunctuation, 'המפרשים', isTrue),
+    ],
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'סגירת כרטיסיית המפרשים מאפסת את העקיפות הזמניות',
+    build: () => bloc,
+    seed: () =>
+        seed(
+          nikudExemptByTanach: true,
+          punctuationExemptByTanach: true,
+        ).copyWith(
+          commentaryRemoveNikudOverride: false,
+          commentaryRemovePunctuationOverride: false,
+        ),
+    act: (bloc) => bloc.add(const ResetCommentaryDisplayOverrides()),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having(
+            (s) => s.commentaryRemoveNikudOverride,
+            'עקיפת הניקוד',
+            isNull,
+          )
+          .having(
+            (s) => s.commentaryRemovePunctuationOverride,
+            'עקיפת הפיסוק',
+            isNull,
+          )
+          .having((s) => s.commentaryRemoveNikud, 'המפרשים', isTrue)
+          .having((s) => s.commentaryRemovePunctuation, 'המפרשים', isTrue),
     ],
   );
 }

--- a/test/text_book/bloc/toggle_display_flags_test.dart
+++ b/test/text_book/bloc/toggle_display_flags_test.dart
@@ -1,0 +1,133 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import '../../test_helpers/memory_cache_provider.dart';
+
+class _FakeTextBookRepository extends TextBookRepository {
+  _FakeTextBookRepository() : super(fileSystem: FileSystemData.instance);
+}
+
+/// ההחלפה היזומה בסרגל: בכרטיסיית הטקסט היא חלה על הספר בלבד, ובכרטיסיית
+/// המפרשים (`applyToCommentaries`) היא מבטלת את פטור התנ״ך וחלה על המפרשים.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TextBookBloc bloc;
+  late TextBook book;
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  setUp(() {
+    book = TextBook(title: 'ספר בדיקה');
+    bloc = TextBookBloc(
+      repository: _FakeTextBookRepository(),
+      initialState: TextBookInitial.named(book, 0, true, const []),
+      scrollController: ItemScrollController(),
+      positionsListener: ItemPositionsListener.create(),
+    );
+  });
+
+  tearDown(() async {
+    await bloc.close();
+  });
+
+  TextBookLoaded seed({
+    bool removeNikud = false,
+    bool nikudExemptByTanach = false,
+    bool removePunctuation = false,
+    bool punctuationExemptByTanach = false,
+  }) => TextBookLoaded(
+    book: book,
+    content: const ['שורה א'],
+    fontSize: 20,
+    showLeftPane: true,
+    showSplitView: false,
+    activeCommentators: const [],
+    commentatorGroups: const [],
+    availableCommentators: const [],
+    links: const [],
+    linksByLine: const {},
+    tableOfContents: const [],
+    isTanach: true,
+    removeNikud: removeNikud,
+    nikudExemptByTanach: nikudExemptByTanach,
+    removePunctuation: removePunctuation,
+    punctuationExemptByTanach: punctuationExemptByTanach,
+    visibleIndices: const [0],
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'ToggleNikud רגיל אינו מבטל את פטור התנ״ך',
+    build: () => bloc,
+    seed: () => seed(removeNikud: true, nikudExemptByTanach: true),
+    act: (bloc) => bloc.add(const ToggleNikud(false)),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having((s) => s.removeNikud, 'removeNikud', isFalse)
+          .having((s) => s.commentaryRemoveNikud, 'המפרשים', isTrue),
+    ],
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'ToggleNikud עם applyToCommentaries מבטל את הפטור ומחזיר ניקוד למפרשים',
+    build: () => bloc,
+    seed: () => seed(nikudExemptByTanach: true),
+    act: (bloc) =>
+        bloc.add(const ToggleNikud(false, applyToCommentaries: true)),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having((s) => s.nikudExemptByTanach, 'הפטור', isFalse)
+          .having((s) => s.commentaryRemoveNikud, 'המפרשים', isFalse),
+    ],
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'ToggleNikud(true) עם applyToCommentaries מסתיר ניקוד בשניהם',
+    build: () => bloc,
+    seed: () => seed(nikudExemptByTanach: true),
+    act: (bloc) => bloc.add(const ToggleNikud(true, applyToCommentaries: true)),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having((s) => s.removeNikud, 'removeNikud', isTrue)
+          .having((s) => s.commentaryRemoveNikud, 'המפרשים', isTrue),
+    ],
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'TogglePunctuation רגיל אינו מבטל את פטור התנ״ך',
+    build: () => bloc,
+    seed: () => seed(removePunctuation: true, punctuationExemptByTanach: true),
+    act: (bloc) => bloc.add(const TogglePunctuation(false)),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having((s) => s.removePunctuation, 'removePunctuation', isFalse)
+          .having((s) => s.commentaryRemovePunctuation, 'המפרשים', isTrue),
+    ],
+  );
+
+  blocTest<TextBookBloc, TextBookState>(
+    'TogglePunctuation עם applyToCommentaries מחזיר פיסוק למפרשים',
+    build: () => bloc,
+    seed: () => seed(punctuationExemptByTanach: true),
+    act: (bloc) =>
+        bloc.add(const TogglePunctuation(false, applyToCommentaries: true)),
+    expect: () => [
+      isA<TextBookLoaded>()
+          .having((s) => s.punctuationExemptByTanach, 'הפטור', isFalse)
+          .having((s) => s.commentaryRemovePunctuation, 'המפרשים', isFalse),
+    ],
+  );
+}

--- a/test/text_book/utils/per_book_display_settings_test.dart
+++ b/test/text_book/utils/per_book_display_settings_test.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:otzaria/core/app_paths.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
+import 'package:otzaria/settings/services/per_book_settings_service.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/utils/per_book_display_settings.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import '../../helpers/memory_settings_cache.dart';
+
+class _FakeSettingsBloc extends Fake implements SettingsBloc {
+  _FakeSettingsBloc(this.state);
+
+  @override
+  final SettingsState state;
+}
+
+/// השמירה פר-ספר משווה מול ברירת המחדל האפקטיבית, כולל החרגות התנ"ך. בלעדיה
+/// בחירה שסוטה מההחרגה נחשבת "כמו ברירת המחדל" ונעלמת בפתיחה הבאה.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('per_book_display');
+    AppPaths.debugOverrideDataRootPath(tempDir.path);
+  });
+
+  tearDown(() async {
+    AppPaths.debugOverrideDataRootPath(null);
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  final book = TextBook(title: 'בראשית', categoryId: 1);
+
+  TextBookLoaded loaded({required bool isTanach}) => TextBookLoaded(
+    book: book,
+    showLeftPane: false,
+    content: const ['שורה א'],
+    fontSize: 25,
+    showSplitView: false,
+    activeCommentators: const [],
+    commentatorGroups: const [],
+    availableCommentators: const [],
+    links: const [],
+    linksByLine: const {},
+    tableOfContents: const [],
+    isTanach: isTanach,
+    removeNikud: false,
+    visibleIndices: const [0],
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+
+  /// מריץ את השמירה בתוך עץ ווידג'טים ומחזיר את מה שנכתב לקובץ.
+  /// גישת הקבצים חייבת לרוץ ב-[WidgetTester.runAsync] — ה-async המדומה של
+  /// testWidgets אינו מקדם I/O אמיתי, וההמתנה נתקעת.
+  Future<Map<String, dynamic>?> saveAndRead(
+    WidgetTester tester,
+    SettingsState settings,
+    TextBookLoaded state, {
+    bool? removeNikud,
+    bool? removePunctuation,
+  }) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      Provider<SettingsBloc>.value(
+        value: _FakeSettingsBloc(settings),
+        child: Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    Map<String, dynamic>? json;
+    await tester.runAsync(() async {
+      await savePerBookDisplaySettings(
+        capturedContext,
+        state,
+        removeNikud: removeNikud,
+        removePunctuation: removePunctuation,
+      );
+      json = await PerBookSettings.loadSettings(PerBookSettings.bookKey(book));
+    });
+    return json;
+  }
+
+  final tanachOnly = SettingsState.initial().copyWith(
+    enablePerBookSettings: true,
+    defaultRemoveNikud: true,
+    removeNikudFromTanach: false,
+  );
+
+  testWidgets('הסתרת ניקוד בתנ"ך במצב "הצג ניקוד בתנ"ך" נשמרת', (tester) async {
+    // הברירה האפקטיבית בתנ"ך היא false (פטור), ולכן true הוא override אמיתי.
+    final json = await saveAndRead(
+      tester,
+      tanachOnly,
+      loaded(isTanach: true),
+      removeNikud: true,
+    );
+
+    expect(json?['removeNikud'], isTrue);
+    expect(json?['isTanach'], isTrue, reason: 'דגל הלוויין נדרש לניקוי');
+  });
+
+  testWidgets('הצגת ניקוד בתנ"ך שווה לברירה האפקטיבית ואינה נשמרת', (
+    tester,
+  ) async {
+    final json = await saveAndRead(
+      tester,
+      tanachOnly,
+      loaded(isTanach: true),
+      removeNikud: false,
+    );
+
+    expect(json, isNull);
+  });
+
+  testWidgets('בספר שאינו תנ"ך הברירה האפקטיבית היא ההגדרה הגלובלית', (
+    tester,
+  ) async {
+    final json = await saveAndRead(
+      tester,
+      tanachOnly,
+      loaded(isTanach: false),
+      removeNikud: true,
+    );
+
+    expect(json, isNull, reason: 'true שווה לברירת המחדל בספר שאינו תנ"ך');
+  });
+
+  testWidgets('override פיסוק בתנ"ך נשמר עם דגל הלוויין', (tester) async {
+    final settings = SettingsState.initial().copyWith(
+      enablePerBookSettings: true,
+      defaultRemovePunctuation: true,
+    );
+
+    final json = await saveAndRead(
+      tester,
+      settings,
+      loaded(isTanach: true),
+      removePunctuation: true,
+    );
+
+    expect(json?['removePunctuation'], isTrue);
+    expect(json?['isTanach'], isTrue);
+  });
+
+  testWidgets('כשההתאמות פר-ספר כבויות לא נשמר דבר', (tester) async {
+    final settings = tanachOnly.copyWith(enablePerBookSettings: false);
+
+    final json = await saveAndRead(
+      tester,
+      settings,
+      loaded(isTanach: true),
+      removeNikud: true,
+    );
+
+    expect(json, isNull);
+  });
+}


### PR DESCRIPTION
## הבאג

ההגדרה **"הצג ניקוד בתנ״ך"** פוטרת ספר תנ"ך מהסרת ניקוד. הפטור הזה הוחל גם על תוכן שאינו תנ"ך שמוצג לצידו — המפרשים, הקישורים, התצוגות המקדימות בריחוף ותפריטי ההקשר. רש"י על התורה אינו תנ"ך, ולכן הוצג עם ניקוד בניגוד למה שההגדרה אומרת.

אותו דבר קרה בהסרת פיסוק, שאינה חלה על תנ"ך: בתנ"ך גם המפרשים נשארו עם פיסוק.

הרגרסיה בניקוד נכנסה ב-15e4f7ab6, שהחליף את הרזולוציה פר-ספר-יעד בהעברה ישירה של מצב הטאב לכל המפרשים.

## התיקון

`TextBookLoaded` מחזיק את הפטור בנפרד (`nikudExemptByTanach` / `punctuationExemptByTanach`), ושני getters גוזרים ממנו את המצב שחל על תוכן של ספר אחר:

```dart
bool get commentaryRemoveNikud => removeNikud || nikudExemptByTanach;
bool get commentaryRemovePunctuation => removePunctuation || punctuationExemptByTanach;
```

כל אתר שמציג תוכן של ספר אחר עבר ל-getters; הטקסט של הספר עצמו, ההערות המוטבעות בו וההעתקה ממנו נשארו על השדות המקוריים. ב-`simple_text_viewer.dart`, שמשמש גם לטקסט הראשי וגם לטורי המפרשים, ההבחנה נעשית לפי `isMainText`.

**התנהגות הכפתורים:** בכרטיסיית טקסט של ספר תנ"ך הכפתור בסרגל שולט בטקסט הראשי בלבד — לחיצה עליו אינה מחזירה ניקוד למפרשים כל זמן שההגדרה היא "רק בתנ״ך". בכרטיסיית המפרשים, שמציגה מפרשים בלבד, הכפתור שולט בהם דרך `applyToCommentaries` שמבטל את הפטור.

## שלושה באגים נוספים שנמצאו באותו שורש

1. **PDF** — אותו באג היה בפאנל המפרשים ובכרטיסיית המפרשים של PDF. שם התיקון הוא **מחיקת** ההחרגה: הערך ההתחלתי היה נכון מלכתחילה, וכל המנגנון סביבו (`_resolveIsTanachBook`, `_isTanachBook`, `_displayFlagsTouchedByUser`) התייתר.

2. **כרטיסיית המפרשים דרסה את הגדרת הטקסט הראשי** — קובץ ההגדרות פר-ספר משותף לשני הכרטיסיות (אותו `bookKey`), ולכן שמירה מכרטיסיית המפרשים חלה על הטקסט הראשי בפתיחה הבאה, כולל הפיכת `removePunctuation` ל-`true` בתנ"ך בניגוד לחוזה. השמירה שם הוסרה — כמו ב-PDF, הבחירה חיה כל זמן שהכרטיסייה פתוחה.

3. **בחירה שסוטה מהחרגת התנ"ך לא נשמרה** — השמירה פר-ספר השוותה מול ההגדרה הגלובלית הגולמית ולא מול ברירת המחדל האפקטיבית של הספר, ולכן "הסתר ניקוד" בתנ"ך נחשב "כמו ברירת המחדל" ונעלם בפתיחה הבאה. תוקן גם הניקוי התקופתי, שאחרת היה מוחק את ה-override מיד; דגל `isTanach` נשמר עכשיו כלוויין של שני ה-overrides.

## בדיקות

`flutter analyze lib/ test/` — נקי. ~45 טסטים חדשים:

- `test/text_book/bloc/commentary_display_flags_test.dart` — טבלת האמת המלאה: שלושת מצבי ההגדרה × תנ"ך/לא-תנ"ך × ספר/מפרשים, כולל ההתנהגות של הכפתור בכל מצב
- `test/text_book/bloc/toggle_display_flags_test.dart` — `ToggleNikud`/`TogglePunctuation` מול `applyToCommentaries`, על bloc אמיתי
- `test/text_book/utils/per_book_display_settings_test.dart` — השמירה פר-ספר מול ברירת המחדל האפקטיבית ודגל הלוויין
- תוספות ל-`nikud_display_service_test.dart`, `per_book_settings_test.dart` ו-`text_book_state_test.dart`

## מה נשאר פתוח

מסך ההדפסה מחזיק דגל ניקוד אחד לכל עבודת ההדפסה (טקסט ראשי + מפרשים), ולכן הדפסת תנ"ך עם מפרשים תיפתח עם ניקוד כברירת מחדל, בשונה מהמסך. זה מבנה קיים של `printing_screen.dart` שלא נוגע לרגרסיה הזו, והמשתמש יכול לשנות אותו במתג בדיאלוג.

🤖 Generated with [Claude Code](https://claude.com/claude-code)