### PR TITLE
תוצאות חיפוש: זכירת בחירת המיון והאיחוד

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -668,6 +668,8 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Facet helper | `test/search/facet_helper_test.dart` |
 | Search BLoC facet counts | `test/search/search_bloc_facet_counts_test.dart` |
 | Search scope preferences | `test/search/search_scope_preferences_test.dart` |
+| זכירת המיון ואיחוד התוצאות (העדפה, BLoC, טאב חדש) | `test/search/search_results_preferences_test.dart` |
+| אותן העדפות בלי אתחול `Settings` | `test/search/search_results_preferences_uninitialized_test.dart` |
 | עץ ניווט תוצאות (רשימת סינון, גלוּת הבחירה, פתיחת ענפים) | `test/search/search_navigation_tree_test.dart` |
 | חלונית סינון התוצאות מקצה לקצה (שדה "איתור ספר") | `test/search/search_facet_filtering_book_filter_test.dart` |
 | ניתוב חיפוש-בספר: פשוט מול מנוע | `test/search/utils/in_book_search_routing_test.dart` |
@@ -676,6 +678,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | שקילות מנוע ↔ הדגשה במרווח בין מילים | `test/search/highlight_engine_distance_parity_test.dart` |
 | הדגשה במדיניות התאמה — רק בשורות שהמנוע החזיר | `test/utils/highlight_match_policy_test.dart` |
 | שימור קונפיגורציית החיפוש בשכפול/שחזור טאב ובשמירה ל-JSON | `test/tabs/models/tab_search_state_clone_test.dart` |
+| איחוד התוצאות וטווח הקרבה ב-JSON של טאב החיפוש | `test/tabs/models/searching_tab_json_config_test.dart` |
 | Gematria search | `test/tools/gematria/gematria_search_test.dart` |
 
 **Personal Notes**
@@ -779,6 +782,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Link types (נרמול, סוג קנוני, תוויות) | `test/models/link_types_test.dart` |
 | Utils (page map builder, page converter, TOC parser) | `test/utils/page_map_builder_test.dart`, `…page_converter_test.dart`, `…toc_parser_test.dart` |
 | Utils (link processing) | `test/text_book/utils/link_processing_test.dart` |
+| חיתוך HTML לפי טווח הבחירה (שימור עיצוב בהעתקה חלקית) | `test/utils/text/html_slice_test.dart` |
 | גודל פענוח תמונות (cacheWidth על נכסים כבדים) | `test/utils/ui/image_decode_size_test.dart` |
 | Hebrew text utils (migration) | `test/migration/hebrew_text_utils_test.dart` |
 | Text book searcher (in-book search) | `test/text_book/models/text_book_searcher_test.dart` |

--- a/lib/find_ref/view/find_ref_dialog.dart
+++ b/lib/find_ref/view/find_ref_dialog.dart
@@ -28,6 +28,7 @@ import 'package:otzaria/utils/ui/reading_left_pane_policy.dart';
 import 'package:otzaria/tour/tour_target_keys.dart';
 import 'package:otzaria/library/view/grid_items.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
 import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/navigation/view/main_window_screen.dart';
