### PR TITLE
כרטיסיות: קיפאון התוכנה כשפתוחות מאות כרטיסיות

### DIFF
--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -80,6 +80,13 @@ const double _kTabCloseHideBelowWidth = 80.0;
 /// כשהחלוקה השווה יורדת מתחת לזה, שאר הטאבים מתחלקים ביתרה.
 const double _kTabSelectedMinWidth = 60.0;
 
+/// מתחת לרוחב הזה הריפודים בולעים את כל רוחב הכרטיסיה ולא נותר בה פיקסל
+/// לכותרת, לאייקונים או ל-X — ולכן התוכן שלה אינו נבנה כלל.
+const double _kTabContentMinWidth = 12.0;
+
+/// גובה גוף הכרטיסיה, בלי המפריד שלצדה.
+const double _kTabBodyHeight = 32.0;
+
 /// רוחבי הטאבים בשורה: הנבחר עשוי להיות רחב מהשאר (ראה [_kTabSelectedMinWidth]).
 typedef _TabWidths = ({double selected, double unselected});
 
@@ -566,7 +573,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
         behavior: HitTestBehavior.opaque,
         child: SizedBox(
           width: tabWidth,
-          child: _buildTab(context, tab, state, tabWidth),
+          child: _buildTab(context, tab, index, state, tabWidth),
         ),
       ),
     );
@@ -751,13 +758,124 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
     }
   }
 
