### PR TITLE
תיקון העתקה ריקה במפרשים מתחת הטקסט (issue #674)

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
+import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/widgets/misc/direct_link_menu_entries.dart';
 import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
@@ -618,14 +619,11 @@ class _CombinedViewState extends State<CombinedView> {
   // מנהל בחירת טקסט משופר
   late final TextSelectionManager _selectionManager;
 
-  int _selectionAreaRevision = 0;
+  final GlobalKey<SelectionAreaState> _selectionAreaKey = GlobalKey();
   final Object _selectionOwner = Object();
 
-  // listener לניקוי בחירה - נשמור אותו כדי להסיר אותו ב-dispose
   void _onSelectionModeChanged() {
     if (!_selectionManager.isInSelectionMode && mounted) {
-      // כשיוצאים ממצב בחירה, קוראים ל-setState כדי לכפות בנייה מחדש
-      // של SelectionArea ולנקות את הבחירה באופן ויזואלי.
       setState(() {});
     }
   }
@@ -681,7 +679,6 @@ class _CombinedViewState extends State<CombinedView> {
     // אתחול מנהל הבחירה
     _selectionManager = TextSelectionManager();
 
-    // האזנה לשינויים במצב הבחירה כדי לכפות rebuild של SelectionArea
     _selectionManager.addListener(_onSelectionModeChanged);
     widget.selectionSyncController?.addListener(_handleExternalSelectionChange);
     PluginHighlightRevealService.instance.addListener(
@@ -845,20 +842,23 @@ class _CombinedViewState extends State<CombinedView> {
       return;
     }
 
-    final shouldRebuild = shouldRebuildSelectionAreaOnExternalChange(
+    final shouldClear = shouldClearSelectionOnExternalChange(
       activeOwner: controller.activeOwner,
       selfOwner: _selectionOwner,
       hasOwnSelection:
           _savedSelectedText.value != null ||
           _selectionManager.isInSelectionMode,
     );
-    if (!shouldRebuild) {
+    if (!shouldClear) {
       return;
     }
 
+    // ניקוי ישיר ולא החלפת מפתח: כרטיס המפרשים מקונן בעץ הזה, והחלפת מפתח
+    // הייתה הורסת אותו יחד עם הבחירה שזה עתה סומנה בו (issue #674).
+    _selectionAreaKey.currentState?.selectableRegion.clearSelection();
+
     _selectionManager.exitSelectionMode();
     setState(() {
-      _selectionAreaRevision = controller.revision;
       _savedSelectedText.value = null;
       _savedSelectedIndex.value = null;
       _currentSelectedIndex.value = null;
@@ -1583,233 +1583,229 @@ class _CombinedViewState extends State<CombinedView> {
             _viewportHeight = constraints.maxHeight;
             context.watch<SettingsBloc>().state;
 
-            return RtlSelectionShortcuts(
-              child: SelectionArea(
-                key: ValueKey('combined_selection_$_selectionAreaRevision'),
-                // SelectionArea אחד לכל הרשימה - מאפשר בחירה רציפה בין פסקאות
-                contextMenuBuilder: (context, selectableRegionState) {
-                  return const SizedBox.shrink();
-                },
-                onSelectionChanged: (selection) {
-                  final plain = selection?.plainText;
-                  // עדכון מעקב כיוון הגרירה (ל-RtlSelectionShortcuts).
-                  trackRtlSelection(plain);
-                  // שינוי בחירה זמני בזמן priming — לא לעבד.
-                  if (rtlSelectionPriming) return;
-                  if (!shouldPersistSelectedText(plain)) {
-                    widget.selectionSyncController?.clear(_selectionOwner);
-                    _selectionManager.exitSelectionMode();
-                    _savedSelectedText.value = null;
-                    _selectionLineStart = null;
-                    _selectionLineEnd = null;
-                    _selectionStartColumn = null;
-                    return;
-                  }
-                  widget.selectionSyncController?.activate(_selectionOwner);
-                  // כניסה למצב בחירה כשיש טקסט נבחר
-                  if (!_selectionManager.isInSelectionMode) {
-                    // שימוש באינדקס העליון הנראה במקום 0
-                    _selectionManager.setAnchor(
-                      topmostVisibleIndex(
-                        widget.tab.positionsListener.itemPositions.value,
-                      ),
-                    );
-                  }
-
-                  // חשוב: כדי ש-Ctrl+C יעבוד מיד אחרי סימון טקסט עם העכבר
-                  // נוודא שהפוקוס נמצא על אזור הקריאה.
-                  _focusNode.requestFocus();
-
-                  // מחשב את מספר השורה המדויק של הטקסט המודגש
-                  // משתמש באותה לוגיקה כמו בדיווח שגיאות
-                  final TextBookLoaded? loadedState =
-                      _textBookBloc.state is TextBookLoaded
-                      ? _textBookBloc.state as TextBookLoaded
-                      : null;
-                  int? foundIndex;
-                  var fixedPlain = plain;
-
-                  if (loadedState != null) {
-                    final settingsState = context.read<SettingsBloc>().state;
-                    final window = _buildSelectionWindow(
-                      loadedState,
-                      settingsState,
-                      plain!.length,
-                    );
-                    final baseIndex = window.baseIndex;
-                    final visibleLines = window.lines;
-                    final previousIndex = sessionSelectionIndex(
-                      savedSelectedText: _savedSelectedText.value,
-                      savedSelectedIndex: _savedSelectedIndex.value,
-                    );
-                    final restored = restoreSelectedTextLineBreaksDetailed(
-                      selectedText: plain,
-                      visibleLines: visibleLines,
-                      preferredLine: previousIndex == null
-                          ? null
-                          : previousIndex - baseIndex,
-                    );
-                    fixedPlain = restored.text;
-
-                    final location = resolveSelectionLocation(
-                      restored: restored,
-                      baseIndex: baseIndex,
-                      fallbackIndex: loadedState.selectedIndex,
-                    );
-                    final sourceIndices = List<int>.generate(
-                      visibleLines.length,
-                      (offset) => baseIndex + offset,
-                    );
-                    final pointerLocation = locateSingleLineSelectionAtPointer(
-                      renderedLines: visibleLines,
-                      sourceIndices: sourceIndices,
-                      selectedText: fixedPlain,
-                      pointerLineIndex: _selectionPointerLineIndex,
-                      pointerColumn: _selectionPointerColumn,
-                    );
-                    foundIndex =
-                        pointerLocation?.lineIndex ?? location.selectedIndex;
-                    // טווח השורות שהבחירה משתרעת עליהן — לזיהוי סלחני של לחיצה
-                    // ימנית על הבחירה, ועמודת ההתחלה — רמז לזיהוי המופע הנכון
-                    // כשאותו טקסט חוזר באותה שורה.
-                    _selectionLineStart =
-                        pointerLocation?.lineIndex ?? location.lineStart;
-                    _selectionLineEnd =
-                        pointerLocation?.lineIndex ?? location.lineEnd;
-                    _selectionStartColumn =
-                        pointerLocation?.column ?? location.startColumn;
-                  }
-
-                  if (mounted) {
-                    _savedSelectedText.value = fixedPlain;
-                    _savedSelectedIndex.value = foundIndex;
-                    _currentSelectedIndex.value = foundIndex;
-                    widget.onSelectedTextChanged?.call(
-                      fixedPlain,
-                      foundIndex,
-                      _selectionStartColumn,
-                    );
-
-                    // שליחת event לפלאגינים עם ה-index המדויק
-                    final selectionText = fixedPlain?.trim() ?? '';
-                    if (selectionText.isNotEmpty && loadedState != null) {
-                      unawaited(
-                        PluginRuntimeDispatcher.instance.dispatchEvent(
-                          'reader.selection_changed',
-                          {
-                            'text': selectionText,
-                            'currentRef': loadedState.currentTitle ?? '',
-                            'currentBook': loadedState.book.title,
-                            'currentBookId': loadedState.book.title,
-                            'currentIndex': foundIndex ?? 0,
-                          },
+            // יירוט Ctrl+C ממוקם *מעל* ה-SelectionArea — שם מנגנון ה-override
+            // של CopySelectionTextIntent מאתר אותו. מתחתיו הוא בלתי-נראה, ואז
+            // רצה העתקת ברירת המחדל של Flutter: בלחיצה בודדת הבחירה מתכווצת
+            // ל-plainText ריק, והיא נכתבת ללוח כפריט ריק (issue #674).
+            return SelectionCopyShortcuts(
+              onCopy: _copyFormattedText,
+              child: RtlSelectionShortcuts(
+                child: SelectionArea(
+                  key: _selectionAreaKey,
+                  // SelectionArea אחד לכל הרשימה - מאפשר בחירה רציפה בין פסקאות
+                  contextMenuBuilder: (context, selectableRegionState) {
+                    return const SizedBox.shrink();
+                  },
+                  onSelectionChanged: (selection) {
+                    final plain = selection?.plainText;
+                    // עדכון מעקב כיוון הגרירה (ל-RtlSelectionShortcuts).
+                    trackRtlSelection(plain);
+                    // שינוי בחירה זמני בזמן priming — לא לעבד.
+                    if (rtlSelectionPriming) return;
+                    if (!shouldPersistSelectedText(plain)) {
+                      widget.selectionSyncController?.clear(_selectionOwner);
+                      _selectionManager.exitSelectionMode();
+                      _savedSelectedText.value = null;
+                      _selectionLineStart = null;
+                      _selectionLineEnd = null;
+                      _selectionStartColumn = null;
+                      return;
+                    }
+                    widget.selectionSyncController?.activate(_selectionOwner);
+                    // כניסה למצב בחירה כשיש טקסט נבחר
+                    if (!_selectionManager.isInSelectionMode) {
+                      // שימוש באינדקס העליון הנראה במקום 0
+                      _selectionManager.setAnchor(
+                        topmostVisibleIndex(
+                          widget.tab.positionsListener.itemPositions.value,
                         ),
                       );
                     }
-                  }
-                  _prefetchDictionaryLookups(fixedPlain);
-                },
-                child: Shortcuts(
-                  shortcuts: <ShortcutActivator, Intent>{
-                    // Windows/Linux
-                    LogicalKeySet(
-                      LogicalKeyboardKey.control,
-                      LogicalKeyboardKey.keyC,
-                    ): const _CopySelectedTextIntent(),
-                    // Windows "classic" copy
-                    LogicalKeySet(
-                      LogicalKeyboardKey.control,
-                      LogicalKeyboardKey.insert,
-                    ): const _CopySelectedTextIntent(),
-                    // macOS (למקרה שמריצים שם)
-                    LogicalKeySet(
-                      LogicalKeyboardKey.meta,
-                      LogicalKeyboardKey.keyC,
-                    ): const _CopySelectedTextIntent(),
-                    // Esc לניקוי בחירה
-                    LogicalKeySet(LogicalKeyboardKey.escape):
-                        const ClearSelectionIntent(),
+
+                    // חשוב: כדי ש-Ctrl+C יעבוד מיד אחרי סימון טקסט עם העכבר
+                    // נוודא שהפוקוס נמצא על אזור הקריאה.
+                    _focusNode.requestFocus();
+
+                    // מחשב את מספר השורה המדויק של הטקסט המודגש
+                    // משתמש באותה לוגיקה כמו בדיווח שגיאות
+                    final TextBookLoaded? loadedState =
+                        _textBookBloc.state is TextBookLoaded
+                        ? _textBookBloc.state as TextBookLoaded
+                        : null;
+                    int? foundIndex;
+                    var fixedPlain = plain;
+
+                    if (loadedState != null) {
+                      final settingsState = context.read<SettingsBloc>().state;
+                      final window = _buildSelectionWindow(
+                        loadedState,
+                        settingsState,
+                        plain!.length,
+                      );
+                      final baseIndex = window.baseIndex;
+                      final visibleLines = window.lines;
+                      final previousIndex = sessionSelectionIndex(
+                        savedSelectedText: _savedSelectedText.value,
+                        savedSelectedIndex: _savedSelectedIndex.value,
+                      );
+                      final restored = restoreSelectedTextLineBreaksDetailed(
+                        selectedText: plain,
+                        visibleLines: visibleLines,
+                        preferredLine: previousIndex == null
+                            ? null
+                            : previousIndex - baseIndex,
+                      );
+                      fixedPlain = restored.text;
+
+                      final location = resolveSelectionLocation(
+                        restored: restored,
+                        baseIndex: baseIndex,
+                        fallbackIndex: loadedState.selectedIndex,
+                      );
+                      final sourceIndices = List<int>.generate(
+                        visibleLines.length,
+                        (offset) => baseIndex + offset,
+                      );
+                      final pointerLocation =
+                          locateSingleLineSelectionAtPointer(
+                            renderedLines: visibleLines,
+                            sourceIndices: sourceIndices,
+                            selectedText: fixedPlain,
+                            pointerLineIndex: _selectionPointerLineIndex,
+                            pointerColumn: _selectionPointerColumn,
+                          );
+                      foundIndex =
+                          pointerLocation?.lineIndex ?? location.selectedIndex;
+                      // טווח השורות שהבחירה משתרעת עליהן — לזיהוי סלחני של לחיצה
+                      // ימנית על הבחירה, ועמודת ההתחלה — רמז לזיהוי המופע הנכון
+                      // כשאותו טקסט חוזר באותה שורה.
+                      _selectionLineStart =
+                          pointerLocation?.lineIndex ?? location.lineStart;
+                      _selectionLineEnd =
+                          pointerLocation?.lineIndex ?? location.lineEnd;
+                      _selectionStartColumn =
+                          pointerLocation?.column ?? location.startColumn;
+                    }
+
+                    if (mounted) {
+                      _savedSelectedText.value = fixedPlain;
+                      _savedSelectedIndex.value = foundIndex;
+                      _currentSelectedIndex.value = foundIndex;
+                      widget.onSelectedTextChanged?.call(
+                        fixedPlain,
+                        foundIndex,
+                        _selectionStartColumn,
+                      );
+
+                      // שליחת event לפלאגינים עם ה-index המדויק
+                      final selectionText = fixedPlain?.trim() ?? '';
+                      if (selectionText.isNotEmpty && loadedState != null) {
+                        unawaited(
+                          PluginRuntimeDispatcher.instance.dispatchEvent(
+                            'reader.selection_changed',
+                            {
+                              'text': selectionText,
+                              'currentRef': loadedState.currentTitle ?? '',
+                              'currentBook': loadedState.book.title,
+                              'currentBookId': loadedState.book.title,
+                              'currentIndex': foundIndex ?? 0,
+                            },
+                          ),
+                        );
+                      }
+                    }
+                    _prefetchDictionaryLookups(fixedPlain);
                   },
-                  child: Actions(
-                    actions: <Type, Action<Intent>>{
-                      _CopySelectedTextIntent:
-                          CallbackAction<_CopySelectedTextIntent>(
-                            onInvoke: (_) {
-                              _copyFormattedText();
-                              return null;
-                            },
-                          ),
-                      CopySelectionTextIntent:
-                          CallbackAction<CopySelectionTextIntent>(
-                            onInvoke: (_) {
-                              _copyFormattedText();
-                              return null;
-                            },
-                          ),
-                      ClearSelectionIntent: _ClearSelectionAction(this),
+                  child: Shortcuts(
+                    // Ctrl+C / Cmd+C מטופלים ב-SelectionCopyShortcuts שמעל.
+                    shortcuts: <ShortcutActivator, Intent>{
+                      // Windows "classic" copy
+                      LogicalKeySet(
+                        LogicalKeyboardKey.control,
+                        LogicalKeyboardKey.insert,
+                      ): const _CopySelectedTextIntent(),
+                      // Esc לניקוי בחירה
+                      LogicalKeySet(LogicalKeyboardKey.escape):
+                          const ClearSelectionIntent(),
                     },
-                    child: widget.isPreviewMode
-                        ? _buildPreviewList(state)
-                        : ScrollablePositionedListScrollbar(
-                            scrollController: widget.tab.scrollController,
-                            itemPositionsListener: widget.tab.positionsListener,
-                            itemCount: state.readingSegments.isNotEmpty
-                                ? state.readingSegments.length
-                                : widget.data.length,
-                            labelForIndex: state.tableOfContents.isEmpty
-                                ? null
-                                : (index) {
-                                    // במצב קריאה רציף האינדקס הוא אינדקס
-                                    // סגמנט; ממירים לשורת המקור כדי שמיפוי
-                                    // ה-TOC (שמבוסס על מספרי שורות) יהיה נכון.
-                                    final segments = state.readingSegments;
-                                    final lineIndex = segments.isNotEmpty
-                                        ? (index >= 0 && index < segments.length
-                                              ? segments[index].startLineIndex
-                                              : index)
-                                        : index;
-                                    final ref = refFromTocList(
-                                      lineIndex,
-                                      state.tableOfContents,
-                                    );
-                                    return addBookTitleToRef(
-                                      ref,
-                                      state.book.title,
-                                    );
-                                  },
-                            child: ProgressiveScroll(
-                              focusNode: _focusNode,
-                              maxSpeed: 10000.0,
-                              curve: 10.0,
-                              accelerationFactor: 5,
-                              scrollController: widget.tab.mainOffsetController,
-                              itemScrollController: widget.tab.scrollController,
-                              child:
-                                  BlocBuilder<
-                                    PersonalNotesBloc,
-                                    PersonalNotesState
-                                  >(
-                                    builder: (context, notesState) {
-                                      final noteMap =
-                                          <int, List<PersonalNote>>{};
-                                      if (notesState.bookId ==
-                                          state.book.title) {
-                                        for (final note
-                                            in notesState.locatedNotes) {
-                                          final line = note.lineNumber;
-                                          if (line == null) continue;
-                                          noteMap
-                                              .putIfAbsent(line, () => [])
-                                              .add(note);
-                                        }
-                                      }
-                                      return SmoothWheelScroll(
-                                        child: buildOuterList(state, noteMap),
+                    child: Actions(
+                      actions: <Type, Action<Intent>>{
+                        _CopySelectedTextIntent:
+                            CallbackAction<_CopySelectedTextIntent>(
+                              onInvoke: (_) {
+                                _copyFormattedText();
+                                return null;
+                              },
+                            ),
+                        ClearSelectionIntent: _ClearSelectionAction(this),
+                      },
+                      child: widget.isPreviewMode
+                          ? _buildPreviewList(state)
+                          : ScrollablePositionedListScrollbar(
+                              scrollController: widget.tab.scrollController,
+                              itemPositionsListener:
+                                  widget.tab.positionsListener,
+                              itemCount: state.readingSegments.isNotEmpty
+                                  ? state.readingSegments.length
+                                  : widget.data.length,
+                              labelForIndex: state.tableOfContents.isEmpty
+                                  ? null
+                                  : (index) {
+                                      // במצב קריאה רציף האינדקס הוא אינדקס
+                                      // סגמנט; ממירים לשורת המקור כדי שמיפוי
+                                      // ה-TOC (שמבוסס על מספרי שורות) יהיה נכון.
+                                      final segments = state.readingSegments;
+                                      final lineIndex = segments.isNotEmpty
+                                          ? (index >= 0 &&
+                                                    index < segments.length
+                                                ? segments[index].startLineIndex
+                                                : index)
+                                          : index;
+                                      final ref = refFromTocList(
+                                        lineIndex,
+                                        state.tableOfContents,
+                                      );
+                                      return addBookTitleToRef(
+                                        ref,
+                                        state.book.title,
                                       );
                                     },
-                                  ),
+                              child: ProgressiveScroll(
+                                focusNode: _focusNode,
+                                maxSpeed: 10000.0,
+                                curve: 10.0,
+                                accelerationFactor: 5,
+                                scrollController:
+                                    widget.tab.mainOffsetController,
+                                itemScrollController:
+                                    widget.tab.scrollController,
+                                child:
+                                    BlocBuilder<
+                                      PersonalNotesBloc,
+                                      PersonalNotesState
+                                    >(
+                                      builder: (context, notesState) {
+                                        final noteMap =
+                                            <int, List<PersonalNote>>{};
+                                        if (notesState.bookId ==
+                                            state.book.title) {
+                                          for (final note
+                                              in notesState.locatedNotes) {
+                                            final line = note.lineNumber;
+                                            if (line == null) continue;
+                                            noteMap
+                                                .putIfAbsent(line, () => [])
+                                                .add(note);
+                                          }
+                                        }
+                                        return SmoothWheelScroll(
+                                          child: buildOuterList(state, noteMap),
+                                        );
+                                      },
+                                    ),
+                              ),
                             ),
-                          ),
+                    ),
                   ),
                 ),
               ),
@@ -1820,9 +1816,6 @@ class _CombinedViewState extends State<CombinedView> {
     );
   }
 
-  /// רשימת התצוגה המקדימה, עם אותו מחוון גלילה של אזור הקריאה. ListView
-  /// אומד את היקף הגלילה מגובה הפריטים שבנויים כרגע, וכששורות הספר בגבהים
-  /// שונים האומדן משתנה בכל פריים והאגודל קפץ למעלה ולמטה במקום לנסוע ישר.
   Widget _buildPreviewList(TextBookLoaded state) {
     final itemCount = state.readingSegments.isNotEmpty
         ? state.readingSegments.length

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
+import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
 import 'package:otzaria/text_book/view/selection/selected_text_restore.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/models/links.dart';
@@ -229,7 +229,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
     null,
   ); // ה-link האחרון שנוגעו בו (לכותרות בהעתקה)
   final Object _selectionOwner = Object(); // מזהה ייחודי לבעלות על הבחירה
-  int _selectionRevision = 0; // גרסה לאיפוס SelectionArea כשבחירה חיצונית מנקה
+  final GlobalKey<SelectionAreaState> _selectionAreaKey = GlobalKey();
   bool _showCommentatorsFilter = false; // האם להציג את מסך בחירת המפרשים
   bool _filterWasAutoOpened = false; // האם מסך הסינון נפתח אוטומטית (לא ידנית)
   // latch חד-פעמי: מסמן שהפתיחה האוטומטית דרך onFilterOpenRequested כבר נשלחה.
@@ -984,17 +984,17 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
   void _handleExternalSelectionChange() {
     final controller = widget.selectionSyncController;
     if (controller == null || !mounted) return;
-    final shouldRebuild = shouldRebuildSelectionAreaOnExternalChange(
+    final shouldClear = shouldClearSelectionOnExternalChange(
       activeOwner: controller.activeOwner,
       selfOwner: _selectionOwner,
       hasOwnSelection: _savedSelectedText.value != null,
     );
-    if (!shouldRebuild) return;
+    if (!shouldClear) return;
+    // ניקוי ישיר ולא החלפת מפתח: החלפה הייתה טוענת מחדש את כל המפרשים
+    // ומאבדת את מיקום הגלילה בהם.
+    _selectionAreaKey.currentState?.selectableRegion.clearSelection();
     _savedSelectedText.value = null;
     _lastSelectedLink.value = null;
-    setState(() {
-      _selectionRevision = controller.revision;
-    });
   }
 
   Future<void> _scrollToSearchResult() async {
@@ -1757,121 +1757,103 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                     ),
                   );
 
-                  return Shortcuts(
-                    shortcuts: <ShortcutActivator, Intent>{
-                      LogicalKeySet(
-                        LogicalKeyboardKey.control,
-                        LogicalKeyboardKey.keyC,
-                      ): const _CopyCommentaryIntent(),
-                      LogicalKeySet(
-                        LogicalKeyboardKey.meta,
-                        LogicalKeyboardKey.keyC,
-                      ): const _CopyCommentaryIntent(),
+                  // מיירט גם את CopySelectionTextIntent, ולא רק את צירוף
+                  // המקשים: בלעדיו Ctrl+C נופל להעתקת ברירת המחדל של Flutter,
+                  // שכותבת ללוח את הבחירה כמות שהיא — גם כשהיא ריקה (#674).
+                  return SelectionCopyShortcuts(
+                    onCopy: () {
+                      // בחירה החוצה כמה מפרשים — לא מייחסים כותרת מקור
+                      // (היא הייתה משתייכת למפרש בודד בלבד).
+                      final link = _selectionSpansMultipleItems()
+                          ? null
+                          : _lastSelectedLink.value;
+                      ContextMenuUtils.copyFormattedText(
+                        context: context,
+                        savedSelectedText: _restoreLineBreaks(
+                          _savedSelectedText.value,
+                        ),
+                        fontSize: widget.fontSize,
+                        link: link,
+                      );
                     },
-                    child: Actions(
-                      actions: <Type, Action<Intent>>{
-                        _CopyCommentaryIntent:
-                            CallbackAction<_CopyCommentaryIntent>(
-                              onInvoke: (_) {
-                                // בחירה החוצה כמה מפרשים — לא מייחסים כותרת מקור
-                                // (היא הייתה משתייכת למפרש בודד בלבד).
-                                final link = _selectionSpansMultipleItems()
-                                    ? null
-                                    : _lastSelectedLink.value;
-                                ContextMenuUtils.copyFormattedText(
-                                  context: context,
-                                  savedSelectedText: _restoreLineBreaks(
-                                    _savedSelectedText.value,
-                                  ),
-                                  fontSize: widget.fontSize,
-                                  link: link,
-                                );
-                                return null;
-                              },
-                            ),
+                    child: Listener(
+                      // לחיצה בכל מקום בחלונית ממקדת את ה-ProgressiveScroll
+                      // כדי שגלילה עם החיצים תעבוד בלי לבחור טקסט קודם.
+                      behavior: HitTestBehavior.translucent,
+                      onPointerDown: (event) {
+                        if (!shouldFocusScrollOnPointerDown(event.buttons)) {
+                          return;
+                        }
+                        _focusNode.requestFocus();
                       },
-                      child: Listener(
-                        // לחיצה בכל מקום בחלונית ממקדת את ה-ProgressiveScroll
-                        // כדי שגלילה עם החיצים תעבוד בלי לבחור טקסט קודם.
-                        behavior: HitTestBehavior.translucent,
-                        onPointerDown: (event) {
-                          if (!shouldFocusScrollOnPointerDown(event.buttons)) {
-                            return;
-                          }
-                          _focusNode.requestFocus();
-                        },
-                        child: AppFutureBuilder<List<CommentaryGroup>>(
-                          future: _getCachedGroups(data),
-                          loadingWidget: _buildSkeletonLoading(),
-                          builder: (context, groups) {
-                            for (final group in groups) {
-                              final groupKey = group.bookTitle;
-                              _expansionStates.putIfAbsent(
-                                groupKey,
-                                () => _allExpanded,
-                              );
-                            }
-
-                            final Widget
-                            listView = ScrollablePositionedList.builder(
-                              itemScrollController: _itemScrollController,
-                              itemPositionsListener: _itemPositionsListener,
-                              initialScrollIndex: _lastScrollIndex.clamp(
-                                0,
-                                groups.length - 1,
-                              ),
-                              key: PageStorageKey(
-                                'commentary_${selectedCommentators.join(',')}',
-                              ),
-                              physics: const ClampingScrollPhysics(),
-                              scrollOffsetController: scrollController,
-                              shrinkWrap: widget.shrinkWrap,
-                              itemCount: groups.length,
-                              itemBuilder: (context, groupIndex) {
-                                final group = groups[groupIndex];
-                                return _buildCommentaryGroupTile(
-                                  group: group,
-                                  state: state,
-                                  groupIndex: groupIndex,
-                                );
-                              },
+                      child: AppFutureBuilder<List<CommentaryGroup>>(
+                        future: _getCachedGroups(data),
+                        loadingWidget: _buildSkeletonLoading(),
+                        builder: (context, groups) {
+                          for (final group in groups) {
+                            final groupKey = group.bookTitle;
+                            _expansionStates.putIfAbsent(
+                              groupKey,
+                              () => _allExpanded,
                             );
+                          }
 
-                            // ProgressiveScroll עוטף את SelectionArea (מעליו),
-                            // כך שגלילת החיצים נקלטת גם כש-SelectableRegion הוא
-                            // ה-primaryFocus — האירוע מתפשט כלפי מעלה דרכו.
-                            return ProgressiveScroll(
-                              focusNode: _focusNode,
-                              autofocus: widget.autofocus,
-                              scrollController: scrollController,
-                              maxSpeed: 10000.0,
-                              curve: 10.0,
-                              accelerationFactor: 5,
-                              itemScrollController: _itemScrollController,
-                              child: RtlSelectionShortcuts(
-                                child: SelectionArea(
-                                  key: ValueKey(
-                                    'commentary_list_$_selectionRevision',
-                                  ),
-                                  contextMenuBuilder: (context, _) =>
-                                      const SizedBox.shrink(),
-                                  onSelectionChanged: (selection) =>
-                                      _onListSelectionChanged(
-                                        selection?.plainText,
-                                      ),
-                                  child: ScrollablePositionedListScrollbar(
-                                    scrollController: _itemScrollController,
-                                    offsetController: scrollController,
-                                    itemPositionsListener:
-                                        _itemPositionsListener,
-                                    itemCount: groups.length,
-                                    child: SmoothWheelScroll(child: listView),
-                                  ),
+                          final Widget
+                          listView = ScrollablePositionedList.builder(
+                            itemScrollController: _itemScrollController,
+                            itemPositionsListener: _itemPositionsListener,
+                            initialScrollIndex: _lastScrollIndex.clamp(
+                              0,
+                              groups.length - 1,
+                            ),
+                            key: PageStorageKey(
+                              'commentary_${selectedCommentators.join(',')}',
+                            ),
+                            physics: const ClampingScrollPhysics(),
+                            scrollOffsetController: scrollController,
+                            shrinkWrap: widget.shrinkWrap,
+                            itemCount: groups.length,
+                            itemBuilder: (context, groupIndex) {
+                              final group = groups[groupIndex];
+                              return _buildCommentaryGroupTile(
+                                group: group,
+                                state: state,
+                                groupIndex: groupIndex,
+                              );
+                            },
+                          );
+
+                          // ProgressiveScroll עוטף את SelectionArea (מעליו),
+                          // כך שגלילת החיצים נקלטת גם כש-SelectableRegion הוא
+                          // ה-primaryFocus — האירוע מתפשט כלפי מעלה דרכו.
+                          return ProgressiveScroll(
+                            focusNode: _focusNode,
+                            autofocus: widget.autofocus,
+                            scrollController: scrollController,
+                            maxSpeed: 10000.0,
+                            curve: 10.0,
+                            accelerationFactor: 5,
+                            itemScrollController: _itemScrollController,
+                            child: RtlSelectionShortcuts(
+                              child: SelectionArea(
+                                key: _selectionAreaKey,
+                                contextMenuBuilder: (context, _) =>
+                                    const SizedBox.shrink(),
+                                onSelectionChanged: (selection) =>
+                                    _onListSelectionChanged(
+                                      selection?.plainText,
+                                    ),
+                                child: ScrollablePositionedListScrollbar(
+                                  scrollController: _itemScrollController,
+                                  offsetController: scrollController,
+                                  itemPositionsListener: _itemPositionsListener,
+                                  itemCount: groups.length,
+                                  child: SmoothWheelScroll(child: listView),
                                 ),
                               ),
-                            );
-                          },
-                        ),
+                            ),
+                          );
+                        },
                       ),
                     ),
                   );
@@ -2473,10 +2455,6 @@ class _CollapsibleCommentaryGroupState
       ],
     );
   }
-}
-
-class _CopyCommentaryIntent extends Intent {
-  const _CopyCommentaryIntent();
 }
 
 /// תצוגת המפרש הוירטואלי 'הערות' — מציגה את גוף ההערות ה-inline

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -1005,12 +1005,12 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       return;
     }
 
-    final shouldRebuild = shouldRebuildSelectionAreaOnExternalChange(
+    final shouldClear = shouldClearSelectionOnExternalChange(
       activeOwner: controller.activeOwner,
       selfOwner: _selectionOwner,
       hasOwnSelection: _savedSelectedText != null,
     );
-    if (!shouldRebuild) {
+    if (!shouldClear) {
       return;
     }
 

--- a/lib/text_book/view/selection/selection_sync_controller.dart
+++ b/lib/text_book/view/selection/selection_sync_controller.dart
@@ -1,15 +1,10 @@
 import 'package:flutter/foundation.dart';
 
-/// מסנכרן בחירת טקסט בין כמה אזורי SelectionArea באותו מסך.
-///
-/// ל-SelectionArea של Flutter אין API ישיר ל"נקה בחירה באזור אחר",
-/// לכן כל אזור מאזין לגרסה (`revision`) ומבצע rebuild מקומי כשהבחירה
-/// עברה לאזור אחר.
+/// מסנכרן בחירת טקסט בין כמה אזורי SelectionArea באותו מסך: רק אזור אחד
+/// מחזיק בחירה בכל רגע, והשאר מנקים את שלהם כשהבעלות עוברת.
 class SelectionSyncController extends ChangeNotifier {
-  int _revision = 0;
   Object? _activeOwner;
 
-  int get revision => _revision;
   Object? get activeOwner => _activeOwner;
 
   void activate(Object owner) {
@@ -18,7 +13,6 @@ class SelectionSyncController extends ChangeNotifier {
     }
 
     _activeOwner = owner;
-    _revision++;
     notifyListeners();
   }
 
@@ -28,21 +22,17 @@ class SelectionSyncController extends ChangeNotifier {
     }
 
     _activeOwner = null;
-    _revision++;
     notifyListeners();
   }
 }
 
-/// קובע האם צריך לבנות מחדש את ה-SelectionArea של אזור בתגובה לשינוי בעלות
-/// ב-[SelectionSyncController]. הבנייה מחדש מתבצעת על-ידי קידום ערך revision
-/// ששימש כ-`ValueKey` של ה-SelectionArea — ולכן היא משחזרת את כל עץ הצאצאים.
+/// קובע האם אזור צריך לנקות את הבחירה שלו כשאזור אחר תפס בעלות.
 ///
-/// מטרת הבנייה היא לנקות בחירה ויזואלית של ה-SelectionArea שלנו כשאזור אחר
-/// תפס בעלות. אם אין לנו בחירה משלנו — אין מה לנקות, ו-rebuild רק יהרוס
-/// את עץ הצאצאים שלא לצורך (במצב 'מפרשים מתחת' זה גורם לטעינה מחדש של
-/// המפרשים בכל פעם שמנסים לסמן בהם טקסט; ב'צורת הדף' זה גורם לאיפוס
-/// סטייט פנימי של הצאצאים).
-bool shouldRebuildSelectionAreaOnExternalChange({
+/// הניקוי חייב להתבצע דרך `SelectableRegionState.clearSelection()`. ניקוי
+/// על-ידי החלפת מפתח ה-SelectionArea הורס את עץ הצאצאים, ובמצב 'מפרשים מתחת'
+/// (שבו רשימת המפרשים מקוננת בתוך אזור הטקסט הראשי) הוא מוחק את הבחירה
+/// שהמשתמש זה עתה סימן במפרש — והעתקה יוצאת ריקה (issue #674).
+bool shouldClearSelectionOnExternalChange({
   required Object? activeOwner,
   required Object selfOwner,
   required bool hasOwnSelection,

--- a/lib/widgets/commentary/links_list_view.dart
+++ b/lib/widgets/commentary/links_list_view.dart
@@ -346,18 +346,24 @@ class _LinksListViewState extends State<LinksListView> {
 
   void _handleExternalSelectionChange() {
     final controller = widget.selectionSyncController;
-    if (controller == null ||
-        controller.activeOwner == null ||
-        identical(controller.activeOwner, _selectionOwner)) {
+    if (controller == null || !mounted) {
       return;
     }
 
-    if (!mounted) {
+    final shouldClear = shouldClearSelectionOnExternalChange(
+      activeOwner: controller.activeOwner,
+      selfOwner: _selectionOwner,
+      hasOwnSelection: _savedSelectedText != null,
+    );
+    if (!shouldClear) {
       return;
     }
 
+    // כאן הניקוי כן נעשה בהחלפת מפתח: הרשימה מרנדרת SelectionArea לכל קישור
+    // מורחב, ולכן אין GlobalKey יחיד לפנות אליו. ההריסה בטוחה — אין כאן אזור
+    // בחירה מקונן שאפשר להרוס לו את הבחירה.
     setState(() {
-      _selectionRevision = controller.revision;
+      _selectionRevision++;
       _savedSelectedText = null;
       _savedSelectedLink = null;
     });

--- a/test/text_book/view/combined_view/combined_book_screen_test.dart
+++ b/test/text_book/view/combined_view/combined_book_screen_test.dart
@@ -24,6 +24,7 @@ import 'package:otzaria/widgets/misc/app_context_menu.dart';
 import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
 import 'package:otzaria/widgets/misc/link_preview_overlay.dart';
 import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
+import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../../../test_helpers/memory_cache_provider.dart';
 
@@ -226,13 +227,13 @@ void main() {
     });
   });
 
-  group('shouldRebuildSelectionAreaOnExternalChange', () {
+  group('shouldClearSelectionOnExternalChange', () {
     test('מחזירה false כש-activeOwner הוא null (ניקוי בעלות)', () {
-      // אחרי clear ה-controller מודיע עם activeOwner=null — אסור לבנות מחדש,
-      // אחרת ניקוי בחירה גורם לקפיצה בגלילה.
+      // אחרי clear ה-controller מודיע עם activeOwner=null — אין אזור אחר
+      // שתפס בעלות, ולכן אין מה לנקות.
       final selfOwner = Object();
       expect(
-        shouldRebuildSelectionAreaOnExternalChange(
+        shouldClearSelectionOnExternalChange(
           activeOwner: null,
           selfOwner: selfOwner,
           hasOwnSelection: true,
@@ -242,9 +243,10 @@ void main() {
     });
 
     test('מחזירה false כש-activeOwner זהה ל-selfOwner', () {
+      // אנחנו הבעלים — ניקוי כאן היה מוחק את הבחירה שהמשתמש בדיוק סימן.
       final selfOwner = Object();
       expect(
-        shouldRebuildSelectionAreaOnExternalChange(
+        shouldClearSelectionOnExternalChange(
           activeOwner: selfOwner,
           selfOwner: selfOwner,
           hasOwnSelection: true,
@@ -254,18 +256,12 @@ void main() {
     });
 
     test(
-      "מחזירה false כשאזור חיצוני מקבל בעלות אבל אין לנו בחירה משלנו לנקות "
-      "(תרחיש 'מפרשים מתחת': בחירת טקסט במפרש המקונן לא צריכה להרוס את עץ הצאצאים)",
+      "מחזירה false כשאזור חיצוני מקבל בעלות אבל אין לנו בחירה משלנו לנקות",
       () {
-        // הבאג שתוקן: במצב 'מפרשים מתחת' ה-CommentaryListBase מקונן בעץ
-        // ה-SelectionArea של ה-CombinedView. כשהמשתמש מסמן טקסט במפרש,
-        // ה-controller מעביר בעלות לאזור המפרש. לפני התיקון, ה-CombinedView
-        // היה מעלה את revision ובונה את ה-SelectionArea מחדש — מה שהשמיד את
-        // ה-CommentaryListBase וגרם לטעינה מחדש של המפרש.
         final selfOwner = Object();
         final commentaryOwner = Object();
         expect(
-          shouldRebuildSelectionAreaOnExternalChange(
+          shouldClearSelectionOnExternalChange(
             activeOwner: commentaryOwner,
             selfOwner: selfOwner,
             hasOwnSelection: false,
@@ -279,13 +275,144 @@ void main() {
       final selfOwner = Object();
       final externalOwner = Object();
       expect(
-        shouldRebuildSelectionAreaOnExternalChange(
+        shouldClearSelectionOnExternalChange(
           activeOwner: externalOwner,
           selfOwner: selfOwner,
           hasOwnSelection: true,
         ),
         isTrue,
       );
+    });
+
+    test(
+      'הבעלות עוברת למפרש בזמן שיש בחירה בטקסט הראשי — מנקים, אך רק דרך '
+      'clearSelection ולא בהחלפת מפתח (issue #674)',
+      () {
+        // התרחיש של #674: המשתמש סימן בטקסט הראשי, ואז סימן במפרש שמתחת.
+        // התשובה כאן היא true (יש בחירה ישנה לנקות) — ולכן קריטי שהניקוי
+        // בפועל ייעשה ב-clearSelection: החלפת מפתח הייתה הורסת את כרטיס
+        // המפרשים המקונן יחד עם הבחירה החדשה שבתוכו.
+        final mainTextOwner = Object();
+        final commentaryOwner = Object();
+        expect(
+          shouldClearSelectionOnExternalChange(
+            activeOwner: commentaryOwner,
+            selfOwner: mainTextOwner,
+            hasOwnSelection: true,
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('אזור הבחירה של התצוגה המשולבת (issue #674)', () {
+    Future<SelectionSyncController> pumpCombinedView(
+      WidgetTester tester,
+    ) async {
+      final controller = SelectionSyncController();
+      addTearDown(controller.dispose);
+      final textBookBloc = _ClosedTextBookBloc(_loadedState());
+      final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+      final personalNotesBloc = _TestPersonalNotesBloc(
+        PersonalNotesState(
+          isLoading: false,
+          bookId: 'ספר בדיקה',
+          locatedNotes: const [],
+          missingNotes: const [],
+          errorMessage: null,
+          filteredLocatedNotes: const [],
+          filteredMissingNotes: const [],
+        ),
+      );
+      final tab = TextBookTab(book: TextBook(title: 'ספר בדיקה'), index: 0);
+      addTearDown(tab.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<TextBookBloc>.value(value: textBookBloc),
+              BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+              BlocProvider<SettingsBloc>.value(value: settingsBloc),
+            ],
+            child: Scaffold(
+              body: CombinedView(
+                data: const ['שורה א'],
+                openBookCallback: (_) {},
+                openLeftPaneTab: (_, {searchText}) {},
+                textSize: 18,
+                showCommentaryAsExpansionTiles: true,
+                selectionSyncController: controller,
+                tab: tab,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      addTearDown(() async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(milliseconds: 20));
+      });
+      return controller;
+    }
+
+    testWidgets(
+      'ה-SelectionArea נושא מפתח יציב ולא מפתח שנגזר ממצב הבחירה',
+      (tester) async {
+        // נסיגה לדפוס הישן — ValueKey('combined_selection_$revision') — גרמה
+        // לכך שכל מעבר בעלות בחירה בנה מחדש את תת-העץ, כולל כרטיס המפרשים
+        // המקונן, ואיתו נמחקה הבחירה שהמשתמש זה עתה סימן במפרש.
+        await pumpCombinedView(tester);
+
+        expect(_combinedSelectionAreaFinder(), findsOneWidget);
+      },
+    );
+
+    testWidgets('יירוט ההעתקה ממוקם מעל ה-SelectionArea', (tester) async {
+      // מתחת ל-SelectionArea מנגנון ה-override של CopySelectionTextIntent
+      // אינו רואה אותו, ואז רצה העתקת ברירת המחדל של Flutter — שכותבת ללוח
+      // גם בחירה מכווצת (plainText ריק), וזה הפריט הריק שדווח.
+      await pumpCombinedView(tester);
+
+      expect(
+        find.ancestor(
+          of: _combinedSelectionAreaFinder(),
+          matching: find.byType(SelectionCopyShortcuts),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('מעבר בעלות לכרטיס המפרשים אינו הורס את אזור הטקסט הראשי', (
+      tester,
+    ) async {
+      final controller = await pumpCombinedView(tester);
+
+      SelectableRegionState region() => tester.state<SelectableRegionState>(
+        find.descendant(
+          of: _combinedSelectionAreaFinder(),
+          matching: find.byType(SelectableRegion),
+        ),
+      );
+
+      final regionBefore = region();
+      region().selectAll();
+      await tester.pump();
+      // בלי בחירה משלנו מסלול הניקוי יוצא מוקדם, והטסט היה עובר ריק מתוכן.
+      expect(
+        controller.activeOwner,
+        isNotNull,
+        reason: 'הבחירה בטקסט הראשי חייבת להיווצר כדי שהתרחיש ייבדק',
+      );
+
+      // כרטיס המפרשים תופס בעלות בזמן שלטקסט הראשי יש בחירה — בדיוק התרחיש
+      // שבו הבאג התרחש.
+      controller.activate(Object());
+      await tester.pump();
+
+      expect(region(), same(regionBefore));
     });
   });
 
@@ -861,3 +988,9 @@ class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
+
+/// ה-SelectionArea של אזור הטקסט הראשי, לפי סוג המפתח שלו. חיפוש לפי סוג
+/// המפתח הוא מה שמכשיל נסיגה חזרה ל-ValueKey שנגזר ממונה revision.
+Finder _combinedSelectionAreaFinder() => find.byWidgetPredicate(
+  (w) => w is SelectionArea && w.key is GlobalKey<SelectionAreaState>,
+);

--- a/test/text_book/view/commentary_list_selection_sync_test.dart
+++ b/test/text_book/view/commentary_list_selection_sync_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
@@ -16,12 +17,14 @@ import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/view/commentary_list_base.dart';
 import 'package:otzaria/text_book/view/selection/selection_sync_controller.dart';
+import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../../test_helpers/memory_cache_provider.dart';
 
-/// issue #530: מעבר בעלות בחירה לאזור אחר לא יהרוס את ה-SelectionArea של
-/// המפרשים כשאין להם בחירה משלהם (ההריסה איפסה את הרשימה ואת מצב הבחירה
-/// באמצע אינטראקציה, מה ששבר את ההעתקה במצב 'מפרשים מתחת').
+/// issues #530 ו-#674: מעבר בעלות בחירה בין אזורים לא יהרוס את ה-SelectionArea
+/// של המפרשים. הניקוי נעשה ב-`clearSelection()` ולא בהחלפת מפתח — החלפת מפתח
+/// הורסת את עץ הצאצאים, ובמצב 'מפרשים מתחת' היא מחקה את הבחירה שבמפרש והעתקה
+/// יצאה ריקה.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -68,17 +71,17 @@ void main() {
       controller: controller,
     );
 
-    final keyBefore = tester.widget(_selectionAreaFinder()).key;
+    final stateBefore = _regionState(tester);
 
     // אזור אחר (הטקסט הראשי) תופס בעלות בזמן שאין בחירה במפרשים.
     controller.activate(Object());
     await tester.pump();
 
-    expect(tester.widget(_selectionAreaFinder()).key, keyBefore);
+    expect(_regionState(tester), same(stateBefore));
   });
 
   testWidgets(
-    'בעלות חיצונית כשיש בחירה משלנו — ה-SelectionArea מתנקה ב-rebuild',
+    'בעלות חיצונית כשיש בחירה משלנו — הבחירה מתנקה בלי להרוס את הרשימה',
     (tester) async {
       final controller = SelectionSyncController();
       addTearDown(controller.dispose);
@@ -90,34 +93,171 @@ void main() {
         controller: controller,
       );
 
-      final keyBefore = tester.widget(_selectionAreaFinder()).key;
+      final stateBefore = _regionState(tester);
 
       // בחירת כל הטקסט במפרשים — הופכת את הפאנל לבעל הבחירה.
-      final region = tester.state<SelectableRegionState>(
-        find.descendant(
-          of: _selectionAreaFinder(),
-          matching: find.byType(SelectableRegion),
-        ),
-      );
-      region.selectAll();
+      _regionState(tester).selectAll();
       await _pumpUntil(tester, () => controller.activeOwner != null);
       expect(controller.activeOwner, isNotNull);
+      expect(_regionState(tester).selectionEndpoints, isNotEmpty);
 
-      // אזור אחר תופס בעלות — עכשיו כן צריך rebuild כדי לנקות את הבחירה.
+      // אזור אחר תופס בעלות — הבחירה שלנו צריכה להתנקות.
       controller.activate(Object());
       await tester.pump();
 
-      expect(tester.widget(_selectionAreaFinder()).key, isNot(keyBefore));
+      expect(
+        _regionState(tester),
+        same(stateBefore),
+        reason:
+            'ניקוי הבחירה חייב להשאיר את אותו SelectableRegion — הריסתו הייתה '
+            'טוענת מחדש את המפרשים ומאבדת את מיקום הגלילה בהם',
+      );
+      expect(
+        _hasVisibleSelection(tester),
+        isFalse,
+        reason: 'הבחירה עצמה כן צריכה להתנקות',
+      );
     },
   );
+
+  testWidgets(
+    'מעבר בעלות חוזר לא מאבד את ה-state של רשימת המפרשים (issue #674)',
+    (tester) async {
+      // הלב של #674: כרטיס המפרשים מקונן בעץ של הטקסט הראשי. כל מעבר בעלות
+      // שמוביל לבנייה מחדש היה משמיד את ה-State — ואיתו את הבחירה שהמשתמש
+      // בדיוק סימן, כך ש-Ctrl+C נשאר בלי טקסט.
+      final controller = SelectionSyncController();
+      addTearDown(controller.dispose);
+
+      await _pump(
+        tester,
+        textBookBloc: textBookBloc,
+        settingsBloc: settingsBloc,
+        controller: controller,
+      );
+
+      final listStateBefore = tester.state<CommentaryListBaseState>(
+        find.byType(CommentaryListBase),
+      );
+      final regionBefore = _regionState(tester);
+
+      // שלוש העברות בעלות הלוך ושוב, כולל אחת עם בחירה פעילה שלנו.
+      final mainTextOwner = Object();
+      controller.activate(mainTextOwner);
+      await tester.pump();
+
+      _regionState(tester).selectAll();
+      await _pumpUntil(tester, () => controller.activeOwner != mainTextOwner);
+
+      controller.activate(mainTextOwner);
+      await tester.pump();
+      controller.clear(mainTextOwner);
+      await tester.pump();
+
+      expect(
+        tester.state<CommentaryListBaseState>(find.byType(CommentaryListBase)),
+        same(listStateBefore),
+      );
+      expect(_regionState(tester), same(regionBefore));
+    },
+  );
+
+  testWidgets(
+    'ה-SelectionArea של המפרשים עטוף ב-SelectionCopyShortcuts (הגנת #674)',
+    (tester) async {
+      // בלי העטיפה Ctrl+C נופל להעתקת ברירת המחדל של Flutter, שכותבת ללוח את
+      // הבחירה כמות שהיא — כולל מחרוזת ריקה, וזה בדיוק התסמין שדווח.
+      final controller = SelectionSyncController();
+      addTearDown(controller.dispose);
+
+      await _pump(
+        tester,
+        textBookBloc: textBookBloc,
+        settingsBloc: settingsBloc,
+        controller: controller,
+      );
+
+      expect(
+        find.ancestor(
+          of: _selectionAreaFinder(),
+          matching: find.byType(SelectionCopyShortcuts),
+        ),
+        findsOneWidget,
+        reason: 'העטיפה חייבת להיות *מעל* ה-SelectionArea כדי ליירט',
+      );
+    },
+  );
+
+  testWidgets('Ctrl+C בלי בחירה אינו כותב פריט ריק ללוח (issue #674)', (
+    tester,
+  ) async {
+    final clipboardWrites = <String?>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardWrites.add(
+            (call.arguments as Map?)?['text'] as String?,
+          );
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    final controller = SelectionSyncController();
+    addTearDown(controller.dispose);
+
+    await _pump(
+      tester,
+      textBookBloc: textBookBloc,
+      settingsBloc: settingsBloc,
+      controller: controller,
+      autofocus: true,
+    );
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(
+      clipboardWrites,
+      isEmpty,
+      reason: 'בלי טקסט נבחר אין להעתיק כלום — ובוודאי לא מחרוזת ריקה',
+    );
+  });
 }
 
-Finder _selectionAreaFinder() => find.byWidgetPredicate(
-  (w) =>
-      w is SelectionArea &&
-      (w.key is ValueKey<String>) &&
-      (w.key as ValueKey<String>).value.startsWith('commentary_list_'),
+Finder _selectionAreaFinder() => find.descendant(
+  of: find.byType(CommentaryListBase),
+  matching: find.byWidgetPredicate(
+    (w) => w is SelectionArea && w.key is GlobalKey<SelectionAreaState>,
+  ),
 );
+
+SelectableRegionState _regionState(WidgetTester tester) =>
+    tester.state<SelectableRegionState>(
+      find.descendant(
+        of: _selectionAreaFinder(),
+        matching: find.byType(SelectableRegion),
+      ),
+    );
+
+/// האם ל-SelectableRegion יש כרגע בחירה מוצגת. `selectionEndpoints` זורק
+/// כשאין בחירה פעילה, ולכן החריגה עצמה היא התשובה.
+bool _hasVisibleSelection(WidgetTester tester) {
+  try {
+    return _regionState(tester).selectionEndpoints.isNotEmpty;
+  } catch (_) {
+    return false;
+  }
+}
 
 /// שואב פריימים עד שהתנאי מתקיים או שנגמרו הניסיונות. עמיד יותר מ-
 /// `pumpAndSettle` כשתוכן נטען דרך Future (שעלול להיפתר אחרי ש-settle חוזר).
@@ -137,6 +277,7 @@ Future<void> _pump(
   required TextBookBloc textBookBloc,
   required SettingsBloc settingsBloc,
   required SelectionSyncController controller,
+  bool autofocus = false,
 }) async {
   addTearDown(() async {
     await tester.pumpWidget(const SizedBox.shrink());
@@ -156,6 +297,7 @@ Future<void> _pump(
             fontSize: 18,
             showSearch: false,
             shrinkWrap: false,
+            autofocus: autofocus,
             selectionSyncController: controller,
           ),
         ),

--- a/test/text_book/view/selection/selection_sync_controller_test.dart
+++ b/test/text_book/view/selection/selection_sync_controller_test.dart
@@ -16,13 +16,11 @@ void main() {
       controller.activate(firstOwner);
 
       expect(controller.activeOwner, same(firstOwner));
-      expect(controller.revision, 1);
       expect(notifications, 1);
 
       controller.activate(secondOwner);
 
       expect(controller.activeOwner, same(secondOwner));
-      expect(controller.revision, 2);
       expect(notifications, 2);
     });
 
@@ -39,7 +37,6 @@ void main() {
       controller.activate(owner);
 
       expect(controller.activeOwner, same(owner));
-      expect(controller.revision, 1);
       expect(notifications, 1);
     });
 
@@ -58,7 +55,6 @@ void main() {
       controller.clear(firstOwner);
 
       expect(controller.activeOwner, same(secondOwner));
-      expect(controller.revision, 2);
       expect(notifications, 2);
     });
 
@@ -75,7 +71,6 @@ void main() {
       controller.clear(owner);
 
       expect(controller.activeOwner, isNull);
-      expect(controller.revision, 2);
       expect(notifications, 2);
     });
 

--- a/test/widgets/text/selection_copy_shortcuts_test.dart
+++ b/test/widgets/text/selection_copy_shortcuts_test.dart
@@ -229,5 +229,43 @@ void main() {
         reason: 'Flutter לא יכתוב ללוח בעצמו כשהעטיפה מיירטת',
       );
     });
+
+    testWidgets('עם בחירה פעילה — ההעתקה מנותבת ל-onCopy ולא ל-Flutter', (
+      tester,
+    ) async {
+      mockClipboard(tester);
+      var copyCount = 0;
+      final fn = FocusNode();
+      addTearDown(fn.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SelectionCopyShortcuts(
+              onCopy: () => copyCount++,
+              child: SelectionArea(
+                focusNode: fn,
+                child: const Text('שלום עולם'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      fn.requestFocus();
+      await tester.pump();
+      tester
+          .state<SelectableRegionState>(find.byType(SelectableRegion))
+          .selectAll();
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(copyCount, 1);
+      expect(clipboardWrites, isEmpty);
+    });
   });
 }

--- a/test/widgets/text/selection_copy_shortcuts_test.dart
+++ b/test/widgets/text/selection_copy_shortcuts_test.dart
@@ -100,4 +100,134 @@ void main() {
     expect(copyCount, 1);
     fn.dispose();
   });
+
+  // issue #674: התסמין שדווח היה "פריט ריק בלוח הגזירים". המקור הוא
+  // SelectableRegion._copy של Flutter, שכותב את הבחירה ללוח בלי לבדוק שהיא
+  // אינה ריקה. שני הטסטים הבאים מתעדים את ההתנהגות בלי העטיפה ואיתה.
+  group('Ctrl+C על SelectionArea בלי בחירה', () {
+    late List<String?> clipboardWrites;
+
+    void mockClipboard(WidgetTester tester) {
+      clipboardWrites = <String?>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardWrites.add((call.arguments as Map?)?['text'] as String?);
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+    }
+
+    testWidgets('יירוט *מתחת* ל-SelectionArea אינו נראה — ההעתקה נשארת של '
+        'Flutter', (tester) async {
+      // זה הדפוס השבור שהוליד את #674: Actions עם CopySelectionTextIntent
+      // שממוקם בתוך ה-SelectionArea. מנגנון ה-override מחפש רק כלפי מעלה,
+      // ולכן רצה העתקת ברירת המחדל של Flutter — שכותבת ללוח את הבחירה בלי
+      // לבדוק שהיא אינה ריקה.
+      mockClipboard(tester);
+      var copyCount = 0;
+      final fn = FocusNode();
+      addTearDown(fn.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SelectionArea(
+              focusNode: fn,
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  CopySelectionTextIntent:
+                      CallbackAction<CopySelectionTextIntent>(
+                        onInvoke: (_) {
+                          copyCount++;
+                          return null;
+                        },
+                      ),
+                },
+                child: const Text('שלום עולם'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      fn.requestFocus();
+      await tester.pump();
+      tester
+          .state<SelectableRegionState>(find.byType(SelectableRegion))
+          .selectAll();
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(
+        copyCount,
+        0,
+        reason: 'יירוט מתחת ל-SelectionArea אינו נראה למנגנון ה-override',
+      );
+      expect(
+        clipboardWrites,
+        isNotEmpty,
+        reason: 'במקום זאת רצה ההעתקה של Flutter, שכותבת ישירות ללוח',
+      );
+    });
+
+    testWidgets('עם העטיפה — ההעתקה מנותבת ל-onCopy ולא נכתב ללוח כלום', (
+      tester,
+    ) async {
+      mockClipboard(tester);
+      var copyCount = 0;
+      final fn = FocusNode();
+      addTearDown(fn.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SelectionCopyShortcuts(
+              // המסלול של אוצריא בודק ריקנות ומציג הודעה במקום להעתיק.
+              onCopy: () => copyCount++,
+              child: SelectionArea(
+                focusNode: fn,
+                child: const Text('שלום עולם'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      fn.requestFocus();
+      await tester.pump();
+
+      final region = tester.state<SelectableRegionState>(
+        find.byType(SelectableRegion),
+      );
+      region.selectAll();
+      await tester.pump();
+      region.clearSelection();
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(copyCount, 1, reason: 'ההעתקה חייבת לעבור דרך המסלול שלנו');
+      expect(
+        clipboardWrites,
+        isEmpty,
+        reason: 'Flutter לא יכתוב ללוח בעצמו כשהעטיפה מיירטת',
+      );
+    });
+  });
 }


### PR DESCRIPTION
סוגר את #674 (ומשלים את התיקון החלקי של #530).

## התסמין

Ctrl+C על טקסט שסומן במפרש, במצב "מפרשים מתחת", כתב ללוח פריט ריק — המשתמש ראה בלוח הגזירים של Windows רשומה ריקה בלי טקסט. הבאג התרחש אצל חלק מהמשתמשים בלבד, וזה מה שהקשה על האבחון.

## שורש הבעיה

שני מסלולים נפרדים הובילו לאותו תסמין:

**1. ניקוי הבחירה נעשה בהחלפת מפתח.** אזור הבחירה של הטקסט הראשי נשא `ValueKey('combined_selection_$revision')`. כשאזור אחר תפס בעלות על הבחירה, ה-revision עלה, המפתח השתנה, וכל תת-העץ נהרס — כולל כרטיס המפרשים המקונן והבחירה שהמשתמש זה עתה סימן בו.

זה מסביר גם למה הבאג לא קרה לכולם: הניקוי מותנה בכך שיש בחירה ישנה לנקות, כלומר הוא נדרס רק כשהמשתמש סימן קודם טקסט בגוף הספר ואז סימן במפרש.

הנימוק המקורי למנגנון ה-revision היה ש"ל-SelectionArea של Flutter אין API ישיר לניקוי בחירה באזור אחר". זה לא נכון: `SelectionAreaState.selectableRegion` ו-`SelectableRegionState.clearSelection()` הם API ציבורי, ו-`simple_text_viewer.dart` (צורת הדף) כבר השתמש בהם. התיקון מחיל את הדפוס הקיים, ומסיר את מונה ה-revision מ-`SelectionSyncController`.

**2. יירוט ההעתקה ישב מתחת ל-SelectionArea.** מנגנון ה-override של `CopySelectionTextIntent` מאתר override רק כלפי מעלה בעץ, ולכן ה-`Actions` שישב *בתוך* ה-SelectionArea של התצוגה המשולבת נשאר בלתי-נראה. במקומו רצה `SelectableRegion._copy()` של Flutter, שכותב `data.plainText` ללוח **בלי לבדוק שהוא אינו ריק** — ובלחיצה בודדת ב-Windows הבחירה מתכווצת ומחזירה `plainText: ''`.

שני המשטחים עוברים ל-`SelectionCopyShortcuts`, ה-widget שכבר שימש לאותה מטרה בחלונית הקישורים ובפאנל מפרשי ה-PDF. כך כל מסלולי ההעתקה עוברים דרך `copyFormattedText`, שבודק ריקנות ומציג הודעה במקום להעתיק.

## מה השתנה

| קובץ | שינוי |
|---|---|
| `selection_sync_controller.dart` | הוסר מונה `revision`; `shouldRebuildSelectionAreaOnExternalChange` → `shouldClearSelectionOnExternalChange` |
| `combined_book_screen.dart` | `GlobalKey<SelectionAreaState>` במקום ValueKey; היירוט הועבר מעל ה-SelectionArea |
| `commentary_list_base.dart` | אותו שינוי מפתח; ה-`Shortcuts`/`Actions` הידניים הוחלפו ב-`SelectionCopyShortcuts` |
| `simple_text_viewer.dart` | שינוי שם בלבד (כבר השתמש ב-`clearSelection()`) |
| `links_list_view.dart` | יושר לעוזר המשותף. מנגנון המפתח נשמר שם במכוון — הוא מרנדר SelectionArea לכל קישור מורחב, ואינו מקנן אזור בחירה אחר |

תופעת לוואי חיובית: מעבר בעלות בחירה כבר לא בונה מחדש את רשימות הקריאה, כך שנעלמת גם קפיצת מיקום הגלילה שנלוותה לכך.

## בדיקות

- `flutter analyze` — No issues found
- 2378 טסטים ב-`test/text_book/`, `test/widgets/`, `test/pdf_book/` עוברים
- טסטים חדשים: שרידות אזור הבחירה במעברי בעלות (בשני המשטחים), מיקום היירוט מעל ה-SelectionArea, ותיעוד הדפוס השבור — יירוט מתחת ל-SelectionArea אינו נתפס ו-Flutter כותב ללוח במקומו
- הטסט שציפה להתנהגות הישנה (`isNot(keyBefore)`) הוחלף בחוזה ההפוך: אותו `State` שורד את הניקוי

🤖 Generated with [Claude Code](https://claude.com/claude-code)