@@ -573,7 +574,11 @@ class _FindRefDialogState extends State<FindRefDialog> {
   /// פותח את דיאלוג החיפוש עם [query] מוכן בשדה — ללא הרצת חיפוש.
   void _openTextSearch(String query) {
     Navigator.of(context).pop();
-    final tab = SearchingTab('חיפוש', query);
+    final tab = SearchingTab(
+      'חיפוש',
+      query,
+      initialConfiguration: const SearchConfiguration(),
+    );
     showDialog(
       context: context,
       builder: (context) => SearchDialog(existingTab: tab),

--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -22,6 +22,7 @@ import 'package:otzaria/library/view/grid_items.dart';
 import 'package:otzaria/library/view/otzar_book_dialog.dart';
 import 'package:otzaria/library/view/book_preview_panel.dart';
 import 'package:otzaria/library/view/library_empty_state_widget.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
 import 'package:otzaria/library/view/library_panel_controller.dart';
@@ -1095,7 +1096,11 @@ class _LibraryBrowserState extends State<LibraryBrowser>
 
   void _openSearchDialog(BuildContext context, {String? searchQuery}) {
     final tab = searchQuery != null && searchQuery.isNotEmpty
-        ? SearchingTab('חיפוש', searchQuery)
+        ? SearchingTab(
+            'חיפוש',
+            searchQuery,
+            initialConfiguration: const SearchConfiguration(),
+          )
         : null;
     showDialog(
       context: context,

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -31,6 +31,7 @@ import 'package:otzaria/find_ref/bloc/find_ref_event.dart';
 import 'package:otzaria/find_ref/bloc/find_ref_state.dart';
 import 'package:otzaria/library/models/library.dart' as library_model;
 import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_defaults.dart';
 import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/library/view/library_browser.dart';
 import 'package:otzaria/tabs/reading_screen.dart';
@@ -1220,9 +1221,11 @@ class MainWindowScreenState extends State<MainWindowScreen>
       query,
       initialConfiguration: mode == null
           ? null
-          : SearchConfiguration(
-              searchMode: mode,
-              distance: mode == SearchMode.fuzzy ? 2 : 0,
+          : SearchDefaults.withResultPreferences(
+              SearchConfiguration(
+                searchMode: mode,
+                distance: mode == SearchMode.fuzzy ? 2 : 0,
+              ),
             ),
     );
     context.read<HistoryBloc>().add(AddHistory(tab));

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/search_defaults.dart';
 import 'package:otzaria/search/search_repository.dart';
 import 'package:otzaria/search/utils/search_catalogue_order_helper.dart';
 import 'package:otzaria/search/search_query_builder.dart';
@@ -905,6 +906,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     Emitter<SearchState> emit,
   ) {
     final newConfig = state.configuration.copyWith(sortBy: event.order);
+    SearchDefaults.saveSortOrderDefault(event.order);
     emit(state.copyWith(configuration: newConfig));
     _reSearch();
   }
@@ -913,6 +915,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     UpdateResultGrouping event,
     Emitter<SearchState> emit,
   ) {
+    // השמירה קודמת ל-early return: בטאב משוחזר ה-state עשוי כבר להיות במצב
+    // שנבחר, ובחירת המשתמש עדיין צריכה להיות זו שתיזכר לחיפוש הבא.
+    SearchDefaults.saveResultGroupingDefault(event.grouping);
     if (event.grouping == state.configuration.resultGrouping) return;
     final newConfig = state.configuration.copyWith(
       resultGrouping: event.grouping,

--- a/lib/search/search_defaults.dart
+++ b/lib/search/search_defaults.dart
@@ -3,12 +3,17 @@ import 'dart:convert';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/search_query_builder.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show ResultsOrder;
 
 /// ברירות מחדל לחיפוש, נפרדות לכל מצב: אפשרויות החיפוש המתקדם (7 תיבות
 /// הסימון + ניקוד/טעמים), אפשרויות החיפוש הרגיל (5 תיבות סימון בלבד)
-/// והמרווח בין מילים שלו, ומצב החיפוש שבו נפתח הדיאלוג.
-/// חיפוש חדש נפתח לפי ברירת המחדל השמורה; שינוי בחלונית נשמר לסשן
-/// הנוכחי בלבד וחוזר לברירת המחדל בהפעלה הבאה של התוכנה.
+/// והמרווח בין מילים שלו, מצב החיפוש שבו נפתח הדיאלוג, ותצוגת התוצאות
+/// (מיון ואיחוד).
+///
+/// חיפוש חדש נפתח לפי ברירת המחדל השמורה. למה שנקבע בדיאלוג יש גם שכבת
+/// סשן — `remember*Session*` נשמר עד סגירת התוכנה בלבד — ולעומת זאת
+/// תצוגת התוצאות, שנקבעת בסרגל התוצאות, נשמרת ישר לברירת המחדל.
 class SearchDefaults {
   static const _settingsKey = 'key-search-default-options';
   static const _exactSettingsKey = 'key-search-default-options-exact';
@@ -141,5 +146,62 @@ class SearchDefaults {
   /// משמר את המרווח להמשך הסשן (נקרא בסגירת דיאלוג החיפוש).
   static void rememberSessionDistance(int distance) {
     _sessionDistance = distance;
+  }
+
+  // ── תצוגת התוצאות: מיון ואיחוד ──────────────────────────────────────
+  // שתי ההעדפות נשמרות בשם הערך ולא באינדקסו, כדי שהוספת ערך באמצע ה-enum
+  // לא תהפוך העדפה שמורה לערך אחר. (ה-JSON של הטאב אינדקסי מאז ומתמיד.)
+
+  static const _sortOrderKey = 'key-search-results-sort-order';
+  static const _groupingKey = 'key-search-results-grouping';
+
+  /// המיון שאיתו נפתח חיפוש חדש — בחירת המשתמש האחרונה במסך התוצאות.
+  static ResultsOrder initialSortOrderForNewSearch() => _loadEnum(
+    _sortOrderKey,
+    ResultsOrder.values,
+    const SearchConfiguration().sortBy,
+  );
+
+  /// שומר את המיון שהמשתמש בחר כברירת מחדל לחיפושים הבאים.
+  static void saveSortOrderDefault(ResultsOrder order) =>
+      _saveEnum(_sortOrderKey, order.name);
+
+  /// מצב איחוד התוצאות שאיתו נפתח חיפוש חדש — בחירת המשתמש האחרונה.
+  static ResultGroupingMode initialResultGroupingForNewSearch() => _loadEnum(
+    _groupingKey,
+    ResultGroupingMode.values,
+    const SearchConfiguration().resultGrouping,
+  );
+
+  /// שומר את מצב איחוד התוצאות שהמשתמש בחר כברירת מחדל לחיפושים הבאים.
+  static void saveResultGroupingDefault(ResultGroupingMode grouping) =>
+      _saveEnum(_groupingKey, grouping.name);
+
+  /// [base] בתוספת ברירות המחדל השמורות לתצוגת התוצאות — מיון ואיחוד —
+  /// הדורסות את מה שיש ב-[base]. מסלולי השחזור (JSON, שכפול, היסטוריה)
+  /// אינם עוברים כאן, כדי שטאב משוחזר יישאר עם הערכים שנשמרו איתו.
+  static SearchConfiguration withResultPreferences([
+    SearchConfiguration base = const SearchConfiguration(),
+  ]) {
+    return base.copyWith(
+      sortBy: initialSortOrderForNewSearch(),
+      resultGrouping: initialResultGroupingForNewSearch(),
+    );
+  }
+
+  static T _loadEnum<T extends Enum>(String key, List<T> values, T fallback) {
+    // Settings לא אותחל (בדיקות ווידג'ט / אתחול מוקדם) — אין העדפות לקרוא.
+    if (!Settings.isInitialized) return fallback;
+    final raw = Settings.getValue<String>(key);
+    if (raw == null || raw.isEmpty) return fallback;
+    for (final value in values) {
+      if (value.name == raw) return value;
+    }
+    return fallback;
+  }
+
+  static void _saveEnum(String key, String name) {
+    if (!Settings.isInitialized) return;
+    Settings.setValue<String>(key, name);
   }
 }

--- a/lib/search/view/search_dialog.dart
+++ b/lib/search/view/search_dialog.dart
@@ -176,6 +176,8 @@ class _SearchDialogState extends State<SearchDialog> {
       _searchTab = SearchingTab(
         "חיפוש",
         lastTyping,
+        // בלי העדפות תצוגת התוצאות: זה טאב השירות של הדיאלוג, והמיון/האיחוד
+        // שלו נראים רק בבקשת החיפוש שנשלחת לתוספים.
         initialConfiguration: SearchConfiguration(
           searchMode: searchMode,
           distance: searchMode == SearchMode.fuzzy
@@ -723,13 +725,15 @@ class _SearchDialogState extends State<SearchDialog> {
     final newSearchTab = SearchingTab(
       "חיפוש: $query",
       query,
-      initialConfiguration: SearchConfiguration(
-        searchMode: currentMode,
-        distance: distance,
-        proximityScope: proximityScope,
-        currentFacets: facetsToSearch,
-        searchScopeFacets: facetsToSearch,
-        pluginSearchSelections: _allPluginSearchSelections(),
+      initialConfiguration: SearchDefaults.withResultPreferences(
+        SearchConfiguration(
+          searchMode: currentMode,
+          distance: distance,
+          proximityScope: proximityScope,
+          currentFacets: facetsToSearch,
+          searchScopeFacets: facetsToSearch,
+          pluginSearchSelections: _allPluginSearchSelections(),
+        ),
       ),
     );
 

--- a/lib/tabs/models/searching_tab.dart
+++ b/lib/tabs/models/searching_tab.dart
@@ -3,6 +3,7 @@ import 'package:otzaria/search/bloc/search_bloc.dart';
 import 'package:otzaria/search/bloc/search_event.dart';
 import 'package:otzaria/search/models/external_search_summary.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_defaults.dart';
 import 'package:otzaria/search/search_query_builder.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
@@ -80,7 +81,12 @@ class SearchingTab extends OpenedTab {
     super.dedupeKey,
     SearchConfiguration? initialConfiguration,
   }) {
-    searchBloc = SearchBloc(initialConfiguration: initialConfiguration);
+    // בלי configuration מפורשת זה טאב חיפוש חדש — הוא נפתח עם המיון ומצב
+    // האיחוד שהמשתמש בחר לאחרונה.
+    searchBloc = SearchBloc(
+      initialConfiguration:
+          initialConfiguration ?? SearchDefaults.withResultPreferences(),
+    );
     titleNotifier = ValueNotifier(title);
     if (searchText != null) {
       queryController.text = searchText;
@@ -362,6 +368,20 @@ class SearchingTab extends OpenedTab {
             sortByIndex < ResultsOrder.values.length)
         ? ResultsOrder.values[sortByIndex]
         : defaultConfig.sortBy;
+    final scopeIndex = json['proximityScope'];
+    final initialProximityScope =
+        (scopeIndex is int &&
+            scopeIndex >= 0 &&
+            scopeIndex < SearchScope.values.length)
+        ? SearchScope.values[scopeIndex]
+        : defaultConfig.proximityScope;
+    final groupingIndex = json['resultGrouping'];
+    final initialGrouping =
+        (groupingIndex is int &&
+            groupingIndex >= 0 &&
+            groupingIndex < ResultGroupingMode.values.length)
+        ? ResultGroupingMode.values[groupingIndex]
+        : defaultConfig.resultGrouping;
     final initialCurrentFacets = rawCurrentFacets is List
         ? rawCurrentFacets.map((e) => e.toString()).toList(growable: false)
         : defaultConfig.currentFacets;
@@ -383,9 +403,11 @@ class SearchingTab extends OpenedTab {
 
     final initialConfig = SearchConfiguration(
       distance: initialDistance,
+      proximityScope: initialProximityScope,
       searchMode: initialMode,
       numResults: initialNumResults,
       sortBy: initialSortBy,
+      resultGrouping: initialGrouping,
       currentFacets: initialCurrentFacets,
       searchScopeFacets: initialScopeFacets,
       wordMatchMode: initialWordMatchMode,
@@ -566,9 +588,11 @@ class SearchingTab extends OpenedTab {
       'isPinned': isPinned,
       'type': 'SearchingTabWindow',
       'distance': config.distance,
+      'proximityScope': config.proximityScope.index,
       'searchMode': config.searchMode.index,
       'numResults': config.numResults,
       'sortBy': config.sortBy.index,
+      'resultGrouping': config.resultGrouping.index,
       'currentFacets': config.currentFacets,
       'searchScopeFacets': config.searchScopeFacets,
       'wordMatchMode': config.wordMatchMode.index,

--- a/test/search/search_dialog_test.dart
+++ b/test/search/search_dialog_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:otzaria/bookmarks/models/bookmark.dart';
 import 'package:otzaria/history/bloc/history_bloc.dart';
 import 'package:otzaria/history/bloc/history_event.dart';
@@ -27,7 +28,12 @@ import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/search_defaults.dart';
 import 'package:otzaria/search/view/search_dialog.dart';
 import 'package:otzaria/search/view/search_scope_menu.dart';
+import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
+import 'package:otzaria/tabs/bloc/tabs_event.dart';
+import 'package:otzaria/tabs/bloc/tabs_state.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show ResultsOrder;
 
 import '../support/search_engine_test_init.dart';
 import '../test_helpers/memory_cache_provider.dart';
@@ -43,6 +49,10 @@ class MockNavigationBloc extends MockBloc<NavigationEvent, NavigationState>
 
 class MockLibraryBloc extends MockBloc<LibraryEvent, LibraryState>
     implements LibraryBloc {}
+
+class MockTabsBloc extends MockBloc<TabsEvent, TabsState> implements TabsBloc {}
+
+class _FakeTabsEvent extends Fake implements TabsEvent {}
 
 /// LibraryBloc מדומה עם ספרייה ריקה — מספיק ל-parseCategoryQuery בדיאלוג.
 MockLibraryBloc _stubLibraryBloc() {
@@ -81,7 +91,11 @@ Future<void> main() async {
   // ה-Rust; הטסטים המסומנים מדולגים כשאין build נייטיבי זמין.
   final engineReady = await tryInitSearchEngine();
 
-  setUpAll(() async {
+  setUpAll(() => registerFallbackValue(_FakeTabsEvent()));
+
+  // מחסן טרי לכל טסט: טסט ששומר העדפת תצוגת תוצאות אחרת מזליג אותה לכל
+  // טאב חיפוש שייבנה אחריו בקובץ.
+  setUp(() async {
     await Settings.init(cacheProvider: MemoryCacheProvider());
   });
 
@@ -1239,4 +1253,104 @@ Future<void> main() async {
       reason: 'סיומות כלליות בלעדיות למצב המתקדם',
     );
   });
+
+  // המסלול הראשי של המשתמש: דיאלוג → "חפש" → טאב חדש. הטאב נבנה כאן עם
+  // configuration מפורשת, ולכן העדפות תצוגת התוצאות חייבות להיות מוזרקות בו
+  // במפורש — ברירת המחדל של הבנאי אינה חלה על מסלול זה.
+  testWidgets(
+    'טאב שנפתח מהדיאלוג נושא את המיון והאיחוד השמורים',
+    (WidgetTester tester) async {
+      final historyBloc = MockHistoryBloc();
+      final indexingBloc = MockIndexingBloc();
+      final navigationBloc = MockNavigationBloc();
+      final tabsBloc = MockTabsBloc();
+      final theme = ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFB85C38)),
+      );
+
+      whenListen(
+        historyBloc,
+        const Stream<HistoryState>.empty(),
+        initialState: HistoryLoaded([]),
+      );
+      whenListen(
+        indexingBloc,
+        const Stream<IndexingState>.empty(),
+        initialState: IndexingInitial(),
+      );
+      whenListen(
+        navigationBloc,
+        const Stream<NavigationState>.empty(),
+        initialState: const NavigationState(currentScreen: Screen.search),
+      );
+      whenListen(
+        tabsBloc,
+        const Stream<TabsState>.empty(),
+        initialState: const TabsState(tabs: [], currentTabIndex: 0),
+      );
+
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        await historyBloc.close();
+        await indexingBloc.close();
+        await navigationBloc.close();
+        await tabsBloc.close();
+      });
+
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.sameSection);
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance);
+
+      await tester.binding.setSurfaceSize(const Size(1400, 900));
+      await tester.pumpWidget(
+        MultiBlocProvider(
+          providers: [
+            BlocProvider<HistoryBloc>.value(value: historyBloc),
+            BlocProvider<IndexingBloc>.value(value: indexingBloc),
+            BlocProvider<NavigationBloc>.value(value: navigationBloc),
+            BlocProvider<LibraryBloc>.value(value: _stubLibraryBloc()),
+            BlocProvider<TabsBloc>.value(value: tabsBloc),
+          ],
+          child: MaterialApp(
+            theme: theme,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: ElevatedButton(
+                    onPressed: () => showDialog<void>(
+                      context: context,
+                      builder: (_) => const SearchDialog(),
+                    ),
+                    child: const Text('פתח'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('פתח'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).first, 'חכמה בינה');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('חפש'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(() => tabsBloc.add(captureAny())).captured;
+      final addedTabs = captured.whereType<AddTab>().toList();
+      expect(addedTabs, hasLength(1));
+      final tab = addedTabs.single.tab as SearchingTab;
+      addTearDown(tab.dispose);
+
+      expect(
+        tab.searchBloc.state.resultGrouping,
+        ResultGroupingMode.sameSection,
+      );
+      expect(tab.searchBloc.state.sortBy, ResultsOrder.relevance);
+      // העטיפה מוסיפה להעדפות ואינה מחליפה את מה שנבחר בדיאלוג.
+      expect(tab.searchBloc.state.currentFacets, isNotEmpty);
+    },
+    skip: !engineReady,
+  );
 }

--- a/test/search/search_results_preferences_test.dart
+++ b/test/search/search_results_preferences_test.dart
@@ -1,0 +1,401 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/bloc/search_bloc.dart';
+import 'package:otzaria/search/bloc/search_event.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_defaults.dart';
+import 'package:otzaria/search/search_repository.dart';
+import 'package:otzaria/tabs/models/searching_tab.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show ResultGrouping, ResultsOrder, SearchScope;
+
+import '../helpers/memory_settings_cache.dart';
+import '../support/recording_search_engine.dart';
+import '../support/search_engine_test_init.dart';
+
+/// מיון התוצאות ומצב איחוד התוצאות הם בחירת תצוגה שהמשתמש עושה פעם אחת.
+/// בלי שמירה, כל חיפוש חדש נפתח שוב ב"ללא איחוד" — והמשתמש חוזר ובוחר.
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final engineReady = await tryInitSearchEngine();
+
+  const sortKey = 'key-search-results-sort-order';
+  const groupingKey = 'key-search-results-grouping';
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+  });
+
+  group('העדפות תצוגת התוצאות נשמרות', () {
+    test('בלי העדפה שמורה מוחזרות ברירות המחדל', () {
+      expect(
+        SearchDefaults.initialSortOrderForNewSearch(),
+        ResultsOrder.catalogue,
+      );
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.none,
+      );
+    });
+
+    test('כל מצבי האיחוד נשמרים ונטענים', () {
+      for (final mode in ResultGroupingMode.values) {
+        SearchDefaults.saveResultGroupingDefault(mode);
+        expect(
+          SearchDefaults.initialResultGroupingForNewSearch(),
+          mode,
+          reason: mode.label,
+        );
+      }
+    });
+
+    test('כל סדרי המיון נשמרים ונטענים', () {
+      for (final order in ResultsOrder.values) {
+        SearchDefaults.saveSortOrderDefault(order);
+        expect(
+          SearchDefaults.initialSortOrderForNewSearch(),
+          order,
+          reason: order.name,
+        );
+      }
+    });
+
+    test('חזרה ל"ללא איחוד" נשמרת אף היא ואינה נופלת לערך הקודם', () {
+      SearchDefaults.saveResultGroupingDefault(
+        ResultGroupingMode.identicalText,
+      );
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.none);
+
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.none,
+      );
+    });
+
+    test('המיון והאיחוד נשמרים במפתחות נפרדים ואינם דורסים זה את זה', () {
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance);
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.sameSection);
+
+      expect(
+        SearchDefaults.initialSortOrderForNewSearch(),
+        ResultsOrder.relevance,
+      );
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.sameSection,
+      );
+    });
+
+    test('ההעדפה נשמרת בשם ולא באינדקס', () {
+      SearchDefaults.saveResultGroupingDefault(
+        ResultGroupingMode.identicalText,
+      );
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.generation);
+
+      expect(Settings.getValue<String>(groupingKey), 'identicalText');
+      expect(Settings.getValue<String>(sortKey), 'generation');
+    });
+
+    test('ערך שמור שאינו מוכר נופל לברירת המחדל', () async {
+      await Settings.setValue<String>(groupingKey, 'byChapter');
+      await Settings.setValue<String>(sortKey, 'byAuthor');
+
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.none,
+      );
+      expect(
+        SearchDefaults.initialSortOrderForNewSearch(),
+        ResultsOrder.catalogue,
+      );
+    });
+
+    test('ערך שמור ריק נופל לברירת המחדל', () async {
+      await Settings.setValue<String>(groupingKey, '');
+      await Settings.setValue<String>(sortKey, '');
+
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.none,
+      );
+      expect(
+        SearchDefaults.initialSortOrderForNewSearch(),
+        ResultsOrder.catalogue,
+      );
+    });
+  });
+
+  group('withResultPreferences', () {
+    test('בלי base — ברירות המחדל בתוספת ההעדפות השמורות', () {
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance);
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.sameSection);
+
+      final config = SearchDefaults.withResultPreferences();
+
+      expect(config.sortBy, ResultsOrder.relevance);
+      expect(config.resultGrouping, ResultGroupingMode.sameSection);
+    });
+
+    test('שאר שדות ה-base נשמרים במלואם', () {
+      SearchDefaults.saveResultGroupingDefault(
+        ResultGroupingMode.identicalText,
+      );
+
+      const base = SearchConfiguration(
+        searchMode: SearchMode.fuzzy,
+        distance: 3,
+        proximityScope: SearchScope.sameParagraph,
+        currentFacets: ['/תנך'],
+        searchScopeFacets: ['/תנך'],
+        numResults: 250,
+        wordMatchCount: 4,
+      );
+
+      final config = SearchDefaults.withResultPreferences(base);
+
+      expect(config.resultGrouping, ResultGroupingMode.identicalText);
+      expect(config.searchMode, SearchMode.fuzzy);
+      expect(config.distance, 3);
+      expect(config.proximityScope, SearchScope.sameParagraph);
+      expect(config.currentFacets, ['/תנך']);
+      expect(config.searchScopeFacets, ['/תנך']);
+      expect(config.numResults, 250);
+      expect(config.wordMatchCount, 4);
+    });
+
+    test('בלי העדפה שמורה ה-base אינו משתנה בכלל', () {
+      const base = SearchConfiguration(
+        searchMode: SearchMode.exact,
+        distance: 2,
+      );
+
+      expect(SearchDefaults.withResultPreferences(base), base);
+    });
+  });
+
+  group('SearchBloc שומר את בחירת המשתמש', () {
+    SearchBloc buildBloc({SearchConfiguration? configuration}) {
+      final bloc = SearchBloc(
+        initialConfiguration:
+            configuration ?? const SearchConfiguration(currentFacets: ['/']),
+        repository: SearchRepository(
+          engineProvider: () async => RecordingSearchEngine(),
+        ),
+      );
+      addTearDown(bloc.close);
+      return bloc;
+    }
+
+    test('בחירת מצב איחוד נשמרת להעדפות', () async {
+      final bloc = buildBloc();
+
+      bloc.add(UpdateResultGrouping(ResultGroupingMode.sameSection));
+      await pumpEventQueue();
+
+      expect(bloc.state.resultGrouping, ResultGroupingMode.sameSection);
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.sameSection,
+      );
+    });
+
+    test('בחירת מיון נשמרת להעדפות', () async {
+      final bloc = buildBloc();
+
+      bloc.add(UpdateSortOrder(ResultsOrder.relevance));
+      await pumpEventQueue();
+
+      expect(bloc.state.sortBy, ResultsOrder.relevance);
+      expect(
+        SearchDefaults.initialSortOrderForNewSearch(),
+        ResultsOrder.relevance,
+      );
+    });
+
+    test('בחירה אחרונה גוברת על קודמת', () async {
+      final bloc = buildBloc();
+
+      bloc.add(UpdateResultGrouping(ResultGroupingMode.identicalText));
+      await pumpEventQueue();
+      bloc.add(UpdateResultGrouping(ResultGroupingMode.none));
+      await pumpEventQueue();
+
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.none,
+      );
+    });
+
+    // בטאב משוחזר ה-state כבר במצב שהמשתמש בוחר, וההעדפה עדיין מפגרת אחריו.
+    test('בחירה שזהה למוצג נשמרת גם כשאין שינוי state', () async {
+      final bloc = buildBloc(
+        configuration: const SearchConfiguration(
+          currentFacets: ['/'],
+          resultGrouping: ResultGroupingMode.sameSection,
+        ),
+      );
+
+      bloc.add(UpdateResultGrouping(ResultGroupingMode.sameSection));
+      await pumpEventQueue();
+
+      expect(
+        SearchDefaults.initialResultGroupingForNewSearch(),
+        ResultGroupingMode.sameSection,
+      );
+    });
+
+    // אותו מלכוד במיון: אין שם early return היום, ואם יתווסף אחד — הבחירה
+    // בטאב משוחזר חייבת להמשיך להישמר.
+    test('בחירת מיון שזהה למוצג נשמרת אף היא', () async {
+      final bloc = buildBloc(
+        configuration: const SearchConfiguration(
+          currentFacets: ['/'],
+          sortBy: ResultsOrder.relevance,
+        ),
+      );
+
+      bloc.add(UpdateSortOrder(ResultsOrder.relevance));
+      await pumpEventQueue();
+
+      expect(
+        SearchDefaults.initialSortOrderForNewSearch(),
+        ResultsOrder.relevance,
+      );
+    });
+  });
+
+  group('טאב חיפוש חדש נפתח עם ההעדפה', () {
+    test('טאב בלי configuration מקבל את המיון והאיחוד השמורים', () {
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance);
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.sameSection);
+
+      final tab = SearchingTab('חיפוש', 'בראשית ברא');
+      addTearDown(tab.dispose);
+
+      expect(tab.searchBloc.state.sortBy, ResultsOrder.relevance);
+      expect(
+        tab.searchBloc.state.resultGrouping,
+        ResultGroupingMode.sameSection,
+      );
+    });
+
+    test('טאב בלי configuration ובלי העדפה שמורה — ברירות המחדל', () {
+      final tab = SearchingTab('חיפוש', null);
+      addTearDown(tab.dispose);
+
+      expect(tab.searchBloc.state.sortBy, ResultsOrder.catalogue);
+      expect(tab.searchBloc.state.resultGrouping, ResultGroupingMode.none);
+    });
+
+    test('configuration מפורשת גוברת על ההעדפה — שחזור אינו נחטף', () {
+      SearchDefaults.saveResultGroupingDefault(
+        ResultGroupingMode.identicalText,
+      );
+
+      final tab = SearchingTab(
+        'חיפוש',
+        null,
+        initialConfiguration: const SearchConfiguration(
+          resultGrouping: ResultGroupingMode.none,
+          sortBy: ResultsOrder.generation,
+        ),
+      );
+      addTearDown(tab.dispose);
+
+      expect(tab.searchBloc.state.resultGrouping, ResultGroupingMode.none);
+      expect(tab.searchBloc.state.sortBy, ResultsOrder.generation);
+    });
+
+    // ההיסטוריה שומרת את הקונפיגורציה כמפה ובונה ממנה את הטאב; זה מסלול
+    // השחזור השלישי, והיחיד שמרכיב את ה-config בעצמו.
+    test('פריט היסטוריה נושא את המיון והאיחוד שנשמרו איתו', () {
+      const saved = SearchConfiguration(
+        sortBy: ResultsOrder.relevance,
+        resultGrouping: ResultGroupingMode.sameSection,
+      );
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.none);
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.catalogue);
+
+      final fromHistory = SearchConfiguration.fromMap(
+        saved.toMap(),
+      ).copyWith(currentFacets: ['/תנך'], searchScopeFacets: ['/תנך']);
+      final tab = SearchingTab(
+        'חיפוש',
+        null,
+        initialConfiguration: fromHistory,
+      );
+      addTearDown(tab.dispose);
+
+      expect(tab.searchBloc.state.sortBy, ResultsOrder.relevance);
+      expect(
+        tab.searchBloc.state.resultGrouping,
+        ResultGroupingMode.sameSection,
+      );
+      expect(tab.searchBloc.state.currentFacets, ['/תנך']);
+    });
+
+    test('שכפול טאב נושא את מצב המקור ולא את ההעדפה', () {
+      final original = SearchingTab(
+        'חיפוש',
+        'בראשית',
+        initialConfiguration: const SearchConfiguration(
+          resultGrouping: ResultGroupingMode.identicalText,
+        ),
+      );
+      addTearDown(original.dispose);
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.none);
+
+      final clone = SearchingTab.clone(original);
+      addTearDown(clone.dispose);
+
+      expect(
+        clone.searchBloc.state.resultGrouping,
+        ResultGroupingMode.identicalText,
+      );
+    });
+  });
+
+  group(
+    'ההעדפה מגיעה עד למנוע',
+    () {
+      test('החיפוש הראשון בטאב חדש נשלח למנוע מקובץ', () async {
+        SearchDefaults.saveResultGroupingDefault(
+          ResultGroupingMode.sameSection,
+        );
+        SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance);
+        final engine = RecordingSearchEngine();
+        final bloc = SearchBloc(
+          initialConfiguration: SearchDefaults.withResultPreferences(
+            const SearchConfiguration(currentFacets: ['/']),
+          ),
+          repository: SearchRepository(engineProvider: () async => engine),
+        );
+        addTearDown(bloc.close);
+
+        bloc.add(UpdateSearchQuery('בראשית ברא'));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+
+        expect(engine.lastRequest!.grouping, ResultGrouping.sameSection);
+        expect(engine.lastRequest!.order, ResultsOrder.relevance);
+      });
+
+      test('"ללא איחוד" שמור אינו מקבץ במנוע', () async {
+        SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.none);
+        final engine = RecordingSearchEngine();
+        final bloc = SearchBloc(
+          initialConfiguration: SearchDefaults.withResultPreferences(
+            const SearchConfiguration(currentFacets: ['/']),
+          ),
+          repository: SearchRepository(engineProvider: () async => engine),
+        );
+        addTearDown(bloc.close);
+
+        bloc.add(UpdateSearchQuery('בראשית ברא'));
+        await bloc.stream.firstWhere((state) => !state.isLoading);
+
+        expect(engine.lastRequest!.grouping, isNull);
+      });
+    },
+    skip: engineReady ? null : searchEngineSkipReason,
+  );
+}

