### PR TITLE
איתור מקורות: איתור סימן בטור עם שם החלק המלא ובראשי תיבות

### DIFF
--- a/lib/find_ref/repository/find_ref_repository.dart
+++ b/lib/find_ref/repository/find_ref_repository.dart
@@ -614,6 +614,10 @@ class FindRefRepository {
             : (secondaryPhraseTokenCount[hit] ?? bookQueryTokenCount),
       );
 
+      // ראש-תיבות שזנבו אינו מילת-כותרת ("טור יורה דעה" / "טור יו"ד" מול
+      // הכותרת "טור") מציין חלק *בתוך* הספר — ראה [_acronymSectionTokens].
+      final sectionTokens = _acronymSectionTokens(hit);
+
       // הטוקן שאחרי שם-הספר עלול להיות בעצמו ספר עצמאי ("תורה אור" — "אור" ספר),
       // ואז חיפוש TOC לפיו יוצר התאמות-שווא חוצות-ספרים. אבל אם הטוקן הוא חלק
       // מכותרת הספר הנוכחי ("ברכות" בתוך "פסקי הרא"ש על ברכות") — אין חציית ספר,
@@ -707,11 +711,20 @@ class FindRefRepository {
         if (tocLookups >= maxTocLookups) continue;
         tocLookups++;
 
-        final tocEntries = await fetchTocEntries(
+        var tocEntries = await fetchTocEntries(
           bookId,
           title,
-          queryTokens: remainingTokens,
+          queryTokens: [...sectionTokens, ...remainingTokens],
         );
+        // הזנב אינו בהכרח חלק פנימי ("חזקוני על התורה") — נסיגה לחיפוש בלעדיו
+        // כדי שראש-תיבות כזה ימשיך להחזיר את מה שהחזיר.
+        if (tocEntries.isEmpty && sectionTokens.isNotEmpty) {
+          tocEntries = await fetchTocEntries(
+            bookId,
+            title,
+            queryTokens: remainingTokens,
+          );
+        }
 
         for (final entry in tocEntries) {
           results.add(
@@ -1173,6 +1186,24 @@ class FindRefRepository {
           return c != 0 ? c : a.index.compareTo(b.index);
         });
     return [for (final e in indexed) e.hit];
+  }
+
+  /// טוקני הזנב של ראש-התיבות שהותאם שאינם מילים מכותרת הספר — הם מציינים חלק
+  /// *בתוך* הספר ("טור יורה דעה" / "טור יו"ד" מול הכותרת "טור"), ולכן חייבים
+  /// להגיע לחיפוש ה-TOC ולא להיבלע עם שם הספר. מוחזר ריק כשראש-התיבות כולו
+  /// מזהה את הספר ("שוע אוח" ← "שולחן ערוך אורח חיים").
+  static List<String> _acronymSectionTokens(ReferenceBookHit hit) {
+    final term = hit.matchedTerm;
+    if (hit.matchRank != 3 || term == null) return const [];
+
+    final termTokens = term.split(' ').where((t) => t.isNotEmpty).toList();
+    final titleTokens = titleMatchTokens(hit.normalizedTitle);
+    var start = termTokens.length;
+    while (start > 0 && !titleTokens.contains(termTokens[start - 1])) {
+      start--;
+    }
+    if (start == 0) return const [];
+    return termTokens.sublist(start);
   }
 
   List<String> _getRemainingTokens(

--- a/lib/migration/database/repository/seforim_repository.dart
+++ b/lib/migration/database/repository/seforim_repository.dart
@@ -3123,7 +3123,25 @@ extension BookAcronymRepository on SeforimRepository {
         }
       }
 
-      if (found.isEmpty) break;
+      // ראשי-תיבות של כותרת רב-מילים ("יו"ד" ← "יורה דעה") — רק אחרי שההתאמה
+      // המילולית נכשלה, כדי שלא ייתפסו טוקני-מיקום לגיטימיים.
+      if (found.isEmpty) {
+        found = searchScope
+            .where((e) => hebrewAbbreviationMatchesWords(token, e.ownTokens))
+            .toList();
+      }
+
+      if (found.isEmpty) {
+        // מילה נוספת של הכותרת שכבר הותאמה ("חיים" אחרי "אורח") אינה מצמצמת,
+        // אבל אסור שתפיל את שאר השאילתה ("סימן יב" שבא אחריה).
+        if (currentMatches.isNotEmpty &&
+            currentMatches.every(
+              (e) => alts.any((a) => e.ownTokens.contains(a)),
+            )) {
+          continue;
+        }
+        break;
+      }
 
       // שומר רק את הרמה הרדודה ביותר בין ההתאמות.
       var minLevel = found.first.level;

--- a/lib/utils/text/text_manipulation.dart
+++ b/lib/utils/text/text_manipulation.dart
@@ -1293,6 +1293,28 @@ List<String> hebrewTokenAlternatives(String token) {
   return [token];
 }
 
+/// האם [token] הוא ראשי-תיבות של [words] — כל מילה תורמת תחילית רצופה
+/// והצירוף שווה בדיוק לטוקן ("יוד" ← "יורה דעה", "אהע" ← "אבן העזר").
+/// הסף (3 תווים, שתי מילים לפחות) מונע מטוקן-מיקום קצר להיתפס ככותרת.
+bool hebrewAbbreviationMatchesWords(String token, List<String> words) {
+  if (token.length < 3 || words.length < 2) return false;
+
+  bool walk(int wordIndex, int pos) {
+    if (wordIndex == words.length) return pos == token.length;
+    final word = words[wordIndex];
+    final remaining = token.length - pos;
+    if (remaining <= 0) return false;
+    final maxLen = word.length < remaining ? word.length : remaining;
+    for (var len = 1; len <= maxLen; len++) {
+      if (word.codeUnitAt(len - 1) != token.codeUnitAt(pos + len - 1)) break;
+      if (walk(wordIndex + 1, pos + len)) return true;
+    }
+    return false;
+  }
+
+  return walk(0, 0);
+}
+
 /// מנתח טוקני-מיקום כציטוט דף בפורמט "מספר ואחריו עמוד אופציונלי" (אחרי הפשטת
 /// "דף"/"עמוד"). מחזיר null אם אינו ציטוט דף נקי — אז המתקשר משתמש בהתאמה
 /// הרגילה. הבחנה זו מונעת ש-"ב" בודד (מספר דף) ייתפס ע"י סימון צד ע"ב

--- a/test/find_ref/find_ref_acronym_match_test.dart
+++ b/test/find_ref/find_ref_acronym_match_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/find_ref/repository/reference_books_cache.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
@@ -45,8 +46,10 @@ const _tur = (
   acronyms: [
     'ארבעה טורים',
     'הטור',
-    'טור אורח חיים',
+    'טור או"ח',
+    'טור חו"מ',
     'טור חושן משפט',
+    'טור יו"ד',
     'טור יורה דעה',
   ],
 );
@@ -182,6 +185,69 @@ void main() {
         );
       },
     );
