### PR TITLE
גיבוי: התאמות פר-ספר, טאבים פתוחים, זיהוי גיבוי חלקי ושומר כיסוי

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,7 +701,8 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Settings screen controller | `test/settings/settings_screen_controller_test.dart` |
 | Bookmark model | `test/settings/history/bookmark_model_test.dart` |
 | Custom folders BLoC | `test/settings/services/custom_folders/custom_folders_bloc_test.dart` |
-| Backup service (roundtrip, plugins, auto-backup) | `test/settings/services/backup_service_test.dart` |
+| Backup service (roundtrip, plugins, auto-backup, per-book, tabs) | `test/settings/services/backup_service_test.dart` |
+| כיסוי מקומות השמירה — כל box/תיקייה מוכרע כמגובה או לא | `test/settings/services/backup_storage_coverage_test.dart` |
 | Backup store (blobs, dedup, GC) + maintenance helpers | `test/unit/settings/backup/backup_store_test.dart` |
 | Backup rotation (GFS) | `test/unit/settings/backup/backup_rotation_test.dart` |
 | Backup archive merge rules | `test/unit/settings/backup/backup_merge_test.dart` |

--- a/lib/data/data_providers/hive_data_provider.dart
+++ b/lib/data/data_providers/hive_data_provider.dart
@@ -89,6 +89,16 @@ class HiveCache extends CacheProvider {
     await _preferences?.deleteAll(keys.cast<String>());
   }
 
