### PR TITLE
ספריה: צמצום גובה כרטיסי הספר בחצי בתצוגה צרה

### DIFF
--- a/lib/library/view/grid_items.dart
+++ b/lib/library/view/grid_items.dart
@@ -747,6 +747,13 @@ class _BookGridActionColumn extends StatelessWidget {
 /// ריווח אחיד בין כרטיסי הרשת — משותף לתצוגת הספרייה ולתוצאות החיפוש.
 const double kLibraryGridSpacing = 14;
 
+/// גובה מינימלי לכרטיס ספר בתצוגה צרה — מספיק לכותרת (עד 2 שורות), למחבר
+/// ולטור האייקונים בלי גלישה.
+const double kNarrowGridCardMinHeight = 112;
+
+/// השוליים האופקיים של רשת הספרייה — משמשים גם בחישוב רוחב התא בפועל.
+const double _kGridHorizontalPadding = 30;
+
 class MyGridView extends StatelessWidget {
   final List<Widget> items;
 
@@ -768,7 +775,22 @@ class MyGridView extends StatelessWidget {
         final textAdjustment = textScale <= 1.0
             ? 1.0
             : (1.0 / (1.0 + ((textScale - 1.0) * 0.65)));
-        final childAspectRatio = (baseRatio * textAdjustment).clamp(1.45, 2.15);
+        final crossAxisCount = max(1, min(width ~/ 250, 5));
+
+        // בתצוגה צרה (<800) הכרטיסים גבוהים במיוחד: מקטינים את גובהם בחצי,
+        // עם רצפת גובה שמותירה מקום לשם הספר, למחבר ולטור האייקונים.
+        final double childAspectRatio;
+        if (width < 800) {
+          final gridWidth = width - 2 * _kGridHorizontalPadding;
+          final cellWidth =
+              (gridWidth - kLibraryGridSpacing * (crossAxisCount - 1)) /
+              crossAxisCount;
+          final halfHeight = cellWidth / (2 * baseRatio * textAdjustment);
+          final minHeight = kNarrowGridCardMinHeight * textScale;
+          childAspectRatio = cellWidth / max(minHeight, halfHeight);
+        } else {
+          childAspectRatio = (baseRatio * textAdjustment).clamp(1.45, 2.15);
+        }
 
         return FocusTraversalGroup(
           policy: ReadingOrderTraversalPolicy(),
@@ -776,13 +798,13 @@ class MyGridView extends StatelessWidget {
             // top: 8 או מרווח מתאים; horizontal: 45 או רוחב אף
             padding: const EdgeInsets.only(
               top: 8,
-              left: 30,
-              right: 30,
+              left: _kGridHorizontalPadding,
+              right: _kGridHorizontalPadding,
               bottom: 8,
             ),
             child: GridView.builder(
               gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: max(1, min(constraints.maxWidth ~/ 250, 5)),
+                crossAxisCount: crossAxisCount,
                 childAspectRatio: childAspectRatio,
                 crossAxisSpacing: kLibraryGridSpacing,
                 mainAxisSpacing: kLibraryGridSpacing,

--- a/test/library/view/grid_items_test.dart
+++ b/test/library/view/grid_items_test.dart
@@ -575,5 +575,62 @@ void main() {
       expect(size.height, closeTo(224.5 / 1.8, 0.5));
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('סף 800px מעביר בין פריסת צרה לרחבה', (tester) async {
+      final book = TextBook(title: 'ספר', author: 'מחבר');
+
+      Future<Size> pumpAtWidth(double width) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: width,
+                child: MyGridView(
+                  items: [BookGridItem(book: book, onBookClickCallback: () {})],
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        return tester.getSize(find.byType(BookGridItem));
+      }
+
+      final narrowSize = await pumpAtWidth(799);
+      expect(narrowSize.height, closeTo(kNarrowGridCardMinHeight, 0.5));
+
+      final wideSize = await pumpAtWidth(800);
+      final wideCellWidth = (800 - 60 - 14 * 2) / 3;
+      expect(wideSize.height, closeTo(wideCellWidth / 1.8, 0.5));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('רצפת הגובה גדלה עם מידת הטקסט', (tester) async {
+      final book = TextBook(
+        title: 'שם ספר ארוך מאוד שמתפרס על שתי שורות בכרטיס',
+        author: 'מחבר ארוך מאוד שמתפרס על שתי שורות',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: Scaffold(
+              body: SizedBox(
+                width: 400,
+                child: MyGridView(
+                  items: [BookGridItem(book: book, onBookClickCallback: () {})],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final size = tester.getSize(find.byType(BookGridItem));
+      expect(size.height, closeTo(kNarrowGridCardMinHeight * 2, 0.5));
+      expect(tester.takeException(), isNull);
+    });
   });
 }

--- a/test/library/view/grid_items_test.dart
+++ b/test/library/view/grid_items_test.dart
@@ -512,4 +512,68 @@ void main() {
       expect(externalCatalogLogoAsset(book), 'assets/logos/otzar.ico');
     });
   });
+
+  group('MyGridView בתצוגה צרה', () {
+    testWidgets('מקטין את גובה כרטיס הספר בחצי עם רצפת גובה לקריאה', (
+      tester,
+    ) async {
+      final book = TextBook(
+        title: 'שם ספר ארוך מאוד שמתפרס על שתי שורות בכרטיס',
+        author: 'מחבר ארוך מאוד שמתפרס על שתי שורות',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              child: MyGridView(
+                items: [
+                  BookGridItem(book: book, onBookClickCallback: () {}),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // רוחב הרשת: 400 - 60 (שוליים 30+30) = 340. הגובה הקודם היה
+      // 340/1.65 ≈ 206, והחדש נחתך לחצי עם רצפה של 112 — בלי גלישה.
+      final size = tester.getSize(find.byType(BookGridItem));
+      expect(size.width, closeTo(340, 0.5));
+      expect(size.height, closeTo(kNarrowGridCardMinHeight, 0.5));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('בתצוגה רחבה הגובה נשאר ללא שינוי', (tester) async {
+      // משטח ברירת המחדל הוא 800×600 וחותך את הרוחב — מרחיבים אותו.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final book = TextBook(title: 'ספר', author: 'מחבר');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 1000,
+              child: MyGridView(
+                items: [
+                  BookGridItem(book: book, onBookClickCallback: () {}),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 4 עמודות, רוחב תא (1000 - 60 - 14*3)/4 = 224.5, יחס 1.8 → גובה ≈ 125.
+      final size = tester.getSize(find.byType(BookGridItem));
+      expect(size.height, closeTo(224.5 / 1.8, 0.5));
+      expect(tester.takeException(), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## מה השתנה

בתצוגה צרה (רוחב < 800px, כשסרגל הניווט עובר למטה) כרטיסי הספר במסך הספרייה נמתחו לגובה של ~200–300px. כעת גובה הכרטיס נחתך בחצי, עם רצפת גובה (112px) ששומרת מקום לשם הספר, למחבר ולטור האייקונים בלי גלישה. התצוגה הרחבה (≥800px) לא השתנתה.

## בדיקות

- `flutter test test/library/` — 82 טסטים עוברים
- `flutter analyze` — נקי לגבי הקבצים ששונו

## תמונות

<img width="639" height="1008" alt="image" src="https://github.com/user-attachments/assets/f0b53e3e-3977-40a4-b803-9b03fcc0c423" />
<img width="820" height="1008" alt="image" src="https://github.com/user-attachments/assets/9dbce61e-0ced-45c3-8676-5ac5fbb5d2b4" />

#677 