+
+    test('"טור אורח חיים יב" — שם החלק המלא מגיע לחיפוש ה-TOC', () async {
+      // ל"אורח חיים" אין ראש-תיבות מאוית ב-DB (רק "טור או״ח"), ולכן השאילתה
+      // יורדת ל-"טור" בלבד ושתי מילות החלק נשארות לחיפוש הפנימי.
+      seedLibrary(const [_tur]);
+      final seen = <List<String>?>[];
+      await buildFindRefRepo(
+        tocQueryTokensSeen: seen,
+      ).findRefs('טור אורח חיים יב');
+
+      expect(
+        seen.any((t) => listEquals(t, const ['אורח', 'חיים', 'יב'])),
+        isTrue,
+      );
+    });
+
+    test('"טור יורה דעה יב" — שם החלק מגיע לחיפוש ה-TOC ולא נבלע', () async {
+      // "טור יורה דעה" הוא ראש-תיבות *מלא* של הספר "טור" (rank 3), אבל
+      // "יורה דעה" הוא חלק פנימי שלו. בליעת שלושת הטוקנים השאירה רק "יב",
+      // שנחפש משורש ה-TOC (שם יושבים שמות החלקים) ולכן לא נמצא כלל.
+      seedLibrary(const [_tur]);
+      final seen = <List<String>?>[];
+      await buildFindRefRepo(
+        tocQueryTokensSeen: seen,
+      ).findRefs('טור יורה דעה יב');
+
+      expect(
+        seen.any((t) => listEquals(t, const ['יורה', 'דעה', 'יב'])),
+        isTrue,
+        reason: 'ה-TOC חייב להיחפש עם שם החלק, לא רק עם "יב"',
+      );
+    });
+
+    test('"טור יו״ד יב" — ראש-התיבות של החלק מגיע לחיפוש ה-TOC', () async {
+      seedLibrary(const [_tur]);
+      final seen = <List<String>?>[];
+      await buildFindRefRepo(tocQueryTokensSeen: seen).findRefs('טור יו"ד יב');
+
+      expect(
+        seen.any((t) => listEquals(t, const ['יוד', 'יב'])),
+        isTrue,
+        reason: '"יו״ד" מזהה את החלק "יורה דעה" ולכן חייב להישלח ל-TOC',
+      );
+    });
+
+    test('ראש-תיבות שכולו שם הספר אינו מוסיף טוקני-חלק', () async {
+      // "שוע אוח" מזהה את *כותרת* הספר במלואה — אין כאן חלק פנימי, ולכן
+      // חיפוש ה-TOC נשאר על טוקן הסימן בלבד.
+      seedLibrary(const [
+        (
+          id: 2,
+          title: 'שולחן ערוך אורח חיים',
+          acronyms: ['שו"ע או"ח', 'שו"ע'],
+        ),
+      ]);
+      final seen = <List<String>?>[];
+      await buildFindRefRepo(tocQueryTokensSeen: seen).findRefs('שו"ע או"ח יב');
+
+      expect(seen, isNotEmpty);
+      for (final tokens in seen) {
+        expect(tokens, equals(const ['יב']));
+      }
+    });
 
     test(
       'שאילתת מילה אחת ("רמב"ם") מחזירה את כל הספרים בלי חיפוש TOC',

--- a/test/migration/seforim_repository_toc_cache_test.dart
+++ b/test/migration/seforim_repository_toc_cache_test.dart
@@ -859,4 +859,84 @@ void main() {
       },
     );
   });