-  Widget _buildTab(
+  /// רקע הכרטיסיה: סימון בחירה מרובה, ואחריו הכרטיסיה הפעילה.
+  CustomPainter? _tabBackgroundPainter(
     BuildContext context,
     OpenedTab tab,
+    TabsState state, {
+    required bool isSelected,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    if (state.selectedTabs.contains(tab)) {
+      return _TabBackgroundPainter(colorScheme.secondaryContainer);
+    }
+    return isSelected
+        ? _TabBackgroundPainter(AppSurfaces.topBarBackground(context))
+        : null;
+  }
+
+  /// הצללת הריחוף, שמצוירת מעל הרקע.
+  CustomPainter? _tabHoverPainter(
+    BuildContext context, {
+    required bool isHovered,
+    required bool isSelected,
+  }) {
+    if (!isHovered || isSelected) return null;
+    return _TabBackgroundPainter(
+      Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.08),
+    );
+  }
+
+  /// כרטיסיה שהצטמצמה מתחת ל-[_kTabContentMinWidth]. כל שכבות האינטראקציה
+  /// נשמרות; רק התוכן — שאין לו כאן ולו פיקסל אחד — אינו נבנה.
+  Widget _buildNarrowTab(
+    BuildContext context,
+    OpenedTab tab,
+    int index,
     TabsState state,
     double tabWidth,
   ) {
-    final index = state.tabs.indexOf(tab);
+    final isSelected = index == state.currentTabIndex;
+    final showLeadingDivider = index == 0
+        ? !isSelected
+        : !isSelected && index - 1 != state.currentTabIndex;
+    bool isTabHovered = identical(_hoveredTab, tab);
+
+    return _wrapWithTabPointer(
+      context,
+      tab,
+      index,
+      state,
+      child: AppContextMenuRegion(
+        menuBuilder: (menuCtx, _) =>
+            _buildTabContextMenuEntries(menuCtx, tab, state),
+        child: StatefulBuilder(
+          builder: (context, setLocalState) => MouseRegion(
+            onEnter: (_) => setLocalState(() {
+              isTabHovered = true;
+              _hoveredTab = tab;
+            }),
+            onExit: (_) => setLocalState(() {
+              isTabHovered = false;
+              if (identical(_hoveredTab, tab)) _hoveredTab = null;
+            }),
+            child: Row(
+              children: [
+                if (showLeadingDivider)
+                  Container(
+                    // ברוחב שברירי המפריד עצמו רחב מהכרטיסיה כולה, וקו קבוע
+                    // של 1 היה גולש ממנה.
+                    width: math.min(1.0, tabWidth),
+                    height: 24,
+                    margin: const EdgeInsets.only(top: 6, bottom: 6),
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                  ),
+                Expanded(
+                  child: Container(
+                    constraints: const BoxConstraints(
+                      maxHeight: _kTabBodyHeight,
+                    ),
+                    padding: EdgeInsets.only(
+                      left: 3,
+                      right: index == 0 ? 0 : 3,
+                    ),
+                    // הגובה מפורש: ל-CustomPaint ללא ילד אין גודל טבעי, והוא
+                    // היה מתכווץ לאפס — גם הציור וגם שטח הלחיצה.
+                    child: CustomPaint(
+                      size: const Size.fromHeight(_kTabBodyHeight),
+                      painter: _tabBackgroundPainter(
+                        context,
+                        tab,
+                        state,
+                        isSelected: isSelected,
+                      ),
+                      foregroundPainter: _tabHoverPainter(
+                        context,
+                        isHovered: isTabHovered,
+                        isSelected: isSelected,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTab(
+    BuildContext context,
+    OpenedTab tab,
+    int index,
+    TabsState state,
+    double tabWidth,
+  ) {
+    if (tabWidth < _kTabContentMinWidth) {
+      return _buildNarrowTab(context, tab, index, state, tabWidth);
+    }
+
     final isSelected = index == state.currentTabIndex;
     final closeTabShortcut =
         Settings.getValue<String>('key-shortcut-close-tab') ?? 'ctrl+w';
@@ -918,7 +1036,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
           // שתתכווץ ותטושטש לקראת הסוף. ה-X/נעץ מוצגים רק אם נשאר להם מקום.
           Expanded(
             child: Container(
-              constraints: const BoxConstraints(maxHeight: 32),
+              constraints: const BoxConstraints(maxHeight: _kTabBodyHeight),
               padding: EdgeInsets.only(
                 left: outerPad,
                 right: index == 0 ? 0 : outerPad,
@@ -926,18 +1044,17 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
               child: CustomPaint(
                 // טאב בבחירה מרובה נצבע ב-secondaryContainer כדי לסמן שהוא
                 // חלק מהקבוצה שתיסגר יחד.
-                painter: state.selectedTabs.contains(tab)
-                    ? _TabBackgroundPainter(colorScheme.secondaryContainer)
-                    : isSelected
-                    ? _TabBackgroundPainter(
-                        AppSurfaces.topBarBackground(context),
-                      )
-                    : null,
-                foregroundPainter: isTabHovered && !isSelected
-                    ? _TabBackgroundPainter(
-                        colorScheme.onSurface.withValues(alpha: 0.08),
-                      )
-                    : null,
+                painter: _tabBackgroundPainter(
+                  context,
+                  tab,
+                  state,
+                  isSelected: isSelected,
+                ),
+                foregroundPainter: _tabHoverPainter(
+                  context,
+                  isHovered: isTabHovered,
+                  isSelected: isSelected,
+                ),
                 child: Tab(
                   child: Padding(
                     padding: EdgeInsets.symmetric(horizontal: innerPad),
@@ -1011,12 +1128,49 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
       );
     }
 
+    return _wrapWithTabPointer(
+      context,
+      tab,
+      index,
+      state,
+      child: AppContextMenuRegion(
+        menuBuilder: (menuCtx, _) =>
+            _buildTabContextMenuEntries(menuCtx, tab, state),
+        child: StatefulBuilder(
+          builder: (context, setLocalState) {
+            return MouseRegion(
+              // setLocalState מצייר מחדש את הטאב הזה בלבד; השדה שומר את המצב
+              // כך שישרוד rebuild של שורת הטאבים.
+              onEnter: (_) => setLocalState(() {
+                isTabHovered = true;
+                _hoveredTab = tab;
+              }),
+              onExit: (_) => setLocalState(() {
+                isTabHovered = false;
+                if (identical(_hoveredTab, tab)) _hoveredTab = null;
+              }),
+              child: buildTabAppearance(setLocalState),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  /// עוטף כרטיסיה בטיפול הלחיצות שלה.
+  ///
+  /// בחירת הטאב על pointer-down: לחצן אמצעי סוגר, לחצן ראשי (או תחילת גרירה)
+  /// בוחר. לחצן ימני אינו בוחר — אחרת הבחירה גוררת rebuild שהורס את
+  /// ה-AppContextMenuRegion לפני שתפריט ההקשר נפתח. משתמשים ב-Listener פסיבי
+  /// כי הגרירה המיידית (ReorderableDragStartListener) זוכה ב-arena וחוסמת onTap.
+  Widget _wrapWithTabPointer(
+    BuildContext context,
+    OpenedTab tab,
+    int index,
+    TabsState state, {
+    required Widget child,
+  }) {
     return Listener(
-      // בחירת הטאב על pointer-down: לחצן אמצעי סוגר, לחצן ראשי (או תחילת
-      // גרירה) בוחר. לחצן ימני אינו בוחר — אחרת הבחירה גוררת rebuild שהורס את
-      // ה-AppContextMenuRegion לפני שתפריט ההקשר נפתח. משתמשים ב-Listener
-      // פסיבי כי הגרירה המיידית (ReorderableDragStartListener) זוכה ב-arena
-      // וחוסמת onTap.
       onPointerUp: (_) {
         final pending = _pendingTabSelection;
         _pendingTabSelection = null;
@@ -1057,27 +1211,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
           _pendingTabSelection = tab;
         }
       },
-      child: AppContextMenuRegion(
-        menuBuilder: (menuCtx, _) =>
-            _buildTabContextMenuEntries(menuCtx, tab, state),
-        child: StatefulBuilder(
-          builder: (context, setLocalState) {
-            return MouseRegion(
-              // setLocalState מצייר מחדש את הטאב הזה בלבד; השדה שומר את המצב
-              // כך שישרוד rebuild של שורת הטאבים.
-              onEnter: (_) => setLocalState(() {
-                isTabHovered = true;
-                _hoveredTab = tab;
-              }),
-              onExit: (_) => setLocalState(() {
-                isTabHovered = false;
-                if (identical(_hoveredTab, tab)) _hoveredTab = null;
-              }),
-              child: buildTabAppearance(setLocalState),
-            );
-          },
-        ),
-      ),
+      child: child,
     );
   }
 

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -2700,12 +2700,13 @@ class MainWindowScreenState extends State<MainWindowScreen>
             },
           ),
           // סנכרון רשימת הטאבים הפתוחים ל-Jump List של שורת המשימות (Windows).
-          // נדלק כשהכותרות או סדרן משתנים; השירות עצמו no-op מחוץ ל-Windows.
+          // נדלק כשרשימת הטאבים מוחלפת; השירות עצמו no-op מחוץ ל-Windows,
+          // ומסנן כותרות שלא השתנו.
           BlocListener<TabsBloc, TabsState>(
-            listenWhen: (previous, current) => !listEquals(
-              previous.tabs.map((tab) => tab.title).toList(),
-              current.tabs.map((tab) => tab.title).toList(),
-            ),
+            // הרשימה נשמרת כאובייקט זהה כשהיא לא משתנה, ולכן בדיקת הזהות
+            // מספיקה וחוסכת מיפוי של כל הכותרות בכל שינוי מצב.
+            listenWhen: (previous, current) =>
+                !identical(previous.tabs, current.tabs),
             listener: (context, state) => _jumpListService.sync(state.tabs),
           ),
           // settings.changed עבור selectedCity ו-calendarType —

--- a/lib/tabs/bloc/tabs_bloc.dart
+++ b/lib/tabs/bloc/tabs_bloc.dart
@@ -5,6 +5,8 @@ import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:otzaria/core/error_log_file.dart';
+import 'package:otzaria/core/pre_close_registry.dart';
 import 'package:otzaria/tabs/bloc/tabs_event.dart';
 import 'package:otzaria/tabs/tabs_repository.dart';
 import 'package:otzaria/tabs/bloc/tabs_state.dart';
@@ -31,6 +33,61 @@ class _ClosedTabEntry {
 class TabsBloc extends Bloc<TabsEvent, TabsState> {
   final TabsRepository _repository;
   final List<_ClosedTabEntry> _recentlyClosedTabs = <_ClosedTabEntry>[];
+
+  List<OpenedTab>? _pendingSaveTabs;
+  int _pendingSaveIndex = 0;
+  Future<void>? _saveDrain;
+
+  /// מבקש שמירה של הטאבים, בלי להמתין לה.
+  ///
+  /// כל שמירה מקודדת את *כל* הטאבים, ולכן בקשות שמגיעות בזמן שכתיבה רצה
+  /// מתמזגות לכתיבה אחת שאחריה.
+  void _scheduleSave(List<OpenedTab> tabs, int currentTabIndex) {
+    _pendingSaveTabs = tabs;
+    _pendingSaveIndex = currentTabIndex;
+    _saveDrain ??= _drainSaves();
+  }
+
+  Future<void> _drainSaves() async {
+    try {
+      while (_pendingSaveTabs != null) {
+        final tabs = _pendingSaveTabs!;
+        final index = _pendingSaveIndex;
+        _pendingSaveTabs = null;
+        try {
+          await _repository.saveTabs(tabs, index);
+        } catch (error, stackTrace) {
+          // אף אחד לא ממתין לשמירה הזו; בלי הרישום כאן כשל כתיבה (דיסק מלא,
+          // קובץ נעול) היה נעלם בשקט והמשתמש היה מאבד את הכרטיסיות הפתוחות.
+          ErrorLogFile.append(
+            title: 'שמירת הכרטיסיות הפתוחות נכשלה',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+        // הכתיבה נשאה את האינדקס שהיה בתחילתה; אם המשתמש החליף טאב בזמנה,
+        // היא דרסה את מה שכתב [_saveCurrentTabIndex].
+        if (_pendingSaveTabs == null && _pendingSaveIndex != index) {
+          await _repository.saveCurrentTabIndex(tabs, _pendingSaveIndex);
+        }
+      }
+    } finally {
+      _saveDrain = null;
+    }
+  }
+
+  /// שומר את האינדקס הפעיל בלבד, ומעדכן גם את האינדקס של השמירה המלאה —
+  /// זו שממתינה וזו שרצה — כדי שלא תחזיר לאחור את הטאב שנבחר.
+  Future<void> _saveCurrentTabIndex(List<OpenedTab> tabs, int index) {
+    _pendingSaveIndex = index;
+    return _repository.saveCurrentTabIndex(tabs, index);
+  }
+
+  /// ממתין לכתיבת הטאבים שטרם הסתיימה, לפני סגירת התוכנה. ה-timeout מונע
+  /// היתקעות ביציאה כשכתיבת Hive נחסמת (כמו ב-[remapBookPathsAwaitable]).
+  Future<void> _flushPendingSaves() =>
+      _saveDrain?.timeout(const Duration(seconds: 5), onTimeout: () {}) ??
+      Future<void>.value();
 
   void _disposeTabLater(OpenedTab tab) {
     unawaited(
@@ -87,6 +144,18 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     on<SwapSideBySideTabs>(_onSwapSideBySideTabs, transformer: sequential());
     on<ClosePane>(_onClosePane, transformer: sequential());
     on<SetActivePane>(_onSetActivePane);
+
+    _preCloseCallback = _flushPendingSaves;
+    PreCloseRegistry.register(_preCloseCallback);
+  }
+
+  late final Future<void> Function() _preCloseCallback;
+
+  @override
+  Future<void> close() async {
+    PreCloseRegistry.unregister(_preCloseCallback);
+    await _flushPendingSaves();
+    await super.close();
   }
 
   void _onLoadTabs(LoadTabs event, Emitter<TabsState> emit) {
@@ -139,6 +208,8 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
           ).every((i) => identical(remapped[i], state.tabs[i]));
       if (!unchanged) {
         emit(state.copyWith(tabs: remapped));
+        // המיפוי חייב להיכתב אחרי הכתיבה שרצה, כי היא נושאת את הנתיבים הישנים.
+        await _saveDrain;
         await _repository.saveTabs(remapped, state.currentTabIndex);
       }
       event.completer?.complete();
@@ -168,15 +239,18 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: const <OpenedTab>[],
       ),
     );
-    await _repository.saveTabs(event.tabs, event.currentTabIndex);
+    _scheduleSave(event.tabs, event.currentTabIndex);
 
     for (final tab in tabsToDispose) {
       _disposeTabLater(tab);
     }
   }
 
+  /// נשלח ביציאה מהתוכנה ובמעבר לרקע — כאן ממתינים לסיום הכתיבה בפועל, אחרת
+  /// שמירה שממתינה תלך לאיבוד עם התהליך.
   Future<void> _onSaveTabs(SaveTabs event, Emitter<TabsState> emit) async {
-    await _repository.saveTabs(state.tabs, state.currentTabIndex);
+    _scheduleSave(state.tabs, state.currentTabIndex);
+    await _saveDrain;
   }
 
   Future<void> _onAddTab(AddTab event, Emitter<TabsState> emit) async {
@@ -193,7 +267,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         currentTabIndex: newIndex,
       ),
     );
-    await _repository.saveTabs(newTabs, newIndex);
+    _scheduleSave(newTabs, newIndex);
   }
 
   Future<void> _onOpenOrFocusTab(
@@ -247,7 +321,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
           rawActivePane: matchingPane,
         ),
       );
-      await _repository.saveTabs(tabsToSave, matchingIndex);
+      _scheduleSave(tabsToSave, matchingIndex);
       return;
     }
 
@@ -276,7 +350,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: _normalizedSelection(newTabs),
       ),
     );
-    await _repository.saveTabs(newTabs, state.currentTabIndex);
+    _scheduleSave(newTabs, state.currentTabIndex);
     _disposeTabLater(event.oldTab);
   }
 
@@ -802,7 +876,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
           selectedTabs: prunedSelection,
         ),
       );
-      await _repository.saveTabs(newTabs, 0);
+      _scheduleSave(newTabs, 0);
       _disposeTabLater(event.tab);
       return;
     }
@@ -823,7 +897,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: prunedSelection,
       ),
     );
-    await _repository.saveTabs(newTabs, newIndex);
+    _scheduleSave(newTabs, newIndex);
     _disposeTabLater(event.tab);
   }
 
@@ -867,7 +941,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: _normalizedSelection(newTabs),
       ),
     );
-    await _repository.saveTabs(newTabs, newIndex);
+    _scheduleSave(newTabs, newIndex);
 
     for (final tab in toRemove) {
       _disposeTabLater(tab);
@@ -922,7 +996,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
       emit(state.copyWith(currentTabIndex: event.index));
       // מעבר טאב לא משנה את רשימת הטאבים — שומרים רק את האינדקס הנוכחי
       // במקום לקודד מחדש את כל הטאבים.
-      await _repository.saveCurrentTabIndex(tabsToSave, event.index);
+      await _saveCurrentTabIndex(tabsToSave, event.index);
     }
   }
 
@@ -952,7 +1026,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
       closedEntry.tab.dispose();
       final tabsToSave = state.tabs;
       emit(state.copyWith(currentTabIndex: existingIndex));
-      await _repository.saveCurrentTabIndex(tabsToSave, existingIndex);
+      await _saveCurrentTabIndex(tabsToSave, existingIndex);
       return;
     }
     final restoredTabs = List<OpenedTab>.from(state.tabs);
@@ -968,7 +1042,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         currentTabIndex: restoreIndex,
       ),
     );
-    await _repository.saveTabs(restoredTabs, restoreIndex);
+    _scheduleSave(restoredTabs, restoreIndex);
   }
 
   Future<void> _onCloseAllTabs(
@@ -995,7 +1069,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: const <OpenedTab>[],
       ),
     );