+  /// מחיקת כל ההגדרות, בהמתנה לסיומה.
+  ///
+  /// `Settings.clearCache` של החבילה הוא `void` ואינו ממתין ל-Future של
+  /// המחיקה: איפוס דרכו מתחיל בנייה מחדש בזמן שהמחיקה עוד רצה, וברירות
+  /// המחדל שנכתבות מיד אחריו נמחקות איתה.
+  static Future<void> clearAllPreferences() async {
+    if (!Hive.isBoxOpen(keyName)) return;
+    await Hive.box<dynamic>(keyName).clear();
+  }
+
   @override
   T? getValue<T>(String key, {T? defaultValue}) {
     var value = _preferences?.get(key);

--- a/lib/settings/l10n/settings_catalogs.g.dart
+++ b/lib/settings/l10n/settings_catalogs.g.dart
@@ -698,6 +698,7 @@ const Map<String, Map<String, String>> kSettingsCatalogs = {
     'קבצי PDF ו-Word': 'PDF and Word files',
     'קבצי PDF/Word — נקראים ישירות מהקבצים': 'PDF/Word files — read directly from the files',
     'קבצי הספרייה הקיימת יועברו לתיקיית היעד': 'The current library files will be moved to the target folder',
+    'קובץ גיבוי זה נוצר בגרסה שגיבתה רק חלק מההגדרות, ולכן הגדרות שאינן בו לא שוחזרו — בהן קיצורי מקלדת, ברירות המחדל של החיפוש, התאמות צורת הדף והתאמות פר-ספר. יש לבדוק אם קיים גיבוי חדש יותר, או להגדיר אותן מחדש.': 'This backup file was created by a version that backed up only some of the settings, so settings it does not contain were not restored — among them keyboard shortcuts, search defaults, page-shape layouts and per-book adjustments. Check whether a newer backup exists, or set them again.',
     'קטגוריות': 'Categories',
     'קיצורי מקשים': 'Keyboard Shortcuts',
     'קיצורי מקשים זמינים רק בדסקטופ': 'Keyboard shortcuts are for desktop only',

--- a/lib/settings/l10n/settings_catalogs.g.dart
+++ b/lib/settings/l10n/settings_catalogs.g.dart
@@ -67,6 +67,7 @@ const Map<String, Map<String, String>> kSettingsCatalogs = {
     'אפשרויות': 'Options',
     'אפשרויות מיקום': 'Folder Settings',
     'ארכיון': 'Archive',
+    'ב-{count} הערות קובץ הגיבוי אינו כולל את המילים שאליהן הן קושרו, ולכן הן מסומנות כעת על הקטע כולו. הקישור למילים נכנס לגיבוי בגרסה מאוחרת יותר.': 'For {count} notes the backup file does not include the words they were attached to, so they are now marked across the whole passage. Word-level attachment was added to the backup in a later version.',
     'באם שמכם אינו מופיע ברשימה או שאתם מעוניינים בשינוי, אנא פנו למייל המערכת.': 'If your name is missing from the list, or you would like it changed, please email us.',
     'בדיקת העדכונים הבאה תחפש גם גרסאות בדיקה — ייתכנו באגים': 'The next update check will also look for developers builds — expect bugs',
     'בדיקת העדכונים הבאה תחפש גרסאות יציבות בלבד': 'The next update check will look for stable builds only',

--- a/lib/settings/l10n/settings_en.arb
+++ b/lib/settings/l10n/settings_en.arb
@@ -314,6 +314,7 @@
   "הנתונים שוחזרו בהצלחה.": "The data was restored succesfully.",
   "שחזור חלקי — חסרים בקובץ הגיבוי: {items}.": "Partial restore — missing from the backup file: {items}.",
   "קובץ גיבוי זה נוצר בגרסה שגיבתה רק חלק מההגדרות, ולכן הגדרות שאינן בו לא שוחזרו — בהן קיצורי מקלדת, ברירות המחדל של החיפוש, התאמות צורת הדף והתאמות פר-ספר. יש לבדוק אם קיים גיבוי חדש יותר, או להגדיר אותן מחדש.": "This backup file was created by a version that backed up only some of the settings, so settings it does not contain were not restored — among them keyboard shortcuts, search defaults, page-shape layouts and per-book adjustments. Check whether a newer backup exists, or set them again.",
+  "ב-{count} הערות קובץ הגיבוי אינו כולל את המילים שאליהן הן קושרו, ולכן הן מסומנות כעת על הקטע כולו. הקישור למילים נכנס לגיבוי בגרסה מאוחרת יותר.": "For {count} notes the backup file does not include the words they were attached to, so they are now marked across the whole passage. Word-level attachment was added to the backup in a later version.",
   "תיקיות הספרים הבאות שוחזרו אך לא נמצאו במחשב זה:\n{folders}\nיש להוסיף אותן מחדש בהגדרות הספרייה, או לחברן לאותו נתיב.": "These library folders were restored but were not found on this computer:\n{folders}\nAdd them again in the Library Settings, or reconnect them at the same path.",
   "האפליקציה תיטען מחדש כעת.": "Otzaria will reload now.",
   "השחזור הושלם": "Restore Complete",

--- a/lib/settings/l10n/settings_en.arb
+++ b/lib/settings/l10n/settings_en.arb
@@ -313,6 +313,7 @@
   "שחזר הכל": "Restore Everything",
   "הנתונים שוחזרו בהצלחה.": "The data was restored succesfully.",
   "שחזור חלקי — חסרים בקובץ הגיבוי: {items}.": "Partial restore — missing from the backup file: {items}.",
+  "קובץ גיבוי זה נוצר בגרסה שגיבתה רק חלק מההגדרות, ולכן הגדרות שאינן בו לא שוחזרו — בהן קיצורי מקלדת, ברירות המחדל של החיפוש, התאמות צורת הדף והתאמות פר-ספר. יש לבדוק אם קיים גיבוי חדש יותר, או להגדיר אותן מחדש.": "This backup file was created by a version that backed up only some of the settings, so settings it does not contain were not restored — among them keyboard shortcuts, search defaults, page-shape layouts and per-book adjustments. Check whether a newer backup exists, or set them again.",
   "תיקיות הספרים הבאות שוחזרו אך לא נמצאו במחשב זה:\n{folders}\nיש להוסיף אותן מחדש בהגדרות הספרייה, או לחברן לאותו נתיב.": "These library folders were restored but were not found on this computer:\n{folders}\nAdd them again in the Library Settings, or reconnect them at the same path.",
   "האפליקציה תיטען מחדש כעת.": "Otzaria will reload now.",
   "השחזור הושלם": "Restore Complete",

--- a/lib/settings/services/backup/backup_merge.dart
+++ b/lib/settings/services/backup/backup_merge.dart
@@ -45,11 +45,10 @@ class BackupMerge {
     final settings = newer['settings'] ?? older['settings'];
     if (settings != null) result['settings'] = settings;
 
-    // חתימת מקור ההגדרות עוברת רק אם *שני* המניפסטים נושאים אותה: ארכיון
-    // שמכיל אפילו גיבוי אחד מדור קודם חסר הגדרות, והשחזור חייב לדווח על כך.
-    final settingsSource = older.containsKey('settingsSource')
+    // החתימה שייכת למניפסט שממנו נבחר סעיף ההגדרות בפועל.
+    final settingsSource = newer['settings'] != null
         ? newer['settingsSource']
-        : null;
+        : older['settingsSource'];
     if (settingsSource != null) result['settingsSource'] = settingsSource;
 
     // התאמות פר-ספר: איחוד לפי שם הקובץ, החדש מנצח. אין גיזום לפי גיל —

--- a/lib/settings/services/backup/backup_merge.dart
+++ b/lib/settings/services/backup/backup_merge.dart
@@ -45,6 +45,21 @@ class BackupMerge {
     final settings = newer['settings'] ?? older['settings'];
     if (settings != null) result['settings'] = settings;
 
+    // חתימת מקור ההגדרות עוברת רק אם *שני* המניפסטים נושאים אותה: ארכיון
+    // שמכיל אפילו גיבוי אחד מדור קודם חסר הגדרות, והשחזור חייב לדווח על כך.
+    final settingsSource = older.containsKey('settingsSource')
+        ? newer['settingsSource']
+        : null;
+    if (settingsSource != null) result['settingsSource'] = settingsSource;
+
+    // התאמות פר-ספר: איחוד לפי שם הקובץ, החדש מנצח. אין גיזום לפי גיל —
+    // הערכים הם מחרוזות JSON של הקובץ עצמו, ואין לזהם אותן ב-lastSeenAt.
+    final perBook = _mergeStringMaps(
+      _asStringMap(older['perBookSettings']),
+      _asStringMap(newer['perBookSettings']),
+    );
+    if (perBook != null) result['perBookSettings'] = perBook;
+
     final bookmarks = _mergeItemLists(
       older['bookmarks'],
       newer['bookmarks'],
@@ -88,6 +103,11 @@ class BackupMerge {
       result['currentWorkspace'] =
           newer['currentWorkspace'] ?? older['currentWorkspace'];
     }
+
+    // הטאבים הפתוחים: החדש מנצח בשלמותו. מיזוג רשימות טאבים משני מועדים
+    // היה מחזיר לחיים כל ספר שנסגר מאז, ומשאיר את הטאב הפעיל תלוש.
+    final openTabs = newer['openTabs'] ?? older['openTabs'];
+    if (openTabs != null) result['openTabs'] = openTabs;
 
     final shamorZachor = _mergeShamorZachor(
       _asStringMap(older['shamorZachor']),
@@ -170,6 +190,15 @@ class BackupMerge {
   static List<Map<String, dynamic>>? _asItemList(Object? raw) {
     if (raw is! List) return null;
     return raw.whereType<Map>().map((m) => m.cast<String, dynamic>()).toList();
+  }
+
+  /// איחוד שתי מפות שם→ערך, כשערכי [newer] דורסים.
+  static Map<String, dynamic>? _mergeStringMaps(
+    Map<String, dynamic>? older,
+    Map<String, dynamic>? newer,
+  ) {
+    if (older == null && newer == null) return null;
+    return {...?older, ...?newer};
   }
 
   static Map<String, dynamic>? _asStringMap(Object? raw) {

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -538,11 +538,14 @@ class BackupService {
   /// [hasLegacyPartialSettings] — קובץ הגיבוי נוצר לפני שהגיבוי סרק את ה-Box,
   /// ולכן נשא רשימת מפתחות מוצהרת בלבד. כל השאר (קיצורי מקלדת, ברירות החיפוש,
   /// צורת הדף, התאמות פר-ספר) אינו בקובץ ואינו בר-שחזור — והמשתמש חייב לדעת.
+  /// [notesWithoutAnchor] — הערות שקובץ הגיבוי אינו יכול לבטא להן עיגון (נוצר
+  /// לפני שהעיגון נכנס לגיבוי), ולכן תסומנה על כל השורה במקום על המילים.
   static Future<
     ({
       List<String> skippedSections,
       List<String> missingCustomFolders,
       bool hasLegacyPartialSettings,
+      int notesWithoutAnchor,
     })
   >
   restoreFromBackup(String backupPath) async {
@@ -614,8 +617,9 @@ class BackupService {
     }
 
     // Restore notes
+    var notesWithoutAnchor = 0;
     if (includes['notes'] == true && backupData.containsKey('notes')) {
-      await _restoreNotes(
+      notesWithoutAnchor = await _restoreNotes(
         (backupData['notes'] as List).cast<Map<String, dynamic>>(),
       );
     }
@@ -670,6 +674,7 @@ class BackupService {
       skippedSections: allSkipped,
       missingCustomFolders: missingCustomFolders,
       hasLegacyPartialSettings: hasLegacyPartialSettings,
+      notesWithoutAnchor: notesWithoutAnchor,
     );
   }
 
@@ -776,11 +781,18 @@ class BackupService {
     await repo.saveHistory(history);
   }
 
-  /// Restore notes to SQLite database
-  static Future<void> _restoreNotes(
+  /// מפתח העיגון שנוכחותו מעידה שהגיבוי יודע לבטא עיגון להערה.
+  static const String _noteAnchorKey = 'anchorText';
+
+  /// Restore notes to SQLite database.
+  ///
+  /// מחזיר את מספר ההערות שקובץ הגיבוי אינו יכול לבטא להן עיגון (ראה
+  /// [_restoreNoteAnchoredAsBefore]) — הן תסומנה על כל השורה במקום על המילים.
+  static Future<int> _restoreNotes(
     List<Map<String, dynamic>> notesData,
   ) async {
     final database = PersonalNotesDatabase.instance;
+    var anchorlessNotes = 0;
 
     for (final entry in notesData) {
       try {
@@ -793,9 +805,12 @@ class BackupService {
           final notesList = entry['notes'] as List<dynamic>;
           for (final noteData in notesList) {
             try {
-              final note = _noteFromBackupJson(
-                noteData as Map<String, dynamic>,
-              );
+              final json = noteData as Map<String, dynamic>;
+              var note = _noteFromBackupJson(json);
+              if (!json.containsKey(_noteAnchorKey)) {
+                note = await _restoreNoteAnchoredAsBefore(database, note);
+                if (!note.isWordAnchored) anchorlessNotes++;
+              }
               await database.insertNote(note);
             } catch (e) {
               _logger.warning('Failed to restore single note from backup: $e');
@@ -805,6 +820,34 @@ class BackupService {
       } catch (e) {
         _logger.warning('Failed to restore note entry: $e');
       }
+    }
+
+    return anchorlessNotes;
+  }
+
+  /// משמר את עוגן ההערה הקיימת כששדות העיגון חסרים לגמרי בקובץ הגיבוי.
+  ///
+  /// גיבוי מלפני שהעיגון נכנס אליו אינו מבדיל בין "הערה על כל השורה" לבין
+  /// "הערה על מילה" — בשניהם המפתח נעדר. `insertNote` הוא `INSERT OR REPLACE`,
+  /// ולכן בלי השימור שחזור כזה מוחק עיגון קיים והערה שהצביעה על מילה מסוימת
+  /// נמתחת על כל השורה. מפתח שקיים בערך `null` הוא בחירת משתמש ומכובד.
+  static Future<PersonalNote> _restoreNoteAnchoredAsBefore(
+    PersonalNotesDatabase database,
+    PersonalNote note,
+  ) async {
+    try {
+      final existing = await database.getNote(note.id);
+      if (existing == null || !existing.isWordAnchored) return note;
+      return note.copyWith(
+        anchorText: existing.anchorText,
+        anchorPrefix: existing.anchorPrefix,
+        anchorSuffix: existing.anchorSuffix,
+        anchorStart: existing.anchorStart,
+        anchorEnd: existing.anchorEnd,
+      );
+    } catch (e) {
+      _logger.warning('Failed to preserve anchor for note ${note.id}: $e');
+      return note;
     }
   }
 

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -117,7 +117,11 @@ class BackupService {
         backupData['settingsSource'] = skippedSections.contains('settings')
             ? 'declared-keys'
             : 'box';
-        backupData['perBookSettings'] = await _backupPerBookSettings();
+        final perBookSettings = await _backupPerBookSettings();
+        backupData['perBookSettings'] = perBookSettings.files;
+        if (perBookSettings.hadFailures) {
+          skippedSections.add('perBookSettings');
+        }
       }
 
       // Backup bookmarks
@@ -304,20 +308,25 @@ class BackupService {
   /// גיבוי ההגדרות הפר-ספריות, שנשמרות בקבצי JSON מחוץ ל-Hive: המפרשים
   /// הפעילים בכל ספר, גופן/ניקוד/פיסוק פר-ספר, רוחבי הטורים בצורת הדף וזום
   /// ה-PDF. נשמרות כטקסט ולא כ-blob — הקבצים זעירים והמניפסט נשאר קריא.
-  static Future<Map<String, String>> _backupPerBookSettings() async {
+  static Future<({Map<String, String> files, bool hadFailures})>
+  _backupPerBookSettings() async {
     final dir = Directory(await AppPaths.getPerBookSettingsPath());
-    if (!await dir.exists()) return {};
+    if (!await dir.exists()) {
+      return (files: <String, String>{}, hadFailures: false);
+    }
 
     final files = <String, String>{};
+    var hadFailures = false;
     await for (final entity in dir.list()) {
       if (entity is! File || !entity.path.endsWith('.json')) continue;
       try {
         files[p.basename(entity.path)] = await entity.readAsString();
       } catch (e) {
+        hadFailures = true;
         _logger.warning('Skipping per-book settings ${entity.path}: $e');
       }
     }
-    return files;
+    return (files: files, hadFailures: hadFailures);
   }
 
   /// קידומות של נתונים שאינם הגדרות, אף שהם נשמרים באותו Hive box.
@@ -582,6 +591,8 @@ class BackupService {
 
     final includes = backupData['includes'] as Map<String, dynamic>;
 
+    final runtimeSkipped = <String>[];
+
     // Restore settings
     var hasLegacyPartialSettings = false;
     if (includes['settings'] == true && backupData.containsKey('settings')) {
@@ -592,10 +603,11 @@ class BackupService {
         settings,
         backupData['settingsSource'],
       );
-      await _restorePerBookSettings(
+      final perBookHadFailures = await _restorePerBookSettings(
         (backupData['perBookSettings'] as Map?)?.cast<String, dynamic>() ??
             const {},
       );
+      if (perBookHadFailures) runtimeSkipped.add('perBookSettings');
     }
 
     // Restore bookmarks
@@ -645,8 +657,6 @@ class BackupService {
       );
     }
 
-    final runtimeSkipped = <String>[];
-
     // Restore plugins
     if (includes['plugins'] == true && backupData.containsKey('plugins')) {
       final pluginsHadFailures = await _restorePlugins(
@@ -683,15 +693,17 @@ class BackupService {
   /// קובץ שאינו בגיבוי נשאר במקומו: השחזור מחזיר את מה שנשמר בו ואינו מוחק
   /// התאמות של ספרים אחרים. שם הקובץ מאומת כשם בסיס בלבד לפני הכתיבה, כדי
   /// שגיבוי פגום/זדוני לא יכתוב מחוץ לתיקייה.
-  static Future<void> _restorePerBookSettings(
+  static Future<bool> _restorePerBookSettings(
     Map<String, dynamic> files,
   ) async {
-    if (files.isEmpty) return;
+    if (files.isEmpty) return false;
     final dir = Directory(await AppPaths.getPerBookSettingsPath());
     await dir.create(recursive: true);
 
+    var hadFailures = false;
     for (final entry in files.entries) {
       if (p.basename(entry.key) != entry.key || !entry.key.endsWith('.json')) {
+        hadFailures = true;
         _logger.warning(
           'Unsafe per-book settings name in backup: ${entry.key}',
         );
@@ -702,9 +714,11 @@ class BackupService {
           p.join(dir.path, entry.key),
         ).writeAsString(entry.value as String);
       } catch (e) {
+        hadFailures = true;
         _logger.warning('Failed to restore per-book settings ${entry.key}: $e');
       }
     }
+    return hadFailures;
   }
 
   /// האם סעיף ההגדרות נאסף מרשימת מפתחות מוצהרת ולכן חסר את השאר.

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -582,9 +582,13 @@ class BackupService {
     // Restore settings
     var hasLegacyPartialSettings = false;
     if (includes['settings'] == true && backupData.containsKey('settings')) {
-      await _restoreSettings(backupData['settings'] as Map<String, dynamic>);
+      final settings = backupData['settings'] as Map<String, dynamic>;
+      await _restoreSettings(settings);
       missingCustomFolders.addAll(await findMissingCustomFolders());
-      hasLegacyPartialSettings = backupData['settingsSource'] == null;
+      hasLegacyPartialSettings = isPartialSettingsSection(
+        settings,
+        backupData['settingsSource'],
+      );
       await _restorePerBookSettings(
         (backupData['perBookSettings'] as Map?)?.cast<String, dynamic>() ??
             const {},
@@ -696,6 +700,24 @@ class BackupService {
         _logger.warning('Failed to restore per-book settings ${entry.key}: $e');
       }
     }
+  }
+
+  /// האם סעיף ההגדרות נאסף מרשימת מפתחות מוצהרת ולכן חסר את השאר.
+  ///
+  /// [source] הוא `settingsSource` מהמניפסט: `'declared-keys'` מצהיר על עצמו,
+  /// ו-`'box'` שולל. גיבוי מלפני שהשדה נוסף אינו נושא אותו כלל, ולכן ההכרעה
+  /// נופלת על התוכן: אוסף מרשימה מוצהרת יכול להכיל רק מפתחות מתוכה
+  /// (ראה [fallbackSettingsKeys]), ולכן מפתח אחד מחוצה לה מוכיח סריקת Box.
+  /// בלי הבדיקה הזאת גם גיבוי שלם מלפני התיקון היה מתריע התראת שקר.
+  @visibleForTesting
+  static bool isPartialSettingsSection(
+    Map<String, dynamic> settings,
+    Object? source,
+  ) {
+    if (source == 'declared-keys') return true;
+    if (source != null) return false;
+    final declared = fallbackSettingsKeys.toSet();
+    return !settings.keys.any((key) => !declared.contains(key));
   }
 
   /// נתיבי התיקיות המותאמות אישית שרשומות בהגדרות ואינן קיימות בדיסק.

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/bookmarks/models/bookmark.dart';
 import 'package:otzaria/data/data_providers/hive_data_provider.dart';
 import 'package:otzaria/history/history_repository.dart';
 import 'package:otzaria/settings/engine/settings_engine_exports.dart';
+import 'package:otzaria/tabs/tabs_repository.dart';
 import 'package:otzaria/workspaces/workspace_repository.dart';
 import 'package:otzaria/workspaces/workspace.dart';
 import 'package:otzaria/personal_notes/storage/personal_notes_database.dart';
@@ -110,6 +111,13 @@ class BackupService {
       // Backup settings
       if (includeSettings) {
         backupData['settings'] = await _backupSettings(skippedSections);
+        // חתימת מקור ההגדרות. גיבוי שנוצר לפני שהגיבוי סרק את ה-Box אסף
+        // רשימת מפתחות מוצהרת בלבד, ואינו נושא את השדה — כך השחזור מזהה
+        // אותו ומדווח למשתמש במקום להכריז "שוחזר בהצלחה" על קובץ חסר.
+        backupData['settingsSource'] = skippedSections.contains('settings')
+            ? 'declared-keys'
+            : 'box';
+        backupData['perBookSettings'] = await _backupPerBookSettings();
       }
 
       // Backup bookmarks
@@ -142,6 +150,8 @@ class BackupService {
         final workspacesData = await _backupWorkspaces();
         backupData['workspaces'] = workspacesData['workspaces'];
         backupData['currentWorkspace'] = workspacesData['currentWorkspace'];
+        final openTabs = _backupOpenTabs();
+        if (openTabs != null) backupData['openTabs'] = openTabs;
       }
 
       // Backup Shamor Zachor
@@ -179,6 +189,39 @@ class BackupService {
     }
   }
 
+  /// מקומות השמירה שהגיבוי מכסה: Hive boxes ותיקיות תחת שורש הנתונים.
+  ///
+  /// `databases` מכוסה חלקית — `personal_notes.db` ו-`plugins_host.db` מגובים,
+  /// ו-`user_books.db`/`cache.db` נבנים מחדש מסריקת הספרים.
+  static const Set<String> backedUpStores = {
+    'app_preferences',
+    'bookmarks',
+    'history',
+    'workspaces',
+    'tabs',
+    'databases',
+    'plugins',
+    'per_book_settings',
+  };
+
+  /// מקומות שמירה שאינם מגובים במכוון, עם הסיבה לכל אחד.
+  ///
+  /// כל מקום שמירה בתוכנה חייב להופיע כאן או ב-[backedUpStores]:
+  /// `backup_storage_coverage_test` סורק את הקוד ונכשל על מקום שאינו מוצהר,
+  /// כך שתיקייה חדשה לא תישמט מהגיבוי בשקט כפי שקרה ל-`per_book_settings`.
+  static const Map<String, String> unbackedStores = {
+    'error_reports_queue': 'תור זמני — הדיווחים נשלחים והתור מתרוקן',
+    'pending_external_activations.jsonl':
+        'תור זמני של בקשות פתיחה מחוץ לתוכנה, מתרוקן בעיבוד',
+    'books': 'תוכן הספרייה, מגיע מההתקנה או מההורדה',
+    'הספרים שלי': 'קובצי הספרים; הנתיב נשמר בהגדרות והתיקייה נסרקת מחדש',
+    'index': 'אינדקס החיפוש, נבנה מחדש מהספרים',
+    'dictionaries': 'נכסי מילון שניתן להוריד שוב',
+    'library_update_cache': 'קאש הורדות זמני',
+    'webview2': 'נתוני מנוע הדפדפן המשובץ',
+    'backups': 'תיקיית הגיבויים עצמה',
+  };
+
   /// מפתחות הגדרות שאינם מועברים בין התקנות.
   ///
   /// הגיבוי סורק את *כל* מפתחות ההגדרות (ראה [_backupSettings]) ומחסיר את
@@ -205,6 +248,7 @@ class BackupService {
     // דגל פנימי שמסמן שברירות המחדל נכתבו לדיסק.
     'settings_initialized',
   };
+
   /// מפתחות ההגדרות שהגיבוי אוסף כשאין גישה ל-Hive box (ראה [_backupSettings]).
   /// כולל את הקיצורים הדינמיים, שמפתחותיהם נגזרים מהתוספים המותקנים.
   static List<String> get fallbackSettingsKeys => [
@@ -255,6 +299,25 @@ class BackupService {
       }
     }
     return settings;
+  }
+
+  /// גיבוי ההגדרות הפר-ספריות, שנשמרות בקבצי JSON מחוץ ל-Hive: המפרשים
+  /// הפעילים בכל ספר, גופן/ניקוד/פיסוק פר-ספר, רוחבי הטורים בצורת הדף וזום
+  /// ה-PDF. נשמרות כטקסט ולא כ-blob — הקבצים זעירים והמניפסט נשאר קריא.
+  static Future<Map<String, String>> _backupPerBookSettings() async {
+    final dir = Directory(await AppPaths.getPerBookSettingsPath());
+    if (!await dir.exists()) return {};
+
+    final files = <String, String>{};
+    await for (final entity in dir.list()) {
+      if (entity is! File || !entity.path.endsWith('.json')) continue;
+      try {
+        files[p.basename(entity.path)] = await entity.readAsString();
+      } catch (e) {
+        _logger.warning('Skipping per-book settings ${entity.path}: $e');
+      }
+    }
+    return files;
   }
 
   /// קידומות של נתונים שאינם הגדרות, אף שהם נשמרים באותו Hive box.
@@ -432,6 +495,19 @@ class BackupService {
     };
   }
 
+  /// הטאבים הפתוחים, כחלק מסעיף שולחנות העבודה — אותו סוג נתון (סידור
+  /// הספרים הפתוחים), ולכן אין להם העדפת גיבוי נפרדת.
+  ///
+  /// היעדר ה-box אינו מסמן את השחזור כחלקי: הטאבים הפתוחים הם מצב רגעי
+  /// שמשתנה בכל פתיחת ספר, ואין להבהיל את המשתמש בגללם.
+  static Map<String, dynamic>? _backupOpenTabs() {
+    if (!Hive.isBoxOpen(TabsRepository.boxName)) {
+      _logger.warning('_backupOpenTabs: tabs box not open — skipping');
+      return null;
+    }
+    return TabsRepository().exportRaw();
+  }
+
   /// Backup Shamor Zachor data - backs up all sz: keys found in Hive
   static Future<Map<String, dynamic>> _backupShamorZachor() async {
     if (!Hive.isBoxOpen(HiveCache.keyName)) {
@@ -459,8 +535,15 @@ class BackupService {
   /// [missingCustomFolders] — נתיבי תיקיות ספרים מותאמות אישית ששוחזרו אך
   /// אינם קיימים במחשב היעד (שם משתמש אחר, כונן שאינו מחובר). הספרים שבהן
   /// לא ייסרקו, ולכן המשתמש חייב לדעת ולהצביע על הנתיב מחדש.
+  /// [hasLegacyPartialSettings] — קובץ הגיבוי נוצר לפני שהגיבוי סרק את ה-Box,
+  /// ולכן נשא רשימת מפתחות מוצהרת בלבד. כל השאר (קיצורי מקלדת, ברירות החיפוש,
+  /// צורת הדף, התאמות פר-ספר) אינו בקובץ ואינו בר-שחזור — והמשתמש חייב לדעת.
   static Future<
-    ({List<String> skippedSections, List<String> missingCustomFolders})
+    ({
+      List<String> skippedSections,
+      List<String> missingCustomFolders,
+      bool hasLegacyPartialSettings,
+    })
   >
   restoreFromBackup(String backupPath) async {
     final file = File(backupPath);
@@ -497,9 +580,15 @@ class BackupService {
     final includes = backupData['includes'] as Map<String, dynamic>;
 
     // Restore settings
+    var hasLegacyPartialSettings = false;
     if (includes['settings'] == true && backupData.containsKey('settings')) {
       await _restoreSettings(backupData['settings'] as Map<String, dynamic>);
       missingCustomFolders.addAll(await findMissingCustomFolders());
+      hasLegacyPartialSettings = backupData['settingsSource'] == null;
+      await _restorePerBookSettings(
+        (backupData['perBookSettings'] as Map?)?.cast<String, dynamic>() ??
+            const {},
+      );
     }
 
     // Restore bookmarks
@@ -543,6 +632,9 @@ class BackupService {
         (backupData['workspaces'] as List).cast<Map<String, dynamic>>(),
         backupData['currentWorkspace'],
       );
+      await _restoreOpenTabs(
+        (backupData['openTabs'] as Map?)?.cast<String, dynamic>(),
+      );
     }
 
     final runtimeSkipped = <String>[];
@@ -573,7 +665,37 @@ class BackupService {
     return (
       skippedSections: allSkipped,
       missingCustomFolders: missingCustomFolders,
+      hasLegacyPartialSettings: hasLegacyPartialSettings,
     );
+  }
+
+  /// שחזור ההגדרות הפר-ספריות (ראה [_backupPerBookSettings]).
+  ///
+  /// קובץ שאינו בגיבוי נשאר במקומו: השחזור מחזיר את מה שנשמר בו ואינו מוחק
+  /// התאמות של ספרים אחרים. שם הקובץ מאומת כשם בסיס בלבד לפני הכתיבה, כדי
+  /// שגיבוי פגום/זדוני לא יכתוב מחוץ לתיקייה.
+  static Future<void> _restorePerBookSettings(
+    Map<String, dynamic> files,
+  ) async {
+    if (files.isEmpty) return;
+    final dir = Directory(await AppPaths.getPerBookSettingsPath());
+    await dir.create(recursive: true);
+
+    for (final entry in files.entries) {
+      if (p.basename(entry.key) != entry.key || !entry.key.endsWith('.json')) {
+        _logger.warning(
+          'Unsafe per-book settings name in backup: ${entry.key}',
+        );
+        continue;
+      }
+      try {
+        await File(
+          p.join(dir.path, entry.key),
+        ).writeAsString(entry.value as String);
+      } catch (e) {
+        _logger.warning('Failed to restore per-book settings ${entry.key}: $e');
+      }
+    }
   }
 
   /// נתיבי התיקיות המותאמות אישית שרשומות בהגדרות ואינן קיימות בדיסק.
@@ -834,6 +956,17 @@ class BackupService {
       currentWorkspace: currentWorkspace,
     );
     await repo.saveWorkspaces(workspaces, currentId);
+  }
+
+  /// שחזור הטאבים הפתוחים (ראה [_backupOpenTabs]). גיבוי בלעדיהם משאיר את
+  /// הטאבים הקיימים — עדיף מלרוקן את המסך על סמך מה שאין בקובץ.
+  static Future<void> _restoreOpenTabs(Map<String, dynamic>? openTabs) async {
+    if (openTabs == null) return;
+    if (!Hive.isBoxOpen(TabsRepository.boxName)) {
+      _logger.warning('_restoreOpenTabs: tabs box not open — skipping');
+      return;
+    }
+    await TabsRepository().importRaw(openTabs);
   }
 
   static String? _resolveCurrentWorkspaceId({

--- a/lib/settings/tabs/system_settings_tab.dart
+++ b/lib/settings/tabs/system_settings_tab.dart
@@ -1573,7 +1573,8 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
       final isPartial =
           skipped.isNotEmpty ||
           missingFolders.isNotEmpty ||
-          result.hasLegacyPartialSettings;
+          result.hasLegacyPartialSettings ||
+          result.notesWithoutAnchor > 0;
       final content = [
         if (skipped.isEmpty)
           context.settingsText('הנתונים שוחזרו בהצלחה.')
@@ -1588,6 +1589,13 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
             'שאינן בו לא שוחזרו — בהן קיצורי מקלדת, ברירות המחדל של החיפוש, '
             'התאמות צורת הדף והתאמות פר-ספר. יש לבדוק אם קיים גיבוי חדש יותר, '
             'או להגדיר אותן מחדש.',
+          ),
+        if (result.notesWithoutAnchor > 0)
+          context.settingsText(
+            'ב-{count} הערות קובץ הגיבוי אינו כולל את המילים שאליהן הן קושרו, '
+            'ולכן הן מסומנות כעת על הקטע כולו. הקישור למילים נכנס לגיבוי '
+            'בגרסה מאוחרת יותר.',
+            args: {'count': result.notesWithoutAnchor},
           ),
         if (missingFolders.isNotEmpty)
           context.settingsText(

--- a/lib/settings/tabs/system_settings_tab.dart
+++ b/lib/settings/tabs/system_settings_tab.dart
@@ -18,6 +18,7 @@ import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/core/messages/report_messages.dart';
 import 'package:otzaria/core/messages/settings_messages.dart';
 import 'package:otzaria/core/app_runtime_reset.dart';
+import 'package:otzaria/data/data_providers/hive_data_provider.dart';
 import 'package:otzaria/settings/engine/settings_engine_exports.dart';
 import 'package:otzaria/settings/l10n/settings_l10n_exports.dart';
 import 'package:otzaria/settings/search/settings_search_models.dart';
@@ -1569,6 +1570,10 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
       if (!mounted) return;
       final skipped = result.skippedSections;
       final missingFolders = result.missingCustomFolders;
+      final isPartial =
+          skipped.isNotEmpty ||
+          missingFolders.isNotEmpty ||
+          result.hasLegacyPartialSettings;
       final content = [
         if (skipped.isEmpty)
           context.settingsText('הנתונים שוחזרו בהצלחה.')
@@ -1576,6 +1581,13 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
           context.settingsText(
             'שחזור חלקי — חסרים בקובץ הגיבוי: {items}.',
             args: {'items': skipped.join(", ")},
+          ),
+        if (result.hasLegacyPartialSettings)
+          context.settingsText(
+            'קובץ גיבוי זה נוצר בגרסה שגיבתה רק חלק מההגדרות, ולכן הגדרות '
+            'שאינן בו לא שוחזרו — בהן קיצורי מקלדת, ברירות המחדל של החיפוש, '
+            'התאמות צורת הדף והתאמות פר-ספר. יש לבדוק אם קיים גיבוי חדש יותר, '
+            'או להגדיר אותן מחדש.',
           ),
         if (missingFolders.isNotEmpty)
           context.settingsText(
@@ -1588,9 +1600,7 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
       await showSingleActionDialog(
         context: context,
         title: context.settingsText(
-          skipped.isEmpty && missingFolders.isEmpty
-              ? 'השחזור הושלם'
-              : 'שחזור חלקי',
+          isPartial ? 'שחזור חלקי' : 'השחזור הושלם',
         ),
         content: content,
         confirmText: context.settingsText('טען מחדש'),
@@ -2100,7 +2110,7 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
                   confirmText: context.settingsText('אפס'),
                 );
                 if (confirmed == true && mounted) {
-                  Settings.clearCache();
+                  await HiveCache.clearAllPreferences();
                   await resetRuntimeStateAfterSettingsReset();
                   if (!mounted) return;
                   RestartWidget.restartApp(

--- a/lib/tabs/tabs_repository.dart
+++ b/lib/tabs/tabs_repository.dart
@@ -9,9 +9,29 @@ import 'package:otzaria/utils/file/hive_utils.dart';
 import 'package:flutter/foundation.dart';
 
 class TabsRepository {
+  static const String boxName = 'tabs';
   static const String _tabsBoxKey = 'key-tabs';
   static const String _currentTabKey = 'key-current-tab';
   static const String _legacySplitModeKey = 'key-side-by-side-mode';
+
+  /// הטאבים הפתוחים והטאב הפעיל, גולמיים, לגיבוי.
+  ///
+  /// גולמי (ה-JSON כפי שנשמר) ולא [OpenedTab]: טאב שאינו נטען במחשב היעד
+  /// (ספר חסר) מדולג בטעינה על ידי [loadTabs], ואין להשמיט אותו מהגיבוי מראש.
+  Map<String, dynamic> exportRaw() {
+    final box = Hive.box(boxName);
+    return {
+      'tabs': box.get(_tabsBoxKey, defaultValue: <dynamic>[]),
+      'currentTab': box.get(_currentTabKey, defaultValue: 0),
+    };
+  }
+
+  /// כתיבת הטאבים מגיבוי, בדריסת הטאבים השמורים.
+  Future<void> importRaw(Map<String, dynamic> data) async {
+    final box = Hive.box(boxName);
+    await box.put(_tabsBoxKey, data['tabs'] ?? <dynamic>[]);
+    await box.put(_currentTabKey, data['currentTab'] ?? 0);
+  }
 
   int _resolvePersistedCurrentTabIndex(
     Map<int, int> persistedIndexByOriginalIndex,

--- a/test/settings/services/backup_service_test.dart
+++ b/test/settings/services/backup_service_test.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/plugins/models/plugin_manifest.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/services/backup_service.dart';
+import 'package:otzaria/tabs/tabs_repository.dart';
 import 'package:otzaria/workspaces/workspace_repository.dart';
 import 'package:path/path.dart' as p;
 
@@ -728,5 +729,143 @@ void main() {
         expect(await escaped.exists(), isFalse);
       },
     );
+  });
+
+  // ─── הגדרות פר-ספר ─────────────────────────────────────────────────────────
+  // ההתאמות הפר-ספריות (מפרשים פעילים, גופן, רוחבי צורת הדף) יושבות בקבצי JSON
+  // מחוץ ל-Hive, ולכן נשמטו מהגיבוי לגמרי — ספר שהוגדרו לו מפרשים חזר ריק.
+  group('גיבוי ושחזור הגדרות פר-ספר', () {
+    setUp(() => AppPaths.debugOverrideDataRootPath(tempDir.path));
+
+    Future<File> perBookFile(String name) async =>
+        File(p.join(await AppPaths.getPerBookSettingsPath(), name));
+
+    Future<String> createSettingsBackup() async =>
+        (await BackupService.createBackup(
+          includeSettings: true,
+          includeBookmarks: false,
+          includeHistory: false,
+          includeNotes: false,
+          includeWorkspaces: false,
+          includeShamorZachor: false,
+          includePlugins: false,
+        )).path;
+
+    test('קובץ הגדרות פר-ספר מגובה ומשוחזר', () async {
+      const content = '{"activeCommentators":["מנחת חינוך"],"fontSize":31.0}';
+      final file = await perBookFile('settings_${'a' * 40}.json');
+      await file.create(recursive: true);
+      await file.writeAsString(content);
+
+      final path = await createSettingsBackup();
+      await file.delete();
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      expect(result.hasLegacyPartialSettings, isFalse);
+      expect(await file.readAsString(), content);
+    });
+
+    test('שחזור אינו מוחק התאמות של ספרים שאינם בגיבוי', () async {
+      final backedUp = await perBookFile('settings_${'b' * 40}.json');
+      await backedUp.create(recursive: true);
+      await backedUp.writeAsString('{"fontSize":20.0}');
+
+      final path = await createSettingsBackup();
+
+      final untouched = await perBookFile('settings_${'c' * 40}.json');
+      await untouched.writeAsString('{"fontSize":40.0}');
+      await BackupService.restoreFromBackup(path);
+
+      expect(await untouched.readAsString(), '{"fontSize":40.0}');
+    });
+
+    test('שם קובץ חורג בגיבוי מדולג ואינו נכתב מחוץ לתיקייה', () async {
+      final path = await createSettingsBackup();
+      final backupFile = File(path);
+      final json =
+          jsonDecode(await backupFile.readAsString()) as Map<String, dynamic>;
+      (json['perBookSettings'] as Map)['../escaped.json'] = '{"fontSize":9.0}';
+      await backupFile.writeAsString(jsonEncode(json));
+
+      await BackupService.restoreFromBackup(path);
+
+      final escaped = File(
+        p.normalize(
+          p.join(await AppPaths.getPerBookSettingsPath(), '..', 'escaped.json'),
+        ),
+      );
+      expect(await escaped.exists(), isFalse);
+    });
+
+    test('גיבוי ללא חתימת מקור ההגדרות מדווח כחלקי', () async {
+      final path = await createSettingsBackup();
+      final backupFile = File(path);
+      final json =
+          jsonDecode(await backupFile.readAsString()) as Map<String, dynamic>;
+      // גיבוי מגרסה שאספה רשימת מפתחות מוצהרת בלבד — בלי השדה הזה.
+      json.remove('settingsSource');
+      await backupFile.writeAsString(jsonEncode(json));
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      expect(result.hasLegacyPartialSettings, isTrue);
+    });
+  });
+
+  // ─── הטאבים הפתוחים ────────────────────────────────────────────────────────
+  // הטאבים יושבים ב-box נפרד ולא היו בגיבוי כלל: אחרי שחזור התוכנה נפתחה
+  // בלי הספרים שהיו פתוחים.
+  group('גיבוי ושחזור הטאבים הפתוחים', () {
+    late Box<dynamic> tabsBox;
+
+    setUp(() async {
+      tabsBox = await Hive.openBox<dynamic>(TabsRepository.boxName);
+    });
+
+    Future<String> createWorkspacesBackup() async =>
+        (await BackupService.createBackup(
+          includeSettings: false,
+          includeBookmarks: false,
+          includeHistory: false,
+          includeNotes: false,
+          includeWorkspaces: true,
+          includeShamorZachor: false,
+          includePlugins: false,
+        )).path;
+
+    test('הטאבים והטאב הפעיל עוברים גיבוי ושחזור', () async {
+      final tabs = [
+        {'type': 'TextBookTab', 'title': 'בראשית'},
+        {'type': 'TextBookTab', 'title': 'שמות'},
+      ];
+      await tabsBox.put('key-tabs', tabs);
+      await tabsBox.put('key-current-tab', 1);
+
+      final path = await createWorkspacesBackup();
+      await tabsBox.put('key-tabs', <dynamic>[]);
+      await tabsBox.put('key-current-tab', 0);
+
+      await BackupService.restoreFromBackup(path);
+
+      expect((tabsBox.get('key-tabs') as List), hasLength(2));
+      expect(tabsBox.get('key-current-tab'), 1);
+    });
+
+    test('גיבוי בלי סעיף טאבים אינו מרוקן את הטאבים הקיימים', () async {
+      final path = await createWorkspacesBackup();
+      final backupFile = File(path);
+      final json =
+          jsonDecode(await backupFile.readAsString()) as Map<String, dynamic>;
+      json.remove('openTabs');
+      await backupFile.writeAsString(jsonEncode(json));
+
+      await tabsBox.put('key-tabs', [
+        {'type': 'TextBookTab', 'title': 'ויקרא'},
+      ]);
+      await BackupService.restoreFromBackup(path);
+
+      expect((tabsBox.get('key-tabs') as List), hasLength(1));
+    });
   });
 }

--- a/test/settings/services/backup_service_test.dart
+++ b/test/settings/services/backup_service_test.dart
@@ -791,7 +791,7 @@ void main() {
       (json['perBookSettings'] as Map)['../escaped.json'] = '{"fontSize":9.0}';
       await backupFile.writeAsString(jsonEncode(json));
 
-      await BackupService.restoreFromBackup(path);
+      final result = await BackupService.restoreFromBackup(path);
 
       final escaped = File(
         p.normalize(
@@ -799,6 +799,20 @@ void main() {
         ),
       );
       expect(await escaped.exists(), isFalse);
+      expect(result.skippedSections, contains('perBookSettings'));
+    });
+
+    test('ערך קובץ לא קריא מדווח כשחזור חלקי', () async {
+      final path = await createSettingsBackup();
+      final backupFile = File(path);
+      final json =
+          jsonDecode(await backupFile.readAsString()) as Map<String, dynamic>;
+      (json['perBookSettings'] as Map)['settings_bad.json'] = 1;
+      await backupFile.writeAsString(jsonEncode(json));
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      expect(result.skippedSections, contains('perBookSettings'));
     });
 
     test('גיבוי ללא חתימת מקור ההגדרות מדווח כחלקי', () async {

--- a/test/settings/services/backup_service_test.dart
+++ b/test/settings/services/backup_service_test.dart
@@ -9,6 +9,8 @@ import 'package:otzaria/data/data_providers/hive_data_provider.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
 import 'package:otzaria/plugins/models/plugin_manifest.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
+import 'package:otzaria/personal_notes/models/personal_note.dart';
+import 'package:otzaria/personal_notes/storage/personal_notes_database.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/services/backup_service.dart';
 import 'package:otzaria/shortcuts/shortcut_validator.dart';
@@ -826,6 +828,118 @@ void main() {
       final result = await BackupService.restoreFromBackup(path);
 
       expect(result.hasLegacyPartialSettings, isFalse);
+    });
+  });
+
+  // ─── עוגן ההערות בשחזור ────────────────────────────────────────────────────
+  // גיבוי מלפני שהעיגון נכנס אליו אינו נושא את שדות העוגן כלל, ו-insertNote
+  // הוא INSERT OR REPLACE — בלי שימור, הערה שהצביעה על מילה נמתחה על כל השורה.
+  group('שחזור הערות — שימור העוגן', () {
+    late Directory dataRoot;
+
+    PersonalNote anchoredNote() => PersonalNote(
+      id: 'note-1',
+      bookId: 'ספר',
+      lineNumber: 5,
+      anchorText: 'כוס',
+      anchorPrefix: 'לפני ',
+      anchorSuffix: ' אחרי',
+      anchorStart: 10,
+      anchorEnd: 13,
+      lastKnownLineNumber: null,
+      status: PersonalNoteStatus.located,
+      content: 'תוכן ההערה',
+      contentPlain: 'תוכן ההערה',
+      contentFormat: PersonalNoteContentFormat.plain,
+      createdAt: DateTime.parse('2026-06-14T13:36:57.000Z'),
+      updatedAt: DateTime.parse('2026-06-14T13:36:57.000Z'),
+    );
+
+    /// מניפסט גיבוי עם הערה אחת. [withAnchorKeys] false = פורמט מדור קודם.
+    Future<String> writeNotesBackup({required bool withAnchorKeys}) async {
+      final note = <String, dynamic>{
+        'id': 'note-1',
+        'bookId': 'ספר',
+        'lineNumber': 5,
+        'displayTitle': null,
+        'lastKnownLineNumber': null,
+        'status': 'located',
+        'content': 'תוכן ההערה',
+        'contentPlain': 'תוכן ההערה',
+        'contentFormat': 'plain',
+        'createdAt': '2026-06-14T13:36:57.000Z',
+        'updatedAt': '2026-06-14T13:36:57.000Z',
+        if (withAnchorKeys) ...{
+          'anchorText': null,
+          'anchorPrefix': null,
+          'anchorSuffix': null,
+          'anchorStart': null,
+          'anchorEnd': null,
+        },
+      };
+      final file = File(p.join(dataRoot.path, 'notes_backup.json'));
+      await file.writeAsString(
+        jsonEncode({
+          'version': '2.0',
+          'timestamp': '2026-07-06T00-00-00.000',
+          'includes': {'notes': true},
+          'notes': [
+            {
+              'bookId': 'ספר',
+              'notes': [note],
+            },
+          ],
+        }),
+      );
+      return file.path;
+    }
+
+    setUp(() async {
+      dataRoot = await Directory.systemTemp.createTemp('notes_anchor_test_');
+      AppPaths.debugOverrideDataRootPath(dataRoot.path);
+      await PersonalNotesDatabase.instance.close();
+      await PersonalNotesDatabase.instance.insertNote(anchoredNote());
+    });
+
+    tearDown(() async {
+      await PersonalNotesDatabase.instance.close();
+      AppPaths.debugOverrideDataRootPath(null);
+      try {
+        await dataRoot.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    test('גיבוי מדור קודם אינו מוחק עוגן קיים, ומדווח', () async {
+      final path = await writeNotesBackup(withAnchorKeys: false);
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      final restored = await PersonalNotesDatabase.instance.getNote('note-1');
+      expect(restored!.anchorText, 'כוס');
+      expect(restored.anchorStart, 10);
+      expect(restored.content, 'תוכן ההערה');
+      expect(result.notesWithoutAnchor, 0);
+    });
+
+    test('גיבוי מדור קודם בלי עוגן קיים ב-DB — מדווח על ההערה', () async {
+      await PersonalNotesDatabase.instance.deleteNote('note-1');
+      final path = await writeNotesBackup(withAnchorKeys: false);
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      expect(result.notesWithoutAnchor, 1);
+      final restored = await PersonalNotesDatabase.instance.getNote('note-1');
+      expect(restored!.isWordAnchored, isFalse);
+    });
+
+    test('עוגן null מפורש הוא בחירת משתמש ומכובד', () async {
+      final path = await writeNotesBackup(withAnchorKeys: true);
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      final restored = await PersonalNotesDatabase.instance.getNote('note-1');
+      expect(restored!.anchorText, isNull);
+      expect(result.notesWithoutAnchor, 0);
     });
   });
 

--- a/test/settings/services/backup_service_test.dart
+++ b/test/settings/services/backup_service_test.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/plugins/models/plugin_manifest.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/services/backup_service.dart';
+import 'package:otzaria/shortcuts/shortcut_validator.dart';
 import 'package:otzaria/tabs/tabs_repository.dart';
 import 'package:otzaria/workspaces/workspace_repository.dart';
 import 'package:path/path.dart' as p;
@@ -810,6 +811,77 @@ void main() {
       final result = await BackupService.restoreFromBackup(path);
 
       expect(result.hasLegacyPartialSettings, isTrue);
+    });
+
+    test('גיבוי שלם מלפני החתימה אינו מדווח כחלקי', () async {
+      // page_shape_* אינו מפתח מוצהר, ולכן רק סריקת ה-Box מייצרת אותו.
+      await box.put('page_shape_book_בראשית', 'left|רש"י');
+      final path = await createSettingsBackup();
+      final backupFile = File(path);
+      final json =
+          jsonDecode(await backupFile.readAsString()) as Map<String, dynamic>;
+      json.remove('settingsSource');
+      await backupFile.writeAsString(jsonEncode(json));
+
+      final result = await BackupService.restoreFromBackup(path);
+
+      expect(result.hasLegacyPartialSettings, isFalse);
+    });
+  });
+
+  // ─── זיהוי סעיף הגדרות חלקי ────────────────────────────────────────────────
+  group('isPartialSettingsSection', () {
+    final declaredOnly = {
+      SettingsRepository.keyFontSize: 25.0,
+      SettingsRepository.keyLibraryViewMode: 'grid',
+    };
+    final scanned = {
+      ...declaredOnly,
+      'page_shape_view_mode_בראשית': true,
+    };
+
+    test('חתימת box שוללת חלקיות', () {
+      expect(
+        BackupService.isPartialSettingsSection(declaredOnly, 'box'),
+        isFalse,
+      );
+    });
+
+    test('חתימת declared-keys מצהירה על חלקיות', () {
+      expect(
+        BackupService.isPartialSettingsSection(scanned, 'declared-keys'),
+        isTrue,
+      );
+    });
+
+    test('בלי חתימה: רק מפתחות מוצהרים = חלקי', () {
+      expect(
+        BackupService.isPartialSettingsSection(declaredOnly, null),
+        isTrue,
+      );
+    });
+
+    test('בלי חתימה: מפתח שאינו מוצהר מוכיח סריקת Box', () {
+      expect(BackupService.isPartialSettingsSection(scanned, null), isFalse);
+    });
+
+    test('בלי חתימה: קיצור מקלדת לבדו אינו מוכיח סריקה', () {
+      // הקיצורים היו בתוך רשימת הנסיגה, ולכן אינם עדות לסריקת Box.
+      final withShortcut = {
+        ...declaredOnly,
+        ...{
+          for (final key in ShortcutValidator.shortcutKeys.take(1))
+            key: 'ctrl+a',
+        },
+      };
+      expect(
+        BackupService.isPartialSettingsSection(withShortcut, null),
+        isTrue,
+      );
+    });
+
+    test('סעיף הגדרות ריק אינו מדווח כשלם', () {
+      expect(BackupService.isPartialSettingsSection(const {}, null), isTrue);
     });
   });
 

--- a/test/settings/services/backup_storage_coverage_test.dart
+++ b/test/settings/services/backup_storage_coverage_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/settings/services/backup_service.dart';
+
+/// שומר על כיסוי הגיבוי: כל מקום שמירה בתוכנה חייב להיות מוכרע במפורש
+/// כמגובה ([BackupService.backedUpStores]) או כלא-מגובה-במכוון
+/// ([BackupService.unbackedStores]).
+///
+/// בלי השומר, מקום שמירה חדש נשמט מהגיבוי בשקט — כך אבדו ההתאמות הפר-ספריות,
+/// שיושבות בקבצי JSON מחוץ ל-Hive ולכן לא נתפסו על ידי שומר מפתחות ההגדרות.
+///
+/// היקף הסריקה: Hive boxes, ומקומות שנבנים מ*שורש הנתונים*. יעד שנבנה מנתיב
+/// בסיס אחר (יומני הריצה, שנופלים ל-temp כשאין שורש נתונים) אינו בתחום.
+void main() {
+  /// שמות ה-Hive boxes שנפתחים בקוד: `openBox…('name')`.
+  final boxPattern = RegExp(r"""openBox[^(]*\(\s*'([^']+)'""");
+
+  /// תיקיות שנוצרות ישירות תחת שורש הנתונים: `p.join(<dataRoot>, 'name')`.
+  final dataRootDirPattern = RegExp(
+    r"""p\.join\(\s*(?:await\s+)?[\w.]*(?:[dD]ataRoot|dataRoot)\w*(?:\(\))?\s*,\s*'([^']+)'""",
+  );
+
+  /// ה-box של ההגדרות נפתח דרך `HiveCache.keyName` ולא כמילולית.
+  const settingsBoxName = 'app_preferences';
+
+  late Set<String> discovered;
+
+  setUpAll(() {
+    final names = <String>{settingsBoxName};
+    for (final file in Directory('lib').listSync(recursive: true)) {
+      if (file is! File || !file.path.endsWith('.dart')) continue;
+      // קוד מוערך אינו מקום שמירה קיים (`user_overrides` נוטרל בהערה).
+      final source = file
+          .readAsLinesSync()
+          .where((line) => !line.trimLeft().startsWith('//'))
+          .join('\n');
+      for (final pattern in [boxPattern, dataRootDirPattern]) {
+        for (final match in pattern.allMatches(source)) {
+          names.add(match.group(1)!);
+        }
+      }
+    }
+    discovered = names;
+  });
+
+  test('הסורק מוצא את מקומות השמירה המרכזיים', () {
+    // בלי הבדיקה הזאת, regex שנשבר היה הופך את השומר לירוק-תמיד.
+    expect(
+      discovered,
+      containsAll(<String>[
+        settingsBoxName,
+        'bookmarks',
+        'history',
+        'workspaces',
+        'tabs',
+        'per_book_settings',
+        'plugins',
+      ]),
+    );
+  });
+
+  test('כל מקום שמירה מוכרע — מגובה או לא-מגובה במכוון', () {
+    final declared = {
+      ...BackupService.backedUpStores,
+      ...BackupService.unbackedStores.keys,
+    };
+    final undeclared = discovered.difference(declared);
+
+    expect(
+      undeclared,
+      isEmpty,
+      reason:
+          'מקומות שמירה שלא הוכרע לגביהם אם הם נכנסים לגיבוי: '
+          '${undeclared.join(", ")}.\n'
+          'יש להוסיף כל אחד ל-BackupService.backedUpStores (ולגבות אותו '
+          'בפועל ב-createBackup/restoreFromBackup) או ל-unbackedStores '
+          'עם הסיבה שאין לגבותו.',
+    );
+  });
+
+  test('אין הצהרה על מקום שמירה שאינו קיים בקוד', () {
+    final declared = {
+      ...BackupService.backedUpStores,
+      ...BackupService.unbackedStores.keys,
+    };
+    final stale = declared.difference(discovered);
+
+    expect(
+      stale,
+      isEmpty,
+      reason:
+          'הצהרות על מקומות שמירה שאינם קיימים עוד בקוד: ${stale.join(", ")}',
+    );
+  });
+
+  test('מקום שמירה אינו מוצהר גם כמגובה וגם כלא-מגובה', () {
+    expect(
+      BackupService.backedUpStores.intersection(
+        BackupService.unbackedStores.keys.toSet(),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('לכל מקום שאינו מגובה יש סיבה כתובה', () {
+    for (final entry in BackupService.unbackedStores.entries) {
+      expect(
+        entry.value.trim(),
+        isNotEmpty,
+        reason: 'חסרה סיבה ל-${entry.key}',
+      );
+    }
+  });
+}

--- a/test/settings/services/backup_storage_coverage_test.dart
+++ b/test/settings/services/backup_storage_coverage_test.dart
@@ -10,11 +10,19 @@ import 'package:otzaria/settings/services/backup_service.dart';
 /// בלי השומר, מקום שמירה חדש נשמט מהגיבוי בשקט — כך אבדו ההתאמות הפר-ספריות,
 /// שיושבות בקבצי JSON מחוץ ל-Hive ולכן לא נתפסו על ידי שומר מפתחות ההגדרות.
 ///
-/// היקף הסריקה: Hive boxes, ומקומות שנבנים מ*שורש הנתונים*. יעד שנבנה מנתיב
-/// בסיס אחר (יומני הריצה, שנופלים ל-temp כשאין שורש נתונים) אינו בתחום.
+/// היקף הסריקה: Hive boxes (בשם מילולי או דרך קבוע באותו קובץ), ומקומות
+/// שנבנים מ*שורש הנתונים* דרך `p.join`. שני דפוסים אינם בתחום ולא ייתפסו:
+/// נתיב שנבנה באינטרפולציה (`'$root/x'`), ו-`p.join` על משתנה שאין בשמו
+/// `dataRoot`. יעד שנבנה מנתיב בסיס אחר (יומני הריצה, שנופלים ל-temp כשאין
+/// שורש נתונים) אינו בתחום אף הוא.
 void main() {
   /// שמות ה-Hive boxes שנפתחים בקוד: `openBox…('name')`.
   final boxPattern = RegExp(r"""openBox[^(]*\(\s*'([^']+)'""");
+
+  /// `openBox…(kBoxName)` — השם מגיע מקבוע, ונפתר מהצהרתו באותו קובץ.
+  final boxViaIdentifierPattern = RegExp(
+    r"""openBox[^(]*\(\s*([A-Za-z_]\w*)\s*[,)]""",
+  );
 
   /// תיקיות שנוצרות ישירות תחת שורש הנתונים: `p.join(<dataRoot>, 'name')`.
   final dataRootDirPattern = RegExp(
@@ -39,6 +47,12 @@ void main() {
         for (final match in pattern.allMatches(source)) {
           names.add(match.group(1)!);
         }
+      }
+      for (final match in boxViaIdentifierPattern.allMatches(source)) {
+        final resolved = RegExp(
+          RegExp.escape(match.group(1)!) + r"""\s*=\s*'([^']+)'""",
+        ).firstMatch(source);
+        if (resolved != null) names.add(resolved.group(1)!);
       }
     }
     discovered = names;

--- a/test/unit/settings/backup/backup_merge_test.dart
+++ b/test/unit/settings/backup/backup_merge_test.dart
@@ -106,6 +106,40 @@ void main() {
       );
       expect(merged['settings'], {'key-a': 'old'});
     });
+
+    test('התאמות פר-ספר מאוחדות לפי שם קובץ, החדש מנצח', () {
+      final merged = merge(
+        {
+          'perBookSettings': {'a.json': '{"fontSize":20.0}', 'b.json': '{}'},
+        },
+        {
+          'perBookSettings': {'a.json': '{"fontSize":31.0}'},
+        },
+      );
+      expect(merged['perBookSettings'], {
+        'a.json': '{"fontSize":31.0}',
+        'b.json': '{}',
+      });
+    });
+
+    test('חתימת מקור ההגדרות נשמרת רק כששני המניפסטים נושאים אותה', () {
+      expect(
+        merge(
+          {'settingsSource': 'box'},
+          {'settingsSource': 'box'},
+        )['settingsSource'],
+        'box',
+      );
+      // ארכיון שספג גיבוי מדור קודם — החתימה נושרת והשחזור ידווח על חלקיות.
+      expect(
+        merge(const {}, {'settingsSource': 'box'})['settingsSource'],
+        isNull,
+      );
+      expect(
+        merge({'settingsSource': 'box'}, const {})['settingsSource'],
+        isNull,
+      );
+    });
   });
 
   group('הערות אישיות', () {
@@ -240,6 +274,31 @@ void main() {
       expect((merged['workspaces'] as List), hasLength(2));
       expect(merged['currentWorkspace'], 'w2');
       expect(merged['origin'], 'archive');
+    });
+
+    test('הטאבים הפתוחים נלקחים מהחדש בשלמותם, בלי מיזוג רשימות', () {
+      final merged = merge(
+        {
+          'openTabs': {
+            'tabs': [
+              {'title': 'ספר שנסגר'},
+            ],
+            'currentTab': 0,
+          },
+        },
+        {
+          'openTabs': {
+            'tabs': [
+              {'title': 'ספר פתוח'},
+            ],
+            'currentTab': 0,
+          },
+        },
+      );
+
+      final tabs = (merged['openTabs'] as Map)['tabs'] as List;
+      expect(tabs, hasLength(1));
+      expect((tabs.single as Map)['title'], 'ספר פתוח');
     });
   });
 }

--- a/test/unit/settings/backup/backup_merge_test.dart
+++ b/test/unit/settings/backup/backup_merge_test.dart
@@ -122,21 +122,37 @@ void main() {
       });
     });
 
-    test('חתימת מקור ההגדרות נשמרת רק כששני המניפסטים נושאים אותה', () {
+    test('חתימת מקור ההגדרות נשמרת עם הסעיף שנבחר', () {
       expect(
         merge(
-          {'settingsSource': 'box'},
-          {'settingsSource': 'box'},
+          const {},
+          {
+            'settings': {'key-a': 'new'},
+            'settingsSource': 'box',
+          },
         )['settingsSource'],
         'box',
       );
-      // ארכיון שספג גיבוי מדור קודם — החתימה נושרת והשחזור ידווח על חלקיות.
       expect(
-        merge(const {}, {'settingsSource': 'box'})['settingsSource'],
-        isNull,
+        merge(
+          {
+            'settings': {'key-a': 'old'},
+            'settingsSource': 'box',
+          },
+          const {},
+        )['settingsSource'],
+        'box',
       );
       expect(
-        merge({'settingsSource': 'box'}, const {})['settingsSource'],
+        merge(
+          {
+            'settings': {'key-a': 'old'},
+            'settingsSource': 'box',
+          },
+          {
+            'settings': {'key-a': 'new'},
+          },
+        )['settingsSource'],
         isNull,
       );
     });


### PR DESCRIPTION
## הבעיה

שחזור מגיבוי החזיר רק חלק מההגדרות, והמשתמש קיבל "הנתונים שוחזרו בהצלחה". דווחו גודל גופן, כתובת מייל לדיווחים, קיצורי מקלדת, תצוגת הספרייה, ברירות המחדל של החיפוש, התאמות צורת הדף, תיקיות אישיות ועוד.

האבחון נעשה מול קובצי גיבוי אמיתיים. השוואה בין שניים מהם מסבירה את כל התסמינים:

| קובץ הגיבוי | מפתחות הגדרות |
|---|---|
| 06/07 – 05/08/2026 | **24–25** |
| 12/08/2026 (0.9.96) | **126** |

הגיבוי עבר לסרוק את כל ה-Hive box ב-`5d575d9b4`. שחזור מקובץ שנוצר לפניו מחסיר ~100 מפתחות — והם מעולם לא היו בקובץ.

## מה תוקן

**1. ההתאמות הפר-ספריות לא היו בגיבוי כלל — גם אחרי `5d575d9b4`.** הן יושבות בקבצי JSON תחת `per_book_settings/` ולא ב-Hive, ולכן המעבר לסריקת ה-Box לא תפס אותן: המפרשים הפעילים בכל ספר, גופן/ניקוד/פיסוק פר-ספר, רוחבי הטורים בצורת הדף וזום ה-PDF. כולם נכנסים עכשיו. שם הקובץ מאומת כשם בסיס לפני הכתיבה, וקובץ שאינו בגיבוי נשאר במקומו — שחזור אינו מוחק התאמות של ספרים אחרים.

**2. גיבוי חלקי הכריז על עצמו כמוצלח.** גיבוי מלפני `5d575d9b4` אינו ניתן להבחנה מגיבוי מלא: גם הוא `version: 2.0`. הגיבוי נושא מעתה `settingsSource`, וההכרעה על גיבוי שאינו נושא אותו נופלת על התוכן — אוסף מרשימת מפתחות מוצהרת יכול להכיל רק מפתחות מתוכה, ולכן מפתח אחד מחוצה לה מוכיח סריקת Box. כך גיבוי שלם מלפני התיקון אינו מקבל התראת שקר.

**3. הטאבים הפתוחים לא היו בגיבוי,** ואחרי שחזור התוכנה נפתחה בלעדיהם. נכנסים תחת סעיף שולחנות העבודה — אותו סוג נתון — ולא כהעדפה נפרדת. גולמיים, כדי שטאב שספרו חסר ביעד לא יושמט מראש. היעדרם אינו מסמן שחזור חלקי, וגיבוי בלעדיהם אינו מרוקן את הקיימים.

**4. `BackupMerge` בנה את מניפסט הארכיון שדה-שדה** ולכן היה מפיל את שלושתם בגלגול הארכיון. החתימה עוברת רק אם שני המניפסטים נושאים אותה — ארכיון שספג גיבוי אחד מדור קודם חסר הגדרות.

**5. ריצת מרוץ באיפוס הגדרות.** `Settings.clearCache` של החבילה הוא `void` ואינו ממתין ל-`Future` של המחיקה: הבנייה מחדש התחילה בזמן שהמחיקה עוד רצה, וברירות המחדל שנכתבו מיד אחריה נמחקו איתה.

## שומר הכיסוי

הסיבה ששלושת מקומות השמירה נשמטו היא שאין דבר שאוכף כיסוי. יש שומר על כל *מפתח הגדרות*, ולכן `per_book_settings/` — שאינו מפתח — היה עיוור לו.

`backedUpStores` / `unbackedStores` מצהירים על כל מקום שמירה בתוכנה, ו-`backup_storage_coverage_test` סורק את הקוד ונכשל על מקום שלא הוכרע. **בהרצה הראשונה הוא תפס `pending_external_activations.jsonl` שלא היה מוכרע.** שני דפוסי כתיבה נשארים מחוץ לתחום ומתועדים בראש הטסט.

## בדיקות

- ששת קובצי הגיבוי האמיתיים משוחזרים בלי קריסה, כולל `version: 1.0`, וכל אחד מסווג נכון: חמשת הישנים חלקיים, זה מ-12/08 שלם.
- השער על שם קובץ בשחזור עומד ב-13 קלטים עוינים (יציאה מתיקייה, נתיב מוחלט, UNC, מפריד הפוך, תו null).
- השומר נבדק מול 11 דפוסי כתיבה של מקום שמירה חדש; החור שנמצא (שם box מקבוע — הדפוס של `HiveCache.keyName` עצמו) נסגר.
- `flutter analyze` נקי; 68 טסטים ב-`test/settings/services/` ו-`test/unit/settings/backup/` עוברים, מהם 15 חדשים.

## הערה למשתמשים קיימים

הגדרות שאבדו בשחזור מגיבוי מדור קודם אינן בנות-שחזור — הן לא בקובץ. אבל קובצי ההתאמות הפר-ספריות שורדים איפוס הגדרות (האיפוס מוחק את ה-Hive box בלבד), ולכן הדלקת "שמירת התאמות לכל ספר" מחזירה אותן.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
