### PR TITLE
ספרייה: פס הגלילה בקצה ימין

### DIFF
--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -16,6 +16,7 @@ import 'package:otzaria/tools/calendar/helpers/daf_yomi_navigation.dart';
 import 'package:otzaria/library_update/bloc/library_update_bloc.dart';
 import 'package:otzaria/library/view/library_daf_yomi.dart';
 import 'package:otzaria/settings/services/custom_folders/bloc/custom_folders_bloc.dart';
+import 'package:otzaria/widgets/feedback/edge_scrollbar_behavior.dart';
 import 'package:otzaria/widgets/lists/filter_chips_widget.dart';
 import 'package:otzaria/navigation/view/main_window_screen.dart';
 import 'package:otzaria/library/view/grid_items.dart';
@@ -876,7 +877,14 @@ class _LibraryBrowserState extends State<LibraryBrowser>
           // אין ספרייה — התצוגה המקדימה סגורה כפויה (אין ספרים להציג).
           isOpen: !isLibraryEmpty && _isPreviewPanelVisible(settingsState),
           alignment: AlignmentDirectional.centerStart, // שמאל בעברית (RTL)
-          mainContent: RepaintBoundary(child: mainContent),
+          // פס הגלילה של הספרייה בקצה ימין: ברירת המחדל בעברית היא הקצה
+          // השמאלי, שם נפגש התוכן עם חלונית התצוגה המקדימה.
+          mainContent: RepaintBoundary(
+            child: ScrollConfiguration(
+              behavior: const EdgeScrollbarBehavior.right(),
+              child: mainContent,
+            ),
+          ),
           paneContent: _buildPreviewPane(settingsState),
           paneWidth: previewPaneWidths.paneWidth,
           minMainContentWidth: 200,

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -25,6 +25,7 @@ import 'package:otzaria/tools/built_in_tools_catalog.dart';
 import 'package:otzaria/tools/tool_catalog_entry.dart';
 import 'package:otzaria/tools/tool_order.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
+import 'package:otzaria/widgets/feedback/edge_scrollbar_behavior.dart';
 import 'package:otzaria/widgets/layout/app_card.dart';
 import 'package:otzaria/widgets/misc/app_popup_menu.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
@@ -629,7 +630,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
           autofocus: false,
           onKeyEvent: (_, event) => _handleKey(event, entries, columns),
           child: ScrollConfiguration(
-            behavior: const _RightScrollbarBehavior(),
+            behavior: const EdgeScrollbarBehavior.right(),
             child: ListView(
               controller: _gridScrollController,
               // הרווח בימין שמור לפס הגלילה, כדי שלא יעלה על הקוביות.
@@ -749,35 +750,6 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         onTap: () => widget.onToolSelected(entry),
       ),
     );
-  }
-}
-
-/// פס הגלילה של רשת הכלים תמיד בקצה ימין, בתוך המרווח ששמור לו — כך אינו
-/// מצטייר על הקוביות ואינו מתנגש בידית שינוי הרוחב שבקצה שמאל.
-class _RightScrollbarBehavior extends MaterialScrollBehavior {
-  const _RightScrollbarBehavior();
-
-  @override
-  Widget buildScrollbar(
-    BuildContext context,
-    Widget child,
-    ScrollableDetails details,
-  ) {
-    if (axisDirectionToAxis(details.direction) != Axis.vertical) return child;
-    switch (getPlatform(context)) {
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        return Scrollbar(
-          controller: details.controller,
-          scrollbarOrientation: ScrollbarOrientation.right,
-          child: child,
-        );
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-        return child;
-    }
   }
 }
 

--- a/lib/widgets/feedback/edge_scrollbar_behavior.dart
+++ b/lib/widgets/feedback/edge_scrollbar_behavior.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// התנהגות גלילה שמצמידה את פס הגלילה האנכי לצד מבוקש, ולא לקצה ה-trailing
+/// שנקבע לפי כיוון הטקסט (בעברית — שמאל). כל מחווני הגלילה של אוצריא יושבים
+/// בקצה ימין, וכך גם פסי הגלילה האוטומטיים של הרשימות.
+///
+/// משכפלת את לוגיקת [MaterialScrollBehavior] (פס אנכי בדסקטופ בלבד) ומוסיפה
+/// רק את [orientation].
+class EdgeScrollbarBehavior extends MaterialScrollBehavior {
+  const EdgeScrollbarBehavior(this.orientation);
+
+  /// פס בקצה ימין — הצד שבו יושבים מחווני הגלילה של אזור הקריאה.
+  const EdgeScrollbarBehavior.right()
+    : orientation = ScrollbarOrientation.right;
+
+  final ScrollbarOrientation orientation;
+
+  @override
+  Widget buildScrollbar(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) {
+    if (axisDirectionToAxis(details.direction) != Axis.vertical) {
+      return child;
+    }
+    switch (getPlatform(context)) {
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return Scrollbar(
+          controller: details.controller,
+          scrollbarOrientation: orientation,
+          child: child,
+        );
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        return child;
+    }
+  }
+}

