### PR TITLE
חיפוש: מספר תוצאה בן 4 ספרות נשבר לשתי שורות

### DIFF
--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -37,11 +37,7 @@ import 'package:otzaria_search_engine/otzaria_search_engine.dart'
 class TantivySearchResults extends StatefulWidget {
   final SearchingTab tab;
   final VoidCallback? onEditSearch;
-  const TantivySearchResults({
-    super.key,
-    required this.tab,
-    this.onEditSearch,
-  });
+  const TantivySearchResults({super.key, required this.tab, this.onEditSearch});
 
   @override
   State<TantivySearchResults> createState() => _TantivySearchResultsState();
@@ -75,11 +71,7 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
           // בלי min ה-Column היה דורש גובה אינסופי.
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              icon,
-              size: 52,
-              color: colorScheme.onSurfaceVariant,
-            ),
+            Icon(icon, size: 52, color: colorScheme.onSurfaceVariant),
             const SizedBox(height: 16),
             Text(
               title,
@@ -721,8 +713,9 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                       children: [
                         // מספר התוצאה
                         Container(
-                          width: 32,
+                          constraints: const BoxConstraints(minWidth: 32),
                           height: 32,
+                          padding: const EdgeInsets.symmetric(horizontal: 6),
                           decoration: BoxDecoration(
                             color: Theme.of(
                               context,
@@ -730,6 +723,7 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                             borderRadius: AppTokens.borderRadiusAll,
                           ),
                           child: Center(
+                            widthFactor: 1,
                             child: Text(
                               '${index + 1}',
                               style: TextStyle(

--- a/test/search/tantivy_search_results_test.dart
+++ b/test/search/tantivy_search_results_test.dart
@@ -132,11 +132,7 @@ void main() {
       ];
 
       searchBloc = RecordingSearchBloc(
-        SearchState(
-          searchQuery: 'בדיקה',
-          totalResults: 200,
-          results: results,
-        ),
+        SearchState(searchQuery: 'בדיקה', totalResults: 200, results: results),
       );
 
       whenListen(
@@ -162,10 +158,7 @@ void main() {
             ),
           ],
           child: Scaffold(
-            body: SizedBox(
-              height: 500,
-              child: TantivySearchResults(tab: tab),
-            ),
+            body: SizedBox(height: 500, child: TantivySearchResults(tab: tab)),
           ),
         ),
       );
@@ -202,13 +195,13 @@ void main() {
       await tester.pumpWidget(buildWidget());
 
       await tester.pump();
-      await tester.drag(find.byType(CustomScrollView), const Offset(0, -100000));
+      await tester.drag(
+        find.byType(CustomScrollView),
+        const Offset(0, -100000),
+      );
       await tester.pump();
 
-      expect(
-        searchBloc.recordedEvents.whereType<LoadMoreResults>().length,
-        1,
-      );
+      expect(searchBloc.recordedEvents.whereType<LoadMoreResults>().length, 1);
     });
 
     testWidgets('חיפוש חדש (שינוי קטגוריה) מאפס את הגלילה לראש הרשימה', (
@@ -370,6 +363,41 @@ void main() {
         _highlightedTextFromInlineSpan(highlightedResultText.text),
         'טקסט',
       );
+    });
+
+    testWidgets('מספר תוצאה בן 4 ספרות נשאר בשורה אחת בתוך הריבוע', (
+      tester,
+    ) async {
+      searchBloc.emitState(
+        SearchState(
+          searchQuery: 'בדיקה',
+          totalResults: 1000,
+          results: List.generate(
+            1000,
+            (i) => SearchResult(
+              id: BigInt.from(i + 1),
+              title: 'ספר ${i + 1}',
+              reference: 'סימן ${i + 1}',
+              text: 'טקסט ${i + 1}',
+              segment: BigInt.from(i),
+              isPdf: false,
+              filePath: 'book_$i.txt',
+              mergedCount: 1,
+              merged: const [],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pump();
+
+      final badge = find.text('1000');
+      await tester.scrollUntilVisible(badge, 20000, maxScrolls: 200);
+
+      expect(badge, findsOneWidget);
+      // שבירה לשתי שורות הייתה מכפילה את גובה הטקסט (גופן 16)
+      expect(tester.getSize(badge).height, lessThan(30));
     });
 
     testWidgets(


### PR DESCRIPTION
## הבעיה

בתוצאות החיפוש, הריבוע שמציג את מספר התוצאה שבר את המספר לשתי שורות כשהוא בן 4 ספרות — הספרה האחרונה ירדה שורה ונחתכה בגבול הריבוע.

## שורש הבעיה

הריבוע הוגדר ברוחב קבוע של 32 פיקסלים, בעוד המספר בתוכו מוצג בגופן 16 מודגש. שלוש ספרות נכנסות בדוחק, וארבע ספרות כבר חורגות.

## התיקון

הרוחב הקבוע הוחלף ברוחב מינימלי שגדל לפי התוכן:

```dart
constraints: const BoxConstraints(minWidth: 32),
height: 32,
padding: const EdgeInsets.symmetric(horizontal: 6),
```

עד שתי ספרות הריבוע נשאר 32×32 בדיוק כמקודם, ומשלוש ספרות ומעלה הוא מתרחב מעט. `widthFactor: 1` נוסף ל-`Center` כדי שיתאים עצמו לתוכן ולא ידרוש רוחב לא מוגבל.

## בדיקות

נוספה בדיקה ב-`test/search/tantivy_search_results_test.dart` שמרנדרת 1000 תוצאות, גוללת עד התוצאה ה-1000 ומוודאת שגובה הטקסט הוא של שורה אחת. אומתה נגד הקוד המקורי — הבדיקה נכשלת בלעדי התיקון.

- `flutter analyze` — ללא שגיאות
- `flutter test test/search/tantivy_search_results_test.dart` — 9/9 עוברות
- `flutter test test/search/tantivy_search_results_in_book_routing_test.dart` — 7/7 עוברות

🤖 Generated with [Claude Code](https://claude.com/claude-code)