-    await _repository.saveTabs(pinnedTabs, newIndex);
+    _scheduleSave(pinnedTabs, newIndex);
 
     for (final tab in tabsToDispose) {
       _disposeTabLater(tab);
@@ -1025,7 +1099,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: const <OpenedTab>[],
       ),
     );
-    await _repository.saveTabs(newTabs, 0);
+    _scheduleSave(newTabs, 0);
 
     for (final tab in tabsToDispose) {
       _disposeTabLater(tab);
@@ -1050,7 +1124,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         currentTabIndex: newIndex,
       ),
     );
-    await _repository.saveTabs(newTabs, newIndex);
+    _scheduleSave(newTabs, newIndex);
   }
 
   Future<void> _onNavigateToNextTab(
@@ -1061,7 +1135,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     final newIndex = (state.currentTabIndex + 1) % state.tabs.length;
     final tabsToSave = state.tabs;
     emit(state.copyWith(currentTabIndex: newIndex));
-    await _repository.saveCurrentTabIndex(tabsToSave, newIndex);
+    await _saveCurrentTabIndex(tabsToSave, newIndex);
   }
 
   Future<void> _onNavigateToPreviousTab(
@@ -1074,7 +1148,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         : state.currentTabIndex - 1;
     final tabsToSave = state.tabs;
     emit(state.copyWith(currentTabIndex: newIndex));
-    await _repository.saveCurrentTabIndex(tabsToSave, newIndex);
+    await _saveCurrentTabIndex(tabsToSave, newIndex);
   }
 
   Future<void> _onTogglePinTab(
@@ -1104,7 +1178,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
       ),
     );
     // שמירת השינויים
