### PR TITLE
תצוגה מקדימה: מחוון גלילה יציב בקצה ימין

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -646,16 +646,12 @@ class _CombinedViewState extends State<CombinedView> {
   // שמירת גובה הבלוק בפועל לחישובים דינאמיים
   double _viewportHeight = 0;
 
-  ScrollController? _previewScrollController;
   final DictionaryLookupRepository _dictionaryLookupRepository =
       DictionaryLookupRepository.instance;
 
   @override
   void initState() {
     super.initState();
-    if (widget.isPreviewMode) {
-      _previewScrollController = ScrollController();
-    }
     _focusNode = FocusNode();
     // רישום למיקוד אזור הקריאה במעבר טאב (לא ב-preview שאינו טאב פעיל).
     if (!widget.isPreviewMode) {
@@ -824,7 +820,6 @@ class _CombinedViewState extends State<CombinedView> {
     _disposed = true;
     _cancelPendingAnchorHover();
     LinkPreviewOverlay.dismiss();
-    _previewScrollController?.dispose();
     widget.tab.positionsListener.itemPositions.removeListener(_onScroll);
     widget.tab.positionsListener.itemPositions.removeListener(_updateTabIndex);
     _savedSelectedText.dispose();
@@ -1754,30 +1749,7 @@ class _CombinedViewState extends State<CombinedView> {
                       ClearSelectionIntent: _ClearSelectionAction(this),
                     },
                     child: widget.isPreviewMode
-                        ? Scrollbar(
-                            controller: _previewScrollController,
-                            thickness: 8.0,
-                            radius: const Radius.circular(4.0),
-                            child: ListView.builder(
-                              controller: _previewScrollController,
-                              // מרווח אופקי סימטרי שמשאיר תעלה לפס הגלילה (8px)
-                              // בצד שמאל ב-RTL, כך שלא יכסה את הטקסט.
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12.0,
-                              ),
-                              itemCount: state.readingSegments.isNotEmpty
-                                  ? state.readingSegments.length
-                                  : widget.data.length,
-                              itemBuilder: (context, index) {
-                                return buildExpansiomTile(
-                                  ExpansibleController(),
-                                  index,
-                                  state,
-                                  const <int, List<PersonalNote>>{},
-                                );
-                              },
-                            ),
-                          )
+                        ? _buildPreviewList(state)
                         : ScrollablePositionedListScrollbar(
                             scrollController: widget.tab.scrollController,
                             itemPositionsListener: widget.tab.positionsListener,
@@ -1845,6 +1817,39 @@ class _CombinedViewState extends State<CombinedView> {
           },
         );
       },
+    );
+  }
+
+  /// רשימת התצוגה המקדימה, עם אותו מחוון גלילה של אזור הקריאה. ListView
+  /// אומד את היקף הגלילה מגובה הפריטים שבנויים כרגע, וכששורות הספר בגבהים
+  /// שונים האומדן משתנה בכל פריים והאגודל קפץ למעלה ולמטה במקום לנסוע ישר.
+  Widget _buildPreviewList(TextBookLoaded state) {
+    final itemCount = state.readingSegments.isNotEmpty
+        ? state.readingSegments.length
+        : widget.data.length;
+
+    return ScrollablePositionedListScrollbar(
+      scrollController: widget.tab.scrollController,
+      itemPositionsListener: widget.tab.positionsListener,
+      offsetController: widget.tab.mainOffsetController,
+      itemCount: itemCount,
+      child: SmoothWheelScroll(
+        child: ScrollablePositionedList.builder(
+          itemScrollController: widget.tab.scrollController,
+          itemPositionsListener: widget.tab.positionsListener,
+          scrollOffsetController: widget.tab.mainOffsetController,
+          padding: const EdgeInsets.symmetric(horizontal: 12.0),
+          itemCount: itemCount,
+          itemBuilder: (context, index) => RepaintBoundary(
+            child: buildExpansiomTile(
+              ExpansibleController(),
+              index,
+              state,
+              const <int, List<PersonalNote>>{},
+            ),
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
+++ b/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
@@ -8,6 +8,11 @@ import 'package:otzaria/widgets/feedback/scrollbar_target_label.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ScrollablePositionedListScrollbar extends StatefulWidget {
+  /// המסילה (שטח המחווה) והאגודל. הרשימה עצמה היא ילד של הסרגל, ולכן חיפוש
+  /// לפי טיפוס תופס גם רכיבים מהתוכן — הטסטים מאתרים אותם דרך המפתחות.
+  static const Key trackKey = Key('positioned-list-scrollbar-track');
+  static const Key thumbKey = Key('positioned-list-scrollbar-thumb');
+
   final ItemScrollController scrollController;
   final ItemPositionsListener itemPositionsListener;
   final int itemCount;
@@ -462,6 +467,7 @@ class _ScrollablePositionedListScrollbarState
                     _hideLabel();
                   },
                   child: GestureDetector(
+                    key: ScrollablePositionedListScrollbar.trackKey,
                     // opaque: מבטיח שהגרירה והלחיצה יתקבלו בכל שטח ה-track,
                     // לא רק מעל ה-thumb עצמו — ללא צורך ברקע צבעוני.
                     behavior: HitTestBehavior.opaque,
@@ -518,6 +524,7 @@ class _ScrollablePositionedListScrollbarState
                           right: 2,
                           height: thumbPixelHeight,
                           child: Container(
+                            key: ScrollablePositionedListScrollbar.thumbKey,
                             decoration: BoxDecoration(
                               color: AppSurfaces.scrollbarThumb(
                                 colorScheme,

--- a/test/text_book/view/combined_view/preview_mode_scrollbar_test.dart
+++ b/test/text_book/view/combined_view/preview_mode_scrollbar_test.dart
@@ -1,0 +1,381 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_bloc.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_event.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_state.dart';
+import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
+import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/view/combined_view/combined_book_screen.dart';
+import 'package:otzaria/widgets/feedback/scrollable_positioned_list_scrollbar.dart';
+import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
+import 'package:otzaria/widgets/layout/resizable_drag_handle.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import '../../../test_helpers/memory_cache_provider.dart';
+
+/// שורות ספר אמיתיות אינן בגובה אחיד — שורה קצרה לעומת פסקה שנשברת לכמה
+/// שורות. זה בדיוק המצב שבו אומדן ההיקף של ListView מתנודד.
+const int _lineCount = 120;
+
+List<String> _variableHeightContent() => List.generate(_lineCount, (i) {
+  final words = const [2, 4, 30, 3, 12, 60][i % 6];
+  return List.filled(words, 'מילה$i').join(' ');
+});
+
+TextBookLoaded _loadedState(List<String> content) {
+  return TextBookLoaded(
+    book: TextBook(title: 'ספר בדיקה'),
+    showLeftPane: false,
+    content: content,
+    fontSize: 18,
+    showSplitView: false,
+    showPageShapeView: false,
+    activeCommentators: const [],
+    commentatorGroups: const [],
+    availableCommentators: const [],
+    links: const [],
+    visibleLinks: const [],
+    linksByLine: const {},
+    tableOfContents: const [],
+    removeNikud: false,
+    visibleIndices: const [0],
+    selectedIndex: null,
+    pinLeftPane: false,
+    searchText: '',
+    scrollController: ItemScrollController(),
+    positionsListener: ItemPositionsListener.create(),
+  );
+}
+
+class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
+    implements TextBookBloc {
+  _TestTextBookBloc(super.initialState) {
+    on<TextBookEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestPersonalNotesBloc
+    extends Bloc<PersonalNotesEvent, PersonalNotesState>
+    implements PersonalNotesBloc {
+  _TestPersonalNotesBloc(super.initialState) {
+    on<PersonalNotesEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {
+  _TestSettingsBloc(super.initialState) {
+    on<SettingsEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  /// בונה את התצוגה המקדימה של הספרייה (CombinedView במצב preview) בעברית,
+  /// ומחזיר את ה-tab כדי שאפשר לבדוק את מיקום הגלילה שנשמר בו.
+  Future<TextBookTab> pumpPreview(
+    WidgetTester tester, {
+    bool isPreviewMode = true,
+    Size size = const Size(500, 800),
+    // עוטף את התצוגה כמו בספרייה: חלונית צד בצד שמאל (RTL) הניתנת לשינוי רוחב.
+    bool inSidePane = false,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final content = _variableHeightContent();
+    final textBookBloc = _TestTextBookBloc(_loadedState(content));
+    final personalNotesBloc = _TestPersonalNotesBloc(
+      const PersonalNotesState.initial(),
+    );
+    final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+    final tab = TextBookTab(book: TextBook(title: 'ספר בדיקה'), index: 0);
+    addTearDown(textBookBloc.close);
+    addTearDown(personalNotesBloc.close);
+    addTearDown(settingsBloc.close);
+    addTearDown(tab.dispose);
+
+    final preview = CombinedView(
+      data: content,
+      openBookCallback: (_) {},
+      openLeftPaneTab: (_, {searchText}) {},
+      textSize: 18,
+      showCommentaryAsExpansionTiles: false,
+      tab: tab,
+      isPreviewMode: isPreviewMode,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('he', 'IL'),
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        supportedLocales: const [Locale('he', 'IL')],
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: textBookBloc),
+            BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          ],
+          child: Scaffold(
+            body: inSidePane
+                ? AdaptiveSidePane(
+                    isOpen: true,
+                    alignment: AlignmentDirectional.centerStart,
+                    isResizable: true,
+                    onPaneWidthChanged: (_) {},
+                    onClose: () {},
+                    mainContent: const SizedBox.expand(),
+                    paneContent: preview,
+                  )
+                : preview,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    return tab;
+  }
+
+  Future<TextBookTab> pumpPreviewInSidePane(WidgetTester tester) =>
+      pumpPreview(tester, inSidePane: true);
+
+  Finder thumbFinder() => find.descendant(
+    of: find.byType(ScrollablePositionedListScrollbar),
+    matching: find.byKey(ScrollablePositionedListScrollbar.thumbKey),
+  );
+
+  Finder trackFinder() => find.descendant(
+    of: find.byType(ScrollablePositionedListScrollbar),
+    matching: find.byKey(ScrollablePositionedListScrollbar.trackKey),
+  );
+
+  /// גולל את התצוגה בגלגלת ומחזיר את מיקומי האגודל שנמדדו בכל פריים.
+  Future<List<double>> scrollAndSampleThumbTop(
+    WidgetTester tester, {
+    int frames = 200,
+    double delta = 20,
+  }) async {
+    final samples = <double>[];
+    final center = tester.getCenter(find.byType(ScrollablePositionedList));
+    for (var i = 0; i < frames; i++) {
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: Offset(0, delta)),
+      );
+      await tester.pump(const Duration(milliseconds: 16));
+      samples.add(tester.getRect(thumbFinder()).top);
+    }
+    return samples;
+  }
+
+  group('מחוון הגלילה בתצוגה המקדימה', () {
+    testWidgets('משתמש במחוון של האפליקציה ולא ב-Scrollbar של ListView', (
+      tester,
+    ) async {
+      await pumpPreview(tester);
+
+      expect(find.byType(ScrollablePositionedListScrollbar), findsOneWidget);
+      expect(find.byType(ScrollablePositionedList), findsOneWidget);
+      // Scrollbar של Flutter נשען על אומדן ההיקף של ListView, ואומדן זה משתנה
+      // בכל פריים כששורות הספר בגבהים שונים — שם נולד "ריקוד" האגודל.
+      expect(find.byType(Scrollbar), findsNothing);
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('המסילה בקצה ימין של אזור התצוגה (כיוון הקריאה בעברית)', (
+      tester,
+    ) async {
+      await pumpPreview(tester);
+
+      final scrollbarRect = tester.getRect(
+        find.byType(ScrollablePositionedListScrollbar),
+      );
+      final trackRect = tester.getRect(trackFinder());
+
+      expect(
+        trackRect.center.dx,
+        greaterThan(scrollbarRect.center.dx),
+        reason: 'המסילה בצד שמאל — הפוך משאר מחווני הגלילה באפליקציה',
+      );
+      expect(
+        trackRect.right,
+        closeTo(scrollbarRect.right, 0.5),
+        reason: 'המסילה אינה צמודה לקצה ימין',
+      );
+      expect(
+        tester.getRect(thumbFinder()).center.dx,
+        greaterThan(scrollbarRect.center.dx),
+        reason: 'האגודל אינו בתוך המסילה הימנית',
+      );
+    });
+
+    testWidgets('המסילה אינה מכסה את הטקסט אלא יושבת ברצועה משלה', (
+      tester,
+    ) async {
+      await pumpPreview(tester);
+
+      final trackRect = tester.getRect(trackFinder());
+      final listRect = tester.getRect(find.byType(ScrollablePositionedList));
+
+      expect(
+        listRect.right,
+        lessThanOrEqualTo(trackRect.left + 0.5),
+        reason: 'התוכן נכנס אל מתחת למסילה',
+      );
+    });
+
+    testWidgets('האגודל נוסע ישר בגלילה למטה ואינו רוקד כלפי מעלה', (
+      tester,
+    ) async {
+      // רגרסיה: ListView אומד את היקף הגלילה מגובה הפריטים הבנויים כרגע.
+      // בשורות בגבהים שונים האומדן משתנה בכל פריים, והאגודל קפץ אחורה עד
+      // 17px בזמן גלילה קדימה — "ריקוד" במקום נסיעה ישרה. המחוון האינדקסי
+      // אינו אומד היקף בכלל, ונשאר בתוך פיקסל בודד.
+      await pumpPreview(tester);
+
+      final samples = await scrollAndSampleThumbTop(tester);
+
+      var worstBackwardJump = 0.0;
+      for (var i = 1; i < samples.length; i++) {
+        final backward = samples[i - 1] - samples[i];
+        if (backward > worstBackwardJump) worstBackwardJump = backward;
+      }
+
+      expect(
+        worstBackwardJump,
+        lessThan(1.5),
+        reason:
+            'האגודל נסוג ב-${worstBackwardJump.toStringAsFixed(1)}px בזמן '
+            'גלילה למטה',
+      );
+      expect(
+        samples.last,
+        greaterThan(samples.first),
+        reason: 'האגודל כלל לא זז — הטסט אינו בודק כלום',
+      );
+    });
+
+    testWidgets('גובה האגודל יציב לאורך הגלילה', (tester) async {
+      await pumpPreview(tester);
+
+      final initialHeight = tester.getRect(thumbFinder()).height;
+      var worstChange = 0.0;
+      final center = tester.getCenter(find.byType(ScrollablePositionedList));
+      for (var i = 0; i < 120; i++) {
+        await tester.sendEventToBinding(
+          PointerScrollEvent(
+            position: center,
+            scrollDelta: const Offset(0, 20),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 16));
+        final change = (tester.getRect(thumbFinder()).height - initialHeight)
+            .abs();
+        if (change > worstChange) worstChange = change;
+      }
+
+      expect(
+        worstChange,
+        lessThan(initialHeight * 0.35),
+        reason: 'גובה האגודל משתנה בזמן גלילה ומשווה לו תנועת "נשימה"',
+      );
+    });
+
+    testWidgets('האגודל מתקדם לפי הגלילה — לא נשאר במקום ולא מקדים לסוף', (
+      tester,
+    ) async {
+      await pumpPreview(tester);
+
+      final trackRect = tester.getRect(trackFinder());
+      final samples = await scrollAndSampleThumbTop(tester, frames: 40);
+
+      // 40 פריימים × 20px = 800px מתוך תוכן של עשרות מסכים — האגודל אמור
+      // להתקדם מעט בלבד, ובוודאי לא לקרוס לתחתית.
+      expect(samples.last, greaterThan(trackRect.top));
+      expect(
+        samples.last,
+        lessThan(trackRect.top + trackRect.height * 0.5),
+        reason: 'האגודל זינק לאמצע המסילה אחרי גלילה קצרה',
+      );
+    });
+
+    testWidgets('גלילה בתצוגה המקדימה מעדכנת את מיקום הטאב לפתיחה בעיון', (
+      tester,
+    ) async {
+      // לחיצה כפולה על התצוגה המקדימה פותחת את הספר במיקום הנוכחי, והמיקום
+      // הזה נקרא מ-tab.index. הוא מתעדכן רק מ-itemPositions של הרשימה.
+      final tab = await pumpPreview(tester);
+      expect(tab.index, 0);
+
+      await scrollAndSampleThumbTop(tester, frames: 60);
+
+      expect(
+        tab.index,
+        greaterThan(0),
+        reason: 'מיקום הגלילה בתצוגה המקדימה לא נשמר בטאב',
+      );
+    });
+
+    testWidgets('אין חריגות בזמן החלפת ספר (dispose של הרשימה)', (
+      tester,
+    ) async {
+      await pumpPreview(tester);
+      await scrollAndSampleThumbTop(tester, frames: 20);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('האגודל אינו נחבא מתחת לידית שינוי רוחב החלונית', (
+      tester,
+    ) async {
+      // חלונית התצוגה המקדימה היא AdaptiveSidePane בצד שמאל (RTL) הניתן
+      // לשינוי רוחב, וידית הגרירה יושבת בדופן הימנית — בדיוק מקום המסילה.
+      await pumpPreviewInSidePane(tester);
+
+      final thumbRect = tester.getRect(thumbFinder());
+      final handleRect = tester.getRect(find.byType(ResizableDragHandle));
+
+      expect(
+        handleRect.contains(thumbRect.center),
+        isFalse,
+        reason:
+            'שטח המגע של הידית ($handleRect) בולע את מרכז האגודל ($thumbRect) '
+            '— גרירה תשנה את רוחב החלונית במקום לגלול',
+      );
+    });
+
+    testWidgets('אזור הקריאה הרגיל ממשיך להשתמש באותו מחוון', (tester) async {
+      await pumpPreview(tester, isPreviewMode: false);
+
+      expect(find.byType(ScrollablePositionedListScrollbar), findsWidgets);
+      expect(find.byType(Scrollbar), findsNothing);
+    });
+  });
+}

--- a/test/widgets/scrollable_positioned_list_scrollbar_test.dart
+++ b/test/widgets/scrollable_positioned_list_scrollbar_test.dart
@@ -1430,4 +1430,173 @@ void main() {
       reason: 'האגודל זז אחרי שהתוכן נחת — המיפוי קדימה וההפוך אינם מתאימים',
     );
   });
+
+  group('שורות בגבהים שונים (ספר אמיתי)', () {
+    // גבהים משתנים כמו שורות ספר — שורה קצרה מול פסקה שנשברת לכמה שורות.
+    double heightFor(int index) =>
+        const [40.0, 90.0, 240.0, 60.0, 150.0, 320.0][index % 6];
+
+    Future<Finder> pumpVariableHeightList(
+      WidgetTester tester, {
+      required int itemCount,
+    }) async {
+      tester.view.physicalSize = const Size(600, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final listener = ItemPositionsListener.create();
+      final controller = ItemScrollController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScrollablePositionedListScrollbar(
+              scrollController: controller,
+              itemPositionsListener: listener,
+              itemCount: itemCount,
+              child: ScrollablePositionedList.builder(
+                itemScrollController: controller,
+                itemPositionsListener: listener,
+                itemCount: itemCount,
+                itemBuilder: (context, i) =>
+                    SizedBox(height: heightFor(i), child: Text('פריט $i')),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      return find.descendant(
+        of: find.byType(ScrollablePositionedListScrollbar),
+        matching: find.byKey(ScrollablePositionedListScrollbar.thumbKey),
+      );
+    }
+
+    Future<void> wheel(WidgetTester tester, {int frames = 1}) async {
+      for (var i = 0; i < frames; i++) {
+        await tester.sendEventToBinding(
+          const PointerScrollEvent(
+            position: Offset(300, 450),
+            scrollDelta: Offset(0, 20),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+    }
+
+    testWidgets('האגודל אינו נסוג כלפי מעלה בזמן גלילה למטה', (tester) async {
+      // המחוון אינדקסי ואינו אומד היקף גלילה, ולכן שינוי צפיפות השורות אינו
+      // מזיז אותו אחורה. אומדן ההיקף של ListView, לעומת זאת, מקפיץ ~17px.
+      final thumb = await pumpVariableHeightList(tester, itemCount: 200);
+
+      var previousTop = tester.getRect(thumb).top;
+      var worstBackwardJump = 0.0;
+      for (var i = 0; i < 300; i++) {
+        await wheel(tester);
+        final top = tester.getRect(thumb).top;
+        final backward = previousTop - top;
+        if (backward > worstBackwardJump) worstBackwardJump = backward;
+        previousTop = top;
+      }
+
+      expect(worstBackwardJump, lessThan(1.5));
+    });
+
+    testWidgets('האגודל נוגע בתחתית המסילה בסוף התוכן', (tester) async {
+      final thumb = await pumpVariableHeightList(tester, itemCount: 40);
+      final track = find.descendant(
+        of: find.byType(ScrollablePositionedListScrollbar),
+        matching: find.byKey(ScrollablePositionedListScrollbar.trackKey),
+      );
+
+      // גלילה מוגזמת בכוונה — הרשימה נעצרת בסוף התוכן.
+      await wheel(tester, frames: 400);
+
+      expect(
+        tester.getRect(thumb).bottom,
+        closeTo(tester.getRect(track).bottom, 1.5),
+        reason: 'בסוף התוכן האגודל לא הגיע לתחתית המסילה',
+      );
+    });
+
+    testWidgets('גובה האגודל אינו "נושם" בין אזורי צפיפות', (tester) async {
+      final thumb = await pumpVariableHeightList(tester, itemCount: 200);
+
+      final initialHeight = tester.getRect(thumb).height;
+      var worstChange = 0.0;
+      for (var i = 0; i < 200; i++) {
+        await wheel(tester);
+        final change = (tester.getRect(thumb).height - initialHeight).abs();
+        if (change > worstChange) worstChange = change;
+      }
+
+      expect(worstChange, lessThan(initialHeight * 0.35));
+    });
+  });
+
+  group('צד המסילה לפי כיוון הקריאה', () {
+    Future<Rect> pumpAndMeasureTrack(
+      WidgetTester tester, {
+      required TextDirection direction,
+    }) async {
+      final listener = ItemPositionsListener.create();
+      final controller = ItemScrollController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: direction,
+            child: Scaffold(
+              body: ScrollablePositionedListScrollbar(
+                scrollController: controller,
+                itemPositionsListener: listener,
+                itemCount: 10,
+                child: const _ScrollableStub(),
+              ),
+            ),
+          ),
+        ),
+      );
+      (listener.itemPositions as ValueNotifier<Iterable<ItemPosition>>).value =
+          const [
+            ItemPosition(index: 0, itemLeadingEdge: 0, itemTrailingEdge: 0.5),
+            ItemPosition(index: 1, itemLeadingEdge: 0.5, itemTrailingEdge: 1.0),
+          ];
+      await tester.pump();
+
+      return tester.getRect(
+        find.descendant(
+          of: find.byType(ScrollablePositionedListScrollbar),
+          matching: find.byKey(ScrollablePositionedListScrollbar.trackKey),
+        ),
+      );
+    }
+
+    testWidgets('בעברית המסילה בקצה ימין', (tester) async {
+      final track = await pumpAndMeasureTrack(
+        tester,
+        direction: TextDirection.rtl,
+      );
+      final scrollbar = tester.getRect(
+        find.byType(ScrollablePositionedListScrollbar),
+      );
+
+      expect(track.right, closeTo(scrollbar.right, 0.5));
+      expect(track.center.dx, greaterThan(scrollbar.center.dx));
+    });
+
+    testWidgets('בלטינית המסילה בקצה שמאל', (tester) async {
+      final track = await pumpAndMeasureTrack(
+        tester,
+        direction: TextDirection.ltr,
+      );
+      final scrollbar = tester.getRect(
+        find.byType(ScrollablePositionedListScrollbar),
+      );
+
+      expect(track.left, closeTo(scrollbar.left, 0.5));
+      expect(track.center.dx, lessThan(scrollbar.center.dx));
+    });
+  });
 }


### PR DESCRIPTION
## הבאג

בתצוגה המקדימה בספרייה מחוון הגלילה "רקד" למעלה ולמטה במקום לנסוע ישר, וגם ישב בצד שמאל.

## שורש הבעיה

התצוגה המקדימה הייתה המקום היחיד באפליקציה שהשתמש ב-`Scrollbar` של Flutter מעל `ListView.builder`:

* `ListView` **אומד** את היקף הגלילה מגובה הפריטים הבנויים כרגע (`estimateMaxScrollOffset`). שורות ספר אינן בגובה אחיד — שורה קצרה מול פסקה שנשברת לכמה שורות — ולכן האומדן משתנה בכל פריים, והאגודל זז אחורה בזמן שהמשתמש גולל קדימה.
* `Scrollbar` של Flutter נופל בעברית (RTL) לצד שמאל.

מדידה על תוכן עם גבהים משתנים (200 פריטים, 300 פריימים של גלילה):

| | נסיגת האגודל בזמן גלילה קדימה | תנודת גובה האגודל |
|---|---|---|
| `ListView` + `Scrollbar` (לפני) | **17.4px** | 2.8px |
| `ScrollablePositionedListScrollbar` (אחרי) | **1.2px** | זניחה |

## התיקון

הסרת המסלול המיוחד. התצוגה המקדימה משתמשת באותו `ScrollablePositionedListScrollbar` של אזור הקריאה — מחוון אינדקסי שאינו אומד היקף כלל, ומסילתו יושבת בקצה ימין כמו כל מחווני הגלילה באפליקציה.

שני שיפורים שנגררים מכך:

* מיקום הגלילה נשמר עכשיו ב-`tab.index` (הוא מתעדכן מ-`itemPositions`, שרשימת ה-`ListView` לא הזינה). לחיצה כפולה על התצוגה המקדימה פותחת בעיון במקום שבו המשתמש עומד, כפי שהקוד כבר התיימר לעשות.
* חלון התוכן הנטען עוקב אחרי הגלילה, כמו באזור הקריאה.

## טסטים

`test/text_book/view/combined_view/preview_mode_scrollbar_test.dart` — 10 טסטים חדשים: זהות המחוון, המסילה בקצה ימין ולא מעל הטקסט, האגודל אינו נסוג בגלילה, יציבות גובהו, התקדמות תואמת-גלילה, שמירת המיקום בטאב, האגודל אינו נחבא מתחת לידית שינוי רוחב החלונית, ואין חריגות בהחלפת ספר.

`test/widgets/scrollable_positioned_list_scrollbar_test.dart` — 5 טסטים חדשים שמגנים על כל המשתמשים במחוון (חלונית מפרשים, הערות, הדפסה): גבהים משתנים ללא נסיגה, נגיעה בתחתית בסוף התוכן, גובה שאינו "נושם", וצד המסילה לפי כיוון הקריאה.

נוספו `trackKey` / `thumbKey` למחוון: הרשימה היא ילד של המחוון, ולכן חיפוש לפי טיפוס תופס גם רכיבים מהתוכן.

`flutter analyze` נקי; `test/text_book`, `test/widgets`, `test/library` — 1919 טסטים עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
