### PR TITLE
צורת הדף: המפרשים נגללים במקום לקפוץ, וגלילה מהירה שאינה נתקעת

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -677,6 +677,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | התאמת מפרשי צורת הדף בין ספרים (היקף קטגוריה) | `test/text_book/view/page_shape/page_shape_category_commentator_matching_test.dart` |
 | חלונית הצד של צורת הדף (3 לשוניות) | `test/text_book/view/page_shape/page_shape_sidebar_tabs_test.dart` |
 | סנכרון המפרש בצורת הדף (יעד תחילת בלוק, מרחק הגלישה) | `test/text_book/view/page_shape/commentary_sync_helper_test.dart` |
+| שער הבנייה מחדש בגלילה (buildWhen בשורש עץ הספר) | `test/text_book/view/visible_indices_rebuild_gate_test.dart` |
 | תפריט הקשר בצורת הדף (מפרשים / קטע היעד) | `test/text_book/view/page_shape/simple_text_viewer_context_menu_test.dart` |
 | תת-תפריט "מפרשים" המשותף + מדיניות הצגה | `test/text_book/utils/commentators_context_menu_test.dart` |
 | SimpleTextViewer | `test/text_book/view/page_shape/simple_text_viewer_test.dart` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -676,6 +676,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Page shape commentary selection | `test/text_book/view/page_shape_commentary_selection_test.dart` |
 | התאמת מפרשי צורת הדף בין ספרים (היקף קטגוריה) | `test/text_book/view/page_shape/page_shape_category_commentator_matching_test.dart` |
 | חלונית הצד של צורת הדף (3 לשוניות) | `test/text_book/view/page_shape/page_shape_sidebar_tabs_test.dart` |
+| סנכרון המפרש בצורת הדף (יעד תחילת בלוק, מרחק הגלישה) | `test/text_book/view/page_shape/commentary_sync_helper_test.dart` |
 | תפריט הקשר בצורת הדף (מפרשים / קטע היעד) | `test/text_book/view/page_shape/simple_text_viewer_context_menu_test.dart` |
 | תת-תפריט "מפרשים" המשותף + מדיניות הצגה | `test/text_book/utils/commentators_context_menu_test.dart` |
 | SimpleTextViewer | `test/text_book/view/page_shape/simple_text_viewer_test.dart` |

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -35,12 +35,19 @@ import 'package:otzaria/text_book/utils/reading_segments.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
-  // שאילתת הקישורים חוסמת את ה-thread שמצייר (sqlite3 סינכרוני), ולכן החלון
-  // רחב והסף גבוה: בגלילה מהירה הוא נטען פעם ל-~400 שורות במקום כל 20.
+  // השאילתה עצמה רצה ב-Isolate, אבל כל טעינה גוררת פענוח התוצאה, מיזוג
+  // הקישורים ובנייה מחדש של חלונית המפרשים על ה-thread שמצייר. הסף — ולא
+  // גודל החלון — הוא שקובע את התדירות: טעינה כל ~120 שורות במקום כל ~20.
+  /// כמה שורות אחורה נטענות סביב הנראה. חייב להיות ≥ [linksReloadThresholdLines].
   @visibleForTesting
-  static const int linkLookBehindLines = 200;
+  static const int linkLookBehindLines = 150;
+
+  /// כמה שורות קדימה נטענות סביב הנראה. חייב להיות ≥ [linksReloadThresholdLines],
+  /// אחרת שורות בין קצה הכיסוי לנקודת הטעינה יישארו בלי קישורים.
   @visibleForTesting
-  static const int linkLookAheadLines = 400;
+  static const int linkLookAheadLines = 200;
+
+  /// המרחק מקצה החלון הטעון שבו נטענת מנה חדשה. קובע את תדירות הטעינות.
   @visibleForTesting
   static const int linksReloadThresholdLines = 120;
   static const int _initialContentLookBehindLines = 80;
@@ -1496,7 +1503,6 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         _loadLinksInBackground(
           currentState.book,
           event.visibleIndecies,
-          fromScroll: true,
         );
       }
     }
@@ -2607,9 +2613,6 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     }
   }
 
-  /// [fromScroll] מסמן קריאה שנובעת מתזוזת גלילה בלבד. שם היעדים אינם
-  /// משתנים, ולכן די להשוות את החלון מול היעדים שכבר נטענו — בלי לפתור אותם
-  /// מחדש, פעולה שממיינת את כל המפרשים הזמינים ובונה מהם מפתח מחרוזת.
   Future<void> _loadLinksInBackground(
     TextBook book,
     List<int> visibleIndices, {
@@ -2617,7 +2620,6 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     Iterable<String>? targetBookTitlesOverride,
     bool forceLoadAll = false,
     String? workspaceId,
-    bool fromScroll = false,
   }) async {
     final runtimeStateBeforeWindowCheck = state;
     if (!force &&
@@ -2627,20 +2629,6 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     }
 
     final window = _calculateLinksWindow(visibleIndices);
-
-    // יציאה מוקדמת לגלילה: החלון שנטען עדיין מכסה את הנראה, ואין צורך
-    // בפתירת היעדים היקרה שהתבצעה כאן בכל תזוזה.
-    if (fromScroll &&
-        !force &&
-        _loadedLinksTargetBookTitlesSignature != null &&
-        _isLinksWindowSufficient(
-          book.title,
-          window.start,
-          window.end,
-          _loadedLinksTargetBookTitlesSignature!,
-        )) {
-      return;
-    }
 
     if (_isLoadingLinks) {
       _pendingLinksReload = true;

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -35,9 +35,14 @@ import 'package:otzaria/text_book/utils/reading_segments.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
-  static const int _linkLookBehindLines = 60;
-  static const int _linkLookAheadLines = 140;
-  static const int _linksReloadThresholdLines = 20;
+  // שאילתת הקישורים חוסמת את ה-thread שמצייר (sqlite3 סינכרוני), ולכן החלון
+  // רחב והסף גבוה: בגלילה מהירה הוא נטען פעם ל-~400 שורות במקום כל 20.
+  @visibleForTesting
+  static const int linkLookBehindLines = 200;
+  @visibleForTesting
+  static const int linkLookAheadLines = 400;
+  @visibleForTesting
+  static const int linksReloadThresholdLines = 120;
   static const int _initialContentLookBehindLines = 80;
   static const int _initialContentLookAheadLines = 180;
   static const int _contentLookBehindLines = 120;
@@ -1491,6 +1496,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         _loadLinksInBackground(
           currentState.book,
           event.visibleIndecies,
+          fromScroll: true,
         );
       }
     }
@@ -1508,15 +1514,15 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
 
   ({int start, int end}) _calculateLinksWindow(List<int> visibleIndices) {
     if (visibleIndices.isEmpty) {
-      return (start: 0, end: _linkLookAheadLines);
+      return (start: 0, end: linkLookAheadLines);
     }
 
     final minVisible = visibleIndices.reduce((a, b) => a < b ? a : b);
     final maxVisible = visibleIndices.reduce((a, b) => a > b ? a : b);
 
     return (
-      start: (minVisible - _linkLookBehindLines).clamp(0, minVisible),
-      end: maxVisible + _linkLookAheadLines,
+      start: (minVisible - linkLookBehindLines).clamp(0, minVisible),
+      end: maxVisible + linkLookAheadLines,
     );
   }
 
@@ -1530,8 +1536,8 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         _loadedLinksStart != null &&
         _loadedLinksEnd != null &&
         _loadedLinksTargetBookTitlesSignature == targetBookTitlesSignature &&
-        start >= (_loadedLinksStart! - _linksReloadThresholdLines) &&
-        end <= (_loadedLinksEnd! + _linksReloadThresholdLines);
+        start >= (_loadedLinksStart! - linksReloadThresholdLines) &&
+        end <= (_loadedLinksEnd! + linksReloadThresholdLines);
   }
 
   List<String>? _normalizeTargetBookTitles(Iterable<String>? targetBookTitles) {
@@ -2601,6 +2607,9 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     }
   }
 