+
+  // ── כותרת רב-מילים ברמה עליונה ("טור" → "אורח חיים" → "סימן יב") ──────────
+
+  group('כותרת חלק רב-מילים', () {
+    /// מבנה ה-TOC של "טור": חלקים ברמה 1, סימנים ברמה 2 תחתיהם.
+    Future<int> buildTur() async {
+      final catId = await createCategory();
+      final bookId = await createBook(catId, 'טור');
+      await insertLines(bookId, List.generate(12, (i) => 'l$i'));
+
+      var line = 0;
+      for (final part in ['אורח חיים', 'יורה דעה']) {
+        final partId = await insertToc(
+          bookId: bookId,
+          lineIndex: line++,
+          text: part,
+          level: 1,
+        );
+        for (final siman in ['א', 'יב']) {
+          await insertToc(
+            bookId: bookId,
+            lineIndex: line++,
+            text: 'סימן $siman',
+            level: 2,
+            parentId: partId,
+          );
+        }
+      }
+      await repository.updateTocEntryLineIdsByLineIndex(bookId);
+      return bookId;
+    }
+
+    Future<Set<String>> refsFor(int bookId, List<String> tokens) async {
+      final results = await repository.getTocEntriesForReference(
+        bookId,
+        'טור',
+        queryTokens: tokens,
+      );
+      return results.map((r) => r['reference'] as String).toSet();
+    }
+
+    test('מילה שנייה של הכותרת אינה מפילה את שאר השאילתה', () async {
+      // "חיים" כבר נבלע בהתאמת "אורח חיים" ואין לו התאמה בין הסימנים; בעבר
+      // הוא עצר את הסריקה ו-"יב" נזרק, כך שהתוצאה הייתה תחילת "אורח חיים".
+      final bookId = await buildTur();
+
+      expect(
+        await refsFor(bookId, ['אורח', 'חיים', 'יב']),
+        equals({'טור אורח חיים סימן יב'}),
+      );
+      expect(
+        await refsFor(bookId, ['יורה', 'דעה', 'יב']),
+        equals({'טור יורה דעה סימן יב'}),
+      );
+    });
+
+    test('ראשי-תיבות של שם החלק ("יו״ד" ← "יורה דעה")', () async {
+      final bookId = await buildTur();
+
+      expect(
+        await refsFor(bookId, ['אוח', 'יב']),
+        equals({'טור אורח חיים סימן יב'}),
+      );
+      expect(
+        await refsFor(bookId, ['יוד', 'יב']),
+        equals({'טור יורה דעה סימן יב'}),
+      );
+    });
+
+    test('התאמה מילולית קודמת לראשי-תיבות', () async {
+      // "אורח" הוא גם תחילית לגיטימית של "אורח חיים" — ההתאמה המילולית
+      // מכריעה, וראשי-התיבות אינם מרחיבים את התוצאה לחלק השני.
+      final bookId = await buildTur();
+
+      expect(
+        await refsFor(bookId, ['אורח', 'יב']),
+        equals({'טור אורח חיים סימן יב'}),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## הבאג

באיתור מקורות, סימן בטור נמצא רק כשלא כותבים את שם החלק במלואו:

| שאילתה | לפני | אחרי |
|---|---|---|
| `טור אורח יב` | ✅ טור אורח חיים סימן יב | ✅ |
| `טור אורח חיים יב` | ❌ תחילת אורח חיים | ✅ טור אורח חיים סימן יב |
| `טור יורה דעה יב` | ❌ אין תוצאה | ✅ טור יורה דעה סימן יב |
| `טור יו"ד יב` | ❌ אין תוצאה | ✅ טור יורה דעה סימן יב |
| `טור או"ח יב` | ❌ אין תוצאה | ✅ טור אורח חיים סימן יב |

## שורש הבעיה

"טור" הוא **ספר אחד** ב-DB, וארבעת חלקיו הם כותרות TOC ברמה 1 שהסימנים יושבים תחתיהן. שני מסלולים נפרדים איבדו את טוקן הסימן:

**1. `_searchTocHierarchically`** — החיפוש מתאים "אורח" לכותרת "אורח חיים", יורד לילדיה (הסימנים), ואז מחפש שם "חיים". אין התאמה → `break` → שאר השאילתה ("יב") נזרק, ומוחזרת הכותרת עצמה.

**2. בליעת ראש-תיבות ב-`findRefs`** — `טור יורה דעה`, `טור יו"ד`, `טור או"ח` רשומים ב-`book_acronym` כראשי-תיבות של הספר "טור" (נתוני אמת מ-seforim.db). התאמה מלאה (rank 3) בלעה את כל טוקניה, נשאר רק "יב", והוא נחפש משורש ה-TOC — שם יושבים רק שמות החלקים — ולכן לא נמצא כלל.

## התיקון

- **`seforim_repository.dart`** — טוקן שהוא מילה נוספת של הכותרת שכבר הותאמה מדולג במקום להפיל את שאר השאילתה. בנוסף, התאמת ראשי-תיבות לכותרת רב-מילים, **רק** אחרי שההתאמה המילולית נכשלה, כדי שטוקני-מיקום לגיטימיים לא ייתפסו.
- **`find_ref_repository.dart`** — `_acronymSectionTokens`: זנב ראש-התיבות שאינו מילת-כותרת ("יורה דעה" מול הכותרת "טור") נשלח לחיפוש ה-TOC במקום להיבלע. עם **נסיגה** להתנהגות הקודמת אם לא נמצא דבר — כך ראשי-תיבות שזנבם אינו חלק פנימי ("חזקוני על התורה") ממשיכים להחזיר את מה שהחזירו, וראש-תיבות שכולו שם הספר ("שו"ע או"ח" ← "שולחן ערוך אורח חיים") אינו מושפע כלל.
- **`text_manipulation.dart`** — `hebrewAbbreviationMatchesWords`: כל מילה תורמת תחילית רצופה והצירוף שווה בדיוק לטוקן (`יוד` ← `יורה דעה`, `אהע` ← `אבן העזר`). סף של 3 תווים ושתי מילים לפחות מונע מטוקן-מיקום קצר להיתפס ככותרת.

## בדיקות

7 טסטי רגרסיה חדשים (הנתונים — כותרות, מזהי ספרים וראשי-תיבות — לקוחים מ-`seforim.db` האמיתי):

- `test/find_ref/find_ref_acronym_match_test.dart` — 4 טסטים: שלושת הניסוחים מגיעים לחיפוש ה-TOC עם שם החלק, וראש-תיבות שכולו שם הספר אינו מוסיף טוקני-חלק.
- `test/migration/seforim_repository_toc_cache_test.dart` — 3 טסטים על מבנה ה-TOC של הטור: מילה שנייה של הכותרת, ראשי-תיבות של שם החלק, וקדימות ההתאמה המילולית.

`flutter test test/find_ref/ test/migration/seforim_repository_toc_cache_test.dart` — 252 עוברים. `flutter analyze` נקי, `dart format` הורץ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
