### PR TITLE
fix(plugins): סגירת טאב תוסף באמצע פעולה אסינכרונית הפילה את התוכנה

### DIFF
--- a/lib/plugins/services/plugin_runtime_dispatcher.dart
+++ b/lib/plugins/services/plugin_runtime_dispatcher.dart
@@ -430,15 +430,14 @@ class PluginRuntimeDispatcher {
     _enabledCache[pluginId] = isEnabled;
     if (!isEnabled) return false;
 
-    _permissionCache[pluginId] ??= {};
+    // מחזיקים את המפה הפנימית: סגירת טאב באמצע ה-await מוחקת את הרשומה
+    // מ-_permissionCache (unregisterController), וקריאה חוזרת דרכה תזרוק.
+    final permissions = _permissionCache[pluginId] ??= {};
     final permKey = 'events.subscribe:$topic';
-    if (!_permissionCache[pluginId]!.containsKey(permKey)) {
-      _permissionCache[pluginId]![permKey] = await _repository.getPermission(
-        pluginId,
-        permKey,
-      );
+    if (!permissions.containsKey(permKey)) {
+      permissions[permKey] = await _repository.getPermission(pluginId, permKey);
     }
-    return _permissionCache[pluginId]![permKey] == true;
+    return permissions[permKey] == true;
   }
 
   Future<void> dispatchEvent(String topic, Map<String, dynamic> payload) async {
@@ -447,7 +446,9 @@ class PluginRuntimeDispatcher {
     final jsonPayload = jsonEncode(payload);
     debugPrint('PluginRuntimeDispatcher: Dispatching $topic');
 
-    for (final entry in _controllersByPlugin.entries) {
+    // עותק: ה-await שבגוף הלולאה משחרר את לולאת האירועים, וסגירת טאב מסירה
+    // בינתיים את התוסף מהמפה (unregisterController) — איטרציה חיה קורסת.
+    for (final entry in _controllersByPlugin.entries.toList(growable: false)) {
       final pluginId = entry.key;
       final instances = entry.value;
       if (instances.isEmpty) continue;

--- a/test/plugins/services/plugin_runtime_dispatcher_test.dart
+++ b/test/plugins/services/plugin_runtime_dispatcher_test.dart
@@ -32,6 +32,33 @@ class _FakeRegistryRepo extends Fake implements PluginRegistryRepository {
       this.permission;
 }
 
+// ── repository שמדמה סגירת טאב באמצע בדיקה אסינכרונית ─────────────────────
+// ה-await על getIsEnabled/getPermission הוא הנקודה שבה הדיספצ'ר משהה; ה-hook
+// מסיר בדיוק אז תוסף, כפי ש-unregisterController עושה בסגירת טאב.
+class _TabClosingRepo extends Fake implements PluginRegistryRepository {
+  _TabClosingRepo({this.onFirstEnabledCheck, this.onPermissionCheck});
+  final VoidCallback? onFirstEnabledCheck;
+  final void Function(String pluginId)? onPermissionCheck;
+  bool _enabledFired = false;
+
+  @override
+  Future<bool> getIsEnabled(String pluginId) async {
+    await Future<void>.delayed(Duration.zero);
+    if (!_enabledFired) {
+      _enabledFired = true;
+      onFirstEnabledCheck?.call();
+    }
+    return true;
+  }
+
+  @override
+  Future<bool?> getPermission(String pluginId, String permission) async {
+    await Future<void>.delayed(Duration.zero);
+    onPermissionCheck?.call(pluginId);
+    return true;
+  }
+}
+
 // ── fake repository לסנכרון תרומות עלייה (הרשאות מוענקות, בלי SQLite) ──────
 class _ContributionsRepo extends Fake implements PluginRegistryRepository {
   @override
@@ -1123,6 +1150,92 @@ void main() {
       );
 
       expect(opened, isEmpty);
+    });
+  });
+
+  // ── רגרסיה: סגירת טאב באמצע פעולה אסינכרונית ──────────────────────────────
+  //
+  // סגירת טאב עם תוסף קוראת ל-unregisterController, שמסיר סינכרונית גם
+  // מ-_controllersByPlugin וגם מ-_permissionCache. כל קריאה חוזרת אליהם אחרי
+  // await חשופה לכך.
+  group('סגירת טאב תוך כדי פעולה אסינכרונית', () {
+    tearDown(() => _d.repositoryForTesting = PluginRegistryRepository());
+
+    test('הסרת תוסף באמצע ה-await אינה מפילה את השידור', () async {
+      const pids = [
+        'crash.a',
+        'crash.b',
+        'crash.c',
+        'crash.d',
+        'crash.e',
+        'crash.f',
+      ];
+      final controllers = {
+        for (final pid in pids) pid: _FakeWebViewController(),
+      };
+      controllers.forEach(_d.registerController);
+      addTearDown(() {
+        for (final pid in pids) {
+          _d.unregisterController(pid);
+        }
+      });
+
+      _d.repositoryForTesting = _TabClosingRepo(
+        onFirstEnabledCheck: () => _d.unregisterController(pids.last),
+      );
+
+      await expectLater(
+        _d.dispatchEvent('navigation.changed', {'screen': 'library'}),
+        completes,
+      );
+
+      for (final pid in pids.take(pids.length - 1)) {
+        expect(controllers[pid]!.evaluateJavascriptCalls, 1, reason: pid);
+      }
+      expect(
+        controllers[pids.last]!.evaluateJavascriptCalls,
+        0,
+        reason: 'התוסף שהוסר באמצע אינו אמור לקבל את האירוע',
+      );
+    });
+
+    // סגירת הטאב מוחקת את _permissionCache של התוסף; קריאה חוזרת דרכו אחרי
+    // ה-await זרקה, והזריקה קטעה את _reconcileForeground באמצע — כך שתוסף
+    // *אחר* לא קיבל resume ונשאר קפוא.
+    test('הסרת תוסף בבדיקת ההרשאה אינה מונעת resume מתוסף אחר', () async {
+      const closing = 'perm.closing';
+      const survivor = 'perm.survivor';
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _d.resetVisibilityForTesting();
+
+      // קובע את _lastThemePayload כדי ש-_resyncThemeOnResume ירוץ בהתעוררות.
+      // לפני רישום ה-controllers, כך שמטמון ההרשאות נשאר ריק.
+      await _d.dispatchEvent('theme.changed', {'mode': 'dark'});
+
+      final closingController = _LifecycleFakeController();
+      final survivorController = _LifecycleFakeController();
+      _d.registerController(closing, closingController);
+      _d.registerController(survivor, survivorController);
+      addTearDown(() {
+        _d.unregisterController(closing);
+        _d.unregisterController(survivor);
+      });
+
+      _d.repositoryForTesting = _TabClosingRepo(
+        onPermissionCheck: (pluginId) {
+          if (pluginId == closing) _d.unregisterController(closing);
+        },
+      );
+
+      _d.setVisiblePluginTabs({closing, survivor});
+      await pumpEventQueue();
+
+      expect(
+        survivorController.resumeCalls,
+        1,
+        reason: 'הזריקה בתוסף שנסגר קטעה את שרשרת ה-resume',
+      );
     });
   });
 }


### PR DESCRIPTION
## הבעיה

משתמש דיווח שכל התוכנה נסגרה בלחיצה על ה-X של טאב בתצוגה מפוצלת. קובץ השגיאות שלו:

```
=== Unhandled Error 2026-08-14T12:44:13 ===
Version: 0.9.97+90970
Exception: Concurrent modification during iteration: _Map len:6.

Stack:
#0      _CompactEntriesIterator.moveNext (dart:_compact_hash:919)
#1      PluginRuntimeDispatcher.dispatchEvent (plugin_runtime_dispatcher.dart:450)
```

## שורש הבעיה

סגירת טאב שמכיל תוסף קוראת ל-`unregisterController`, שמסיר **סינכרונית** גם מ-`_controllersByPlugin` (שורה 98) וגם מ-`_permissionCache` (שורה 104). ההערה בשורה 111 מתעדת בדיוק את זה: `// ה-controller ה-foreground נסגר (טאב נסגר)`.

שתי נקודות בקובץ ניגשו לאותן מפות מחדש **אחרי `await`**, ולכן נחשפו לסגירה שקרתה בדיוק בחלון ההשהיה:

### 1. `dispatchEvent` — הקריסה שדווחה

הלולאה רצה ישירות על המפה החיה, עם `await` בגופה (`_canReceiveEvent`, `evaluateJavascript`). ה-`await` משחרר את לולאת האירועים; סגירת הטאב מסירה מהמפה; ה-`moveNext` הבא זורק `ConcurrentModificationError`.

ה-`moveNext` יושב **מחוץ** ל-`try/catch` שבגוף הלולאה, ולכן החריגה בורחת מ-`dispatchEvent` כחריגה לא-מטופלת — ומפילה את התוכנה כולה, לא רק את הטאב.

### 2. `_canReceiveEvent` — באג נלווה מאותה מחווה

```dart
_permissionCache[pluginId]![permKey] = await _repository.getPermission(...);  // await
}
return _permissionCache[pluginId]![permKey] == true;   // ← ! על מפה שאולי כבר נמחקה
```

השורה האחרונה קוראת את המפה מחדש אחרי ה-`await`. אם הטאב נסגר בינתיים, `_permissionCache.remove(pluginId)` כבר רץ ו-`!` זורק `Null check operator used on a null value`.

ב-`dispatchEvent` הזריקה נבלעת ב-`try` הקיים (האירוע פשוט אובד), אבל ב-`_resyncThemeOnResume` הקריאה יושבת **מחוץ ל-`try`** (שורה 270 מול 271). משם היא מתפשטת ל-`_reconcileForeground` וקוטעת אותו באמצע הלולאה — אחרי ששורה 215 כבר עדכנה את `_runningForegroundPluginIds`. התוצאה: תוסף אחר לא מקבל `resume` ונשאר **קפוא על המסך**. השגיאה נבלעת ב-`catchError` של מנעול ה-lifecycle, כך שאין קריסה — רק שחיתות מצב שקטה.

## התיקון

שתי הנקודות נפתרות באותה גישה שכבר נהוגה בקובץ עצמו — `reloadPlugin` (שורה 419) כבר עושה בדיוק את זה, עם ההערה `// עותק כדי לא לקרוס אם callback משתמש ב-unregister באמצעו`:

```diff
-    for (final entry in _controllersByPlugin.entries) {
+    for (final entry in _controllersByPlugin.entries.toList(growable: false)) {
```

```diff
-    _permissionCache[pluginId] ??= {};
+    final permissions = _permissionCache[pluginId] ??= {};
     ...
-    return _permissionCache[pluginId]![permKey] == true;
+    return permissions[permKey] == true;
```

בלי `try/catch` ובלי בדיקות `null` הגנתיות — רק הפניה מקומית לפני ה-`await` במקום קריאה חוזרת דרך המפה.

## אימות

שני הטסטים אומתו בשני הכיוונים — כל אחד **נכשל בלי התיקון המתאים ועובר איתו**:

| טסט | בלי התיקון |
|---|---|
| `הסרת תוסף באמצע ה-await אינה מפילה את השידור` | `Concurrent modification during iteration: _Map len:5` — אותה שגיאה ואותו stack כמו בדיווח |
| `הסרת תוסף בבדיקת ההרשאה אינה מונעת resume מתוסף אחר` | `Expected: <1> Actual: <0>` — התוסף השני נשאר קפוא |

הטסט הראשון מאמת גם את שני צדי ההתנהגות: חמשת התוספים ששרדו קיבלו את האירוע, והתוסף שנסגר לא.

```
flutter analyze  (2 קבצים)   → No issues found!
flutter test test/plugins/   → All tests passed! (1085)
dart format                  → 0 changed
```

## יחס ל-#812

שני ה-PR-ים באזור התוספים אך מטפלים בדברים שונים, ו**אין ביניהם ולו קובץ אחד משותף** — כלומר אפס קונפליקט מיזוג, בכל סדר שהוא.

| | #812 | #813 (זה) |
|---|---|---|
| בעיה | תוסף פתוח נטען מאפס בהתקנת תוסף אחר | קריסת התוכנה בסגירת טאב תוסף |
| מוקד | `plugin_system_bloc`, `open_tool_tab`, `tool_tab_screen` | `plugin_runtime_dispatcher` |

הם משלימים, ושני הקומיטים של #812 מושכים לכיוונים הפוכים ביחס לבאג שכאן:

- `487764a9` (תוסף לא נטען מאפס) מונע `dispose` מיותר של `PluginTabPage` בהתקנה, ולכן *מפחית* קריאות ל-`unregisterController`.
- `573fcdbe` (הסרת תוסף סוגרת את הכרטיסיה הפתוחה שלו) *מוסיף* מסלול שסוגר כרטיסיית תוסף אוטומטית. כל סגירה כזו מגיעה ל-`PluginTabPage.dispose` → `unregisterController`, כלומר מייצרת בדיוק את חלון הזמן שמפיל את `dispatchEvent` כאן.

בשני המקרים #812 לא נוגע בשורש — הוא משנה כמה פעמים המחווה קורית, לא מה קורה כשהיא נופלת בזמן `await`. אם #812 נכנס לפני התיקון הזה, כדאי לדעת שהסגירה האוטומטית שהוא מוסיף פועלת על אותו נתיב שקורס.

## מחוץ להיקף

שני ממצאים שעלו בסקירה ולא נכללו כאן, כדי לשמור על תיקון מינימלי וממוקד:

- `dispatchEvent` קורא ל-`PluginLazyActivationService.onBroadcast` (שורה 485) בלי בדיקת `_shutdownMode` חוזרת. מכיוון ש-`_prepareControllersForTeardown` מנקה רק את המפה החיצונית, `hasUsableInstance` מחזיר `false` לכל תוסף ועלול להרים מנוע רקע חדש תוך כדי כיבוי. עד עכשיו ה-`ConcurrentModificationError` "הגן" על הנתיב הזה בכך שקטע את הלולאה לפניו.
- ל-`evaluateJavascript` במסלול המסירה (שורות 470, 577) אין `.timeout`, בעוד ששני מסלולי ה-lifecycle באותו קובץ (279, 298) כן עוטפים ב-3 שניות עם הערה מפורשת שהם חייבים. controller תקוע אחד עוצר את האירוע לשאר התוספים.
