### PR TITLE
קיצור החלפת מצב תצוגה: תיקון הכיוון PDF→טקסט

### DIFF
--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -501,6 +501,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   bool _resolvedParallelEditions = false;
   late final VoidCallback _toggleNavPaneListener;
   late final VoidCallback _toggleCommentatorsPaneListener;
+  late final VoidCallback _toggleTextViewListener;
 
   Future<void> _runInitialSearchIfNeeded() async {
     final controller = widget.tab.searchController;
@@ -790,6 +791,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     widget.tab.toggleCommentatorsPaneNotifier.addListener(
       _toggleCommentatorsPaneListener,
     );
+
+    // קיצור Ctrl+Shift+P: מעבר למהדורת הטקסט — אותה פעולה כמו כפתור הטקסט.
+    _toggleTextViewListener = () => _handleTextButtonPress(context);
+    widget.tab.toggleTextViewNotifier.addListener(_toggleTextViewListener);
   }
 
   Future<void> _loadInitialLayoutMode() async {
@@ -3556,6 +3561,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     widget.tab.toggleCommentatorsPaneNotifier.removeListener(
       _toggleCommentatorsPaneListener,
     );
+    widget.tab.toggleTextViewNotifier.removeListener(_toggleTextViewListener);
     _leftPaneTabController?.dispose();
     _openFilterRequest.dispose();
     _searchFieldFocusNode.dispose();

--- a/lib/shortcuts/keyboard_shortcuts.dart
+++ b/lib/shortcuts/keyboard_shortcuts.dart
@@ -169,6 +169,7 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
     final openCommentatorsTabShortcut = shortcutOf(
       'key-shortcut-open-commentators-tab',
     );
+    final togglePdfViewShortcut = shortcutOf('key-shortcut-toggle-pdf-view');
     final prevSegmentShortcut = shortcutOf('key-shortcut-prev-segment');
     final nextSegmentShortcut = shortcutOf('key-shortcut-next-segment');
     final prevTocShortcut = shortcutOf('key-shortcut-prev-toc');
@@ -224,6 +225,19 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
       }
       if (tab is PdfBookTab) {
         tab.toggleCommentatorsPaneNotifier.value++;
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    }
+
+    // החלפת מצב תצוגה PDF→טקסט. הכיוון ההפוך מטופל במסך ספר הטקסט עצמו,
+    // שה-KeyboardListener שלו עוטף את כל המסך.
+    if (isReadingScreen &&
+        togglePdfViewShortcut.isNotEmpty &&
+        ShortcutHelper.matchesShortcut(event, togglePdfViewShortcut)) {
+      final tab = context.read<TabsBloc>().state.currentTab;
+      if (tab is PdfBookTab) {
+        tab.toggleTextViewNotifier.value++;
         return KeyEventResult.handled;
       }
       return KeyEventResult.ignored;

--- a/lib/tabs/models/pdf_tab.dart
+++ b/lib/tabs/models/pdf_tab.dart
@@ -72,6 +72,10 @@ class PdfBookTab extends OpenedTab {
     0,
   );
 
+  /// counter שמתגלגל עם כל בקשה למעבר למהדורת הטקסט מקיצור מקלדת גלובלי.
+  /// המאזין הוא [PdfBookScreen] בלבד; כל הגדלה = מעבר יחיד.
+  final ValueNotifier<int> toggleTextViewNotifier = ValueNotifier<int>(0);
+
   /// PDF headings mapping for commentaries and links
   PdfHeadings? pdfHeadings;
 
@@ -227,6 +231,7 @@ class PdfBookTab extends OpenedTab {
     pinLeftPane.dispose();
     toggleNavPaneNotifier.dispose();
     toggleCommentatorsPaneNotifier.dispose();
+    toggleTextViewNotifier.dispose();
     incomingSearchConfiguration.dispose();
     externalMatches.dispose();
     super.dispose();

--- a/test/shortcuts/keyboard_shortcuts_test.dart
+++ b/test/shortcuts/keyboard_shortcuts_test.dart
@@ -187,7 +187,7 @@ void main() {
     );
   });
 