--- a/lib/widgets/layout/adaptive_side_pane.dart
+++ b/lib/widgets/layout/adaptive_side_pane.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/theme_exports.dart';
+import 'package:otzaria/widgets/feedback/edge_scrollbar_behavior.dart';
 import 'package:otzaria/widgets/layout/floating_panel.dart';
 import 'package:otzaria/widgets/layout/reading_area_width.dart';
 import 'package:otzaria/widgets/layout/resizable_drag_handle.dart';
@@ -185,7 +186,7 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
         mainAxisMargin: widget.scrollbarTopMargin ?? _kWideTopGap,
       ),
       child: ScrollConfiguration(
-        behavior: _OuterEdgePaneScrollBehavior(
+        behavior: EdgeScrollbarBehavior(
           paneOnRight ? ScrollbarOrientation.right : ScrollbarOrientation.left,
         ),
         child: child,
@@ -530,42 +531,5 @@ class _AdaptiveSidePaneState extends State<AdaptiveSidePane> {
         ),
       ],
     );
-  }
-}
-
-/// התנהגות גלילה המציבה את פס הגלילה האנכי בקצה הנבחר של הפאנל במקום בקצה
-/// ה-trailing שנקבע אוטומטית לפי כיוון הטקסט. נחוץ כי ידית הגרירה לשינוי רוחב
-/// הפאנל יושבת בקצה הפנימי וחוסמת את הלחיצה על פס שנמצא באותו צד.
-///
-/// משכפלת את לוגיקת [MaterialScrollBehavior] (פס אנכי בדסקטופ בלבד) ומוסיפה
-/// רק את [scrollbarOrientation].
-class _OuterEdgePaneScrollBehavior extends MaterialScrollBehavior {
-  const _OuterEdgePaneScrollBehavior(this.orientation);
-
-  final ScrollbarOrientation orientation;
-
-  @override
-  Widget buildScrollbar(
-    BuildContext context,
-    Widget child,
-    ScrollableDetails details,
-  ) {
-    if (axisDirectionToAxis(details.direction) != Axis.vertical) {
-      return child;
-    }
-    switch (getPlatform(context)) {
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        return Scrollbar(
-          controller: details.controller,
-          scrollbarOrientation: orientation,
-          child: child,
-        );
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-        return child;
-    }
   }
 }

--- a/test/library/view/library_scrollbar_side_test.dart
+++ b/test/library/view/library_scrollbar_side_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// בדיקה סטטית: מסכי הספרייה מגלגלים ברשימות רגילות, ופס הגלילה האוטומטי של
+/// Material נופל בעברית לקצה שמאל. LibraryBrowser תלוי בכל ה-BLoCs של
+/// האפליקציה ואינו נבנה בטסט, ולכן הכיסוי כאן הוא על העטיפה עצמה. התנהגות
+/// [EdgeScrollbarBehavior] עצמה נבדקת ב-test/widgets/edge_scrollbar_behavior_test.dart.
+void main() {
+  final source = File(
+    'lib/library/view/library_browser.dart',
+  ).readAsStringSync();
+
+  test('קובץ הספרייה נקרא — הנתיב תקין', () {
+    expect(source, contains('class LibraryBrowser'));
+  });
+
+  test('תוכן הספרייה עטוף בפס גלילה בקצה ימין', () {
+    expect(
+      source,
+      contains('EdgeScrollbarBehavior.right()'),
+      reason:
+          'בלי העטיפה פס הגלילה של עץ הספרייה חוזר לקצה שמאל, הקצה שנפגש '
+          'עם חלונית התצוגה המקדימה',
+    );
+  });
+
+  test('העטיפה חלה על אזור התוכן הראשי (mainContent) של הספרייה', () {
+    final mainContentIdx = source.indexOf('mainContent: RepaintBoundary');
+    expect(mainContentIdx, greaterThan(-1), reason: 'מבנה mainContent השתנה');
+
+    final block = source.substring(
+      mainContentIdx,
+      mainContentIdx + 400 > source.length
+          ? source.length
+          : mainContentIdx + 400,
+    );
+    expect(
+      block,
+      contains('EdgeScrollbarBehavior.right()'),
+      reason: 'העטיפה אינה על אזור התוכן של הספרייה',
+    );
+  });
+
+  test('אין עוד מימוש פרטי מקומי של התנהגות פס הגלילה', () {
+    // ההתנהגות שוכנת ב-lib/widgets/feedback/edge_scrollbar_behavior.dart
+    // ומשותפת לחלונית הצד, לרשת הכלים ולספרייה.
+    for (final path in const [
+      'lib/library/view/library_browser.dart',
+      'lib/widgets/layout/adaptive_side_pane.dart',
+      'lib/tools/view/tools_launcher_panel.dart',
+    ]) {
+      expect(
+        File(path).readAsStringSync(),
+        isNot(contains('extends MaterialScrollBehavior')),
+        reason: '$path מגדיר התנהגות גלילה משלו במקום לחלוק את המשותפת',
+      );
+    }
+  });
+}