-    await _repository.saveTabs(newTabs, indexToSave);
+    _scheduleSave(newTabs, indexToSave);
   }
 
   Future<void> _onCreateCombinedTab(
@@ -1156,7 +1230,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: _normalizedSelection(newTabs),
       ),
     );
-    await _repository.saveTabs(newTabs, newCurrentIndex);
+    _scheduleSave(newTabs, newCurrentIndex);
   }
 
   Future<void> _onOpenTabInSidePane(
@@ -1195,7 +1269,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         rawActivePane: event.tab,
       ),
     );
-    await _repository.saveTabs(newTabs, index);
+    _scheduleSave(newTabs, index);
   }
 
   Future<void> _onExpandCombinedTab(
@@ -1234,7 +1308,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
           selectedTabs: _normalizedSelection(newTabs),
         ),
       );
-      await _repository.saveTabs(newTabs, newCurrentIndex);
+      _scheduleSave(newTabs, newCurrentIndex);
       // אין לשחרר את העוטף, כי החלוניות ממשיכות להיות מוצגות.
     }
   }
@@ -1251,7 +1325,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     final tabsToSave = state.tabs;
     final indexToSave = state.currentTabIndex;
     emit(state.copyWith(forceUpdate: true));
-    await _repository.saveTabs(tabsToSave, indexToSave);
+    _scheduleSave(tabsToSave, indexToSave);
   }
 
   /// אינדקס הטאב שאירוע חלונית פועל עליו, או `null` אם אינו קיים.
