### PR TITLE
תיקון: סינון ספר מתוצאות החיפוש הציג "אין תוצאות"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -672,6 +672,8 @@ dart format lib/file.dart    # Format ONLY files you modified
 | אותן העדפות בלי אתחול `Settings` | `test/search/search_results_preferences_uninitialized_test.dart` |
 | עץ ניווט תוצאות (רשימת סינון, גלוּת הבחירה, פתיחת ענפים) | `test/search/search_navigation_tree_test.dart` |
 | חלונית סינון התוצאות מקצה לקצה (שדה "איתור ספר") | `test/search/search_facet_filtering_book_filter_test.dart` |
+| צמצום מקומי בלחיצה בעץ התוצאות (זיהוי הספר לפי המפתח היציב) | `test/search/search_client_side_facet_narrow_test.dart` |
+| זיהוי ספר של תוצאת חיפוש לפי מפתח האינדקס היציב | `test/search/search_result_book_resolution_test.dart` |
 | ניתוב חיפוש-בספר: פשוט מול מנוע | `test/search/utils/in_book_search_routing_test.dart` |
 | מדיניות ההתאמה (טווח קרבה + התאמת מילים) | `test/search/search_match_policy_test.dart` |
 | פתיחת תוצאה: העברת הקונפיגורציה לטאב הקריאה | `test/search/tantivy_search_results_in_book_routing_test.dart` |

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -1119,14 +1119,6 @@ class IndexingRepository {
     return (BigInt.from(catalogueOrder + 1) << 32) + BigInt.from(ordinal + 1);
   }
 
