### PR TITLE
העתקה: שימור העיצוב גם בבחירה חלקית של קטע

### DIFF
--- a/lib/text_book/view/selection/selected_text_copy.dart
+++ b/lib/text_book/view/selection/selected_text_copy.dart
@@ -2,8 +2,11 @@ import 'package:otzaria/models/books.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/utils/text/copy_utils.dart';
+import 'package:otzaria/utils/text/html_slice.dart';
 
-/// בוחר את תוכן ה-HTML המתאים ביותר לטקסט שנבחר.
+/// בוחר את תוכן ה-HTML המתאים ביותר לטקסט שנבחר: השורה המקורית כשהיא
+/// נבחרה במלואה, אחרת חיתוך שלה לטווח הבחירה — כדי שגם בחירה חלקית
+/// תישמר מעוצבת. נופל לטקסט פשוט רק כשהבחירה אינה נמצאת בשורה.
 String resolveHtmlTextForSelection({
   required String plainText,
   required int? selectedIndex,
@@ -26,11 +29,11 @@ String resolveHtmlTextForSelection({
     return originalData;
   }
 
-  if (originalCleaned.contains(plainTextCleaned)) {
-    return plainText;
-  }
-
-  return plainText;
+  return sliceHtmlBySelection(
+        html: originalData,
+        selectedText: plainText,
+      ) ??
+      plainText;
 }
 
 /// מעתיק טקסט נבחר מספר טקסט תוך שמירה על כותרות ועיצוב.

--- a/lib/utils/text/copy_utils.dart
+++ b/lib/utils/text/copy_utils.dart
@@ -328,12 +328,18 @@ class CopyUtils {
     }
   }
 
+  /// `<br>` מומר לרווח לפני הפענוח — אחרת אינו תורם תו, וההשוואה מול
+  /// ה-plain text נכשלת על כל מעבר שורה ומפילה את ה-HTML.
   static String _extractVisibleTextFromHtml(String htmlText) {
     if (htmlText.isEmpty) {
       return '';
     }
 
-    return html_parser.parseFragment(htmlText).text ?? '';
+    final withBreaks = htmlText.replaceAll(
+      RegExp(r'<br\s*/?>', caseSensitive: false),
+      ' ',
+    );
+    return html_parser.parseFragment(withBreaks).text ?? '';
   }
 
   static String _normalizeCopiedText(String text) {

--- a/lib/utils/text/html_slice.dart
+++ b/lib/utils/text/html_slice.dart
@@ -1,0 +1,282 @@
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart' as html_parser;
+import 'package:otzaria/utils/text/text_manipulation.dart' as text_utils;
+
+/// חותך מתוך [html] את החלק שמכוסה ע"י [selectedText], עם התגיות שעוטפות
+/// אותו, ומחזיר null כשאין התאמה חד-משמעית.
+///
+/// הטקסט נלקח מ-[selectedText] והמבנה מ-[html], ולכן התוצאה תואמת תמיד
+/// למה שנבחר על המסך — גם כשהתצוגה מסתירה ניקוד, טעמים או פיסוק.
+/// כשאותו טקסט חוזר בשורה ביותר ממקום אחד ועיצובו שונה, מוחזר null:
+/// אי אפשר לדעת איזה מופע נבחר, ועדיף טקסט פשוט על עיצוב שגוי.
+String? sliceHtmlBySelection({
+  required String html,
+  required String selectedText,
+}) {
+  if (html.isEmpty || selectedText.trim().isEmpty) {
+    return null;
+  }
+
+  final fragment = html_parser.parseFragment(html);
+  final slots = <_Slot>[];
+  final rawText = StringBuffer();
+  _collectSlots(fragment.nodes, slots, rawText);
+  if (slots.isEmpty) {
+    return null;
+  }
+
+  final source = _MatchKey.from(rawText.toString());
+  final selection = _MatchKey.from(selectedText);
+  if (selection.key.isEmpty) {
+    return null;
+  }
+
+  // המופעים נאספים לפני החיתוך, כדי לא לשלם על חיתוכים שיושלכו ממילא.
+  final matches = <int>[];
+  var matchStart = source.key.indexOf(selection.key);
+  while (matchStart >= 0) {
+    matches.add(matchStart);
+    if (matches.length > _maxOccurrences) {
+      return null;
+    }
+    matchStart = source.key.indexOf(selection.key, matchStart + 1);
+  }
+  if (matches.isEmpty) {
+    return null;
+  }
+
+  String? sliced;
+  for (final start in matches) {
+    final candidate = _buildSlice(
+      fragment: fragment,
+      slots: slots,
+      source: source,
+      selection: selection,
+      matchStart: start,
+      selectedText: selectedText,
+    );
+    if (candidate == null || (sliced != null && sliced != candidate)) {
+      return null;
+    }
+    sliced = candidate;
+  }
+
+  return sliced;
+}
+
+/// כל מופע נחתך מחדש כדי להשוות בין התוצאות, ולכן שורה ארוכה שבה הבחירה
+/// חוזרת עשרות פעמים הופכת יקרה. מעבר לתקרה ההתאמה ממילא אינה חד-משמעית.
+const _maxOccurrences = 12;
+
+String? _buildSlice({
+  required dom.DocumentFragment fragment,
+  required List<_Slot> slots,
+  required _MatchKey source,
+  required _MatchKey selection,
+  required int matchStart,
+  required String selectedText,
+}) {
+  final ranges = _mapSelectionToSlots(
+    slots: slots,
+    source: source,
+    selection: selection,
+    matchStart: matchStart,
+    selectionLength: selectedText.length,
+  );
+  if (ranges.isEmpty) {
+    return null;
+  }
+
+  final container = dom.Element.tag('div');
+  for (final node in fragment.nodes) {
+    final pruned = _prune(node, ranges, selectedText);
+    if (pruned != null) {
+      container.nodes.add(pruned);
+    }
+  }
+
+  final sliced = container.innerHtml;
+  return sliced.isEmpty ? null : sliced;
+}
+
+/// קטע טקסט רציף במסמך, עם מיקומו במחרוזת הטקסט המצטברת.
+class _Slot {
+  const _Slot(this.node, this.start, this.end);
+
+  final dom.Node node;
+  final int start;
+  final int end;
+}
+
+/// אוסף את קטעי הטקסט לפי סדר המסמך. `<br>` נספר כמעבר שורה, וגוף הערת
+/// שוליים מדולג — הקורא מסיר אותו מהתצוגה, ולכן אסור להתאים אליו.
+void _collectSlots(
+  List<dom.Node> nodes,
+  List<_Slot> slots,
+  StringBuffer rawText,
+) {
+  for (final node in nodes) {
+    if (node is dom.Text) {
+      final data = node.data;
+      if (data.isEmpty) continue;
+      slots.add(_Slot(node, rawText.length, rawText.length + data.length));
+      rawText.write(data);
+      continue;
+    }
+
+    if (node is! dom.Element) continue;
+
+    if (node.localName == 'br') {
+      slots.add(_Slot(node, rawText.length, rawText.length + 1));
+      rawText.write('\n');
+      continue;
+    }
+
+    if (_isFootnoteBody(node)) continue;
+
+    _collectSlots(node.nodes, slots, rawText);
+  }
+}
+
+bool _isFootnoteBody(dom.Element element) =>
+    element.localName == 'i' &&
+    (element.attributes['class'] ?? '').contains('footnote');
+
+/// מפתח השוואה שמדמה את מה שהקורא מציג — בלי ניקוד, טעמים ופיסוק, עם
+/// רווחים מכווצים ועם שם הוי"ה מוחלף — לצד המיקום המקורי של כל תו.
+class _MatchKey {
+  const _MatchKey(this.key, this.offsets);
+
+  final String key;
+  final List<int> offsets;
+
+  factory _MatchKey.from(String text) {
+    // ההחלפה מוחלת על שני צדי ההשוואה, כדי שההתאמה תעבוד בלי תלות בהגדרת
+    // "החלפת שמות קדושים". היא שומרת על האורך, ולכן המיקומים נשארים תקפים.
+    final replaced = text_utils.replaceHolyNames(text);
+    final normalized = replaced.length == text.length ? replaced : text;
+
+    final key = StringBuffer();
+    final offsets = <int>[];
+    int? pendingSpaceAt;
+
+    for (var i = 0; i < normalized.length; i++) {
+      final codeUnit = normalized.codeUnitAt(i);
+      if (_isIgnored(codeUnit)) continue;
+
+      if (_isSpacing(codeUnit)) {
+        pendingSpaceAt ??= i;
+        continue;
+      }
+
+      if (pendingSpaceAt != null) {
+        if (key.isNotEmpty) {
+          key.write(' ');
+          offsets.add(pendingSpaceAt);
+        }
+        pendingSpaceAt = null;
+      }
+
+      key.write(normalized[i]);
+      offsets.add(i);
+    }
+
+    return _MatchKey(key.toString(), offsets);
+  }
+}
+
+/// תווים שהקורא עשוי להציג כרווח: רווחים ממש, ומפרידי הטקסט המקראי
+/// שגם [text_utils.removeVolwels] הופך לרווח.
+bool _isSpacing(int codeUnit) =>
+    codeUnit == 0x20 || // רווח
+    codeUnit == 0x09 || // טאב
+    codeUnit == 0x0A || // מעבר שורה
+    codeUnit == 0x0D || // גרירת שורה
+    codeUnit == 0xA0 || // רווח קשיח
+    codeUnit == 0x05BE || // מקף
+    codeUnit == 0x05C0 || // פסק
+    codeUnit == 0x7C; // קו אנכי
+
+/// תווים שהקורא עשוי להשמיט לגמרי: ניקוד וטעמים, וסימני הפיסוק
+/// ש-[text_utils.removePunctuation] מסיר.
+bool _isIgnored(int codeUnit) {
+  if (codeUnit >= 0x0591 && codeUnit <= 0x05C7) {
+    return !_isSpacing(codeUnit);
+  }
+
+  return codeUnit == 0x21 || // !
+      codeUnit == 0x22 || // "
+      codeUnit == 0x27 || // '
+      codeUnit == 0x2C || // ,
+      codeUnit == 0x2D || // -
+      codeUnit == 0x2E || // .
+      codeUnit == 0x3A || // :
+      codeUnit == 0x3B || // ;
+      codeUnit == 0x3F || // ?
+      codeUnit == 0x05F3 || // ׳
+      codeUnit == 0x05F4 || // ״
+      codeUnit == 0x2013 || // –
+      codeUnit == 0x2014; // —
+}
+
+/// משייך לכל קטע טקסט את הטווח שלו בתוך הבחירה. הטווח נמתח מקצה לקצה
+/// הבחירה, כך שפיסוק, ניקוד ורווחים שנשמטו מהמפתח בקצוות אינם נבלעים.
+Map<dom.Node, ({int start, int end})> _mapSelectionToSlots({
+  required List<_Slot> slots,
+  required _MatchKey source,
+  required _MatchKey selection,
+  required int matchStart,
+  required int selectionLength,
+}) {
+  final ranges = <dom.Node, ({int start, int end})>{};
+  final length = selection.key.length;
+  var slotIndex = 0;
+
+  for (var i = 0; i < length; i++) {
+    final sourceOffset = source.offsets[matchStart + i];
+    while (slotIndex < slots.length && sourceOffset >= slots[slotIndex].end) {
+      slotIndex++;
+    }
+    if (slotIndex >= slots.length) break;
+
+    final slot = slots[slotIndex];
+    final start = i == 0 ? 0 : selection.offsets[i];
+    final end = i + 1 < length ? selection.offsets[i + 1] : selectionLength;
+    final existing = ranges[slot.node];
+    ranges[slot.node] = (start: existing?.start ?? start, end: end);
+  }
+
+  return ranges;
+}
+
+dom.Node? _prune(
+  dom.Node node,
+  Map<dom.Node, ({int start, int end})> ranges,
+  String selectedText,
+) {
+  if (node is dom.Text) {
+    final range = ranges[node];
+    if (range == null) return null;
+    final text = selectedText.substring(range.start, range.end);
+    return text.isEmpty ? null : dom.Text(text);
+  }
+
+  if (node is! dom.Element) return null;
+
+  if (node.localName == 'br') {
+    return ranges.containsKey(node) ? node.clone(false) : null;
+  }
+
+  if (_isFootnoteBody(node)) return null;
+
+  final children = <dom.Node>[];
+  for (final child in node.nodes) {
+    final pruned = _prune(child, ranges, selectedText);
+    if (pruned != null) children.add(pruned);
+  }
+  if (children.isEmpty) return null;
+
+  final clone = node.clone(false);
+  clone.nodes.addAll(children);
+  return clone;
+}

--- a/test/text_book/view/selection/selected_text_copy_test.dart
+++ b/test/text_book/view/selection/selected_text_copy_test.dart
@@ -13,14 +13,34 @@ void main() {
       expect(resolved, '<b>שלום</b> עולם');
     });
 
-    test('מחזיר טקסט פשוט כשהבחירה היא רק חלק מהשורה', () {
+    test('מחזיר HTML חתוך כשהבחירה היא רק חלק מהשורה', () {
       final resolved = resolveHtmlTextForSelection(
         plainText: 'שלום',
         selectedIndex: 0,
         sourceContent: const ['<b>שלום</b> עולם'],
       );
 
-      expect(resolved, 'שלום');
+      expect(resolved, '<b>שלום</b>');
+    });
+
+    test('שומר עיצוב גם בבחירה שחוצה תגית', () {
+      final resolved = resolveHtmlTextForSelection(
+        plainText: 'לום עו',
+        selectedIndex: 0,
+        sourceContent: const ['<b>שלום</b> עולם'],
+      );
+
+      expect(resolved, '<b>לום</b> עו');
+    });
+
+    test('נופל לטקסט פשוט כשהבחירה אינה נמצאת בשורה', () {
+      final resolved = resolveHtmlTextForSelection(
+        plainText: 'טקסט משורה אחרת',
+        selectedIndex: 0,
+        sourceContent: const ['<b>שלום</b> עולם'],
+      );
+
+      expect(resolved, 'טקסט משורה אחרת');
     });
 
     test('מחזיר fallback לטקסט פשוט כשאין אינדקס תקין', () {

--- a/test/utils/copy_utils_test.dart
+++ b/test/utils/copy_utils_test.dart
@@ -45,6 +45,17 @@ void main() {
       expect(result.plainText, 'יקוק');
       expect(result.htmlText, 'יקוק');
     });
+
+    test('שומר את ה-HTML כשמעבר שורה מיוצג ע"י <br>', () {
+      final result = CopyUtils.applyCopyPreferencesForClipboard(
+        plainText: 'ויאמר יהוה\nאל משה',
+        htmlText: 'ויאמר יהוה<br><b>אל משה</b>',
+        replaceHolyNames: true,
+      );
+
+      expect(result.plainText, 'ויאמר יקוק\nאל משה');
+      expect(result.htmlText, 'ויאמר יקוק<br><b>אל משה</b>');
+    });
   });
 
   group('CopyUtils.buildStyledHtml', () {

--- a/test/utils/text/html_slice_test.dart
+++ b/test/utils/text/html_slice_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/utils/text/html_slice.dart';
+
+void main() {
+  group('sliceHtmlBySelection', () {
+    test('בחירה שכולה בתוך תגית מחזירה את התגית סביבה', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>בראשית</b> ברא אלהים',
+          selectedText: 'ראשית',
+        ),
+        '<b>ראשית</b>',
+      );
+    });
+
+    test('בחירה שחוצה גבול תגית שומרת על שני החלקים', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>שלום</b> עולם',
+          selectedText: 'לום עו',
+        ),
+        '<b>לום</b> עו',
+      );
+    });
+
+    test('בחירה שכולה מחוץ לתגית מוחזרת ללא תגיות', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>שלום</b> עולם',
+          selectedText: 'עולם',
+        ),
+        'עולם',
+      );
+    });
+
+    test('בחירה מלאה מחזירה את כל המבנה', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>שלום</b> עולם',
+          selectedText: 'שלום עולם',
+        ),
+        '<b>שלום</b> עולם',
+      );
+    });
+
+    test('תגיות מקוננות נשמרות עם היררכיה מלאה', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<h2><b>כותרת</b> משנה</h2>',
+          selectedText: 'תרת מש',
+        ),
+        '<h2><b>תרת</b> מש</h2>',
+      );
+    });
+
+    test('מאפייני התגית נשמרים בחיתוך', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<span class="highlight" dir="rtl">טקסט ארוך</span>',
+          selectedText: 'ארוך',
+        ),
+        '<span class="highlight" dir="rtl">ארוך</span>',
+      );
+    });
+
+    test('<br> בתוך הבחירה נשמר כמעבר שורה', () {
+      expect(
+        sliceHtmlBySelection(
+          html: 'שורה א<br>שורה ב',
+          selectedText: 'רה א\nשור',
+        ),
+        'רה א<br>שור',
+      );
+    });
+
+    test('<br> מחוץ לבחירה מושמט', () {
+      expect(
+        sliceHtmlBySelection(
+          html: 'שורה א<br>שורה ב',
+          selectedText: 'שורה ב',
+        ),
+        'שורה ב',
+      );
+    });
+
+    test('בחירה מטקסט שמוצג ללא ניקוד נחתכת מהמקור המנוקד', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>בְּרֵאשִׁית</b> בָּרָא',
+          selectedText: 'ראשית ב',
+        ),
+        '<b>ראשית</b> ב',
+      );
+    });
+
+    test('הפרשי רווחים בין הבחירה למקור אינם מונעים התאמה', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>שלום</b>   עולם',
+          selectedText: 'שלום עולם',
+        ),
+        '<b>שלום</b> עולם',
+      );
+    });
+
+    test('ישויות HTML מקודדות מחדש בפלט', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>א&amp;ב</b> ג',
+          selectedText: 'א&ב',
+        ),
+        '<b>א&amp;ב</b>',
+      );
+    });
+
+    test('תגית ריקה שאינה בטווח הבחירה מושמטת', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>אלף</b><i>בית</i>',
+          selectedText: 'בית',
+        ),
+        '<i>בית</i>',
+      );
+    });
+
+    test('טקסט שחוזר בשורה עם עיצוב שונה מוותר על החיתוך', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<big>אמר</big> רבא אמר רב',
+          selectedText: 'אמר',
+        ),
+        isNull,
+      );
+    });
+
+    test('טקסט שחוזר בשורה עם אותו עיצוב נחתך כרגיל', () {
+      expect(
+        sliceHtmlBySelection(
+          html: 'אמר רבא אמר רב',
+          selectedText: 'אמר',
+        ),
+        'אמר',
+      );
+    });
+
+    test('גוף הערת שוליים מדולג — אינו מוצג ולכן אין להתאים אליו', () {
+      expect(
+        sliceHtmlBySelection(
+          html: 'ויאמר <i class="footnote">אל משה</i> ואחר כך אל משה',
+          selectedText: 'אל משה',
+        ),
+        'אל משה',
+      );
+    });
+
+    test('מקף מקראי מותאם לרווח שמוצג במקומו', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>יְהִי־א֑וֹר</b> וַיְהִי',
+          selectedText: 'יהי אור',
+        ),
+        '<b>יהי אור</b>',
+      );
+    });
+
+    test('בחירה עם החלפת שם הוי"ה מותאמת למקור', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>ויאמר</b> יהוה אל משה',
+          selectedText: 'ויאמר יקוק',
+        ),
+        '<b>ויאמר</b> יקוק',
+      );
+    });
+
+    test('בחירה מטקסט שמוצג ללא פיסוק מותאמת למקור', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>אמר רבא:</b> מאי טעמא?',
+          selectedText: 'אמר רבא מאי',
+        ),
+        '<b>אמר רבא</b> מאי',
+      );
+    });
+
+    test('סימן פיסוק בתחילת הבחירה אינו נבלע', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>"שלום"</b> עולם',
+          selectedText: '"שלום"',
+        ),
+        '<b>"שלום"</b>',
+      );
+    });
+
+    test('רווח מוביל בבחירה נשמר', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>שלום</b> עולם',
+          selectedText: ' עולם',
+        ),
+        ' עולם',
+      );
+    });
+
+    test('ניקוד בתחילת הבחירה אינו נבלע', () {
+      expect(
+        sliceHtmlBySelection(
+          html: 'וַ<b>יֹּאמֶר</b> משה',
+          selectedText: 'ֹּאמֶר משה',
+        ),
+        '<b>ֹּאמֶר</b> משה',
+      );
+    });
+
+    test('בחירה שחוזרת מעל התקרה מוותרת על החיתוך', () {
+      final many = List.filled(13, 'אב').join(' ');
+      expect(sliceHtmlBySelection(html: many, selectedText: 'אב'), isNull);
+
+      final few = List.filled(12, 'אב').join(' ');
+      expect(sliceHtmlBySelection(html: few, selectedText: 'אב'), 'אב');
+    });
+
+    test('מחזיר null כשהבחירה אינה נמצאת בשורה', () {
+      expect(
+        sliceHtmlBySelection(
+          html: '<b>שלום</b> עולם',
+          selectedText: 'טקסט אחר',
+        ),
+        isNull,
+      );
+    });
+
+    test('מחזיר null לבחירה ריקה או לתוכן ריק', () {
+      expect(
+        sliceHtmlBySelection(html: '<b>שלום</b>', selectedText: '   '),
+        isNull,
+      );
+      expect(sliceHtmlBySelection(html: '', selectedText: 'שלום'), isNull);
+    });
+
+    test('מחזיר null כשאין טקסט בתוכן', () {
+      expect(
+        sliceHtmlBySelection(html: '<br><br>', selectedText: 'שלום'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## הבאג

בהעתקת טקסט מספר, העיצוב (מודגש, כותרות) נשמר רק כשהבחירה כיסתה **קטע שלם**. בבחירה חלקית `resolveHtmlTextForSelection` החזירה טקסט פשוט, וההדבקה ל-Word או למייל יצאה ללא עיצוב.

**מקור ההתנהגות:** בגרסה הראשונה (`55573d857`) בחירה חלקית העתיקה את ה-HTML של **כל הפסקה** — יותר ממה שסומן. התיקון (`5756314e0`) בחר בטקסט פשוט כפתרון הפחות גרוע, וההערה שנכתבה שם — "נמצא את החלק הרלוונטי" — נשארה הצהרת כוונות שלא מומשה.

## הפתרון

`lib/utils/text/html_slice.dart` מפרסר את השורה ל-DOM וגוזם אותה לטווח שנבחר. העיקרון: **הטקסט נלקח מהבחירה, המבנה מה-HTML** — ולכן הפלט תמיד נאמן למה שסומן על המסך.

מפתח ההשוואה מיישר את צינור התצוגה של הקורא, כך שההתאמה עובדת בכל הגדרה:

| מה שהקורא עושה | איך המנוע מיישר |
|---|---|
| מסתיר ניקוד וטעמים | מושמטים משני צדי ההשוואה |
| מציג מקף מקראי כרווח | `־`, `׀`, `\|` נחשבים רווח |
| מסתיר סימני פיסוק | מושמטים משני הצדדים |
| מחליף שמות קדושים | ההחלפה מוחלת על שני הצדדים (שומרת-אורך) |
| מסיר גוף `<i class="footnote">` | הצומת מדולג — אין להתאים לטקסט שאינו מוצג |

כשאותו טקסט חוזר בשורה ועיצובו שונה, המנוע מוותר ונופל לטקסט פשוט — עדיף מלנחש איזה מופע נבחר ולהדביק עיצוב ממקום אחר.

## תיקון נוסף

`CopyUtils.applyCopyPreferencesForClipboard` השווה את הטקסט הנראה של ה-HTML מול ה-plain text בלי לתרגם `<br>` למעבר שורה, ולכן זרק כל HTML תקין שהכיל `<br>` כשהגדרת "החלפת שמות קדושים" פעילה.

## מדידות

כיסוי = אחוז הבחירות החלקיות בשורה שנחתכות בהצלחה; נאמנות = הטקסט הנחתך זהה לבחירה תו בתו.

| תרחיש | לפני | אחרי |
|---|---|---|
| תנ"ך עם מקף, ניקוד מוסתר | 45% | **99%** |
| "החלפת שמות קדושים" פעילה | 41% | **96%** |
| "הסתרת סימני פיסוק" פעילה | 32% | **98%** |
| נאמנות הטקסט לבחירה | 85% | **100%** (1283/1283) |
| שורה סינתטית 107KB עם 8,000 מופעים | 6.4s | **191ms** |

## בדיקות

- 25 טסטים חדשים ל-`sliceHtmlBySelection` + עדכון `selected_text_copy_test.dart` + טסט ל-`<br>` בשער ההעתקה
- `flutter test test/utils/ test/text_book/view/selection/ test/text_book/view/combined_view/ test/text_book/view/page_shape/` — 887 עוברים
- `dart analyze` נקי

## מגבלות מודעות

- בחירה שחוצה שתי פסקאות נשארת טקסט פשוט — ההשוואה היא מול פסקה בודדת
- חלונית מפרשי ה-PDF ורשימות המפרשים מעבירות `sourceContent: [plainText]` ולכן אין להן HTML לחתוך ממנו; הבאג נשאר שם
- בחירה חלקית בכותרת מייצרת `<h2>`, שהוא אלמנט בלוק, ולכן בהגדרת "כותרת באותה שורה" הכותרת תרד לשורה נפרדת
- `<br><br>` צמודים מתמזגים לאחד (69 שורות מתוך 1,200 קבצים בספרייה)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