@@ -1285,7 +1359,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: _normalizedSelection(newTabs),
       ),
     );
-    await _repository.saveTabs(newTabs, state.currentTabIndex);
+    _scheduleSave(newTabs, state.currentTabIndex);
   }
 
   void _onSetActivePane(SetActivePane event, Emitter<TabsState> emit) {
@@ -1318,7 +1392,7 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         selectedTabs: _normalizedSelection(newTabs),
       ),
     );
-    await _repository.saveTabs(newTabs, state.currentTabIndex);
+    _scheduleSave(newTabs, state.currentTabIndex);
 
     // אין לשחרר את הטאב המפוצל כי האחות ממשיכה להיות מוצגת.
     _disposeTabLater(event.pane);

--- a/lib/tabs/bloc/tabs_bloc.dart
+++ b/lib/tabs/bloc/tabs_bloc.dart
@@ -48,6 +48,18 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
     _saveDrain ??= _drainSaves();
   }
 
+  void _logSaveFailure(Object error, StackTrace stackTrace) {
+    try {
+      ErrorLogFile.append(
+        title: 'שמירת הכרטיסיות הפתוחות נכשלה',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } catch (logError, logStackTrace) {
+      debugPrint('רישום כשל שמירת כרטיסיות נכשל: $logError\n$logStackTrace');
+    }
+  }
+
   Future<void> _drainSaves() async {
     try {
       while (_pendingSaveTabs != null) {
@@ -57,18 +69,16 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
         try {
           await _repository.saveTabs(tabs, index);
         } catch (error, stackTrace) {
-          // אף אחד לא ממתין לשמירה הזו; בלי הרישום כאן כשל כתיבה (דיסק מלא,
-          // קובץ נעול) היה נעלם בשקט והמשתמש היה מאבד את הכרטיסיות הפתוחות.
-          ErrorLogFile.append(
-            title: 'שמירת הכרטיסיות הפתוחות נכשלה',
-            error: error,
-            stackTrace: stackTrace,
-          );
+          _logSaveFailure(error, stackTrace);
         }
         // הכתיבה נשאה את האינדקס שהיה בתחילתה; אם המשתמש החליף טאב בזמנה,
         // היא דרסה את מה שכתב [_saveCurrentTabIndex].
         if (_pendingSaveTabs == null && _pendingSaveIndex != index) {
-          await _repository.saveCurrentTabIndex(tabs, _pendingSaveIndex);
+          try {
+            await _repository.saveCurrentTabIndex(tabs, _pendingSaveIndex);
+          } catch (error, stackTrace) {
+            _logSaveFailure(error, stackTrace);
+          }
         }
       }
     } finally {

--- a/lib/tabs/services/windows_jump_list_service.dart
+++ b/lib/tabs/services/windows_jump_list_service.dart
@@ -15,29 +15,51 @@ class WindowsJumpListService {
   /// כותרות הטאבים שנשלחו לאחרונה — מונע קריאות נייטיב מיותרות כשהמצב לא השתנה.
   List<String>? _lastTitles;
 
+  /// הכותרות שנשלחות כרגע ואלה שיישלחו אחריהן.
+  List<String>? _sendingTitles;
+  List<String>? _queuedTitles;
+
   bool get _isSupported => !kIsWeb && Platform.isWindows;
 
   /// מעדכן את ה-Jump List לרשימת הטאבים הנתונה (לפי הסדר). שולח רק כאשר
-  /// הכותרות או סדרן השתנו מאז הקריאה הקודמת.
+  /// הכותרות או סדרן שונים מהמצב שאליו ה-Jump List מתקדם.
+  ///
+  /// עדכון שמגיע בזמן ששליחה רצה מחליף את התור במקום להצטבר — כל שליחה היא
+  /// קריאת COM יקרה, ופתיחת ספרים ברצף מייצרת עדכון לכל ספר.
   Future<void> sync(List<OpenedTab> tabs) async {
     if (!_isSupported) return;
 
     final titles = tabs.map((tab) => tab.title).toList(growable: false);
-    if (listEquals(_lastTitles, titles)) return;
+    // ההשוואה היא מול היעד שאליו מתקדמים, ולא מול מה שנשלח בעבר: אחרת חזרה
+    // למצב הקודם בזמן שליחה נבלעת, וה-Jump List נשאר על מצב שאינו קיים.
+    final target = _queuedTitles ?? _sendingTitles ?? _lastTitles;
+    if (listEquals(target, titles)) return;
+
+    _queuedTitles = titles;
+    if (_sendingTitles != null) return;
 
     try {
-      final ok = await _channel.invokeMethod<bool>('updateTabs', {
-        'titles': titles,
-      });
-      // מעדכנים את הזיכרון רק בהצלחה — אחרת אותה רשימה תישלח שוב בשינוי הבא
-      // במקום להיתקע על מצב שלא נכתב בפועל.
-      if (ok == true) {
-        _lastTitles = titles;
+      while (_queuedTitles != null) {
+        final pending = _queuedTitles!;
+        _queuedTitles = null;
+        _sendingTitles = pending;
+        try {
+          final ok = await _channel.invokeMethod<bool>('updateTabs', {
+            'titles': pending,
+          });
+          // מעדכנים את הזיכרון רק בהצלחה — אחרת אותה רשימה תישלח שוב בשינוי
+          // הבא במקום להיתקע על מצב שלא נכתב בפועל.
+          if (ok == true) {
+            _lastTitles = pending;
+          }
+        } catch (error, stackTrace) {
+          if (kDebugMode) {
+            debugPrint('עדכון ה-Jump List נכשל: $error\n$stackTrace');
+          }
+        }
       }
-    } catch (error, stackTrace) {
-      if (kDebugMode) {
-        debugPrint('עדכון ה-Jump List נכשל: $error\n$stackTrace');
-      }
+    } finally {
+      _sendingTitles = null;
     }
   }
 }

--- a/test/navigation/custom_title_bar_test.dart
+++ b/test/navigation/custom_title_bar_test.dart
@@ -69,6 +69,59 @@ void main() {
     expect(find.byTooltip('ספר א, פרק א'), findsOneWidget);
   });
 
+  group('שורה עמוסה בכרטיסיות', () {
+    // ברוחב הזה כל כרטיסיה שאינה הנבחרת מקבלת פחות מ-12 פיקסל, כלומר אחרי
+    // הריפודים לא נותר בה מקום לתוכן.
+    Future<_TestTabsBloc> pumpCrowdedStrip(WidgetTester tester) async {
+      final tabs = [for (var i = 0; i < 200; i++) _makeTextTab('ספר $i')];
+      final tabsBloc = _TestTabsBloc(
+        TabsState(tabs: tabs, currentTabIndex: 0),
+      );
+      final navigationBloc = _TestNavigationBloc(
+        const NavigationState(currentScreen: Screen.reading),
+      );
+      final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+
+      addTearDown(() async {
+        for (final tab in tabs) {
+          tab.dispose();
+        }
+        await tabsBloc.close();
+        await navigationBloc.close();
+        await settingsBloc.close();
+      });
+
+      await _setSurfaceSize(tester, const Size(1200, 800));
+      await _pumpTitleBar(
+        tester,
+        tabsBloc: tabsBloc,
+        navigationBloc: navigationBloc,
+        settingsBloc: settingsBloc,
+      );
+      return tabsBloc;
+    }
+
+    testWidgets('נבנה תוכן רק לכרטיסיות שיש בהן מקום להציגו', (tester) async {
+      await pumpCrowdedStrip(tester);
+
+      expect(find.text('ספר 0'), findsOneWidget);
+      expect(find.text('ספר 100'), findsNothing);
+    });
+
+    testWidgets('לחיצה על כרטיסיה צרה עדיין בוחרת אותה', (tester) async {
+      final tabsBloc = await pumpCrowdedStrip(tester);
+
+      // אמצע השורה — הרחק מהכרטיסיה הנבחרת שבקצה, כלומר בתוך הכרטיסיות הצרות.
+      final stripRect = tester.getRect(find.byType(ReadingTabStrip));
+      await tester.tapAt(stripRect.center);
+      await tester.pump();
+
+      final selection = tabsBloc.addedEvents.whereType<SetCurrentTab>();
+      expect(selection, isNotEmpty);
+      expect(selection.last.index, greaterThan(0));
+    });
+  });
+
   testWidgets('אייקון pin מוצג כשהכרטיסיה מוצמדת', (tester) async {
     final tab = _makeTextTab('ספר א');
     tab.isPinned = true;

--- a/test/tabs/bloc/tabs_bloc_test.dart
+++ b/test/tabs/bloc/tabs_bloc_test.dart
@@ -556,6 +556,48 @@ void main() {
     });
   });
 
+  group('TabsBloc — איחוד שמירות בפתיחה מרובה', () {
+    setUp(() async {
+      await Settings.init(cacheProvider: _MemoryCacheProvider());
+    });
+
+    test('פתיחת עשרות טאבים ברצף אינה כותבת לדיסק בכל פתיחה', () async {
+      // הכתיבה מושהית כמו כתיבה אמיתית לדיסק; בלי ההשהיה הכתיבה מסתיימת בין
+      // אירוע לאירוע ואין מה לאחד.
+      final repository = _CountingTabsRepository(
+        writeDelay: const Duration(milliseconds: 5),
+      );
+      final bloc = TabsBloc(repository: repository);
+
+      const tabCount = 60;
+      for (var i = 0; i < tabCount; i++) {
+        bloc.add(AddTab(_createTextTab('ספר $i', categoryId: i + 1)));
+      }
+      await bloc.stream.firstWhere((s) => s.tabs.length == tabCount);
+      await bloc.close();
+
+      // כל שמירה מקודדת את כל הטאבים; בלי האיחוד זו הייתה כתיבה לכל פתיחה.
+      expect(repository.saveCount, lessThan(5));
+      expect(repository.lastSavedTabCount, tabCount);
+
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+    });
+
+    test('סגירת ה-bloc ממתינה לכתיבת המצב האחרון', () async {
+      final repository = _CountingTabsRepository();
+      final bloc = TabsBloc(repository: repository);
+
+      bloc.add(AddTab(_createTextTab('ספר א', categoryId: 1)));
+      bloc.add(AddTab(_createTextTab('ספר ב', categoryId: 2)));
+      await bloc.stream.firstWhere((s) => s.tabs.length == 2);
+      await bloc.close();
+
+      expect(repository.lastSavedTabCount, 2);
+
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+    });
+  });
+
   group('TabsBloc insert position', () {
     setUp(() async {
       await Settings.init(cacheProvider: _MemoryCacheProvider());
@@ -2031,6 +2073,25 @@ class _FakeTabsRepository extends TabsRepository {
     int currentTabIndex,
   ) async {
     _currentTabIndex = currentTabIndex;
+  }
+}
+
+/// סופר את הכתיבות בפועל, לבדיקת איחוד השמירות בפתיחה מרובה.
+class _CountingTabsRepository extends _FakeTabsRepository {
+  _CountingTabsRepository({this.writeDelay = Duration.zero});
+
+  final Duration writeDelay;
+  int saveCount = 0;
+  int lastSavedTabCount = -1;
+
+  @override
+  Future<void> saveTabs(List<OpenedTab> tabs, int currentTabIndex) async {
+    saveCount++;
+    lastSavedTabCount = tabs.length;
+    if (writeDelay > Duration.zero) {
+      await Future<void>.delayed(writeDelay);
+    }
+    return super.saveTabs(tabs, currentTabIndex);
   }
 }
 


### PR DESCRIPTION
סוגר את #796.

## הבעיה

תוסף שפותח עשרות ספרים בלחיצה אחת הקפיא את התוכנה, ואחרי הפעלה מחדש היא כלל לא עלתה — עד שהמדווח התקין הכל מחדש.

שלושה מסלולים שילמו מחיר על כל כרטיסיה, שוב ושוב:

| מסלול | מה קרה |
|---|---|
| שורת הכרטיסיות | בונה מחדש את **כל** הכרטיסיות בכל פריים — כולל כותרת, טולטיפ ו-ShaderMask לכרטיסיה שרוחבה 4 פיקסל ולא נראה בה כלום. בתוך כל אחת גם `state.tabs.indexOf(tab)`, כלומר O(n²) בכל פריים |
| שמירה לדיסק | כל פתיחת כרטיסיה מקודדת את כל הכרטיסיות וממתינה לכתיבה. ההמתנה מחזירה את השליטה ללולאת האירועים בין פתיחה לפתיחה, ולכן כל ספר בדרך נבנה על המסך ונשאר בזיכרון |
| רשימת הקפיצה (Windows) | קריאת COM לכל פתיחה, וההשוואה שקבעה אם לעדכן מיפתה את כל הכותרות בכל שינוי מצב |

## התיקון

**אין מגבלה חדשה על מספר הכרטיסיות, ואין שינוי במראה או בהתנהגות.** אפשר להמשיך לפתוח כמה שרוצים; התוכנה נהיית איטית בהדרגה במקום להיתקע.

1. **כרטיסיה שאין בה מקום לתוכן** (מתחת ל-12 פיקסל, שם הריפודים בולעים את כל הרוחב) אינה בונה את התוכן — אבל **כל שכבות האינטראקציה נשמרות**: לחיצה, ריחוף, תפריט הקשר וגרירה. מספר הכרטיסיה מועבר לבנייה במקום להיחפש.
2. **השמירה אינה עוצרת את הפתיחה**, ובקשות שמגיעות בזמן שכתיבה רצה מתמזגות לכתיבה אחת. כשל כתיבה נרשם ל-`errors.txt` במקום להיעלם, וכתיבה שטרם הסתיימה מסתיימת דרך `PreCloseRegistry` לפני סגירת התוכנה.
3. **רשימת הקפיצה** מאחדת עדכונים שמגיעים בזמן שליחה, וההשוואה נעשית מול היעד שאליו מתקדמים (קודם, חזרה למצב הקודם באמצע שליחה נבלעה והרשימה נשארה על מצב שאינו קיים).

## מדידה

שורת הכרטיסיות, זמן בנייה מחדש לפריים (סביבת debug, איטית מהאמיתית):

| כרטיסיות | לפני | אחרי |
|---|---|---|
| 200 | 263ms | 125ms |
| 800 | נופל בשגיאות overflow חוזרות | 207ms |
| 2000 | — | 401ms |

מ-800 כרטיסיות ומעלה השורה זרקה `RenderFlex overflowed` בכל פריים, כי המפריד ברוחב 1 היה רחב מהכרטיסיה כולה. גם זה תוקן.

## בדיקות

נוספו:
* `test/navigation/custom_title_bar_test.dart` — בשורה עמוסה נבנה תוכן רק לכרטיסיות שיש בהן מקום להציגו, **ולחיצה על כרטיסיה צרה עדיין בוחרת אותה**. אומת שהטסט השני נכשל אם שכבת האינטראקציה מוסרת.
* `test/tabs/bloc/tabs_bloc_test.dart` — פתיחת 60 כרטיסיות ברצף מייצרת פחות מ-5 כתיבות, המצב האחרון נשמר במלואו, וסגירת ה-bloc ממתינה לכתיבה האחרונה.

`flutter analyze` נקי, וכל הטסטים של `tabs`, `navigation`, `workspaces`, `shortcuts`, `utils`, `pdf_book` והגיבוי עוברים.

## מה לא נכלל

* כל כרטיסיה שנפתחת נטענת ונשארת בזיכרון. בפתיחה של אלף ספרים בבת אחת זה עדיין כבד; הטיפול בזה (שחרור ספרים שלא נצפו מזמן) הוא שינוי בהתנהגות ולכן נשאר בחוץ.
* `_recentlyClosedTabs` ב-`TabsBloc` אינו חסום בגודלו, וכל כרטיסיה שנסגרת נשמרת בו כשכפול מלא (כולל `TextBookBloc` חדש). סגירת 200 כרטיסיות משאירה 200 שכפולים חיים. באג קיים, לא מהתיקון הזה, וחסימתו משנה את מספר הכרטיסיות שניתן לשחזר.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