-  static int catalogueOrderFromDocumentId(BigInt documentId) {
-    final encodedCatalogueOrder = (documentId >> 32).toInt();
-    if (encodedCatalogueOrder <= 0) {
-      return -1;
-    }
-    return encodedCatalogueOrder - 1;
-  }
-
   static String catalogueOrderKey(Book book) {
     if (book.externalLibraryId != null && book.externalLibraryId!.isNotEmpty) {
       return 'ext:${book.externalLibraryId}';

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -14,7 +14,6 @@ import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/search_defaults.dart';
 import 'package:otzaria/search/search_repository.dart';
-import 'package:otzaria/search/utils/search_catalogue_order_helper.dart';
 import 'package:otzaria/search/search_query_builder.dart';
 import 'package:otzaria/search/utils/facet_helper.dart';
 import 'package:flutter/foundation.dart';
@@ -253,7 +252,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
           // אירוע הספירות — מגיע עוד לפני ה-chunk הראשון של התוצאות.
           Map<String, int>? aggregated;
           if (scopeEqualsSearch && bookCounts != null) {
-            bookByIndexedFilePath ??= _buildBooksByIndexedFilePath(
+            bookByIndexedFilePath ??= _booksByIndexedFilePathFor(
               await DataRepository.instance.library,
             );
             aggregated = FacetHelper.buildFacetCountsFromBookCounts(
@@ -418,7 +417,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
 
     // קבל את כל הספרים מהספרייה כדי למפות key -> Book
     final library = await DataRepository.instance.library;
-    final bookByIndexedFilePath = _buildBooksByIndexedFilePath(library);
+    final bookByIndexedFilePath = _booksByIndexedFilePathFor(library);
 
     // סופר ברמת ספר במנוע עצמו, בלי למשוך עשרות אלפי snippets לדארט.
     // הקלטים מגיעים מהצילום שנלקח עם החתימה — לא מ-state שאולי השתנה מאז.
@@ -739,6 +738,13 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     if (newFacets.contains(event.facet)) {
       debugPrint('➖ RemoveFacet: ${event.facet} (before=$newFacets)');
       newFacets.remove(event.facet);
+      // ביטול הסינון האחרון חוזר לכל ההיקף; רשימה ריקה הייתה נקראת בחיפוש
+      // כ"אין במה לחפש" ומציגה "אין תוצאות" בלי לפנות למנוע.
+      if (newFacets.isEmpty) {
+        newFacets.addAll(
+          state.hasScopedFacetFilter ? state.searchScopeFacets : const ['/'],
+        );
+      }
       final newConfig = state.configuration.copyWith(currentFacets: newFacets);
       final searchEvent = _rerunEvent();
       if (await _applyClientSideFacetNarrow(
@@ -856,13 +862,12 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       return false;
     }
 
-    final bookByCatalogueOrder = _buildBooksByCatalogueOrder(library);
+    // זיהוי לפי `filePath` — המפתח היציב של האינדקס. הסדר הקטלוגי שבמזהה
+    // המסמך זז כשספרים נוספו/נמחקו מאז האינדוקס, ומזהה ספר שגוי.
+    final booksByIndexedFilePath = _booksByIndexedFilePathFor(library);
     final filtered = <SearchResult>[];
     for (final result in state.results) {
-      final catalogueOrder = IndexingRepository.catalogueOrderFromDocumentId(
-        result.id,
-      );
-      final book = bookByCatalogueOrder[catalogueOrder];
+      final book = booksByIndexedFilePath[result.filePath];
       if (book == null) {
         return false;
       }
@@ -873,6 +878,15 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       if (newFacets.any((facet) => facetContains(facet, facetPath))) {
         filtered.add(result);
       }
+    }
+
+    // העץ הבטיח תוצאות ל-facet הזה אך הסינון התרוקן — סימן לאי-התאמה בזיהוי
+    // הספר. חיפוש מנוע מלא עדיף על הצגת "אין תוצאות" על תוצאה שנמצאה.
+    final treePromisedResults = newFacets.any(
+      (facet) => (state.facetCounts[facet] ?? 0) > 0,
+    );
+    if (filtered.isEmpty && treePromisedResults) {
+      return false;
     }
 
     // מבטל המשכים תלויים של החיפוש הקודם (כמו countTexts שעוד ממתין) —
@@ -1224,11 +1238,19 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   /// המפתח לא אותר בקטלוג (ואז נופלים לבנייה לפי כותרת).
   Future<Book?> resolveBookForIndexedPath(String indexedFilePath) async {
     final library = await DataRepository.instance.library;
-    if (!identical(library, _resolveCacheLibrary)) {
-      _resolveCacheLibrary = library;
-      _booksByIndexedFilePathCache = bookForIndexedFilePathMap(library);
+    return _booksByIndexedFilePathFor(library)[indexedFilePath];
+  }
+
+  /// מפת המפתח היציב של האינדקס → ספר, במטמון לכל עוד הספרייה לא הוחלפה.
+  Map<String, Book> _booksByIndexedFilePathFor(Library library) {
+    final cached = _booksByIndexedFilePathCache;
+    if (cached != null && identical(library, _resolveCacheLibrary)) {
+      return cached;
     }
-    return _booksByIndexedFilePathCache?[indexedFilePath];
+    final books = _buildBooksByIndexedFilePath(library);
+    _resolveCacheLibrary = library;
+    _booksByIndexedFilePathCache = books;
+    return books;
   }
 
   Library? _resolveCacheLibrary;
@@ -1237,21 +1259,6 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   @visibleForTesting
   static Map<String, Book> bookForIndexedFilePathMap(Library library) =>
       _buildBooksByIndexedFilePath(library);
-
-  Map<int, Book> _buildBooksByCatalogueOrder(Library library) {
-    final keyOrder = SearchCatalogueOrderHelper.buildKeyOrderMap(
-      library,
-      keyOf: (book) => IndexingRepository.catalogueOrderKey(book as Book),
-    );
-    final booksByOrder = <int, Book>{};
-    for (final book in library.getAllBooks()) {
-      final order = keyOrder[IndexingRepository.catalogueOrderKey(book)];
-      if (order != null) {
-        booksByOrder.putIfAbsent(order, () => book);
-      }
-    }
-    return booksByOrder;
-  }
 
   static Map<String, Book> _buildBooksByIndexedFilePath(Library library) {
     final booksByIndexedFilePath = <String, Book>{};

--- a/test/search/highlight_engine_distance_parity_test.dart
+++ b/test/search/highlight_engine_distance_parity_test.dart
@@ -49,8 +49,13 @@ Future<void> main() async {
 
     tearDownAll(() {
       if (!engineReady) return;
-      if (indexDir.existsSync()) {
+      if (!indexDir.existsSync()) return;
+      // ב-Windows המנוע עדיין מחזיק את קובצי האינדקס פתוחים כשהטסט מסתיים;
+      // ניקוי תיקיית הזמנית אינו סיבה להפיל את הריצה.
+      try {
         indexDir.deleteSync(recursive: true);
+      } on FileSystemException {
+        // ignore
       }
     });
 

--- a/test/search/search_client_side_facet_narrow_test.dart
+++ b/test/search/search_client_side_facet_narrow_test.dart
@@ -1,0 +1,516 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/bloc/search_bloc.dart';
+import 'package:otzaria/search/bloc/search_event.dart';
+import 'package:otzaria/search/bloc/search_state.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/search_repository.dart';
+import 'package:otzaria/search/utils/facet_helper.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart';
+
+import '../support/search_engine_test_init.dart';
+import '../test_helpers/memory_cache_provider.dart';
+
+/// לחיצה על ספר בעץ סינון התוצאות מצמצמת בצד הלקוח, בלי חיפוש מנוע נוסף.
+/// זיהוי הספר של תוצאה הוא לפי `filePath` — המפתח היציב של האינדקס — ולא לפי
+/// הסדר הקטלוגי שבמזהה המסמך, שזז כשספרים נוספו/נמחקו מאז האינדוקס.
+Future<void> main() async {
+  final engineReady = await tryInitSearchEngine();
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const query = 'שיעור הילוך מיל';
+  const dorFacet = '/הלכה/מחברי זמננו/id:5869';
+  const beitShearimFacet = '/שו״ת/אחרונים/id:6234';
+  const pdfPath = r'C:\books\beit-shearim.pdf';
+
+  late TextBook dorHamlaktim;
+  late TextBook beitShearim;
+  late PdfBook beitShearimPdf;
+  late TextBook officialShabbat;
+  late TextBook personalShabbat;
+  late Library library;
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  setUp(() {
+    dorHamlaktim = TextBook(
+      id: 5869,
+      title: 'דור המלקטים על אורח חיים',
+      categoryPath: 'הלכה, מחברי זמננו',
+    );
+    beitShearim = TextBook(
+      id: 6234,
+      title: 'בית שערים אורח חיים',
+      categoryPath: 'שו״ת, אחרונים',
+    );
+    beitShearimPdf = PdfBook(
+      title: 'בית שערים',
+      path: pdfPath,
+      categoryPath: 'שו״ת, אחרונים',
+    );
+    officialShabbat = TextBook(id: 5, title: 'שבת', categoryPath: 'הלכה');
+    personalShabbat = TextBook(
+      id: 5,
+      title: 'שבת',
+      categoryPath: 'הלכה',
+      isUserBook: true,
+    );
+
+    library = Library(categories: const []);
+    library.books.addAll([
+      dorHamlaktim,
+      beitShearim,
+      beitShearimPdf,
+      officialShabbat,
+      personalShabbat,
+    ]);
+    DataRepository.instance.library = Future.value(library);
+  });
+
+  /// מסמן שהעץ נבנה על החיפוש הנוכחי (ספירות + חתימה), ואז שולח את האירוע
+  /// שהלחיצה בחלונית הסינון מייצרת.
+  Future<void> Function(SearchBloc) clickFacet(
+    String facet, {
+    String? signatureOverride,
+    Map<String, int>? treeCounts,
+    SearchEvent Function(String facet)? eventBuilder,
+  }) {
+    return (bloc) async {
+      bloc.add(
+        ReplaceFacetCounts(
+          treeCounts ?? {'/': 2, facet: 1},
+          requestId: 0,
+          signature:
+              signatureOverride ??
+              bloc.facetRecountSignatureForTesting(UpdateSearchQuery(query)),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      // בלי החתימה כל לחיצה הייתה נופלת למנוע, וטסטי הצמצום היו "עוברים"
+      // בלי לבדוק את הצמצום עצמו.
+      expect(bloc.facetCountsSignatureForTesting, isNotNull);
+      bloc.add((eventBuilder ?? SetFacet.new)(facet));
+      await Future<void>.delayed(Duration.zero);
+    };
+  }
+
+  SearchState seededState({
+    required List<SearchResult> results,
+    List<String> currentFacets = const ['/'],
+    int numResults = 100,
+    ResultGroupingMode grouping = ResultGroupingMode.none,
+  }) {
+    return SearchState(
+      searchQuery: query,
+      results: results,
+      totalResults: results.length,
+      configuration: SearchConfiguration(
+        currentFacets: currentFacets,
+        searchScopeFacets: const ['/'],
+        numResults: numResults,
+        resultGrouping: grouping,
+      ),
+    );
+  }
+
+  int streamCallsOf(SearchBloc bloc) =>
+      (bloc.repositoryForTesting as _RecordingSearchRepository).streamCalls;
+
+  group('צמצום מקומי בלחיצה על ספר בעץ התוצאות', () {
+    blocTest<SearchBloc, SearchState>(
+      'מזהה את הספר לפי המפתח היציב גם כשהסדר הקטלוגי שבמזהה המסמך זז',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [
+          _result(book: dorHamlaktim, staleCatalogueOrder: 1, segment: 51538),
+          _result(book: beitShearim, staleCatalogueOrder: 0, segment: 431),
+        ],
+      ),
+      act: clickFacet(beitShearimFacet),
+      verify: (bloc) {
+        expect(
+          bloc.state.results.map((result) => result.filePath),
+          ['id:6234'],
+          reason: 'התוצאה של בית שערים חייבת להישאר',
+        );
+        expect(bloc.state.totalResults, 1);
+        expect(bloc.state.currentFacets, [beitShearimFacet]);
+        expect(bloc.state.isLoading, isFalse);
+        expect(
+          streamCallsOf(bloc),
+          0,
+          reason: 'צמצום מקומי אינו פונה למנוע',
+        );
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'לחיצה על הספר השני מצמצמת אליו, ולא לשכנו בסדר הקטלוגי',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [
+          _result(book: dorHamlaktim, staleCatalogueOrder: 1, segment: 51538),
+          _result(book: beitShearim, staleCatalogueOrder: 0, segment: 431),
+        ],
+      ),
+      act: clickFacet(dorFacet),
+      verify: (bloc) {
+        expect(bloc.state.results.map((result) => result.filePath), [
+          'id:5869',
+        ]);
+        expect(bloc.state.currentFacets, [dorFacet]);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'כמה הופעות באותו ספר נשמרות יחד',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [
+          _result(book: dorHamlaktim, staleCatalogueOrder: 7, segment: 40578),
+          _result(book: dorHamlaktim, staleCatalogueOrder: 7, segment: 51538),
+          _result(book: beitShearim, staleCatalogueOrder: 8, segment: 431),
+        ],
+      ),
+      act: clickFacet(dorFacet),
+      verify: (bloc) {
+        expect(bloc.state.results, hasLength(2));
+        expect(
+          bloc.state.results.map((result) => result.segment.toInt()),
+          [40578, 51538],
+        );
+        expect(bloc.state.totalResults, 2);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'לחיצה על קטגוריה שומרת את הספרים שתחתיה בלבד',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [
+          _result(book: dorHamlaktim, staleCatalogueOrder: 1, segment: 51538),
+          _result(book: beitShearim, staleCatalogueOrder: 0, segment: 431),
+        ],
+      ),
+      act: clickFacet('/הלכה'),
+      verify: (bloc) {
+        expect(bloc.state.results.map((result) => result.filePath), [
+          'id:5869',
+        ]);
+        expect(bloc.state.currentFacets, ['/הלכה']);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'תוצאת PDF מזוהה לפי נתיב הקובץ',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [
+          _result(book: beitShearimPdf, staleCatalogueOrder: 0, segment: 2),
+          _result(book: dorHamlaktim, staleCatalogueOrder: 1, segment: 51538),
+        ],
+      ),
+      act: (bloc) => clickFacet(
+        FacetHelper.buildBookFacet(
+          FacetHelper.resolveCategoryPath(beitShearimPdf),
+          beitShearimPdf,
+        ),
+      )(bloc),
+      verify: (bloc) {
+        expect(bloc.state.results, hasLength(1));
+        expect(bloc.state.results.single.isPdf, isTrue);
+        expect(bloc.state.results.single.filePath, pdfPath);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'ספר אישי וספר רשמי בעלי אותו id נבדלים זה מזה',
+      // המפתח היציב מבחין ביניהם ('uid:5' מול 'id:5'); הסדר הקטלוגי לא.
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [
+          _result(book: officialShabbat, staleCatalogueOrder: 4, segment: 1),
+          _result(book: personalShabbat, staleCatalogueOrder: 3, segment: 2),
+        ],
+      ),
+      act: clickFacet('/הלכה/uid:5'),
+      verify: (bloc) {
+        expect(bloc.state.results.map((result) => result.filePath), ['uid:5']);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'הצמצום אינו נוגע בהיקף הסריקה של החיפוש',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+      ),
+      act: clickFacet(beitShearimFacet),
+      verify: (bloc) {
+        expect(bloc.state.searchScopeFacets, ['/']);
+        expect(bloc.state.currentFacets, [beitShearimFacet]);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'הסרת ספר מבחירה מרובה (Ctrl+לחיצה) מצמצמת לספרים שנשארו',
+      build: () => SearchBloc(repository: _RecordingSearchRepository()),
+      seed: () => seededState(
+        currentFacets: [dorFacet, beitShearimFacet],
+        results: [
+          _result(book: dorHamlaktim, staleCatalogueOrder: 1, segment: 51538),
+          _result(book: beitShearim, staleCatalogueOrder: 0, segment: 431),
+        ],
+      ),
+      act: clickFacet(
+        beitShearimFacet,
+        treeCounts: {'/': 2, dorFacet: 1, beitShearimFacet: 1},
+        eventBuilder: RemoveFacet.new,
+      ),
+      verify: (bloc) {
+        expect(bloc.state.results.map((result) => result.filePath), [
+          'id:5869',
+        ]);
+        expect(bloc.state.currentFacets, [dorFacet]);
+        expect(streamCallsOf(bloc), 0);
+      },
+    );
+  });
+
+  // blocTest אינו תומך בדילוג ישיר (skip שלו סופר states) — לכן העטיפה בקבוצה.
+  group(
+    'נפילה למסלול המנוע (דורש מנוע נייטיבי)',
+    () {
+      blocTest<SearchBloc, SearchState>(
+        'הרחבה — לחיצה על ספר אחר — אינה עוברת במסלול המקומי',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+          currentFacets: [beitShearimFacet],
+        ),
+        act: clickFacet(dorFacet),
+        verify: (bloc) {
+          expect(streamCallsOf(bloc), 1);
+          expect(bloc.state.results, isNotEmpty);
+        },
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'הוספת ספר לבחירה (Ctrl+לחיצה) היא הרחבה וחוזרת למנוע',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+          currentFacets: [beitShearimFacet],
+        ),
+        act: clickFacet(dorFacet, eventBuilder: AddFacet.new),
+        verify: (bloc) {
+          expect(streamCallsOf(bloc), 1);
+          expect(bloc.state.currentFacets, [beitShearimFacet, dorFacet]);
+        },
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'ביטול הסינון האחרון חוזר לכל ההיקף ולא ל"אין תוצאות"',
+        // רשימת facets ריקה נקראת בחיפוש כ"אין במה לחפש", ורוקנה את התוצאות
+        // בלי לפנות למנוע.
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+          currentFacets: [beitShearimFacet],
+        ),
+        act: clickFacet(beitShearimFacet, eventBuilder: RemoveFacet.new),
+        verify: (bloc) {
+          expect(bloc.state.currentFacets, ['/']);
+          expect(streamCallsOf(bloc), 1);
+          expect(bloc.state.results, isNotEmpty);
+        },
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'ביטול הסינון האחרון בחיפוש ממוקד חוזר להיקף הסריקה',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => SearchState(
+          searchQuery: query,
+          results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+          totalResults: 1,
+          configuration: const SearchConfiguration(
+            currentFacets: [beitShearimFacet],
+            searchScopeFacets: ['/שו״ת'],
+          ),
+        ),
+        act: clickFacet(beitShearimFacet, eventBuilder: RemoveFacet.new),
+        verify: (bloc) => expect(bloc.state.currentFacets, ['/שו״ת']),
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'סינון שהתרוקן למרות שהעץ הבטיח תוצאות נופל למנוע',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [_result(book: dorHamlaktim, staleCatalogueOrder: 0)],
+        ),
+        act: clickFacet(beitShearimFacet),
+        verify: (bloc) {
+          expect(streamCallsOf(bloc), 1);
+          expect(bloc.state.results, isNotEmpty);
+        },
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'תוצאה שספרה אינו בקטלוג נופלת למנוע',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [
+            SearchResult(
+              id: IndexingRepository.buildCatalogueDocumentId(
+                catalogueOrder: 0,
+                ordinal: 0,
+              ),
+              title: 'ספר שהוסר מהספרייה',
+              reference: 'סימן א',
+              text: query,
+              segment: BigInt.one,
+              isPdf: false,
+              filePath: 'id:999999',
+              mergedCount: 1,
+              merged: const [],
+            ),
+          ],
+        ),
+        act: clickFacet(beitShearimFacet),
+        verify: (bloc) => expect(streamCallsOf(bloc), 1),
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'תוצאות חתוכות (הגענו למכסה) אינן מצומצמות מקומית',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [
+            _result(book: dorHamlaktim, staleCatalogueOrder: 0, segment: 1),
+            _result(book: beitShearim, staleCatalogueOrder: 1, segment: 2),
+          ],
+          numResults: 2,
+        ),
+        act: clickFacet(beitShearimFacet),
+        verify: (bloc) => expect(streamCallsOf(bloc), 1),
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'במצב איחוד תוצאות הצמצום חוזר למנוע',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        seed: () => seededState(
+          results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+          grouping: ResultGroupingMode.sameSection,
+        ),
+        act: clickFacet(beitShearimFacet),
+        verify: (bloc) => expect(streamCallsOf(bloc), 1),
+      );
+
+      blocTest<SearchBloc, SearchState>(
+        'חתימת ספירות שאינה של החיפוש האחרון מחזירה למנוע',
+        build: () => SearchBloc(repository: _RecordingSearchRepository()),
+        // היקף הסריקה שווה לבחירה, כדי שהנפילה למנוע לא תגרור ספירת-ספרים
+        // נפרדת — היא רצה מול מנוע החיפוש האמיתי ולא מול ה-repository המוזרק.
+        seed: () => SearchState(
+          searchQuery: query,
+          results: [_result(book: beitShearim, staleCatalogueOrder: 0)],
+          totalResults: 1,
+          configuration: const SearchConfiguration(
+            currentFacets: ['/'],
+            searchScopeFacets: [beitShearimFacet],
+          ),
+        ),
+        act: clickFacet(
+          beitShearimFacet,
+          signatureOverride: 'חתימה-של-חיפוש-אחר',
+        ),
+        verify: (bloc) => expect(streamCallsOf(bloc), 1),
+      );
+    },
+    skip: engineReady ? false : searchEngineSkipReason,
+  );
+}
+
+/// תוצאה שמזהה המסמך שלה נושא סדר קטלוגי שכבר אינו תואם למיקום הספר
+/// בספרייה — כמו אינדקס שנבנה לפני שספרים נוספו או נמחקו.
+SearchResult _result({
+  required Book book,
+  required int staleCatalogueOrder,
+  int segment = 1,
+}) {
+  return SearchResult(
+    id: IndexingRepository.buildCatalogueDocumentId(
+      catalogueOrder: staleCatalogueOrder,
+      ordinal: 0,
+    ),
+    title: book.title,
+    reference: '${book.title}, סימן א',
+    text: 'שיעור הילוך מיל',
+    segment: BigInt.from(segment),
+    isPdf: book is PdfBook,
+    filePath: IndexingRepository.buildIndexedBookFilePath(book),
+    mergedCount: 1,
+    merged: const [],
+  );
+}
+
+class _RecordingSearchRepository extends SearchRepository {
+  int streamCalls = 0;
+
+  /// תוצאה שהמנוע מחזיר בנפילה למסלול המלא — כדי שהטסטים יוכלו לאמת שהמשתמש
+  /// רואה תוצאות, ולא רק שהמנוע נקרא.
+  static final SearchResult engineResult = SearchResult(
+    id: BigInt.from(1),
+    title: 'תוצאה מהמנוע',
+    reference: 'סימן א',
+    text: 'שיעור הילוך מיל',
+    segment: BigInt.one,
+    isPdf: false,
+    filePath: 'id:6234',
+    mergedCount: 1,
+    merged: const [],
+  );
+
+  @override
+  Stream<SearchStreamUpdate> searchTextsStreamWithCounts(
+    String query,
+    List<String> facets,
+    int limit, {
+    int offset = 0,
+    int chunkSize = 50,
+    ResultsOrder order = ResultsOrder.relevance,
+    bool fuzzy = false,
+    int distance = 0,
+    String negativeQuery = '',
+    int? negativeDistance,
+    SearchScope scope = SearchScope.wordDistance,
+    SearchScope? negativeScope,
+    SearchMode searchMode = SearchMode.exact,
+    Map<String, String>? customSpacing,
+    Map<String, String>? negativeCustomSpacing,
+    Map<int, List<String>>? alternativeWords,
+    Map<int, List<String>>? negativeAlternativeWords,
+    Map<String, Map<String, bool>>? searchOptions,
+    Map<String, Map<String, bool>>? negativeSearchOptions,
+    bool matchNikud = false,
+    bool matchTaamim = false,
+    ResultGrouping? grouping,
+    WordMatchMode wordMatchMode = WordMatchMode.all,
+    int? wordMatchCount,
+  }) async* {
+    streamCalls++;
+    yield SearchStreamUpdate(
+      totalCount: 1,
+      bookCounts: const {'id:6234': 1},
+      results: [engineResult],
+      truncated: false,
+    );
+  }
+}

--- a/test/support/search_engine_test_init.dart
+++ b/test/support/search_engine_test_init.dart
@@ -26,20 +26,29 @@ String? _searchEnginePackageRoot() {
 /// כל בניות המנוע הזמינות (release/debug), ממוינות מהחדשה לישנה — קוד
 /// ה-FRB המחולל חייב להתאים ל-DLL (בדיקת content hash באתחול), ו-build
 /// ישן בפרופיל אחד אסור שיסתיר build עדכני בפרופיל השני.
+///
+/// נסרקים גם פלטי הבנייה של האפליקציה עצמה — לא פעם זו הבנייה היחידה על
+/// מכונת פיתוח, ובלעדיה כל קבוצות הטסט שתלויות במנוע מדולגות בשקט.
 List<String> searchEngineLibraryCandidates() {
-  final packageRoot = _searchEnginePackageRoot();
-  if (packageRoot == null) return const [];
   const names = [
     'search_engine.dll',
     'libsearch_engine.so',
     'libsearch_engine.dylib',
   ];
+  final packageRoot = _searchEnginePackageRoot();
+  final roots = <String>[
+    for (final profile in ['release', 'debug'])
+      if (packageRoot != null) '$packageRoot/rust/target/$profile',
+    for (final profile in ['Release', 'Debug'])
+      'build/windows/x64/plugins/otzaria_search_engine/$profile',
+    'build/linux/x64/release/plugins/otzaria_search_engine',
+    'build/linux/x64/debug/plugins/otzaria_search_engine',
+  ];
+
   final candidates = <File>[];
-  for (final profile in ['release', 'debug']) {
+  for (final root in roots) {
     for (final name in names) {
-      final path = '$packageRoot/rust/target/$profile/$name'
-          .replaceAll('\\', '/')
-          .replaceAll('//', '/');
+      final path = '$root/$name'.replaceAll('\\', '/').replaceAll('//', '/');
       final file = File(path);
       if (file.existsSync()) {
         candidates.add(file);


### PR DESCRIPTION
סוגר את #673.

## הבאג

בחירת ספר בסרגל סינון תוצאות החיפוש רוקנה את הרשימה והציגה "אין תוצאות" — גם את התוצאות של אותו ספר עצמו, שהוצגו רגע קודם, בזמן שהעץ ממשיך להציג לו מונה תוצאות. לחיצה על ספר אחר, ואז חזרה לספר הראשון, הציגה אותן כרגיל.

## שורש הבעיה

לחיצה שמצמצמת את ההיקף כשכל התוצאות כבר בידינו אינה פונה למנוע אלא מסננת מקומית (`SearchBloc._applyClientSideFacetNarrow`). הסינון זיהה את הספר של כל תוצאה לפי **הסדר הקטלוגי המוטמע במזהה המסמך** — מיקומו של הספר בסריקת הספרייה כפי שהיה **בזמן האינדוקס**. כל ספר שנוסף או נמחק מאז מזיז את המיקומים, ואז כל תוצאה נפתרה לספר שכן: ה-facet שחושב לא התאים ל-facet שנלחץ, כל התוצאות נזרקו, ורשימה ריקה נכתבה ל-state בלי שום שאילתת מנוע.

זו גם הסיבה שלחיצה על ספר אחר "מתקנת": מעבר בין שני ספרים אינו צמצום, ולכן הוא חוזר למסלול המנוע ומחזיר את התוצאות הנכונות.

מסלול ספירת ה-facets כבר נגמל מהמיפוי הזה בעבר (ראו התיעוד ב-`FacetHelper.buildFacetCountsFromResults`) — הסינון המקומי נשאר מאחור.

## התיקון

- הצמצום המקומי מזהה את הספר לפי `filePath` — המפתח היציב שנכתב על מסמכי הספר באינדוקס (`id:5` / `uid:5` / נתיב PDF). זהו אותו מיפוי שבו כבר משתמשים `resolveBookForIndexedPath` וספירות ה-facets, וששורות העץ נבנות ממנו — ולכן facet שאפשר ללחוץ עליו מתאים בהכרח לתוצאות של אותו ספר.
- `_buildBooksByCatalogueOrder` ו-`IndexingRepository.catalogueOrderFromDocumentId` נמחקו: אחרי המעבר לא נותר להם צרכן, והם ה-API שהוליד גם את הבאג הזה וגם את קודמו.
- מטמון המיפוי משותף כעת לשני הצרכנים ונבנה פעם אחת לכל ספרייה, במקום מעבר על כל הספרים בכל חיפוש.
- סינון שהתרוקן למרות שהעץ הבטיח תוצאות ל-facet מעיד על אי-התאמה בזיהוי — ובמקום להציג "אין תוצאות" נופלים לחיפוש מנוע מלא.
- ביטול הסינון האחרון (Ctrl+לחיצה על הספר המסומן היחיד) השאיר רשימת facets ריקה, שנקראת בחיפוש כ"אין במה לחפש" ומציגה "אין תוצאות" בלי לפנות למנוע — והמצב הזה אף נשמר לדיסק ושרד הפעלה מחדש. הרשימה חוזרת עכשיו להיקף הסריקה.

## בדיקות

`test/search/search_client_side_facet_narrow_test.dart` — 17 בדיקות למסלול הצמצום המקומי: זיהוי לפי המפתח היציב כשהסדר הקטלוגי זז, ריבוי הופעות באותו ספר, לחיצה על קטגוריה, תוצאת PDF, הבחנה בין ספר אישי לספר רשמי בעלי אותו id, הסרת ספר מבחירה מרובה, וכל התנאים שמחזירים למסלול המנוע (הרחבה, הוספה לבחירה, ביטול הסינון האחרון בהיקף מלא ובחיפוש ממוקד, סינון שהתרוקן, ספר שאינו בקטלוג, תוצאות חתוכות, איחוד תוצאות, חתימת ספירות לא תואמת). על הקוד שלפני התיקון 11 מהן נופלות.

בנוסף, שתי התאמות בתשתית הבדיקות:
- `tryInitSearchEngine` מאתר גם את המנוע שנבנה עם האפליקציה עצמה, כך שקבוצות הבדיקה שתלויות במנוע רצות על מכונת פיתוח במקום להידלג בשקט.
- ניקוי תיקיית האינדקס הזמנית ב-`highlight_engine_distance_parity_test` אינו מפיל את הריצה ב-Windows, שם המנוע עדיין מחזיק את הקבצים פתוחים בסיום.

`flutter test test/search/ test/indexing/` — 518 עוברות.

## אימות

מעבר לבדיקות, השאילתה מהדיווח (`שיעור הילוך מיל`, חיפוש מדויק, עם קידומות/סיומות דקדוקיות וכתיב מלא/חסר) הורצה ישירות מול אינדקס אמיתי: המנוע מחזיר תוצאות לכל אחד מהספרים שנבחרו בסינון, ונתיב ה-facet שהאפליקציה מחשבת זהה לזה ששמור באינדקס בכל 23 הספרים שנבדקו — כלומר הכשל היה כולו בשלב הסינון המקומי.
