### PR TITLE
רוחב הטקסט: שמירה על רוחב קבוע בפתיחת חלונית צד

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -721,6 +721,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Nav rail item | `test/widgets/nav_rail_item_test.dart` |
 | Reader side panel shell | `test/widgets/reader_side_panel_shell_test.dart` |
 | Responsive action bar | `test/widgets/responsive_action_bar_test.dart` |
+| רוחב עמודת הטקסט (בסיס אזור הקריאה, יציב בפתיחת חלונית) | `test/widgets/layout/reading_area_width_test.dart` |
 | Scrollable list scrollbar | `test/widgets/scrollable_positioned_list_scrollbar_test.dart` |
 | Smooth mouse-wheel scrolling | `test/widgets/smooth_wheel_scroll_test.dart` |
 | Smart text render settings | `test/widgets/smart_text/render_settings_test.dart` |

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -40,6 +40,7 @@ import 'package:otzaria/utils/text/global_search_helper.dart';
 import 'package:otzaria/utils/text/ref_helper.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
+import 'package:otzaria/widgets/layout/reading_area_width.dart';
 import 'package:otzaria/widgets/smart_text/smart_text.dart';
 import 'package:otzaria/text_book/view/selection/text_selection_manager.dart';
 import 'package:otzaria/text_book/view/selection/selection_sync_controller.dart';