--- a/test/search/search_results_preferences_uninitialized_test.dart
+++ b/test/search/search_results_preferences_uninitialized_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_defaults.dart';
+import 'package:otzaria/tabs/models/searching_tab.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show ResultsOrder;
+
+/// טאב חיפוש נבנה גם לפני שההעדפות אותחלו (טסטי ווידג'ט, אתחול מוקדם).
+/// הקובץ הזה מריץ בכוונה בלי `Settings.init` — קריאת ההעדפה שם אסור שתקרוס.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('הקובץ אכן רץ בלי אתחול ההעדפות', () {
+    expect(Settings.isInitialized, isFalse);
+  });
+
+  test('קריאת ההעדפות בלי אתחול מחזירה ברירות מחדל', () {
+    expect(
+      SearchDefaults.initialSortOrderForNewSearch(),
+      ResultsOrder.catalogue,
+    );
+    expect(
+      SearchDefaults.initialResultGroupingForNewSearch(),
+      ResultGroupingMode.none,
+    );
+  });
+
+  test('שמירת העדפה בלי אתחול אינה זורקת', () {
+    expect(
+      () => SearchDefaults.saveResultGroupingDefault(
+        ResultGroupingMode.sameSection,
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance),
+      returnsNormally,
+    );
+  });
+
+  test('withResultPreferences בלי אתחול מחזיר את ה-base כמו שהוא', () {
+    const base = SearchConfiguration(searchMode: SearchMode.exact, distance: 2);
+
+    expect(SearchDefaults.withResultPreferences(base), base);
+  });
+
+  test('בניית טאב חיפוש בלי אתחול ההעדפות אינה זורקת', () {
+    final tab = SearchingTab('חיפוש', 'בראשית');
+    addTearDown(tab.dispose);
+
+    expect(tab.searchBloc.state.sortBy, ResultsOrder.catalogue);
+    expect(tab.searchBloc.state.resultGrouping, ResultGroupingMode.none);
+  });
+}