+  /// [fromScroll] מסמן קריאה שנובעת מתזוזת גלילה בלבד. שם היעדים אינם
+  /// משתנים, ולכן די להשוות את החלון מול היעדים שכבר נטענו — בלי לפתור אותם
+  /// מחדש, פעולה שממיינת את כל המפרשים הזמינים ובונה מהם מפתח מחרוזת.
   Future<void> _loadLinksInBackground(
     TextBook book,
     List<int> visibleIndices, {
@@ -2608,6 +2617,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     Iterable<String>? targetBookTitlesOverride,
     bool forceLoadAll = false,
     String? workspaceId,
+    bool fromScroll = false,
   }) async {
     final runtimeStateBeforeWindowCheck = state;
     if (!force &&
@@ -2617,6 +2627,20 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
     }
 
     final window = _calculateLinksWindow(visibleIndices);
+
+    // יציאה מוקדמת לגלילה: החלון שנטען עדיין מכסה את הנראה, ואין צורך
+    // בפתירת היעדים היקרה שהתבצעה כאן בכל תזוזה.
+    if (fromScroll &&
+        !force &&
+        _loadedLinksTargetBookTitlesSignature != null &&
+        _isLinksWindowSufficient(
+          book.title,
+          window.start,
+          window.end,
+          _loadedLinksTargetBookTitlesSignature!,
+        )) {
+      return;
+    }
 
     if (_isLoadingLinks) {
       _pendingLinksReload = true;

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -648,7 +648,7 @@ class TextBookLoaded extends TextBookState {
 /// [previous] ו-[current] הם המצב הקודם והנוכחי של ה-bloc.
 /// מחזיר `true` כשצריך לבנות מחדש. ההשוואה עוברת דרך `copyWith`, ולכן שדה
 /// שיתווסף ל-props ולא ל-`copyWith` יישבר כאן בשקט — ראו את בדיקת הסחיפה
-/// ב-`text_book_state_test.dart`.
+/// ב-`test/text_book/view/visible_indices_rebuild_gate_test.dart`.
 bool textBookStateDiffersBeyondVisibleIndices(
   TextBookState previous,
   TextBookState current,

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -638,3 +638,23 @@ class TextBookLoaded extends TextBookState {
     permanentHighlightLine,
   ];
 }
+
+/// האם ההבדל בין שני מצבים נוגע במשהו מלבד רשימת השורות הגלויות.
+///
+/// משמש כ-`buildWhen` בעץ תצוגת הספר. `visibleIndices` מתעדכן כמעט בכל
+/// תזוזת גלילה, ואף חלק מהתצוגה אינו נגזר ממנו — מי שצריך את המיקום הנוכחי
+/// קורא אותו חי מ-`positionsListener` דרך `resolveTopmostSourceLine`.
+///
+/// [previous] ו-[current] הם המצב הקודם והנוכחי של ה-bloc.
+/// מחזיר `true` כשצריך לבנות מחדש. ההשוואה עוברת דרך `copyWith`, ולכן שדה
+/// שיתווסף ל-props ולא ל-`copyWith` יישבר כאן בשקט — ראו את בדיקת הסחיפה
+/// ב-`text_book_state_test.dart`.
+bool textBookStateDiffersBeyondVisibleIndices(
+  TextBookState previous,
+  TextBookState current,
+) {
+  if (previous is! TextBookLoaded || current is! TextBookLoaded) {
+    return true;
+  }
+  return previous.copyWith(visibleIndices: current.visibleIndices) != current;
+}

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -1682,6 +1682,8 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
   final ItemScrollController _scrollController = ItemScrollController();
   final ItemPositionsListener _positionsListener =
       ItemPositionsListener.create();
+  final ScrollOffsetController _scrollOffsetController =
+      ScrollOffsetController();
   List<Link> _relevantLinks = [];
   int? _lastSyncedIndex; // האינדקס האחרון שסונכרן
   int _initialSyncAttempts = 0; // ניסיונות סנכרון ראשוני עד שה-controller מחובר
@@ -1929,6 +1931,10 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
   /// בראש). אותו ערך משמש גם לבחירת שורת המקור וגם ליישור המפרש, כדי
   /// ששניהם יהיו באותו מיקום אנכי.
   static const double _syncAlignment = 1 / 3;
+
+  /// סף בפיקסלים שמתחתיו היעד נחשב כבר במקומו. בלעדיו תזוזה של שבר פיקסל
+  /// הייתה יורה אנימציה חדשה שמבטלת את הקודמת.
+  static const double _glideEpsilonPixels = 2;
 
   /// מחזיר את אינדקס השורה שבכשליש העליון של ה-viewport מתוך השורות
   /// הגלויות. הסנכרון מכוון לנקודה זו ולא לשורה העליונה, כדי שהמפרש
@@ -2327,41 +2333,77 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       return;
     }
 
-    // אם כבר סונכרנו לאינדקס הזה ואין לחיצה מפורשת - לא צריך לגלול שוב
-    if (targetIndex == _lastSyncedIndex && state.selectedIndex == null) {
-      return;
-    }
-
-    // גלילה למיקום הנכון במפרש
+    // יעד חוזר אינו נחסם כאן: הגלישה מודדת מרחק אמיתי ויוצאת מעצמה, וכך
+    // גלישה שנקטעה (גרירה בחלונית, שינוי גובה בהשלמת חלון) מתקנת את עצמה.
     if (targetIndex >= 0 &&
         targetIndex < _content!.length &&
         _scrollController.isAttached) {
       // במצב טעינת-חלונות: מזניק טעינה סביב היעד כדי שהשורות ימולאו
       // מיד אחרי הקפיצה (מאזין המיקומים ישלים חלונות בהמשך הגלילה).
-      if (_useWindowedLoading) {
+      if (_useWindowedLoading && targetIndex != _lastSyncedIndex) {
         unawaited(_ensureWindowLoaded(targetIndex, targetIndex));
       }
-      // סנכרון מגלילה רציפה (או ראשוני) — קפיצה מיידית כדי שהמפרש יעקוב
-      // צמוד אחר הטקסט הראשי. אנימציה כאן הייתה יוצרת פיגור והתנגשות בין
-      // אנימציות עוקבות, וגם בונה אלפי פריטים בזמן אנימציה (תקיעה).
-      // רק לחיצה מפורשת על שורה מקבלת גלילה מונפשת.
-      // מציב את שורת היעד בכשליש העליון של חלון המפרש (_syncAlignment),
-      // מקביל לשורת המקור שנבחרה מאותה נקודה ב-viewport של הטקסט הראשי,
-      // ולא בראש החלון.
-      if (_lastSyncedIndex == null || state.selectedIndex == null) {
+      if (_lastSyncedIndex == null) {
+        // סנכרון ראשוני: הרשימה נבנתה מאינדקס 0 וחייבת להגיע למקומה מיד.
         _scrollController.jumpTo(
           index: targetIndex,
           alignment: _syncAlignment,
         );
-      } else {
+      } else if (state.selectedIndex != null) {
         _scrollController.scrollTo(
           index: targetIndex,
           duration: const Duration(milliseconds: 300),
           alignment: _syncAlignment,
         );
+      } else {
+        _glideToTarget(targetIndex);
       }
       _lastSyncedIndex = targetIndex;
     }
+  }
+
+  /// מזיז את המפרש ליעד בגלילה רציפה במקום בקפיצה.
+  ///
+  /// `jumpTo` מחליף את פריט העוגן ומרכיב מחדש את החלונית כולה; כשהיעד כבר
+  /// גלוי די בהזזת ההיסט בפיקסלים, בלי בנייה מחדש.
+  void _glideToTarget(int targetIndex) {
+    final position = _visiblePositionFor(targetIndex);
+    final viewportHeight =
+        context.size?.height ?? MediaQuery.sizeOf(context).height;
+
+    // יעד שלא נפרש — המרחק בפיקסלים אינו ידוע, ורק קפיצה תגיע אליו.
+    if (position == null || viewportHeight <= 0) {
+      _scrollController.jumpTo(index: targetIndex, alignment: _syncAlignment);
+      return;
+    }
+
+    final delta = CommentarySyncHelper.glideDelta(
+      leadingEdge: position.itemLeadingEdge,
+      viewportHeight: viewportHeight,
+      alignment: _syncAlignment,
+      epsilon: _glideEpsilonPixels,
+    );
+    if (delta == null) {
+      return;
+    }
+
+    unawaited(
+      _scrollOffsetController.animateScroll(
+        offset: delta,
+        duration: const Duration(milliseconds: 120),
+        curve: Curves.easeOut,
+      ),
+    );
+  }
+
+  /// המיקום הנוכחי של [index] אם הוא בין הפריטים שנפרשו, אחרת null.
+  ItemPosition? _visiblePositionFor(int index) {
+    for (final position in _positionsListener.itemPositions.value) {
+      if (position.index == index) {
+        return position;
+      }
+    }
+    return null;
   }
 
   @override
@@ -2410,6 +2452,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
               openBookCallback: widget.openBookCallback,
               scrollController: _scrollController,
               positionsListener: _positionsListener,
+              scrollOffsetController: _scrollOffsetController,
               isMainText: false,
               bookTitle: widget.commentatorName, // לפתיחה בטאב נפרד
               labelForIndex: _commentaryToc == null

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -932,6 +932,7 @@ class _PageShapeScreenState extends State<PageShapeScreen> {
               body: LoadingIndicator(),
             )
           : TextBookStateBuilder(
+              buildWhen: textBookStateDiffersBeyondVisibleIndices,
               loadingWidget: const Scaffold(
                 body: LoadingIndicator(),
               ),
@@ -2428,6 +2429,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
     }
 
     return TextBookStateBuilder(
+      buildWhen: textBookStateDiffersBeyondVisibleIndices,
       loadingWidget: const SizedBox(),
       builder: (context, state) {
         return BlocBuilder<SettingsBloc, SettingsState>(

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -2334,14 +2334,19 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       return;
     }
 
-    // יעד חוזר אינו נחסם כאן: הגלישה מודדת מרחק אמיתי ויוצאת מעצמה, וכך
-    // גלישה שנקטעה (גרירה בחלונית, שינוי גובה בהשלמת חלון) מתקנת את עצמה.
+    // יעד שכבר סונכרנו אליו אינו נוגע במפרש שוב. בלי זה כל emission של
+    // ה-bloc (למשל חימום התוכן ברקע) היה גורר חזרה לעוגן גלילה ידנית
+    // שהמשתמש עשה בחלונית.
+    if (targetIndex == _lastSyncedIndex && state.selectedIndex == null) {
+      return;
+    }
+
     if (targetIndex >= 0 &&
         targetIndex < _content!.length &&
         _scrollController.isAttached) {
       // במצב טעינת-חלונות: מזניק טעינה סביב היעד כדי שהשורות ימולאו
       // מיד אחרי הקפיצה (מאזין המיקומים ישלים חלונות בהמשך הגלילה).
-      if (_useWindowedLoading && targetIndex != _lastSyncedIndex) {
+      if (_useWindowedLoading) {
         unawaited(_ensureWindowLoaded(targetIndex, targetIndex));
       }
       if (_lastSyncedIndex == null) {

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -322,6 +322,10 @@ class SimpleTextViewer extends StatefulWidget {
   final Function(OpenedTab) openBookCallback;
   final ItemScrollController? scrollController;
   final ItemPositionsListener? positionsListener;
+
+  /// גלילה יחסית בפיקסלים. הטקסט הראשי לוקח אותו מה-state; מפרש שמסונכרן
+  /// ברציפות מקבל כאן controller משלו, ובלעדיו הסנכרון נופל לקפיצות.
+  final ScrollOffsetController? scrollOffsetController;
   final bool isMainText; // האם זה הטקסט המרכזי או מפרש
   final String? title; // כותרת (לכותרת עליונה)
   final String? bookTitle; // שם הספר (למפרשים - לפתיחה בטאב נפרד)
@@ -367,6 +371,7 @@ class SimpleTextViewer extends StatefulWidget {
     required this.openBookCallback,
     this.scrollController,
     this.positionsListener,
+    this.scrollOffsetController,
     this.isMainText = false,
     this.title,
     this.bookTitle,
@@ -2545,7 +2550,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
                                         scrollOffsetController:
                                             widget.isMainText
                                             ? state.scrollOffsetController
-                                            : null,
+                                            : widget.scrollOffsetController,
                                         itemCount: itemCount,
                                         padding: const EdgeInsets.all(4),
                                         itemBuilder: (context, index) =>

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -2409,6 +2409,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         // תוכן
         Expanded(
           child: BlocBuilder<TextBookBloc, TextBookState>(
+            buildWhen: textBookStateDiffersBeyondVisibleIndices,
             builder: (context, state) {
               if (state is! TextBookLoaded) {
                 return const Center(child: CircularProgressIndicator());

--- a/lib/text_book/view/page_shape/utils/commentary_sync_helper.dart
+++ b/lib/text_book/view/page_shape/utils/commentary_sync_helper.dart
@@ -49,16 +49,21 @@ class CommentarySyncHelper {
 
     final mainLineNumber = logicalMainIndex + 1; // המרה ל-1-based
 
-    // מציאת הקישור הקודם הקרוב ביותר (before) והבא הקרוב ביותר (after)
+    // שורת מקור אחת מקושרת לעיתים לעשרות שורות מפרש; בוחרים את תחילת הבלוק,
+    // אחרת היעד נקבע לפי סדר הרשימה — שאינו מובטח — והנחיתה משתנה בין טעינות.
     Link? before;
     Link? after;
     for (final link in linksForCommentary) {
       if (link.index1 <= mainLineNumber) {
-        if (before == null || link.index1 > before.index1) {
+        if (before == null ||
+            link.index1 > before.index1 ||
+            (link.index1 == before.index1 && link.index2 < before.index2)) {
           before = link;
         }
       } else {
-        if (after == null || link.index1 < after.index1) {
+        if (after == null ||
+            link.index1 < after.index1 ||
+            (link.index1 == after.index1 && link.index2 < after.index2)) {
           after = link;
         }
       }
@@ -69,5 +74,26 @@ class CommentarySyncHelper {
       return before.index2 - 1; // המרה ל-0-based
     }
     return after == null ? null : after.index2 - 1;
+  }
+
+  /// המרחק בפיקסלים שיש לגלול כדי ששורת היעד תשב על קו העוגן.
+  ///
+  /// [leadingEdge] - הקצה העליון של שורת היעד, כשבר מגובה החלון
+  /// [viewportHeight] - גובה חלון המפרש בפיקסלים
+  /// [alignment] - קו העוגן, כשבר מגובה החלון
+  /// [epsilon] - סף בפיקסלים שמתחתיו היעד נחשב במקומו
+  /// מחזיר null כשאין צורך לזוז — כך שתזוזה של שבר פיקסל לא תירה אנימציה
+  /// חדשה שמבטלת את הקודמת.
+  static double? glideDelta({
+    required double leadingEdge,
+    required double viewportHeight,
+    required double alignment,
+    required double epsilon,
+  }) {
+    final delta = (leadingEdge - alignment) * viewportHeight;
+    if (!delta.isFinite || delta.abs() < epsilon) {
+      return null;
+    }
+    return delta;
   }
 }

--- a/lib/text_book/view/text_book_scaffold.dart
+++ b/lib/text_book/view/text_book_scaffold.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/view/strategies/strategies.dart';
 import 'package:otzaria/text_book/widgets/text_book_state_builder.dart';
 
@@ -47,6 +48,7 @@ class TextBookScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextBookStateBuilder(
+      buildWhen: textBookStateDiffersBeyondVisibleIndices,
       builder: (context, state) {
         // Select the appropriate strategy based on current state
         final strategy = _selectStrategy(state);

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -629,7 +629,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
         book: state.book,
         links: state.links,
         activeCommentators: state.activeCommentators,
-        startLine: state.visibleIndices.first,
+        startLine: _topmostVisibleSourceLine(state),
         removeNikud: state.removeNikud,
         removeTaamim: !context.read<SettingsBloc>().state.showTeamim,
         tableOfContents: state.tableOfContents,
@@ -1178,6 +1178,8 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
           builder: (context, tabsState) {
             return BlocConsumer<TextBookBloc, TextBookState>(
               bloc: context.read<TextBookBloc>(),
+              // ה-listener ממשיך לרוץ על כל מצב; רק הבנייה מדלגת.
+              buildWhen: textBookStateDiffersBeyondVisibleIndices,
               listener: (context, state) {
                 // [EDITING DISABLED]
                 // if (state is TextBookLoaded &&
@@ -2447,7 +2449,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
             book: state.book,
             links: state.links,
             activeCommentators: state.activeCommentators,
-            startLine: state.visibleIndices.first,
+            startLine: _topmostVisibleSourceLine(state),
             removeNikud: state.removeNikud,
             removeTaamim: !settingsState.showTeamim,
             tableOfContents: state.tableOfContents,
@@ -3134,7 +3136,7 @@ bool _handleGlobalKeyEvent(
         book: state.book,
         links: state.links,
         activeCommentators: state.activeCommentators,
-        startLine: state.visibleIndices.first,
+        startLine: _topmostVisibleSourceLine(state),
         removeNikud: state.removeNikud,
         removeTaamim: !settingsState.showTeamim,
         tableOfContents: state.tableOfContents,
@@ -3180,9 +3182,7 @@ bool _handleGlobalKeyEvent(
       copySectionMarkLinkShortcut.isNotEmpty ||
       copyTextMarkLinkShortcut.isNotEmpty) {
     final bookId = state.book.id;
-    final index =
-        selectedLineForNote ??
-        (state.visibleIndices.isNotEmpty ? state.visibleIndices.first : 0);
+    final index = selectedLineForNote ?? _topmostVisibleSourceLine(state);
 
     if (ShortcutHelper.matchesShortcut(event, copyBookLinkShortcut)) {
       if (bookId == null) {
@@ -3329,7 +3329,7 @@ Future<void> _addNoteFromKeyboard(
   final currentIndex =
       (hasSelection ? selectedLineIndex : null) ??
       state.selectedIndex ??
-      (state.visibleIndices.isNotEmpty ? state.visibleIndices.first : 0);
+      _topmostVisibleSourceLine(state);
 
   // קבלת הטקסט המזהה של השורה (כמו שיוצג ככותרת ההערה), או הטקסט המסומן
   final referenceText = hasSelection

--- a/test/text_book/bloc/text_book_bloc_test.dart
+++ b/test/text_book/bloc/text_book_bloc_test.dart
@@ -15,6 +15,11 @@ import 'package:otzaria/text_book/text_book_repository.dart';
 import 'package:otzaria/text_book/view/page_shape/utils/page_shape_settings_manager.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
+/// שורה שחורגת בוודאות מחלון הקישורים שנטען סביב תחילת הספר, ולכן מחייבת
+/// שאילתה חדשה. נגזר מהקבועים כדי שכוונון החלון לא ישבור את הבדיקות.
+const int _farLine =
+    TextBookBloc.linkLookAheadLines + TextBookBloc.linksReloadThresholdLines;
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -46,7 +51,7 @@ void main() {
 
       expect(repository.getBookLinksInRangeCalls, 1);
       expect(repository.lastStartIndex, 0);
-      expect(repository.lastEndIndex, 150);
+      expect(repository.lastEndIndex, 10 + TextBookBloc.linkLookAheadLines);
       expect(repository.lastTargetBookTitles, isEmpty);
 
       await bloc.close();
@@ -75,7 +80,7 @@ void main() {
 
       expect(repository.getBookLinksInRangeCalls, 1);
       expect(repository.lastStartIndex, 0);
-      expect(repository.lastEndIndex, 150);
+      expect(repository.lastEndIndex, 10 + TextBookBloc.linkLookAheadLines);
       expect(repository.lastTargetBookTitles, isEmpty);
 
       await bloc.close();
@@ -409,7 +414,7 @@ void main() {
         expect((bloc.state as TextBookLoaded).visibleIndices, const [0]);
         expect(repository.lastStartIndex, 0);
 
-        bloc.add(const UpdateVisibleIndecies([84, 85, 86]));
+        bloc.add(UpdateVisibleIndecies([_farLine, _farLine + 1, _farLine + 2]));
 
         await _waitFor(
           () => repository.getBookLinksInRangeCalls >= 2,
@@ -418,10 +423,16 @@ void main() {
 
         expect(
           (bloc.state as TextBookLoaded).visibleIndices,
-          const [84, 85, 86],
+          [_farLine, _farLine + 1, _farLine + 2],
         );
-        expect(repository.lastStartIndex, 24);
-        expect(repository.lastEndIndex, 226);
+        expect(
+          repository.lastStartIndex,
+          _farLine - TextBookBloc.linkLookBehindLines,
+        );
+        expect(
+          repository.lastEndIndex,
+          _farLine + 2 + TextBookBloc.linkLookAheadLines,
+        );
 
         await bloc.close();
       },
@@ -466,8 +477,14 @@ void main() {
           description: 'getBookLinksInRangeCalls >= 2',
         );
 
-        expect(repository.lastStartIndex, 1741);
-        expect(repository.lastEndIndex, 1941);
+        expect(
+          repository.lastStartIndex,
+          1801 - TextBookBloc.linkLookBehindLines,
+        );
+        expect(
+          repository.lastEndIndex,
+          1801 + TextBookBloc.linkLookAheadLines,
+        );
 
         await bloc.close();
       },
@@ -761,7 +778,8 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
       expect(repository.getBookLinksInRangeCalls, 1);
 
-      bloc.add(const UpdateVisibleIndecies([80, 81, 82]));
+      // חורג מחלון הקישורים שכבר נטען, אחרת הגלילה נענית ממנו בלי שאילתה.
+      bloc.add(UpdateVisibleIndecies([_farLine, _farLine + 1, _farLine + 2]));
       await Future<void>.delayed(const Duration(milliseconds: 30));
 
       expect(repository.getBookLinksInRangeCalls, 2);
@@ -887,16 +905,20 @@ void main() {
 
         await Future<void>.delayed(const Duration(milliseconds: 50));
 
-        bloc.add(const UpdateVisibleIndecies([40, 41, 42]));
+        // גלילה בתוך החלון שכבר נטען אינה מייצרת שאילתה נוספת.
+        bloc.add(const UpdateVisibleIndecies([20, 21, 22]));
         await Future<void>.delayed(const Duration(milliseconds: 80));
-        expect(repository.getBookLinksInRangeCalls, 2);
+        expect(repository.getBookLinksInRangeCalls, 1);
 
         bloc.add(const UpdateCommentators(['אבן עזרא על בראשית']));
         await Future<void>.delayed(const Duration(milliseconds: 80));
 
-        expect(repository.getBookLinksInRangeCalls, 3);
+        expect(repository.getBookLinksInRangeCalls, 2);
         expect(repository.lastStartIndex, 0);
-        expect(repository.lastEndIndex, 182);
+        expect(
+          repository.lastEndIndex,
+          22 + TextBookBloc.linkLookAheadLines,
+        );
         expect(repository.lastTargetBookTitles, ['אבן עזרא על בראשית']);
 
         await bloc.close();

--- a/test/text_book/bloc/text_book_bloc_test.dart
+++ b/test/text_book/bloc/text_book_bloc_test.dart
@@ -925,6 +925,137 @@ void main() {
       },
     );
 
+    group('חלון טעינת הקישורים', () {
+      test('הכיסוי קדימה ואחורה מגיע לפחות עד נקודת הטעינה מחדש', () {
+        // אילו הכיסוי היה קטן מהסף, שורות שבין קצה הכיסוי לנקודת הטעינה
+        // היו מוצגות בלי מפרשים ושום טעינה לא הייתה מופעלת עבורן.
+        expect(
+          TextBookBloc.linkLookAheadLines,
+          greaterThanOrEqualTo(TextBookBloc.linksReloadThresholdLines),
+        );
+        expect(
+          TextBookBloc.linkLookBehindLines,
+          greaterThanOrEqualTo(TextBookBloc.linksReloadThresholdLines),
+        );
+      });
+
+      test('הסף גדול דיו כדי לא לטעון מחדש בכל תזוזת שורה', () {
+        expect(TextBookBloc.linksReloadThresholdLines, greaterThan(20));
+      });
+
+      test('גלילה בתוך החלון הטעון אינה מייצרת שאילתה נוספת', () async {
+        final repository = _FakeTextBookRepository();
+        final bloc = _createBloc(
+          repository: repository,
+          showPageShapeView: false,
+          commentators: const ['רש"י על בראשית'],
+        );
+
+        bloc.add(
+          const LoadContent(
+            fontSize: 20,
+            showSplitView: false,
+            removeNikud: false,
+            loadCommentators: false,
+          ),
+        );
+
+        await _waitFor(
+          () => repository.getBookLinksInRangeCalls >= 1,
+          description: 'טעינה ראשונה',
+        );
+        final afterLoad = repository.getBookLinksInRangeCalls;
+
+        for (final index in [12, 15, 18, 21, 24]) {
+          bloc.add(UpdateVisibleIndecies([index, index + 1]));
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+
+        expect(repository.getBookLinksInRangeCalls, afterLoad);
+
+        await bloc.close();
+      });
+
+      test('גלילה מעבר לחלון הטעון מייצרת שאילתה', () async {
+        final repository = _FakeTextBookRepository();
+        final bloc = _createBloc(
+          repository: repository,
+          showPageShapeView: false,
+          commentators: const ['רש"י על בראשית'],
+        );
+
+        bloc.add(
+          const LoadContent(
+            fontSize: 20,
+            showSplitView: false,
+            removeNikud: false,
+            loadCommentators: false,
+          ),
+        );
+
+        await _waitFor(
+          () => repository.getBookLinksInRangeCalls >= 1,
+          description: 'טעינה ראשונה',
+        );
+
+        bloc.add(UpdateVisibleIndecies([_farLine, _farLine + 1]));
+
+        await _waitFor(
+          () => repository.getBookLinksInRangeCalls >= 2,
+          description: 'טעינה אחרי חריגה מהחלון',
+        );
+
+        expect(
+          repository.lastEndIndex,
+          _farLine + 1 + TextBookBloc.linkLookAheadLines,
+        );
+
+        await bloc.close();
+      });
+
+      test(
+        'בצורת הדף בחירת מפרש בחלונית הצד אינה מנתקת את הקישורים',
+        () async {
+          // רגרסיה: UpdateCommentators דורס את הקישורים ביעדים של הסרגל.
+          // אם הגלילה שאחריו לא תפתור מחדש את יעדי צורת הדף, חלוניות
+          // המפרשים יישארו בלי קישורים ויפסיקו לעקוב אחרי הטקסט.
+          final repository = _FakeTextBookRepository();
+          final bloc = _createBloc(
+            repository: repository,
+            showPageShapeView: true,
+            commentators: const ['רש"י על בראשית'],
+          );
+
+          bloc.add(
+            const LoadContent(
+              fontSize: 20,
+              showSplitView: false,
+              removeNikud: false,
+              loadCommentators: false,
+            ),
+          );
+
+          await _waitFor(
+            () => repository.getBookLinksInRangeCalls >= 1,
+            description: 'טעינה ראשונה',
+          );
+
+          bloc.add(const UpdateCommentators(['אבן עזרא על בראשית']));
+          await Future<void>.delayed(const Duration(milliseconds: 80));
+          final afterOverride = repository.getBookLinksInRangeCalls;
+
+          bloc.add(const UpdateVisibleIndecies([12, 13, 14]));
+
+          await _waitFor(
+            () => repository.getBookLinksInRangeCalls > afterOverride,
+            description: 'הגלילה פותרת מחדש את יעדי צורת הדף',
+          );
+
+          await bloc.close();
+        },
+      );
+    });
+
     test('ToggleLeftPane לא פולט state חדש אם הערך לא השתנה', () async {
       final repository = _FakeTextBookRepository();
       final bloc = _createBloc(

--- a/test/text_book/view/page_shape/commentary_sync_helper_test.dart
+++ b/test/text_book/view/page_shape/commentary_sync_helper_test.dart
@@ -205,5 +205,83 @@ void main() {
       expect(delta(double.nan), isNull);
       expect(delta(0.5, viewportHeight: double.infinity), isNull);
     });
+
+    test('הסף נמדד בפיקסלים ולא בשבר החלון', () {
+      // אותו שבר סטייה: בחלון נמוך הוא פחות מ-2 פיקסלים ונבלע, בחלון גבוה
+      // הוא חורג ומזיז. בלי זה חלוניות בגדלים שונים היו מתנהגות אחרת.
+      const drift = 0.005;
+
+      expect(delta(alignment + drift, viewportHeight: 200), isNull);
+      expect(delta(alignment + drift, viewportHeight: 2000), isNotNull);
+    });
+
+    test('מעט מעל הסף — כן זזים', () {
+      expect(delta(alignment + (epsilon + 0.5) / 600), isNotNull);
+    });
+
+    test('הסימן עקבי עם כיוון הסטייה', () {
+      expect(delta(0.9)!, isPositive);
+      expect(delta(0.05)!, isNegative);
+    });
+
+    test('גובה חלון אפס או שלילי אינו מייצר תזוזה', () {
+      // מגן על מסלול שבו טרם נמדדה פריסה; בלעדיו הדלתא הייתה 0 ומתפרשת
+      // כ"היעד במקומו" גם כשהוא רחוק.
+      expect(delta(0.9, viewportHeight: 0), isNull);
+    });
+
+    test('יעד מחוץ לחלון הנראה מייצר תזוזה גדולה מגובה החלון', () {
+      // itemLeadingEdge יכול לחרוג מ-[0,1] כשהפריט מעל או מתחת ל-viewport.
+      expect(delta(2.0)!.abs(), greaterThan(600));
+    });
+  });
+
+  group('getLogicalIndex', () {
+    test('שורה רגילה מוחזרת כמות שהיא', () {
+      expect(CommentarySyncHelper.getLogicalIndex(1, const ['a', 'b']), 1);
+    });
+
+    test('כותרת מדלגת לשורה שאחריה', () {
+      // כותרות אינן נושאות קישורים, ולכן היעד נגזר מהשורה שמתחתן; בלי זה
+      // כל כותרת נראית כפער מלאכותי במקור.
+      const content = ['<h1>פרק א</h1>', 'תוכן'];
+
+      expect(CommentarySyncHelper.getLogicalIndex(0, content), 1);
+    });
+
+    test('רצף כותרות מדלג עד לתוכן', () {
+      const content = ['<h1>א</h1>', '<h2>ב</h2>', '<h3>ג</h3>', 'תוכן'];
+
+      expect(CommentarySyncHelper.getLogicalIndex(0, content), 3);
+    });
+
+    test('כותרות עד סוף התוכן מחזירות את האינדקס המקורי', () {
+      const content = ['תוכן', '<h1>סוף</h1>'];
+
+      expect(CommentarySyncHelper.getLogicalIndex(1, content), 1);
+    });
+
+    test('אינדקס מחוץ לטווח מוחזר כמות שהוא', () {
+      expect(CommentarySyncHelper.getLogicalIndex(9, const ['a']), 9);
+      expect(CommentarySyncHelper.getLogicalIndex(-1, const ['a']), -1);
+    });
+  });
+
+  group('isHeaderLine', () {
+    test('מזהה כותרות בכל הרמות', () {
+      for (final level in [1, 2, 3, 4, 5, 6]) {
+        expect(CommentarySyncHelper.isHeaderLine('<h$level>כותרת'), isTrue);
+      }
+    });
+
+    test('מזהה כותרת עם רווח מוביל ובאותיות גדולות', () {
+      expect(CommentarySyncHelper.isHeaderLine('  <H2>כותרת'), isTrue);
+    });
+
+    test('טקסט רגיל אינו כותרת', () {
+      expect(CommentarySyncHelper.isHeaderLine('שורת תוכן'), isFalse);
+      expect(CommentarySyncHelper.isHeaderLine('<p>פסקה'), isFalse);
+      expect(CommentarySyncHelper.isHeaderLine(''), isFalse);
+    });
   });
 }

--- a/test/text_book/view/page_shape/commentary_sync_helper_test.dart
+++ b/test/text_book/view/page_shape/commentary_sync_helper_test.dart
@@ -111,5 +111,99 @@ void main() {
         0,
       );
     });
+
+    test('שורת מקור עם כמה קטעי מפרש — נצמד לתחילת הבלוק', () {
+      // אור החיים על בראשית מגיע ל-63 קישורים על שורת מקור אחת.
+      final links = [
+        _link(index1: 10, index2: 80),
+        _link(index1: 10, index2: 42),
+        _link(index1: 10, index2: 57),
+      ];
+      expect(
+        CommentarySyncHelper.getCommentaryTargetIndex(
+          linksForCommentary: links,
+          logicalMainIndex: 9,
+        ),
+        41, // index2(42) - 1 — הקטע הראשון, לא זה שבמקרה ראשון ברשימה
+      );
+    });
+
+    test('היעד אינו תלוי בסדר הקישורים באותה שורת מקור', () {
+      final ascending = [
+        _link(index1: 7, index2: 20),
+        _link(index1: 7, index2: 35),
+      ];
+      final descending = [
+        _link(index1: 7, index2: 35),
+        _link(index1: 7, index2: 20),
+      ];
+      for (final links in [ascending, descending]) {
+        expect(
+          CommentarySyncHelper.getCommentaryTargetIndex(
+            linksForCommentary: links,
+            logicalMainIndex: 6,
+          ),
+          19, // index2(20) - 1, בשני סדרי הקלט
+        );
+      }
+    });
+
+    test('קישור הבא בריבוי קטעים — גם הוא נצמד לתחילת הבלוק', () {
+      // אין קישור קודם, ולכן נופלים על הקישור הבא הראשון.
+      final links = [
+        _link(index1: 30, index2: 90),
+        _link(index1: 30, index2: 65),
+      ];
+      expect(
+        CommentarySyncHelper.getCommentaryTargetIndex(
+          linksForCommentary: links,
+          logicalMainIndex: 4,
+        ),
+        64, // index2(65) - 1
+      );
+    });
+  });
+
+  group('glideDelta', () {
+    const alignment = 1 / 3;
+    const epsilon = 2.0;
+
+    double? delta(double leadingEdge, {double viewportHeight = 600}) =>
+        CommentarySyncHelper.glideDelta(
+          leadingEdge: leadingEdge,
+          viewportHeight: viewportHeight,
+          alignment: alignment,
+          epsilon: epsilon,
+        );
+
+    test('היעד כבר על קו העוגן — אין תזוזה', () {
+      expect(delta(alignment), isNull);
+    });
+
+    test('סטייה מתחת לסף — אין תזוזה', () {
+      // 1.8 פיקסלים: מתחת ל-2, אחרת כל שבר פיקסל היה יורה אנימציה חדשה.
+      expect(delta(alignment + 1.8 / 600), isNull);
+    });
+
+    test('היעד מתחת לקו העוגן — גלילה קדימה', () {
+      // חצי חלון מתחת לשליש: 600*(0.5-1/3) = 100
+      expect(delta(0.5), closeTo(100, 0.001));
+    });
+
+    test('היעד מעל קו העוגן — גלילה אחורה', () {
+      expect(delta(0), closeTo(-200, 0.001));
+    });
+
+    test('גובה חלון גדול יותר מגדיל את התזוזה באותו יחס', () {
+      final small = delta(0.5, viewportHeight: 300)!;
+      final large = delta(0.5, viewportHeight: 900)!;
+
+      expect(large, closeTo(small * 3, 0.001));
+    });
+
+    test('ערך לא סופי אינו מייצר תזוזה', () {
+      expect(delta(double.nan), isNull);
+      expect(delta(0.5, viewportHeight: double.infinity), isNull);
+    });
   });
 }

--- a/test/text_book/view/visible_indices_rebuild_gate_test.dart
+++ b/test/text_book/view/visible_indices_rebuild_gate_test.dart
@@ -2,15 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/links.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/utils/reading_segments.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show SearchScope;
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 /// שער הבנייה מחדש של עץ תצוגת הספר.
 ///
 /// המלכוד המרכזי: `buildWhen` על ווידג'ט פנימי אינו מונע בנייה כשההורה
-/// נבנה — הוא רק מקפיא את המצב שנמסר. לכן השער חייב לשבת גם בשורש העץ,
-/// ובדיקה שמאמתת רק את הפרדיקט הטהור תעבור גם כשהשער כולו חסר תועלת.
+/// נבנה — הוא רק מקפיא את המצב שנמסר. לכן השער חייב לשבת גם בשורש העץ.
 void main() {
   group('textBookStateDiffersBeyondVisibleIndices', () {
     test('תזוזת גלילה בלבד אינה מצדיקה בנייה מחדש', () {
@@ -20,11 +23,20 @@ void main() {
       expect(textBookStateDiffersBeyondVisibleIndices(before, after), isFalse);
     });
 
+    test('רשימת שורות גלויות זהה בערכה אינה מצדיקה בנייה', () {
+      final before = _loaded();
+      final after = before.copyWith(visibleIndices: [...before.visibleIndices]);
+
+      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isFalse);
+    });
+
     test('כותרת שהשתנתה עם הגלילה כן מצדיקה בנייה מחדש', () {
+      // currentTitle נגזר מהשורה הגלויה ומוצג בפס הכותרת; אילו נחסם יחד עם
+      // visibleIndices הוא היה קופא על הכותרת הראשונה.
       final before = _loaded();
       final after = before.copyWith(
         visibleIndices: const [7, 8, 9],
-        currentTitle: 'סימן ב',
+        currentTitle: 'סימן אחר',
       );
 
       expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
@@ -36,7 +48,7 @@ void main() {
       expect(
         textBookStateDiffersBeyondVisibleIndices(
           before,
-          before.copyWith(selectedIndex: 4),
+          before.copyWith(selectedIndex: before.selectedIndex! + 1),
         ),
         isTrue,
       );
@@ -47,6 +59,29 @@ void main() {
       final after = before.copyWith(
         continuousReadingMode: !before.continuousReadingMode,
         visibleIndices: const [3],
+      );
+
+      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+    });
+
+    test('גרסת תוכן חדשה מצדיקה בנייה גם כשאורך התוכן זהה', () {
+      // טעינת חלון מה-DB מחליפה שורות בלי לשנות את האורך; contentVersion
+      // הוא מה שמבדיל, ובלעדיו התוכן החדש לא היה מצויר.
+      final before = _loaded();
+      final after = before.copyWith(
+        content: const ['אחר', 'אחר', 'אחר'],
+        contentVersion: before.contentVersion + 1,
+        visibleIndices: const [5],
+      );
+
+      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+    });
+
+    test('סיום טעינת הקישורים מצדיק בנייה מחדש', () {
+      final before = _loaded();
+      final after = before.copyWith(
+        linksLoading: !before.linksLoading,
+        visibleIndices: const [9],
       );
 
       expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
@@ -63,15 +98,47 @@ void main() {
 
       expect(textBookStateDiffersBeyondVisibleIndices(initial, loaded), isTrue);
       expect(textBookStateDiffersBeyondVisibleIndices(loaded, initial), isTrue);
+      expect(
+        textBookStateDiffersBeyondVisibleIndices(initial, initial),
+        isTrue,
+      );
     });
 
-    test('copyWith מכסה כל שדה שמשתתף בהשוואה', () {
+    test('copyWith משמר כל שדה שמשתתף בהשוואה', () {
       // ההשוואה בנויה על כך ש-copyWith משמר כל שדה ב-props. שדה שיתווסף
       // ל-props ולא ל-copyWith יחזור לברירת המחדל, ההשוואה תראה "זהה",
-      // ובנייה תיחסם בטעות בדיוק כשהיא נדרשת.
+      // ובנייה תיחסם בטעות בדיוק כשהיא נדרשת. הבדיקה תופסת זאת רק אם כל
+      // שדה ב-fixture נושא ערך שאינו ברירת המחדל של הבנאי.
       final state = _loaded();
 
       expect(state.copyWith(), equals(state));
+    });
+
+    test('ה-fixture אינו נשען על ברירות המחדל של הבנאי', () {
+      // שומר על הבדיקה שמעליה: אם שדה כאן יחזור לברירת מחדל, מוטציה
+      // ב-copyWith תעבור בשקט.
+      final state = _loaded();
+
+      expect(state.showLeftPane, isTrue);
+      expect(state.linksLoading, isTrue);
+      expect(state.hasDraft, isTrue);
+      expect(state.isEditorOpen, isTrue);
+      expect(state.pinLeftPane, isTrue);
+      expect(state.removePunctuation, isTrue);
+      expect(state.isTanach, isTrue);
+      expect(state.continuousReadingMode, isTrue);
+      expect(state.searchText, isNotEmpty);
+      expect(state.highlightText, isNotEmpty);
+      expect(state.searchDistance, isNot(0));
+      expect(state.searchMode, isNot(SearchMode.exact));
+      expect(state.selectedIndex, isNotNull);
+      expect(state.currentTitle, isNotNull);
+      expect(state.searchResultLines, isNotNull);
+      expect(state.permanentHighlightLine, isNotNull);
+      expect(state.selectedIndices, isNotEmpty);
+      expect(state.selectedLinkTypes, isNotEmpty);
+      expect(state.readingSegments, isNotEmpty);
+      expect(state.visibleLinks, isNotEmpty);
     });
   });
 
@@ -82,23 +149,15 @@ void main() {
       var leafBuilds = 0;
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: BlocProvider.value(
-            value: cubit,
-            child: BlocBuilder<_StateCubit, TextBookState>(
-              buildWhen: textBookStateDiffersBeyondVisibleIndices,
-              builder: (context, _) {
-                rootBuilds++;
-                return BlocBuilder<_StateCubit, TextBookState>(
-                  buildWhen: textBookStateDiffersBeyondVisibleIndices,
-                  builder: (context, _) {
-                    leafBuilds++;
-                    return const SizedBox();
-                  },
-                );
-              },
-            ),
-          ),
+        _tree(
+          cubit,
+          guardRoot: true,
+          onRoot: () {
+            rootBuilds++;
+          },
+          onLeaf: (_) {
+            leafBuilds++;
+          },
         ),
       );
 
@@ -118,6 +177,29 @@ void main() {
       await cubit.close();
     });
 
+    testWidgets('שינוי שאינו גלילה עובר את השער ובונה מחדש', (tester) async {
+      final cubit = _StateCubit(_loaded());
+      var leafBuilds = 0;
+
+      await tester.pumpWidget(
+        _tree(
+          cubit,
+          guardRoot: true,
+          onLeaf: (_) {
+            leafBuilds++;
+          },
+        ),
+      );
+
+      final baseline = leafBuilds;
+      cubit.retitle('סימן חדש');
+      await tester.pump();
+
+      expect(leafBuilds, greaterThan(baseline));
+
+      await cubit.close();
+    });
+
     testWidgets('הסרת השער מהשורש מבטלת גם את השער בעלה', (tester) async {
       // מתעד למה השער חייב לשבת בשורש: `buildWhen` בעלה אינו עוצר בנייה
       // שמגיעה מההורה, ובנוסף מוסר לו מצב ישן.
@@ -126,22 +208,13 @@ void main() {
       List<int>? leafSaw;
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: BlocProvider.value(
-            value: cubit,
-            child: BlocBuilder<_StateCubit, TextBookState>(
-              builder: (context, _) {
-                return BlocBuilder<_StateCubit, TextBookState>(
-                  buildWhen: textBookStateDiffersBeyondVisibleIndices,
-                  builder: (context, state) {
-                    leafBuilds++;
-                    leafSaw = (state as TextBookLoaded).visibleIndices;
-                    return const SizedBox();
-                  },
-                );
-              },
-            ),
-          ),
+        _tree(
+          cubit,
+          guardRoot: false,
+          onLeaf: (state) {
+            leafBuilds++;
+            leafSaw = state.visibleIndices;
+          },
         ),
       );
 
@@ -162,57 +235,160 @@ void main() {
 
       await cubit.close();
     });
+
+    testWidgets('רצף חסימות אינו צובר פער — המצב מתעדכן בשינוי הבא', (
+      tester,
+    ) async {
+      // הפרדיקט טרנזיטיבי, ולכן שרשרת דילוגים לא יכולה להשאיר את העלה
+      // עם מצב ישן אחרי ששדה אמיתי משתנה.
+      final cubit = _StateCubit(_loaded());
+      TextBookLoaded? leafSaw;
+
+      await tester.pumpWidget(
+        _tree(
+          cubit,
+          guardRoot: true,
+          onLeaf: (state) {
+            leafSaw = state;
+          },
+        ),
+      );
+
+      for (var i = 0; i < 4; i++) {
+        cubit.scrollTo([i]);
+        await tester.pump();
+      }
+      cubit.retitle('אחרי הרצף');
+      await tester.pump();
+
+      expect(leafSaw!.currentTitle, 'אחרי הרצף');
+      expect(leafSaw!.visibleIndices, const [3]);
+
+      await cubit.close();
+    });
   });
+}
+
+Widget _tree(
+  _StateCubit cubit, {
+  required bool guardRoot,
+  VoidCallback? onRoot,
+  required void Function(TextBookLoaded state) onLeaf,
+}) {
+  return MaterialApp(
+    home: BlocProvider.value(
+      value: cubit,
+      child: BlocBuilder<_StateCubit, TextBookState>(
+        buildWhen: guardRoot ? textBookStateDiffersBeyondVisibleIndices : null,
+        builder: (context, _) {
+          onRoot?.call();
+          return BlocBuilder<_StateCubit, TextBookState>(
+            buildWhen: textBookStateDiffersBeyondVisibleIndices,
+            builder: (context, state) {
+              onLeaf(state as TextBookLoaded);
+              return const SizedBox();
+            },
+          );
+        },
+      ),
+    ),
+  );
 }
 
 class _StateCubit extends Cubit<TextBookState> {
   _StateCubit(super.initialState);
 
   void scrollTo(List<int> visibleIndices) {
-    final current = state as TextBookLoaded;
-    emit(current.copyWith(visibleIndices: visibleIndices));
+    emit((state as TextBookLoaded).copyWith(visibleIndices: visibleIndices));
+  }
+
+  void retitle(String title) {
+    emit((state as TextBookLoaded).copyWith(currentTitle: title));
   }
 }
 
+Link _link(int index1, int index2) => Link(
+  heRef: 'ref',
+  index1: index1,
+  path2: 'commentary.txt',
+  index2: index2,
+  connectionType: 'commentary',
+);
+
+/// מצב שבו **כל** שדה שמשתתף בהשוואה נושא ערך שאינו ברירת המחדל של הבנאי,
+/// כדי ששער הסחיפה מעל יתפוס שדה שנשמט מ-`copyWith`.
 TextBookLoaded _loaded() => TextBookLoaded(
   book: TextBook(title: 'ספר בדיקה'),
-  content: const ['שורה א', 'שורה ב'],
-  contentVersion: 1,
-  fontSize: 20,
-  showLeftPane: false,
-  showSplitView: false,
-  showTzuratHadafView: false,
+  content: const ['שורה א', 'שורה ב', 'שורה ג'],
+  contentVersion: 3,
+  fontSize: 22,
+  showLeftPane: true,
+  showSplitView: true,
+  showTzuratHadafView: true,
   showPageShapeView: true,
-  activeCommentators: const [],
+  activeCommentators: const ['רש"י'],
   commentatorGroups: const [],
-  availableCommentators: const [],
-  rareCommentators: const {},
-  links: const [],
-  linksByLine: const {},
-  visibleLinks: const [],
-  selectedLinkTypes: const {},
-  tableOfContents: const [],
-  removeNikud: false,
-  removePunctuation: false,
-  isTanach: false,
-  nikudExemptByTanach: false,
-  punctuationExemptByTanach: false,
-  supportsContinuousReadingMode: false,
-  continuousReadingMode: false,
-  readingSegments: const [],
-  visibleIndices: const [0],
-  selectedIndices: const {},
-  pinLeftPane: false,
-  searchText: '',
-  searchOptions: const {},
-  alternativeWords: const {},
-  spacingValues: const {},
-  searchMode: SearchMode.exact,
-  searchDistance: 0,
-  matchPolicy: SearchMatchPolicy.standard,
+  availableCommentators: const ['רש"י', 'רמב"ן'],
+  rareCommentators: const {'אור החיים'},
+  links: [_link(1, 1)],
+  linksByLine: {
+    1: [_link(1, 1)],
+  },
+  visibleLinks: [_link(1, 1)],
+  selectedLinkTypes: const {'COMMENTARY'},
+  tableOfContents: [TocEntry(text: 'סימן א', index: 0, level: 1)],
+  removeNikud: true,
+  removePunctuation: true,
+  isTanach: true,
+  nikudExemptByTanach: true,
+  punctuationExemptByTanach: true,
+  commentaryRemoveNikudOverride: true,
+  commentaryRemovePunctuationOverride: true,
+  supportsContinuousReadingMode: true,
+  continuousReadingMode: true,
+  readingSegments: const [
+    ReadingSegment(
+      text: 'שורה א',
+      sourceLineIndices: [0],
+      lineRanges: [ReadingLineRange(lineIndex: 0, start: 0, end: 6)],
+      isHeader: false,
+    ),
+  ],
+  visibleIndices: const [1, 2],
+  selectedIndex: 1,
+  selectedIndices: const {1},
+  pinLeftPane: true,
+  searchText: 'חיפוש',
+  searchOptions: const {
+    'חיפוש_0': {'סיומות': true},
+  },
+  alternativeWords: const {
+    0: ['חלופה'],
+  },
+  spacingValues: const {'0-1': '1'},
+  searchMode: SearchMode.advanced,
+  searchDistance: 4,
+  matchPolicy: const SearchMatchPolicy(
+    proximityScope: SearchScope.sameParagraph,
+  ),
+  searchResultLines: const {2},
   scrollController: ItemScrollController(),
   positionsListener: ItemPositionsListener.create(),
-  linksLoading: false,
-  hasLinksFile: false,
-  highlightText: '',
+  currentTitle: 'סימן א',
+  selectedTextForNote: 'טקסט',
+  selectedTextSectionIndex: 1,
+  selectedTextStart: 2,
+  selectedTextEnd: 5,
+  highlightedLine: 2,
+  linksLoading: true,
+  pinpointHighlightIndex: 1,
+  pinpointHighlightText: 'מודגש',
+  isEditorOpen: true,
+  editorIndex: 1,
+  editorSectionId: 'section',
+  editorText: 'עריכה',
+  hasDraft: true,
+  hasLinksFile: true,
+  highlightText: 'הדגשה',
+  permanentHighlightLine: 2,
 );

--- a/test/text_book/view/visible_indices_rebuild_gate_test.dart
+++ b/test/text_book/view/visible_indices_rebuild_gate_test.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+/// שער הבנייה מחדש של עץ תצוגת הספר.
+///
+/// המלכוד המרכזי: `buildWhen` על ווידג'ט פנימי אינו מונע בנייה כשההורה
+/// נבנה — הוא רק מקפיא את המצב שנמסר. לכן השער חייב לשבת גם בשורש העץ,
+/// ובדיקה שמאמתת רק את הפרדיקט הטהור תעבור גם כשהשער כולו חסר תועלת.
+void main() {
+  group('textBookStateDiffersBeyondVisibleIndices', () {
+    test('תזוזת גלילה בלבד אינה מצדיקה בנייה מחדש', () {
+      final before = _loaded();
+      final after = before.copyWith(visibleIndices: const [7, 8, 9]);
+
+      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isFalse);
+    });
+
+    test('כותרת שהשתנתה עם הגלילה כן מצדיקה בנייה מחדש', () {
+      final before = _loaded();
+      final after = before.copyWith(
+        visibleIndices: const [7, 8, 9],
+        currentTitle: 'סימן ב',
+      );
+
+      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+    });
+
+    test('בחירת שורה מצדיקה בנייה מחדש', () {
+      final before = _loaded();
+
+      expect(
+        textBookStateDiffersBeyondVisibleIndices(
+          before,
+          before.copyWith(selectedIndex: 4),
+        ),
+        isTrue,
+      );
+    });
+
+    test('מעבר מצב קריאה רציף מצדיק בנייה מחדש', () {
+      final before = _loaded();
+      final after = before.copyWith(
+        continuousReadingMode: !before.continuousReadingMode,
+        visibleIndices: const [3],
+      );
+
+      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+    });
+
+    test('מצב שאינו טעון תמיד נבנה', () {
+      final loaded = _loaded();
+      final initial = TextBookInitial.named(
+        TextBook(title: 'ספר'),
+        0,
+        false,
+        const [],
+      );
+
+      expect(textBookStateDiffersBeyondVisibleIndices(initial, loaded), isTrue);
+      expect(textBookStateDiffersBeyondVisibleIndices(loaded, initial), isTrue);
+    });
+
+    test('copyWith מכסה כל שדה שמשתתף בהשוואה', () {
+      // ההשוואה בנויה על כך ש-copyWith משמר כל שדה ב-props. שדה שיתווסף
+      // ל-props ולא ל-copyWith יחזור לברירת המחדל, ההשוואה תראה "זהה",
+      // ובנייה תיחסם בטעות בדיוק כשהיא נדרשת.
+      final state = _loaded();
+
+      expect(state.copyWith(), equals(state));
+    });
+  });
+
+  group('שער הבנייה בעץ ווידג\'טים', () {
+    testWidgets('שער בשורש מונע בנייה של כל תת-העץ', (tester) async {
+      final cubit = _StateCubit(_loaded());
+      var rootBuilds = 0;
+      var leafBuilds = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider.value(
+            value: cubit,
+            child: BlocBuilder<_StateCubit, TextBookState>(
+              buildWhen: textBookStateDiffersBeyondVisibleIndices,
+              builder: (context, _) {
+                rootBuilds++;
+                return BlocBuilder<_StateCubit, TextBookState>(
+                  buildWhen: textBookStateDiffersBeyondVisibleIndices,
+                  builder: (context, _) {
+                    leafBuilds++;
+                    return const SizedBox();
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      final baseline = leafBuilds;
+      for (var i = 0; i < 5; i++) {
+        cubit.scrollTo([i, i + 1]);
+        await tester.pump();
+      }
+
+      expect(rootBuilds, 1, reason: 'השורש נבנה רק בפריים הראשון');
+      expect(
+        leafBuilds,
+        baseline,
+        reason: 'תזוזת גלילה אינה בונה מחדש את העלה',
+      );
+
+      await cubit.close();
+    });
+
+    testWidgets('הסרת השער מהשורש מבטלת גם את השער בעלה', (tester) async {
+      // מתעד למה השער חייב לשבת בשורש: `buildWhen` בעלה אינו עוצר בנייה
+      // שמגיעה מההורה, ובנוסף מוסר לו מצב ישן.
+      final cubit = _StateCubit(_loaded());
+      var leafBuilds = 0;
+      List<int>? leafSaw;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider.value(
+            value: cubit,
+            child: BlocBuilder<_StateCubit, TextBookState>(
+              builder: (context, _) {
+                return BlocBuilder<_StateCubit, TextBookState>(
+                  buildWhen: textBookStateDiffersBeyondVisibleIndices,
+                  builder: (context, state) {
+                    leafBuilds++;
+                    leafSaw = (state as TextBookLoaded).visibleIndices;
+                    return const SizedBox();
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      final baseline = leafBuilds;
+      cubit.scrollTo(const [41, 42]);
+      await tester.pump();
+
+      expect(
+        leafBuilds,
+        greaterThan(baseline),
+        reason: 'העלה נבנה למרות buildWhen, כי ההורה נבנה',
+      );
+      expect(
+        leafSaw,
+        isNot(const [41, 42]),
+        reason: 'ובנוסף הוא מקבל מצב ישן — לכן אין להסתמך על שער בעלה בלבד',
+      );
+
+      await cubit.close();
+    });
+  });
+}
+
+class _StateCubit extends Cubit<TextBookState> {
+  _StateCubit(super.initialState);
+
+  void scrollTo(List<int> visibleIndices) {
+    final current = state as TextBookLoaded;
+    emit(current.copyWith(visibleIndices: visibleIndices));
+  }
+}
+
+TextBookLoaded _loaded() => TextBookLoaded(
+  book: TextBook(title: 'ספר בדיקה'),
+  content: const ['שורה א', 'שורה ב'],
+  contentVersion: 1,
+  fontSize: 20,
+  showLeftPane: false,
+  showSplitView: false,
+  showTzuratHadafView: false,
+  showPageShapeView: true,
+  activeCommentators: const [],
+  commentatorGroups: const [],
+  availableCommentators: const [],
+  rareCommentators: const {},
+  links: const [],
+  linksByLine: const {},
+  visibleLinks: const [],
+  selectedLinkTypes: const {},
+  tableOfContents: const [],
+  removeNikud: false,
+  removePunctuation: false,
+  isTanach: false,
+  nikudExemptByTanach: false,
+  punctuationExemptByTanach: false,
+  supportsContinuousReadingMode: false,
+  continuousReadingMode: false,
+  readingSegments: const [],
+  visibleIndices: const [0],
+  selectedIndices: const {},
+  pinLeftPane: false,
+  searchText: '',
+  searchOptions: const {},
+  alternativeWords: const {},
+  spacingValues: const {},
+  searchMode: SearchMode.exact,
+  searchDistance: 0,
+  matchPolicy: SearchMatchPolicy.standard,
+  scrollController: ItemScrollController(),
+  positionsListener: ItemPositionsListener.create(),
+  linksLoading: false,
+  hasLinksFile: false,
+  highlightText: '',
+);


### PR DESCRIPTION
סוגר את issue #757: בתצוגת "צורת הדף" המפרשים קפצו למקום החדש במקום להיגלל אליו, והגלילה המהירה נתקעה.

## המפרשים קופצים

הסנכרון עבר ל-`jumpTo` גם בגלילה שוטפת (קומיט 6e607ec5d, יוני). `jumpTo` מחליף את פריט העוגן ומרכיב מחדש את החלונית כולה, וזה קרה בכל חציית קישור בכל אחת מארבע החלוניות.

כשהיעד כבר גלוי די בהזזת ההיסט בפיקסלים דרך `ScrollOffsetController` — אותו מסלול זול של גלילה רגילה, בלי בנייה מחדש. יעד שלא נפרש נשאר קפיצה, כי המרחק אליו אינו ידוע.

בנוסף, היעד עצמו לא היה יציב: שורת מקור מקושרת לעיתים לעשרות שורות מפרש (עד 63 באור החיים על בראשית), והבחירה ביניהן נקבעה לפי סדר הרשימה — שאינו מובטח. כעת נצמדים לתחילת הבלוק.

## הגלילה נתקעת

**בנייה מחדש של כל המסך בכל תזוזה.** `TextBookStateBuilder` ו-`BlocBuilder` של `SimpleTextViewer` רצו ללא `buildWhen`, ולכן כל emission בנה מחדש את הטקסט הראשי ואת ארבע החלוניות — פי חמישה מהתצוגה הרגילה, שמשלמת את אותו מחיר על רשימה אחת.

השער חייב לשבת בשורש: `buildWhen` על ווידג'ט פנימי אינו מונע בנייה שמגיעה מההורה, הוא רק מקפיא את המצב שנמסר. התנאי לכך הוא שאיש אינו נשען על `visibleIndices` מתוך מצב שנמסר לבנייה — חמישה צרכנים (הדפסה, העתקת קישור בקיצור, סימנייה) עברו ל-`_topmostVisibleSourceLine`, שקורא את המיקום חי מ-`positionsListener`. זה גם מיישר אותם עם שישה צרכנים שכבר השתמשו בו.

**תדירות טעינת הקישורים.** החלון היה 200 שורות עם סף 20, כלומר טעינה כל ~20 שורות תנועה. כעת 350 שורות עם סף 120 — טעינה כל ~120 שורות. השאילתה עצמה רצה ב-`Isolate.run`, אבל כל טעינה גוררת פענוח, מיזוג קישורים ובניית חלונית המפרשים על ה-thread שמצייר, ולכן התדירות היא המנוף.

## מה נבדק ונפסל

- **הרחבת ה-throttle של `visibleIndices` לצורת הדף** — ארבעה טסטים מקודדים במפורש שגלילה רגילה אינה נחסמת, וזו החלטת עיצוב מכוונת: ה-throttle נוצר למצב קריאה רציף, שבו השורה נגזרת משבר הגלילה בתוך פסקה ולכן משתנה בכל פריים.
- **אינטרפולציה בין קישורים** — מדידה על נתוני האמת הראתה שצד היעד כמעט רווי: ברש"י על בראשית יש מקרה אחד מתוך 1072 שבו זה היה משנה, ובברכות אפס. הרווח מוגבל למפרשים דלילים, והסיכון להתנגשות עם התנועה הרציפה ממשי.

## סקירת QA

ארבעה סוכני סקירה עברו על השינוי ומצאו שתי רגרסיות שתוקנו בקומיט האחרון:

1. **הקישורים נותקו בצורת הדף** — יציאה מוקדמת שהוספתי העבירה את חתימת היעדים שכבר נטענו כחתימה המבוקשת, כך שההשוואה בדקה שדה מול עצמו והייתה עיוורת לשינוי יעדים. אחרי בחירת מפרש בחלונית הצד החלוניות נשארו ריקות. היציאה הוסרה.
2. **גלילה ידנית בחלונית נגררה חזרה** — ביטול החסימה על יעד חוזר גרם לכל emission (למשל חימום התוכן ברקע, שרץ דווקא כשהמשתמש עומד וקורא) להנפיש את החלונית לעוגן. החסימה הוחזרה.

כן תוקנה הנחה שגויה שלי: שאילתות הקישורים אינן חוסמות את ה-thread הראשי — הן רצות ב-`Isolate.run`. השינוי נכון מסיבה אחרת, והחשבון תוקן (הסף קובע את התדירות, לא גודל החלון).

## בדיקות

`flutter analyze` נקי, **1363 טסטים עוברים**. נוספו 34 טסטים, ביניהם:

- שער הבנייה מחדש, כולל טסט שמתעד את המלכוד — `buildWhen` בעלה בלבד אינו עוצר בנייה מההורה **וגם** מוסר מצב ישן.
- שער סחיפה שמוודא ש-`copyWith` משמר כל שדה ב-`props`, מול מצב שכל שדה בו אינו ברירת מחדל (אחרת מוטציה עוברת בשקט).
- אינווריאנטים לחלון הקישורים: הכיסוי חייב להגיע לפחות עד נקודת הטעינה, אחרת שורות ביניים יוצגו בלי מפרשים ושום טעינה לא תופעל.
- רגרסיה לניתוק הקישורים אחרי בחירת מפרש.
- כיסוי ל-`glideDelta`, `getLogicalIndex` ו-`isHeaderLine`.

## מה לא נבדק

**האפליקציה לא הורצה על ידי — כל האימות הוא טסטים וקריאת קוד.** מומלץ לבדוק ידנית לפני מיזוג: גלילה בצורת הדף, ובמיוחד שסימנייה והדפסה נשמרות במיקום הנוכחי (שם שונו חמישה מקומות שקוראים את השורה הנוכחית).

נקודה פתוחה שסקירה העלתה ולא טופלה: `animateScroll` מדליק `IgnorePointer` למשך האנימציה (120ms), כך שלחיצה על המפרש בדיוק בחלון הזה עלולה להיבלע. הערכתי שהסיכון נמוך ולא מדדתי.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