@@ -2121,15 +2122,11 @@ class _CombinedViewState extends State<CombinedView> {
                     builder: (context, constraints) {
                       return BlocBuilder<SettingsBloc, SettingsState>(
                         builder: (context, settingsState) {
-                          var textMaxWidth = settingsState.textMaxWidth;
-
-                          // אם הערך שלילי, זו רמה שצריך לחשב לפי גודל המסך
-                          // למשל -2 = רמה 2 = 90% מרוחב המסך
-                          if (textMaxWidth < 0) {
-                            final level = (-textMaxWidth).toInt();
-                            final widthPercent = 1.0 - (level * 0.05);
-                            textMaxWidth = constraints.maxWidth * widthPercent;
-                          }
+                          final textMaxWidth = textColumnMaxWidthOf(
+                            context,
+                            setting: settingsState.textMaxWidth,
+                            availableWidth: constraints.maxWidth,
+                          );
 
                           // במצב רציף — פסקה מכמה שורות מקור.
                           if (isContinuousParagraph) {
@@ -2690,14 +2687,11 @@ class _CommentaryCardState extends State<_CommentaryCard> {
         return BlocBuilder<SettingsBloc, SettingsState>(
           builder: (context, settingsState) {
             // שימוש באותו רוחב מקסימלי כמו הטקסט
-            var textMaxWidth = settingsState.textMaxWidth;
-
-            // אם הערך שלילי, זו רמה שצריך לחשב לפי גודל המסך
-            if (textMaxWidth < 0) {
-              final level = (-textMaxWidth).toInt();
-              final widthPercent = 1.0 - (level * 0.05);
-              textMaxWidth = constraints.maxWidth * widthPercent;
-            }
+            final textMaxWidth = textColumnMaxWidthOf(
+              context,
+              setting: settingsState.textMaxWidth,
+              availableWidth: constraints.maxWidth,
+            );
 
             final commentaryContainer = Container(
               margin: const EdgeInsets.only(bottom: 8.0),

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -35,6 +35,7 @@ import 'package:otzaria/widgets/lists/commentators_selection_panel.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
+import 'package:otzaria/widgets/layout/reading_area_width.dart';
 import 'package:otzaria/widgets/layout/split_pane_content_inset.dart';
 import 'package:otzaria/widgets/navigation/responsive_action_bar.dart';
 import 'package:otzaria/widgets/navigation/app_top_bar.dart';
@@ -827,14 +828,11 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
       builder: (context, constraints) {
         return BlocBuilder<SettingsBloc, SettingsState>(
           builder: (context, settingsState) {
-            // אותו חישוב כמו בתצוגת הטקסט הראשית (combined_book_screen):
-            // ערך שלילי = רמה (95%/90%/...), ערך 0 = ללא הגבלה.
-            var textMaxWidth = settingsState.textMaxWidth;
-            if (textMaxWidth < 0) {
-              final level = (-textMaxWidth).toInt();
-              final widthPercent = 1.0 - (level * 0.05);
-              textMaxWidth = constraints.maxWidth * widthPercent;
-            }
+            final textMaxWidth = textColumnMaxWidthOf(
+              context,
+              setting: settingsState.textMaxWidth,
+              availableWidth: constraints.maxWidth,
+            );
 
             if (textMaxWidth > 0) {
               // יישור לראש (topCenter) ולא Center — אחרת כשהמפרשים מכווצים

--- a/lib/widgets/layout/adaptive_side_pane.dart
+++ b/lib/widgets/layout/adaptive_side_pane.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/widgets/layout/floating_panel.dart';
+import 'package:otzaria/widgets/layout/reading_area_width.dart';
 import 'package:otzaria/widgets/layout/resizable_drag_handle.dart';
 
 /// חלונית צד אדפטיבית:
@@ -294,6 +295,7 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
           return _buildWideLayout(
             context,
             paneOnRight: paneOnRight,
+            areaWidth: constraints.maxWidth,
           );
         }
 
@@ -306,9 +308,19 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
     );
   }
 
+  /// עוטף את התוכן הראשי ברוחב אזור הקריאה המלא, כדי שרוחב עמודת הטקסט יחושב
+  /// ממנו ולא ישתנה כשהחלונית נפתחת ודוחקת את התוכן. פאנל מקונן לא דורס את
+  /// הבסיס של הפאנל שמעליו — הרוחב שהוא רואה כבר צומצם ע"י אותו פאנל.
+  Widget _mainContentWithAreaWidth(BuildContext context, double areaWidth) {
+    final base = ReadingAreaWidth.maybeOf(context) ?? areaWidth;
+    if (!base.isFinite) return widget.mainContent;
+    return ReadingAreaWidth(width: base, child: widget.mainContent);
+  }
+
   Widget _buildWideLayout(
     BuildContext context, {
     required bool paneOnRight,
+    required double areaWidth,
   }) {
     final showHandle =
         widget.isOpen &&
@@ -402,11 +414,13 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
       },
     );
 
+    final mainContent = _mainContentWithAreaWidth(context, areaWidth);
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: paneOnRight
-          ? [paneSlot, Expanded(child: widget.mainContent)]
-          : [Expanded(child: widget.mainContent), paneSlot],
+          ? [paneSlot, Expanded(child: mainContent)]
+          : [Expanded(child: mainContent), paneSlot],
     );
   }
 
@@ -438,7 +452,7 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
 
     return Stack(
       children: [
-        Positioned.fill(child: widget.mainContent),
+        Positioned.fill(child: _mainContentWithAreaWidth(context, maxWidth)),
         IgnorePointer(
           ignoring: !widget.isOpen,
           child: Stack(

--- a/lib/widgets/layout/reading_area_width.dart
+++ b/lib/widgets/layout/reading_area_width.dart
@@ -1,0 +1,52 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+/// רוחב אזור הקריאה המלא, לפני שחלונית צד פתוחה דוחקת את התוכן. משמש בסיס
+/// לחישוב רוחב עמודת הטקסט, כדי שפתיחת חלונית תזיז את הטקסט ולא תצר אותו.
+class ReadingAreaWidth extends InheritedWidget {
+  final double width;
+
+  const ReadingAreaWidth({
+    super.key,
+    required this.width,
+    required super.child,
+  });
+
+  static double? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<ReadingAreaWidth>()?.width;
+
+  @override
+  bool updateShouldNotify(ReadingAreaWidth oldWidget) =>
+      width != oldWidget.width;
+}
+
+/// רוחב מרבי לעמודת הטקסט לפי הגדרת "רוחב הטקסט".
+///
+/// [setting]: 0 = ללא הגבלה, ערך שלילי = רמה (‎-11 = 45%), ערך חיובי = פיקסלים
+/// (פורמט ישן). האחוז מחושב מ-[baseWidth], והתוצאה מוגבלת ל-[availableWidth]
+/// כך שהעמודה מצטמצמת רק כשאין מקום.
+double resolveTextColumnMaxWidth({
+  required double setting,
+  required double availableWidth,
+  required double baseWidth,
+}) {
+  if (setting == 0) return 0;
+  final desired = setting > 0
+      ? setting
+      : baseWidth * (1.0 - (-setting).toInt() * 0.05);
+  return math.min(desired, availableWidth);
+}
+
+/// [resolveTextColumnMaxWidth] כשהבסיס מגיע מ-[ReadingAreaWidth] העוטף.
+double textColumnMaxWidthOf(
+  BuildContext context, {
+  required double setting,
+  required double availableWidth,
+}) {
+  return resolveTextColumnMaxWidth(
+    setting: setting,
+    availableWidth: availableWidth,
+    baseWidth: ReadingAreaWidth.maybeOf(context) ?? availableWidth,
+  );
+}

--- a/test/widgets/layout/reading_area_width_test.dart
+++ b/test/widgets/layout/reading_area_width_test.dart
@@ -1,0 +1,180 @@
+// Regression: רוחב עמודת הטקסט חושב כאחוז מהרוחב הפנוי, ולכן פתיחת חלונית צד
+// (הערות/מפרשים/ניווט) הצרה את הטקסט. הבסיס הוא רוחב אזור הקריאה המלא,
+// והרוחב הפנוי רק מגביל אותו כשאין מקום.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
+import 'package:otzaria/widgets/layout/reading_area_width.dart';
+
+void main() {
+  group('resolveTextColumnMaxWidth', () {
+    test('רמה מחושבת מרוחב אזור הקריאה, לא מהרוחב הפנוי', () {
+      expect(
+        resolveTextColumnMaxWidth(
+          setting: -11,
+          availableWidth: 1200,
+          baseWidth: 1800,
+        ),
+        closeTo(810, 0.001),
+      );
+    });
+
+    test('אותו רוחב עם חלונית פתוחה וסגורה', () {
+      double widthFor(double available) => resolveTextColumnMaxWidth(
+        setting: -11,
+        availableWidth: available,
+        baseWidth: 1800,
+      );
+
+      expect(widthFor(1800), widthFor(1200));
+    });
+
+    test('מצטמצם רק כשאין מקום', () {
+      expect(
+        resolveTextColumnMaxWidth(
+          setting: -2,
+          availableWidth: 700,
+          baseWidth: 1800,
+        ),
+        700,
+      );
+    });
+
+    test('0 = ללא הגבלה', () {
+      expect(
+        resolveTextColumnMaxWidth(
+          setting: 0,
+          availableWidth: 1200,
+          baseWidth: 1800,
+        ),
+        0,
+      );
+    });
+
+    test('ערך חיובי (פורמט ישן) נשמר, ומוגבל לרוחב הפנוי', () {
+      expect(
+        resolveTextColumnMaxWidth(
+          setting: 900,
+          availableWidth: 1200,
+          baseWidth: 1800,
+        ),
+        900,
+      );
+      expect(
+        resolveTextColumnMaxWidth(
+          setting: 900,
+          availableWidth: 600,
+          baseWidth: 1800,
+        ),
+        600,
+      );
+    });
+  });
+
+  testWidgets('AdaptiveSidePane מספק רוחב אזור קריאה קבוע בפתיחת החלונית', (
+    tester,
+  ) async {
+    double? areaWidth;
+    double? availableWidth;
+    final isOpen = ValueNotifier<bool>(false);
+    addTearDown(isOpen.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 800,
+            height: 600,
+            child: ValueListenableBuilder<bool>(
+              valueListenable: isOpen,
+              builder: (context, open, _) => AdaptiveSidePane(
+                isOpen: open,
+                onClose: () => isOpen.value = false,
+                paneWidth: 200,
+                minMainContentWidth: 300,
+                paneContent: const SizedBox.expand(),
+                mainContent: Builder(
+                  builder: (context) {
+                    areaWidth = ReadingAreaWidth.maybeOf(context);
+                    return LayoutBuilder(
+                      builder: (context, constraints) {
+                        availableWidth = constraints.maxWidth;
+                        return const SizedBox.expand();
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(areaWidth, 800);
+    expect(availableWidth, 800);
+
+    isOpen.value = true;
+    await tester.pumpAndSettle();
+
+    expect(availableWidth, lessThan(800));
+    expect(areaWidth, 800);
+  });
+
+  testWidgets('פאנל מקונן לא דורס את בסיס הפאנל החיצוני', (tester) async {
+    double? areaWidth;
+    double? availableWidth;
+    final outerOpen = ValueNotifier<bool>(false);
+    addTearDown(outerOpen.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 800,
+            height: 600,
+            child: ValueListenableBuilder<bool>(
+              valueListenable: outerOpen,
+              builder: (context, open, _) => AdaptiveSidePane(
+                isOpen: open,
+                onClose: () => outerOpen.value = false,
+                paneWidth: 200,
+                minMainContentWidth: 300,
+                paneContent: const SizedBox.expand(),
+                mainContent: AdaptiveSidePane(
+                  isOpen: false,
+                  onClose: () {},
+                  paneWidth: 150,
+                  minMainContentWidth: 200,
+                  paneContent: const SizedBox.expand(),
+                  mainContent: Builder(
+                    builder: (context) {
+                      areaWidth = ReadingAreaWidth.maybeOf(context);
+                      return LayoutBuilder(
+                        builder: (context, constraints) {
+                          availableWidth = constraints.maxWidth;
+                          return const SizedBox.expand();
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(areaWidth, 800);
+
+    outerOpen.value = true;
+    await tester.pumpAndSettle();
+
+    expect(availableWidth, lessThan(800));
+    expect(areaWidth, 800);
+  });
+}


### PR DESCRIPTION
## הבעיה

רוחב עמודת הטקסט בספר משתנה כשנפתחת חלונית צד (הערות / קישורים / מפרשים / ניווט): הטקסט מצטמצם במקום להישאר ברוחבו ורק לזוז.

## שורש הבעיה

מאז מעבר ההגדרה מפיקסלים לרמה באחוזים, האחוז חושב מ-`constraints.maxWidth` — כלומר מהרוחב שנשאר **אחרי** שהחלונית דחקה את התוכן. בהגדרה של 45% ורוחב אזור קריאה 1815: סגור → 817px, פתוח (חלונית 560px) → 45% מ-1255 = 565px.

## התיקון

הבסיס לחישוב הוא רוחב אזור הקריאה המלא, והרוחב הפנוי רק **מגביל** — כך העמודה מצטמצמת רק כשאין מקום:

- `lib/widgets/layout/reading_area_width.dart` (חדש) — `ReadingAreaWidth` (InheritedWidget) + `resolveTextColumnMaxWidth` / `textColumnMaxWidthOf`
- `AdaptiveSidePane` מספק את רוחב אזור הקריאה ל-`mainContent` שלו. פאנל מקונן **אינו** דורס את הבסיס של הפאנל שמעליו — אחרת פתיחת חלונית הניווט (החיצונית) הייתה מצרה שוב את הטקסט
- שלושת הצרכנים (`CombinedView` ×2, `CommentatorsTabScreen`) עברו לפונקציה המשותפת במקום שכפול החישוב

ערך הגדרה ישן בפיקסלים (חיובי) ו-0 (רוחב מלא) ממשיכים לעבוד כמקודם.

## בדיקות

- `test/widgets/layout/reading_area_width_test.dart` (חדש, 7 טסטים) — כולל רגרסיה לקינון פאנלים; אומת שהוא נכשל בלי התיקון (בסיס 578 במקום 800)
- `flutter analyze lib test` — נקי
- `flutter test test/widgets/ test/library/ test/personal_notes/ test/search/ test/pdf_book/ test/tools/ test/text_book/ test/settings/text_width_slider_test.dart` — עוברים (כשל יחיד ב-`personal_notes_file_backed_book_test.dart` קיים גם ב-dev נקי: נעילת קובץ ב-tearDown ב-Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