--- a/test/tabs/models/searching_tab_json_config_test.dart
+++ b/test/tabs/models/searching_tab_json_config_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_defaults.dart';
+import 'package:otzaria/tabs/models/searching_tab.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show ResultsOrder, SearchScope;
+
+import '../../helpers/memory_settings_cache.dart';
+
+/// טאב חיפוש נשמר ל-JSON בסגירת התוכנה ומשוחזר בהפעלה הבאה. `sortBy` היה
+/// שם מאז ומתמיד ו-`resultGrouping`/`proximityScope` לא — ולכן האיחוד וטווח
+/// הקרבה "נשכחו" בכל הפעלה בעוד המיון שרד.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+  });
+
+  SearchingTab tabWith(SearchConfiguration configuration) {
+    final tab = SearchingTab(
+      'חיפוש: בראשית',
+      'בראשית',
+      initialConfiguration: configuration,
+    );
+    addTearDown(tab.dispose);
+    return tab;
+  }
+
+  SearchingTab restore(Map<String, dynamic> json) {
+    final tab = SearchingTab.fromJson(json);
+    addTearDown(tab.dispose);
+    return tab;
+  }
+
+  group('שמירת מצב האיחוד ב-JSON של הטאב', () {
+    test('toJson כולל את מצב האיחוד', () {
+      final tab = tabWith(
+        const SearchConfiguration(
+          resultGrouping: ResultGroupingMode.sameSection,
+        ),
+      );
+
+      expect(
+        tab.toJson()['resultGrouping'],
+        ResultGroupingMode.sameSection.index,
+      );
+    });
+
+    test('כל מצב איחוד עובר שמירה ושחזור', () {
+      for (final mode in ResultGroupingMode.values) {
+        final tab = tabWith(SearchConfiguration(resultGrouping: mode));
+
+        final restored = restore(tab.toJson());
+
+        expect(
+          restored.searchBloc.state.resultGrouping,
+          mode,
+          reason: mode.label,
+        );
+      }
+    });
+
+    test('המיון והאיחוד משוחזרים יחד ואינם דורסים זה את זה', () {
+      final tab = tabWith(
+        const SearchConfiguration(
+          sortBy: ResultsOrder.relevance,
+          resultGrouping: ResultGroupingMode.identicalText,
+        ),
+      );
+
+      final restored = restore(tab.toJson());
+
+      expect(restored.searchBloc.state.sortBy, ResultsOrder.relevance);
+      expect(
+        restored.searchBloc.state.resultGrouping,
+        ResultGroupingMode.identicalText,
+      );
+    });
+
+    test('שאר קונפיגורציית החיפוש שורדת את השחזור', () {
+      final tab = tabWith(
+        const SearchConfiguration(
+          searchMode: SearchMode.exact,
+          distance: 4,
+          numResults: 300,
+          resultGrouping: ResultGroupingMode.sameSection,
+          currentFacets: ['/תנך'],
+          searchScopeFacets: ['/תנך'],
+        ),
+      );
+
+      final restored = restore(tab.toJson()).searchBloc.state.configuration;
+
+      expect(restored.resultGrouping, ResultGroupingMode.sameSection);
+      expect(restored.searchMode, SearchMode.exact);
+      expect(restored.distance, 4);
+      expect(restored.numResults, 300);
+      expect(restored.currentFacets, ['/תנך']);
+    });
+  });
+
+  group('שמירת טווח הקרבה ב-JSON של הטאב', () {
+    test('toJson כולל את טווח הקרבה', () {
+      final tab = tabWith(
+        const SearchConfiguration(proximityScope: SearchScope.sameSection),
+      );
+
+      expect(tab.toJson()['proximityScope'], SearchScope.sameSection.index);
+    });
+
+    test('כל טווח קרבה עובר שמירה ושחזור', () {
+      for (final scope in SearchScope.values) {
+        final tab = tabWith(SearchConfiguration(proximityScope: scope));
+
+        final restored = restore(tab.toJson());
+
+        expect(
+          restored.searchBloc.state.proximityScope,
+          scope,
+          reason: scope.name,
+        );
+      }
+    });
+
+    test('טווח הקרבה, המרווח והמיון משוחזרים יחד', () {
+      final tab = tabWith(
+        const SearchConfiguration(
+          searchMode: SearchMode.advanced,
+          proximityScope: SearchScope.sameParagraph,
+          distance: 5,
+          sortBy: ResultsOrder.relevance,
+          resultGrouping: ResultGroupingMode.sameSection,
+        ),
+      );
+
+      final restored = restore(tab.toJson()).searchBloc.state.configuration;
+
+      expect(restored.proximityScope, SearchScope.sameParagraph);
+      expect(restored.distance, 5);
+      expect(restored.sortBy, ResultsOrder.relevance);
+      expect(restored.resultGrouping, ResultGroupingMode.sameSection);
+    });
+
+    test('טאב שנשמר בגרסה קודמת (בלי המפתח) נפתח במרווח מילים', () {
+      final saved = tabWith(
+        const SearchConfiguration(proximityScope: SearchScope.sameSection),
+      ).toJson()..remove('proximityScope');
+
+      expect(
+        restore(saved).searchBloc.state.proximityScope,
+        SearchScope.wordDistance,
+      );
+    });
+
+    test('אינדקס פגום נופל למרווח מילים', () {
+      final saved = tabWith(const SearchConfiguration()).toJson();
+
+      for (final broken in [
+        SearchScope.values.length,
+        99,
+        -1,
+        'sameSection',
+        null,
+      ]) {
+        expect(
+          restore({
+            ...saved,
+            'proximityScope': broken,
+          }).searchBloc.state.proximityScope,
+          SearchScope.wordDistance,
+          reason: '$broken',
+        );
+      }
+    });
+  });
+
+  group('שחזור טאב אינו נחטף על ידי ההעדפה השמורה', () {
+    test('טאב שנשמר עם "ללא איחוד" נפתח בלי איחוד גם כשההעדפה מאחדת', () {
+      final saved = tabWith(const SearchConfiguration()).toJson();
+      SearchDefaults.saveResultGroupingDefault(
+        ResultGroupingMode.identicalText,
+      );
+      SearchDefaults.saveSortOrderDefault(ResultsOrder.relevance);
+
+      final restored = restore(saved);
+
+      expect(restored.searchBloc.state.resultGrouping, ResultGroupingMode.none);
+      expect(restored.searchBloc.state.sortBy, ResultsOrder.catalogue);
+    });
+
+    test('טאב שנשמר עם איחוד נפתח מאוחד גם כשההעדפה "ללא איחוד"', () {
+      final saved = tabWith(
+        const SearchConfiguration(
+          resultGrouping: ResultGroupingMode.sameSection,
+        ),
+      ).toJson();
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.none);
+
+      final restored = restore(saved);
+
+      expect(
+        restored.searchBloc.state.resultGrouping,
+        ResultGroupingMode.sameSection,
+      );
+    });
+  });
+
+  group('JSON חסר או פגום', () {
+    test('טאב שנשמר בגרסה קודמת (בלי המפתח) נפתח בלי איחוד', () {
+      final saved = tabWith(
+        const SearchConfiguration(
+          resultGrouping: ResultGroupingMode.identicalText,
+        ),
+      ).toJson()..remove('resultGrouping');
+      SearchDefaults.saveResultGroupingDefault(ResultGroupingMode.sameSection);
+
+      final restored = restore(saved);
+
+      expect(restored.searchBloc.state.resultGrouping, ResultGroupingMode.none);
+    });
+
+    test('אינדקס מחוץ לטווח נופל ל"ללא איחוד"', () {
+      final saved = tabWith(const SearchConfiguration()).toJson();
+
+      for (final broken in [ResultGroupingMode.values.length, 99, -1]) {
+        expect(
+          restore({
+            ...saved,
+            'resultGrouping': broken,
+          }).searchBloc.state.resultGrouping,
+          ResultGroupingMode.none,
+          reason: '$broken',
+        );
+      }
+    });
+
+    test('ערך שאינו מספר נופל ל"ללא איחוד"', () {
+      final saved = tabWith(const SearchConfiguration()).toJson();
+
+      expect(
+        restore({
+          ...saved,
+          'resultGrouping': 'sameSection',
+        }).searchBloc.state.resultGrouping,
+        ResultGroupingMode.none,
+      );
+      expect(
+        restore({
+          ...saved,
+          'resultGrouping': null,
+        }).searchBloc.state.resultGrouping,
+        ResultGroupingMode.none,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## הבעיה

בסרגל תוצאות החיפוש יש שני בוררים: **מיון** ו**איחוד תוצאות**. בחירת האיחוד לא נזכרה — כל חיפוש חדש נפתח שוב ב"ללא איחוד", בעוד המיון כן שרד הפעלה מחדש. משתמש שמעדיף לעבוד עם תוצאות מאוחדות נאלץ לבחור מחדש בכל חיפוש.

## השורש

`SearchingTab.toJson` שמר `sortBy` ולא `resultGrouping` — לא בשמירה ולא בטעינה. מכאן ההבדל: המיון שרד את שחזור הטאב, האיחוד נמחק. מעבר לכך, לאף אחד מהשניים לא הייתה ברירת מחדל שמורה, ולכן גם טאב חיפוש חדש תמיד התחיל מאפס.

## התיקון

- **`SearchDefaults`** — שתי הבחירות נשמרות כברירת מחדל ברגע שהמשתמש בוחר, ונטענות לכל חיפוש חדש. הערך נשמר לפי שמו ולא לפי אינדקסו, כדי שהוספת אפשרות באמצע ה-enum לא תהפוך העדפה שמורה לערך אחר.
- **`SearchingTab`** — `resultGrouping` נוסף ל-`toJson`/`fromJson`. לצדו נוסף גם `proximityScope` (טווח הקרבה בחיפוש המתקדם), שסבל מאותה שכחה בדיוק.
- **שחזור אינו נחטף** — טאב שמשוחזר מ-JSON, משכפול או מההיסטוריה ממשיך לשאת את הערכים שנשמרו איתו, ולא את ברירת המחדל. יש על כך בדיקות מפורשות.
- הבנאי של `SearchingTab` מחיל את ברירת המחדל רק כשלא הועברה `configuration` — כלומר על טאב חדש בלבד. מסלולי החיפוש החדש שכן בונים `configuration` (דיאלוג החיפוש, חיפוש חיצוני) מחילים אותה במפורש.
- טאב השירות של דיאלוג החיפוש **אינו** מקבל את ברירת המחדל בכוונה: המיון והאיחוד שלו נראים בבקשה שנשלחת לתוספים, ואין סיבה לשנות את מה שתוסף מקבל.

## בדיקות

‏49 בדיקות חדשות בשלושה קבצים, ואחת בקובץ הקיים של דיאלוג החיפוש:

| קובץ | מכסה |
|---|---|
| `test/search/search_results_preferences_test.dart` | שמירה וטעינה של כל הערכים, מפתחות נפרדים, ערך פגום/ריק, שמירה לפי שם, ה-BLoC שומר על כל בחירה (כולל בחירה שזהה למוצג), טאב חדש, שכפול, שחזור מהיסטוריה, והמסלול עד למנוע |
| `test/tabs/models/searching_tab_json_config_test.dart` | שמירה ושחזור של האיחוד וטווח הקרבה, JSON מגרסה קודמת בלי המפתחות, אינדקס מחוץ לטווח וערך שאינו מספר |
| `test/search/search_results_preferences_uninitialized_test.dart` | קובץ שרץ בכוונה בלי `Settings.init`, כדי שקריאת ההעדפה לא תקרוס באתחול מוקדם או בבדיקות ווידג'ט |
| `test/search/search_dialog_test.dart` | טאב שנפתח מהדיאלוג — המסלול הראשי — נושא את הבחירה השמורה |

`flutter analyze` נקי, ו-`flutter test test/search test/tabs` עובר במלואו על בסיס `dev`.

## הערה למי שסוקר

איחוד תוצאות פעיל משבית את מסלול הסינון המקומי בעץ התוצאות (`search_bloc.dart`, ה-guard על `resultGrouping != none`) — כל לחיצה על קטגוריה חוזרת למנוע. זו התנהגות קיימת של האיחוד, אבל מרגע שהבחירה נזכרת היא הופכת דביקה. זו הייתה בקשה מפורשת של המשתמש שדיווח.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
