### PR TITLE
תיקון: Ctrl+C מעתיק בחירה במפרשים בתצוגה 'מפרשים מתחת'

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -20,6 +20,7 @@ import 'package:otzaria/text_book/models/commentator_group.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/text_book/view/commentary_list_base.dart';
 import 'package:otzaria/text_book/view/sibling_commentaries_menu.dart';
+import 'package:otzaria/utils/ui/context_menu_utils.dart';
 import 'package:otzaria/widgets/misc/progressive_scrolling.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:otzaria/tabs/models/tab.dart';
@@ -1444,6 +1445,23 @@ class _CombinedViewState extends State<CombinedView> {
     debugPrint('_currentSelectedIndex: ${_currentSelectedIndex.value}');
 
     if (plainText == null || plainText.trim().isEmpty) {
+      // בחירה במפרשים מנוהלת ע"י SelectionArea פנימי (עטוף ב-
+      // SelectionContainer.disabled) — היא אינה נרשמת אצל ה-SelectionArea
+      // החיצוני של הטקסט, ולכן אין כאן טקסט שמור. ה-controller נושא את
+      // הבחירה העדכנית של המפרשים — נופלים אליה כדי ש-Ctrl+C יעבוד גם
+      // כשהפוקוס נמצא על אזור הקריאה החיצוני.
+      final controller = widget.selectionSyncController;
+      final commentaryText = controller?.activeSelectionText;
+      if (commentaryText != null && commentaryText.trim().isNotEmpty) {
+        final settingsState = context.read<SettingsBloc>().state;
+        await ContextMenuUtils.copyFormattedText(
+          context: context,
+          savedSelectedText: commentaryText,
+          fontSize: settingsState.commentatorsFontSize,
+          link: controller?.activeSelectionLink,
+        );
+        return;
+      }
       UiSnack.show(TextBookMessages.selectTextToCopy);
       return;
     }
@@ -1610,7 +1628,10 @@ class _CombinedViewState extends State<CombinedView> {
                     _selectionStartColumn = null;
                     return;
                   }
-                  widget.selectionSyncController?.activate(_selectionOwner);
+                  widget.selectionSyncController?.activate(
+                    _selectionOwner,
+                    selectionText: plain,
+                  );
                   // כניסה למצב בחירה כשיש טקסט נבחר
                   if (!_selectionManager.isInSelectionMode) {
                     // שימוש באינדקס העליון הנראה במקום 0

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -1371,7 +1371,17 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
     if (rtlSelectionPriming) return;
     if (text != null && text.trim().isNotEmpty) {
       _savedSelectedText.value = text;
-      widget.selectionSyncController?.activate(_selectionOwner);
+      // פרסום הבחירה ב-controller: מטפל ההעתקה במקלדת (Ctrl+C) במצב
+      // 'מפרשים מתחת' עובד על ה-SelectionArea החיצוני של הטקסט ואינו רואה
+      // את הבחירה הפנימית — לכן ה-controller נושא עבורו את הטקסט ואת
+      // המפרש (לכותרות).
+      widget.selectionSyncController?.activate(
+        _selectionOwner,
+        selectionText: _restoreLineBreaks(text),
+        selectionLink: _selectionSpansMultipleItems()
+            ? null
+            : _lastSelectedLink.value,
+      );
     } else {
       _savedSelectedText.value = null;
       _lastSelectedLink.value = null;
@@ -1567,6 +1577,8 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                     state: state,
                     reportLineIndex:
                         state.selectedIndex ?? currentIndexes.first,
+                    selectionSyncController:
+                        widget.selectionSyncController,
                   );
                 } else if (selectedCommentators.isEmpty) {
                   notesWidget = Center(
@@ -1773,16 +1785,28 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                         _CopyCommentaryIntent:
                             CallbackAction<_CopyCommentaryIntent>(
                               onInvoke: (_) {
-                                // בחירה החוצה כמה מפרשים — לא מייחסים כותרת מקור
-                                // (היא הייתה משתייכת למפרש בודד בלבד).
-                                final link = _selectionSpansMultipleItems()
-                                    ? null
-                                    : _lastSelectedLink.value;
+                                // ה-controller נושא את הבחירה העדכנית ביותר
+                                // (גם מזו של 'הערות' או בחירה באזור פנימי אחר)
+                                // — מעדיפים אותו, ונופלים לטקסט המקומי בלעדיו.
+                                final controller =
+                                    widget.selectionSyncController;
+                                final controllerText =
+                                    controller?.activeSelectionText;
+                                final savedSelectedText =
+                                    controllerText ??
+                                    _restoreLineBreaks(
+                                      _savedSelectedText.value,
+                                    );
+                                // בחירה החוצה כמה מפרשים — לא מייחסים כותרת
+                                // מקור (היא הייתה משתייכת למפרש בודד בלבד).
+                                final link = controller != null
+                                    ? controller.activeSelectionLink
+                                    : (_selectionSpansMultipleItems()
+                                          ? null
+                                          : _lastSelectedLink.value);
                                 ContextMenuUtils.copyFormattedText(
                                   context: context,
-                                  savedSelectedText: _restoreLineBreaks(
-                                    _savedSelectedText.value,
-                                  ),
+                                  savedSelectedText: savedSelectedText,
                                   fontSize: widget.fontSize,
                                   link: link,
                                 );
@@ -2493,6 +2517,10 @@ class _NotesCommentaryWidget extends StatefulWidget {
   /// אינדקס השורה שאליה מיוחסות ההערות המוצגות — לדיווח הטעות.
   final int reportLineIndex;
 
+  /// לפרסום בחירת ההערות — כדי ש-Ctrl+C יעתיק אותן גם כשהפוקוס אינו בתוך
+  /// ה-SelectionArea שלהן (ראו [SelectionSyncController.activeSelectionText]).
+  final SelectionSyncController? selectionSyncController;
+
   const _NotesCommentaryWidget({
     required this.notes,
     required this.fontSize,
@@ -2500,6 +2528,7 @@ class _NotesCommentaryWidget extends StatefulWidget {
     required this.openBookCallback,
     required this.state,
     required this.reportLineIndex,
+    this.selectionSyncController,
   });
 
   @override
@@ -2508,6 +2537,21 @@ class _NotesCommentaryWidget extends StatefulWidget {
 
 class _NotesCommentaryWidgetState extends State<_NotesCommentaryWidget> {
   String? _selectedText;
+
+  /// מזהה בעלות ייחודי לבחירת ההערות ב-[SelectionSyncController].
+  final Object _selectionOwner = Object();
+
+  void _onNotesSelectionChanged(String? text) {
+    _selectedText = text;
+    if (text != null && text.trim().isNotEmpty) {
+      widget.selectionSyncController?.activate(
+        _selectionOwner,
+        selectionText: text,
+      );
+    } else {
+      widget.selectionSyncController?.clear(_selectionOwner);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -2521,7 +2565,7 @@ class _NotesCommentaryWidgetState extends State<_NotesCommentaryWidget> {
             // ביטול תפריט ברירת המחדל של Flutter — נשתמש ב-AppContextMenuRegion.
             contextMenuBuilder: (context, _) => const SizedBox.shrink(),
             onSelectionChanged: (selection) =>
-                _selectedText = selection?.plainText,
+                _onNotesSelectionChanged(selection?.plainText),
             child: AppContextMenuRegion(
               // לחיצה ימנית על טקסט מסומן לא תשחרר את הבחירה (ברירת המחדל של
               // SelectableRegion ב-Windows); לחיצה מחוץ לבחירה מבטלת כרגיל.

--- a/lib/text_book/view/selection/selection_sync_controller.dart
+++ b/lib/text_book/view/selection/selection_sync_controller.dart
@@ -1,25 +1,45 @@
 import 'package:flutter/foundation.dart';
+import 'package:otzaria/models/links.dart';
 
 /// מסנכרן בחירת טקסט בין כמה אזורי SelectionArea באותו מסך.
 ///
 /// ל-SelectionArea של Flutter אין API ישיר ל"נקה בחירה באזור אחר",
 /// לכן כל אזור מאזין לגרסה (`revision`) ומבצע rebuild מקומי כשהבחירה
 /// עברה לאזור אחר.
+///
+/// בנוסף לבעלות, ה-controller נושא גם את הטקסט שנבחר (והמפרש שממנו — לצורך
+/// כותרות בהעתקה) אצל הבעלים הנוכחי. כך מטפל העתקה במקלדת (Ctrl+C) יכול
+/// להעתיק את בחירת המפרשים גם כשה-focus אינו בתוך ה-SelectionArea שלהם —
+/// לדוגמה במצב 'מפרשים מתחת' שבו כרטיס המפרשים עטוף ב-SelectionArea נפרד.
 class SelectionSyncController extends ChangeNotifier {
   int _revision = 0;
   Object? _activeOwner;
+  String? _activeSelectionText;
+  Link? _activeSelectionLink;
 
   int get revision => _revision;
   Object? get activeOwner => _activeOwner;
 
-  void activate(Object owner) {
-    if (identical(_activeOwner, owner)) {
-      return;
-    }
+  /// הטקסט שנבחר אצל הבעלים הנוכחי (null כשאין בחירה פעילה).
+  String? get activeSelectionText => _activeSelectionText;
 
+  /// המפרש שממנו נבחר הטקסט — לייחוס הכותרת בהעתקה עם כותרות.
+  /// null כשהבחירה אינה שייכת למפרש בודד (או שזהו טקסט ראשי).
+  Link? get activeSelectionLink => _activeSelectionLink;
+
+  void activate(
+    Object owner, {
+    String? selectionText,
+    Link? selectionLink,
+  }) {
+    final changedOwner = !identical(_activeOwner, owner);
     _activeOwner = owner;
-    _revision++;
-    notifyListeners();
+    _activeSelectionText = selectionText;
+    _activeSelectionLink = selectionLink;
+    if (changedOwner) {
+      _revision++;
+      notifyListeners();
+    }
   }
 
   void clear(Object owner) {
@@ -28,6 +48,8 @@ class SelectionSyncController extends ChangeNotifier {
     }
 
     _activeOwner = null;
+    _activeSelectionText = null;
+    _activeSelectionLink = null;
     _revision++;
     notifyListeners();
   }

--- a/test/text_book/view/combined_view/commentary_copy_keyboard_test.dart
+++ b/test/text_book/view/combined_view/commentary_copy_keyboard_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/messages/common_messages.dart';
+import 'package:otzaria/core/messages/text_book_messages.dart';
+import 'package:otzaria/core/ui_snack.dart';
+import 'package:otzaria/data/data_providers/book_composite_key.dart';
+import 'package:otzaria/data/data_providers/library_provider.dart';
+import 'package:otzaria/data/data_providers/library_provider_manager.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_bloc.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_event.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_state.dart';
+import 'package:otzaria/settings/engine/settings_bloc.dart';
+import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_state.dart';
+import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/view/combined_view/combined_book_screen.dart';
+import 'package:otzaria/text_book/view/selection/selection_sync_controller.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import '../../../test_helpers/memory_cache_provider.dart';
+
+/// issue #530 (ריגרסיה): Ctrl+C על בחירה במפרשים במצב "מפרשים מתחת" העתיק
+/// ריק — ה-SelectionArea של המפרשים מקונן בתוך זה של הטקסט הראשי (עטוף ב-
+/// SelectionContainer.disabled), וטיפול ההעתקה של ה-SelectionArea החיצוני לא
+/// ראה את בחירת המפרשים. בחירה במפרשים חייבת להופיע בהעתקת המקלדת.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  testWidgets('Ctrl+C על בחירה במפרשים מתחת מפעיל את העתקת המפרשים', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(900, 1400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    LibraryProviderManager.instance.resetForTesting();
+    LibraryProviderManager.instance.seedMappingsForTesting(
+      mapping: {
+        BookCompositeKey.create(
+          title: 'מפרש בדיקה',
+          categoryId: 1,
+          fileType: 'txt',
+        ): _FakeLibraryProvider(),
+      },
+      providers: [_FakeLibraryProvider()],
+    );
+    addTearDown(LibraryProviderManager.instance.resetForTesting);
+
+    final link = Link(
+      heRef: 'בראשית א',
+      index1: 1,
+      path2: 'מפרש בדיקה.txt',
+      index2: 1,
+      connectionType: 'COMMENTARY',
+      targetCategoryId: 1,
+      targetFileType: 'txt',
+    );
+
+    final state = TextBookLoaded(
+      book: TextBook(title: 'ספר בדיקה'),
+      showLeftPane: false,
+      content: const ['שורה א', 'שורה ב'],
+      fontSize: 18,
+      showSplitView: false,
+      activeCommentators: const ['מפרש בדיקה'],
+      commentatorGroups: const [],
+      availableCommentators: const ['מפרש בדיקה'],
+      links: [link],
+      visibleLinks: const [],
+      linksByLine: {
+        1: [link],
+      },
+      tableOfContents: const [],
+      removeNikud: false,
+      visibleIndices: const [0, 1],
+      selectedIndex: 0,
+      selectedIndices: const {0},
+      pinLeftPane: false,
+      searchText: '',
+      scrollController: ItemScrollController(),
+      positionsListener: ItemPositionsListener.create(),
+    );
+
+    final textBookBloc = _TestTextBookBloc(state);
+    addTearDown(textBookBloc.close);
+    final settingsBloc = _TestSettingsBloc(
+      SettingsState.initial().copyWith(copyWithHeaders: 'book_name'),
+    );
+    addTearDown(settingsBloc.close);
+    final personalNotesBloc = _TestPersonalNotesBloc(
+      const PersonalNotesState.initial(),
+    );
+    addTearDown(personalNotesBloc.close);
+    final syncController = SelectionSyncController();
+    addTearDown(syncController.dispose);
+    final tab = TextBookTab(book: TextBook(title: 'ספר בדיקה'), index: 0);
+    addTearDown(tab.dispose);
+
+    // לוכד כתיבה ללוח דרך Clipboard.setData של Flutter (ברירת המחדל של
+    // SelectableRegion) — כדי לוודא שלא ההעתקה הפנימית (הריקה) רצה.
+    final clipboardCalls = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardCalls.add(
+            (call.arguments as Map<Object?, Object?>)['text']?.toString() ?? '',
+          );
+          return null;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: textBookBloc),
+            BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          ],
+          child: Scaffold(
+            body: CombinedView(
+              data: const ['שורה א', 'שורה ב'],
+              openBookCallback: (_) {},
+              openLeftPaneTab: (_, {searchText}) {},
+              textSize: 18,
+              showCommentaryAsExpansionTiles: true,
+              selectionSyncController: syncController,
+              tab: tab,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await _pumpUntil(
+      tester,
+      () => find
+          .textContaining('פירוש לבדיקה', findRichText: true)
+          .evaluate()
+          .isNotEmpty,
+    );
+    expect(
+      find.textContaining('פירוש לבדיקה', findRichText: true),
+      findsWidgets,
+      reason: 'כרטיס המפרשים לא נטען',
+    );
+
+    // בחירה אמיתית בכל הטקסט של המפרש (ה-SelectionArea הפנימי).
+    final innerRegion = tester.state<SelectableRegionState>(
+      find.descendant(
+        of: _commentarySelectionAreaFinder(),
+        matching: find.byType(SelectableRegion),
+      ),
+    );
+    innerRegion.selectAll();
+    await tester.pump();
+
+    // הבחירה צריכה להתפרסם ב-controller כדי שטיפול ההעתקה החיצוני יראה אותה.
+    final publishedText = syncController.activeSelectionText;
+    expect(publishedText, isNotNull);
+    expect(
+      publishedText!.trim().isNotEmpty,
+      isTrue,
+      reason: 'בחירת המפרשים לא פורסמה ב-SelectionSyncController',
+    );
+    expect(publishedText, contains('פירוש לבדיקה'));
+
+    // Ctrl+C — הפוקוס יושב על אזור הקריאה החיצוני (כמו במציאות אחרי
+    // בחירה בספר), והבחירה אינה שם.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+
+    final snackbarTexts = _visibleSnackbarTexts(tester);
+    debugPrint('הודעות Snackbar אחרי Ctrl+C: $snackbarTexts');
+
+    // אסור שתופיע הודעת "אין טקסט נבחר" — הבחירה במפרשים קיימת.
+    expect(
+      snackbarTexts.contains(TextBookMessages.selectTextToCopy),
+      isFalse,
+      reason:
+          'Ctrl+C ראה בחירה ריקה למרות שנבחר טקסט במפרשים '
+          '(הודעה: $snackbarTexts)',
+    );
+
+    // ההעתקה צריכה לעבור דרך מסלול ההעתקה של המפרשים עד לכתיבה ללוח.
+    // בטסט הלוח הפלאגיני אינו זמין: או שהודעת "הלוח אינו זמין" מופיעה,
+    // או שהגישה ללוח זורקת (ערוץ פלאגין חסר) ומוצגת שגיאת העתקה — בשני
+    // המקרים זהו סימן שההעתקה רצה עם הטקסט הנבחר ולא נעצרה על "אין טקסט".
+    final copyPathReachedWrite =
+        snackbarTexts.contains(CommonMessages.clipboardUnavailable) ||
+        snackbarTexts.contains(CommonMessages.textCopyError);
+    expect(
+      copyPathReachedWrite,
+      isTrue,
+      reason: 'מסלול ההעתקה של המפרשים לא הופעל (הודעה: $snackbarTexts)',
+    );
+
+    // ניקוז טיימר הסגירה של ה-Snackbar כדי לא להשאיר טיימרים תלויים.
+    await tester.pump(const Duration(seconds: 5));
+  });
+}
+
+Finder _commentarySelectionAreaFinder() => find.byWidgetPredicate(
+  (w) =>
+      w is SelectionArea &&
+      (w.key is ValueKey<String>) &&
+      (w.key as ValueKey<String>).value.startsWith('commentary_list_'),
+);
+
+List<String> _visibleSnackbarTexts(WidgetTester tester) => find
+    .descendant(
+      of: find.byType(Overlay),
+      matching: find.byType(Text),
+    )
+    .evaluate()
+    .map((e) => (e.widget as Text).data ?? '')
+    .where((t) => t.isNotEmpty)
+    .toList();
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  int maxTries = 80,
+}) async {
+  for (var i = 0; i < maxTries; i++) {
+    if (condition()) return;
+    await tester.pump(const Duration(milliseconds: 20));
+  }
+}
+
+class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
+    implements TextBookBloc {
+  _TestTextBookBloc(super.initialState) {
+    on<TextBookEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestPersonalNotesBloc
+    extends Bloc<PersonalNotesEvent, PersonalNotesState>
+    implements PersonalNotesBloc {
+  _TestPersonalNotesBloc(super.initialState) {
+    on<PersonalNotesEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestSettingsBloc extends Bloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {
+  _TestSettingsBloc(super.initialState) {
+    on<SettingsEvent>((event, emit) {});
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeLibraryProvider implements LibraryProvider {
+  @override
+  String get displayName => 'Fake';
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  int get priority => 0;
+
+  @override
+  String get providerId => 'fake';
+
+  @override
+  String get sourceIndicator => 'T';
+
+  @override
+  Future<Library> buildLibraryCatalog(
+    Map<String, Map<String, dynamic>> metadata,
+    String rootPath,
+  ) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<Link>> getAllLinksForBook(
+    String title,
+    int categoryId,
+    String fileType,
+  ) async {
+    return const [];
+  }
+
+  @override
+  Future<Set<String>> getAvailableBookTitles() async {
+    return {'מפרש בדיקה|1|txt'};
+  }
+
+  @override
+  Future<String?> getBookText(
+    String title,
+    int categoryId,
+    String fileType, {
+    bool preferUserBooks = false,
+  }) async {
+    return null;
+  }
+
+  @override
+  Future<List<TocEntry>?> getBookToc(
+    String title,
+    int categoryId,
+    String fileType, {
+    bool preferUserBooks = false,
+  }) async {
+    return const [];
+  }
+
+  @override
+  Future<String> getLinkContent(Link link) async {
+    return 'זהו פירוש לבדיקה עם טקסט שניתן לבחור ולהעתיק';
+  }
+
+  @override
+  Future<bool> hasBook(String title, int categoryId, String fileType) async {
+    return title == 'מפרש בדיקה';
+  }
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<Map<String, List<Book>>> loadBooks(
+    Map<String, Map<String, dynamic>> metadata,
+  ) async {
+    return const {};
+  }
+}


### PR DESCRIPTION
## הבעיה

במצב "מפרשים מתחת" (תצוגה משולבת), בחירת טקסט במפרשים מתנהלת ב-`SelectionArea` פנימי (עטוף ב-`SelectionContainer.disabled`, תיקון issue #530), ולכן אינה נראית למטפל ההעתקה של ה-`SelectionArea` החיצוני של הטקסט. כשהפוקוס היה על אזור הקריאה הראשי, `Ctrl+C` על בחירה במפרשים העתיק ריק.

## התיקון

- `SelectionSyncController` נושא כעת גם את הטקסט הנבחר ואת המפרש שממנו נבחר (לצורך כותרות בהעתקה).
- רשימת המפרשים (כולל המפרש הווירטואלי "הערות") מפרסמת את בחירתה ב-controller.
- העתקת המקלדת בתצוגה המשולבת נופלת לבחירת המפרשים כשאין בחירה בטקסט הראשי.

## בדיקות

- טסט רגרסיה חדש: `test/text_book/view/combined_view/commentary_copy_keyboard_test.dart`.
- כל סוויטת `test/text_book/` עוברת (1290 בדיקות), כולל בדיקות `page_shape`.

לפני
<img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/d5b45052-bf7b-4e55-a02d-0c36cb1f0599" />
אחרי
<img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/24109e52-de63-4832-aabb-1fd2ff385aab" />