-  group('KeyboardShortcuts - קיצורי חלוניות (Ctrl+Shift+L/C)', () {
+  group('KeyboardShortcuts - קיצורי חלוניות ותצוגה (Ctrl+Shift+L/C/P)', () {
     late MockSettingsBloc settingsBlocLocal;
     late StreamController<SettingsState> settingsControllerLocal;
 
@@ -297,6 +297,24 @@ void main() {
         expect(tab.toggleCommentatorsPaneNotifier.value, 0);
         await sendCtrlShift(tester, LogicalKeyboardKey.keyC);
         expect(tab.toggleCommentatorsPaneNotifier.value, 1);
+      },
+    );
+
+    testWidgets(
+      'Ctrl+Shift+P ב-PdfBookTab מגלגל את toggleTextViewNotifier '
+      '(הקיצור פעל רק בכיוון טקסט→PDF)',
+      (tester) async {
+        final tab = PdfBookTab(
+          book: PdfBook(title: 'ספר PDF', path: '/x.pdf'),
+          pageNumber: 1,
+        );
+        addTearDown(tab.dispose);
+
+        await pumpWithTab(tester, tab);
+
+        expect(tab.toggleTextViewNotifier.value, 0);
+        await sendCtrlShift(tester, LogicalKeyboardKey.keyP);
+        expect(tab.toggleTextViewNotifier.value, 1);
       },
     );
   });


### PR DESCRIPTION
## הבעיה

קיצור "החלף מצב תצוגה (PDF/טקסט)" — `Ctrl+Shift+P` כברירת מחדל — פעל בכיוון אחד בלבד: מספר טקסט אל ה-PDF. מתוך ספר PDF הקיצור לא עשה כלום.

## סיבת השורש

המפתח `key-shortcut-toggle-pdf-view` נקלט אך ורק ב-`text_book_screen.dart`, בתוך ה-`KeyboardListener` שעוטף את מסך ספר הטקסט. במסך ה-PDF אף אחד לא האזין לו — לא ב-`Focus.onKeyEvent` של הצופה ולא במטפל הגלובלי. כלומר הכיוון PDF→טקסט מעולם לא מומש.

## התיקון

לפי אותה תבנית שכבר קיימת בקיצורי חלונית הניווט והמפרשים ב-PDF (notifier על הטאב + מאזין במסך), כדי שהקיצור יעבוד ללא תלות במי שמחזיק את הפוקוס:

- `lib/tabs/models/pdf_tab.dart` — `toggleTextViewNotifier` חדש (+ שחרור ב-`dispose`).
- `lib/pdf_book/view/pdf_book_screen.dart` — מאזין שמפעיל את `_handleTextButtonPress`, בדיוק אותה פעולה של כפתור "פתח ספר במהדורת טקסט", כולל מיפוי העמוד לשורה והודעה כשהמיקום לא נמצא.
- `lib/shortcuts/keyboard_shortcuts.dart` — קליטת הקיצור עבור `PdfBookTab`. לטאב טקסט מוחזר `ignored`, כך שהכיוון הקיים ממשיך להיות מטופל במסך הטקסט ואין הפעלה כפולה.

סה"כ 44 שורות, ללא שכפול של לוגיקת המעבר.

## בדיקות

בדיקה חדשה ב-`test/shortcuts/keyboard_shortcuts_test.dart`: `Ctrl+Shift+P` ב-`PdfBookTab` מגלגל את `toggleTextViewNotifier`.

- `flutter analyze` — נקי
- `flutter test test/shortcuts/keyboard_shortcuts_test.dart` — 25/25 עוברות

🤖 Generated with [Claude Code](https://claude.com/claude-code)