--- a/test/widgets/edge_scrollbar_behavior_test.dart
+++ b/test/widgets/edge_scrollbar_behavior_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/feedback/edge_scrollbar_behavior.dart';
+
+void main() {
+  /// רשימה אנכית בעברית, עם או בלי התנהגות הגלילה שמצמידה את הפס לימין.
+  /// [MaterialScrollBehavior] קורא את הפלטפורמה מה-Theme, ו-flutter_test מריץ
+  /// כברירת מחדל כאנדרואיד — שבו אין פס גלילה אוטומטי כלל, ולכן היא נקבעת כאן
+  /// מפורשות. [thumbAlwaysVisible] נחוץ לבדיקות מגע: הפס דוהה כשאין גלילה או
+  /// ריחוף, ולא ניתן ללחוץ עליו.
+  Future<ScrollController> pumpList(
+    WidgetTester tester, {
+    ScrollBehavior? behavior,
+    Axis axis = Axis.vertical,
+    bool thumbAlwaysVisible = false,
+    TextDirection direction = TextDirection.rtl,
+    TargetPlatform platform = TargetPlatform.windows,
+  }) async {
+    tester.view.physicalSize = const Size(600, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    Widget list = ListView.builder(
+      controller: controller,
+      scrollDirection: axis,
+      itemCount: 100,
+      itemBuilder: (context, i) =>
+          SizedBox(height: 50, width: 200, child: Text('שורה $i')),
+    );
+    if (behavior != null) {
+      list = ScrollConfiguration(behavior: behavior, child: list);
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          platform: platform,
+          scrollbarTheme: thumbAlwaysVisible
+              ? const ScrollbarThemeData(
+                  thumbVisibility: WidgetStatePropertyAll(true),
+                )
+              : const ScrollbarThemeData(),
+        ),
+        home: Directionality(
+          textDirection: direction,
+          child: Scaffold(body: list),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return controller;
+  }
+
+  ScrollbarOrientation? orientationOf(WidgetTester tester) =>
+      tester.widget<Scrollbar>(find.byType(Scrollbar)).scrollbarOrientation;
+
+  group('EdgeScrollbarBehavior', () {
+    testWidgets('מצמידה את הפס האנכי לימין', (tester) async {
+      await pumpList(tester, behavior: const EdgeScrollbarBehavior.right());
+
+      expect(orientationOf(tester), ScrollbarOrientation.right);
+    });
+
+    testWidgets('מקבלת גם צד שמאל במפורש', (tester) async {
+      await pumpList(
+        tester,
+        behavior: const EdgeScrollbarBehavior(ScrollbarOrientation.left),
+      );
+
+      expect(orientationOf(tester), ScrollbarOrientation.left);
+    });
+
+    testWidgets('ברירת המחדל של Material אינה קובעת צד — ומכאן הבאג בעברית', (
+      tester,
+    ) async {
+      // בלי ההתנהגות הזו הצד נגזר מכיוון הטקסט, ובעברית הוא נופל לשמאל.
+      await pumpList(tester);
+
+      expect(orientationOf(tester), isNull);
+    });
+
+    testWidgets('אינה נוגעת בגלילה אופקית', (tester) async {
+      await pumpList(
+        tester,
+        behavior: const EdgeScrollbarBehavior.right(),
+        axis: Axis.horizontal,
+      );
+
+      expect(find.byType(Scrollbar), findsNothing);
+    });
+
+    testWidgets('במובייל אין פס גלילה, כמו ב-MaterialScrollBehavior', (
+      tester,
+    ) async {
+      await pumpList(
+        tester,
+        behavior: const EdgeScrollbarBehavior.right(),
+        platform: TargetPlatform.android,
+      );
+
+      expect(find.byType(Scrollbar), findsNothing);
+    });
+
+    testWidgets('גרירה בקצה ימין גוללת את הרשימה', (tester) async {
+      final controller = await pumpList(
+        tester,
+        behavior: const EdgeScrollbarBehavior.right(),
+        thumbAlwaysVisible: true,
+      );
+      expect(controller.offset, 0);
+
+      final size = tester.getSize(find.byType(ListView));
+      await tester.dragFrom(Offset(size.width - 4, 30), const Offset(0, 200));
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.offset,
+        greaterThan(0),
+        reason: 'האגודל אינו בקצה ימין — גרירה שם לא גללה כלום',
+      );
+    });
+
+    testWidgets('בברירת המחדל בעברית גרירה בקצה ימין אינה גוללת (הבאג)', (
+      tester,
+    ) async {
+      final controller = await pumpList(tester, thumbAlwaysVisible: true);
+
+      final size = tester.getSize(find.byType(ListView));
+      await tester.dragFrom(Offset(size.width - 4, 30), const Offset(0, 200));
+      await tester.pumpAndSettle();
+
+      expect(controller.offset, 0);
+    });
+
+    testWidgets('גרירה בקצה שמאל אינה גוללת כשהפס מוצמד לימין', (tester) async {
+      final controller = await pumpList(
+        tester,
+        behavior: const EdgeScrollbarBehavior.right(),
+        thumbAlwaysVisible: true,
+      );
+
+      await tester.dragFrom(const Offset(4, 30), const Offset(0, 200));
+      await tester.pumpAndSettle();
+
+      expect(controller.offset, 0);
+    });
+  });
+}


### PR DESCRIPTION
## הבאג

פס הגלילה של עץ הספרייה יושב בעברית בקצה **שמאל** — הקצה שנפגש עם חלונית התצוגה המקדימה — בניגוד לכל שאר מחווני הגלילה באפליקציה, שיושבים בימין.

הסיבה: `MaterialScrollBehavior` מוסיף לרשימות פס גלילה אוטומטי, וצדו נגזר מקצה ה-trailing של כיוון הטקסט. בעברית זה שמאל.

## התיקון

אותה התנהגות כבר נדרשה פעמיים בעבר והועתקה פעמיים כמחלקה פרטית זהה — `_OuterEdgePaneScrollBehavior` בחלונית הצד ו-`_RightScrollbarBehavior` ברשת הכלים. במקום העתק שלישי:

* `lib/widgets/feedback/edge_scrollbar_behavior.dart` — `EdgeScrollbarBehavior` משותף (ובנאי `.right()`).
* שני ההעתקים הפרטיים הוסרו, ושלושת המקומות חולקים אותו.
* תוכן הספרייה (`mainContent`) עטוף בו — כך שגם מצב רשימה, גם מצב רשת וגם תוצאות חיפוש מקבלים פס בימין.

## טסטים

`test/widgets/edge_scrollbar_behavior_test.dart` — 8 טסטים: הצמדה לימין ולשמאל, ברירת המחדל של Material שאינה קובעת צד, גלילה אופקית שאינה נוגעת, היעדר פס במובייל, ושלושה טסטי מגע — גרירה בקצה ימין **גוללת**, אותה גרירה בברירת המחדל בעברית **אינה** גוללת (מתעד את הבאג), וגרירה בקצה שמאל אינה גוללת כשהפס מוצמד לימין.

`test/library/view/library_scrollbar_side_test.dart` — 4 טסטים סטטיים: העטיפה קיימת וחלה על אזור התוכן של הספרייה, ואין עוד מימוש פרטי מקומי בשלושת הקבצים. (`LibraryBrowser` תלוי בכל ה-BLoCs של האפליקציה ואינו נבנה בטסט widget, ולכן הכיסוי ההתנהגותי הוא על ההתנהגות המשותפת עצמה.)

`flutter analyze` נקי; `test/widgets`, `test/tools`, `test/library` — 1112 טסטים עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
