### PR TITLE
fix(windows): סמל הפתיחה נשאר תלוי על המסך אחרי קריסה

### DIFF
--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -162,6 +162,12 @@ static void BringWindowToFront(HWND hwnd) {
   if (hwnd == nullptr) return;
   if (IsIconic(hwnd)) {
     ShowWindow(hwnd, SW_RESTORE);
+  } else if (!IsWindowVisible(hwnd) && !splash::IsAnyInstanceShowing()) {
+    // חלון מוסתר בלי splash פעיל: המופע הראשון סיים את האתחול אך חלונו נעלם
+    // (קריסה אחרי החשיפה). בזמן אתחול אין לחשוף — presentMainWindow מדלג אז
+    // על ה-cloak ומחזיר בדיוק את ההבהוב שהוא נועד למנוע. ההבחנה תקפה כל עוד
+    // ה-splash חי, כלומר עד kMaxDisplayMs.
+    ShowWindow(hwnd, SW_SHOW);
   }
   SetForegroundWindow(hwnd);
 }

--- a/windows/runner/splash_window.cpp
+++ b/windows/runner/splash_window.cpp
@@ -28,6 +28,10 @@ constexpr int kFadeOutStep = 30;       // 178/30 ≈ 6 צעדים ≈ 90ms (fade
 // זמן תצוגה מינימלי (החזקה אחרי ה-fade-in): גם אם החשיפה (Close) מגיעה מוקדם
 // (האפליקציה נטענת מהר), הסמל יוחזק לפחות זמן זה לפני ה-fade-out — מונע "הבזק".
 constexpr ULONGLONG kMinDisplayMs = 800;
+// זמן תצוגה מרבי: Close מגיע רק מ-Dart, כך שקריסה לפני חשיפת החלון הראשי
+// הותירה את הסמל תלוי על המסך כל עוד התהליך חי. חייב להישאר גבוה מאתחול
+// תקין הארוך ביותר — שחזור seforim.db (כמה GB) על דיסק קר נמשך דקות.
+constexpr ULONGLONG kMaxDisplayMs = 300000;
 
 // g_splash_hwnd נכתב ע"י ה-thread *לפני* SetEvent(g_created_event) ונקרא ע"י
 // Close רק *אחרי* שה-WaitForSingleObject ב-Show חזר — האירוע מספק happens-before.
@@ -269,6 +273,9 @@ DWORD WINAPI SplashThreadProc(LPVOID) {
       if (!closing && WaitForSingleObject(g_close_event, 0) == WAIT_OBJECT_0) {
         closing = true;
       }
+      if (!closing && (GetTickCount64() - start) >= kMaxDisplayMs) {
+        closing = true;
+      }
       // מתחילים fade-out רק אחרי שעבר זמן התצוגה המינימלי (מונע הבזק).
       if (closing && (GetTickCount64() - start) >= kMinDisplayMs) {
         alpha -= kFadeOutStep;
@@ -283,10 +290,9 @@ DWORD WINAPI SplashThreadProc(LPVOID) {
     g_splash_hwnd = nullptr;
   }
 
-  if (g_close_event) {
-    CloseHandle(g_close_event);
-    g_close_event = nullptr;
-  }
+  // g_close_event אינו נסגר כאן: מאז שה-thread מסיים גם מעצמו (kMaxDisplayMs)
+  // ולא רק בעקבות Close, סגירה כאן עלולה להקדים SetEvent על ידית משוחררת.
+  // ידית בודדת לכל חיי התהליך — המערכת משחררת אותה ביציאה.
   if (SUCCEEDED(co)) {
     CoUninitialize();
   }
@@ -339,6 +345,10 @@ void Close() {
   }
   CloseHandle(g_splash_thread);
   g_splash_thread = nullptr;
+}
+
+bool IsAnyInstanceShowing() {
+  return FindWindowW(kSplashClassName, nullptr) != nullptr;
 }
 
 }  // namespace splash

--- a/windows/runner/splash_window.h
+++ b/windows/runner/splash_window.h
@@ -29,6 +29,10 @@ void Show();
 // בעת חשיפת החלון הראשי.
 void Close();
 
+// האם קיים חלון splash של אוצריא כלשהי — גם של תהליך אחר. מופע שני משתמש בזה
+// כדי להבחין בין מופע ראשון שעדיין באתחול לבין כזה שחלונו מוסתר שלא כדין.
+bool IsAnyInstanceShowing();
+
 }  // namespace splash
 
 #endif  // RUNNER_SPLASH_WINDOW_H_


### PR DESCRIPTION
## הבעיה

משתמש דיווח שאחרי שהתוכנה נסגרה לו, כל ניסיון לפתוח אותה מחדש הציג **סמל צף במרכז המסך למשך דקות, בלי ששום חלון נפתח**.

## שורש הבעיה

`splash::Close()` נקרא ממקום אחד בלבד — מ-Dart, דרך ערוץ `otzaria/splash`, בעת חשיפת החלון הראשי. ללולאת האנימציה ב-`SplashThreadProc` היה זמן תצוגה **מינימלי** (`kMinDisplayMs`) אך **לא מרבי**:

```cpp
if (!closing && WaitForSingleObject(g_close_event, 0) == WAIT_OBJECT_0) {
  closing = true;
}
```

כלומר: אם Dart לא הגיע לחשיפה, האות לעולם לא מגיע והלולאה רצה **כל עוד התהליך חי**.

וזה בדיוק המצב אחרי קריסה — התהליך **שורד** אותה, מפני ש-`PlatformDispatcher.instance.onError` ב-`lib/main.dart` מחזיר `true`. כך שהסמל שהמשתמש רואה תקוע אינו של ההפעלה החדשה, אלא **שריד של התהליך הקודם**.

## התיקון

**1. זמן תצוגה מרבי.** אחרי `kMaxDisplayMs` הלולאה עוברת ל-fade-out גם בלי אות מ-Dart.

הערך נבחר גבוה בהרבה מכל אתחול תקין. שחזור `seforim.db` (כמה GB) על דיסק קר, עם סריקת אנטי-וירוס, נמשך דקות — וזמן זה **אינו** מכוסה על ידי ה-failsafe שבצד Dart, שנדרך רק ב-`initState` של `MainWindowScreen`, כלומר אחרי שה-bootstrap כבר הסתיים. סגירה מוקדמת מדי הייתה מסתירה מהמשתמש אתחול שעודנו רץ תקין — מצב גרוע מהבאג המקורי.

**2. `g_close_event` אינו נסגר עוד ב-thread.** עד כה ה-thread הגיע לסגירה רק בעקבות `SetEvent` שקדם לה מ-`Close()`, וסיבתיות זו הבטיחה את הסדר. משהוא מסיים גם מעצמו, סגירה שם עלולה להקדים `SetEvent` על ידית משוחררת. ידית בודדת לכל חיי התהליך — המערכת משחררת אותה ביציאה.

**3. `BringWindowToFront` מטפל גם בחלון מוסתר.** הוא בדק רק `IsIconic`, כלומר ממוזער. חלון **מוסתר** — מצבו של מופע שקרס — לא זוהה, ו-`SetForegroundWindow` על חלון מוסתר אינו עושה דבר.

החשיפה מותנית בכך שאין `splash` פעיל, וזה מכוון: בזמן אתחול החלון מוסתר **בכוונה**, ו-`presentMainWindow` בודק `!await windowManager.isVisible()` כדי להחליט אם להפעיל `cloak`. חשיפה מוקדמת הייתה גורמת לו לדלג על ה-cloak ולהחזיר בדיוק את ההבהוב שכל המנגנון נועד למנוע.

## אימות

אין בפרויקט תשתית בדיקות ל-runner ב-C++, ולכן האימות הוא קומפילציה וסקירה:

```
flutter build windows --debug  →  √ Built build\windows\x64\runner\Debug\otzaria.exe
```

אומת ש-`main.obj` ו-`splash_window.obj` אכן נבנו מחדש.

נבדק גם שהמסלול החדש מגיע ל-fade-out: `kMaxDisplayMs` (300000) גדול מ-`kMinDisplayMs` (800), ולכן תנאי ה-fade-out מתקיים באותה איטרציה, `alpha` יורד ב-6 צעדים ומגיע ל-`break` ול-`DestroyWindow`.

## היקף — מה זה לא פותר

התיקון מסלק את הסמל התקוע ומאפשר לחלון מוסתר של מופע שקרס לעלות. הוא **אינו** משחרר את ה-mutex של המופע היחיד: אם התהליך הקודם תקוע לגמרי ואין לו חלון תקין להציג, המשתמש עדיין יזדקק למנהל המשימות. זיהוי-והריגה אוטומטיים של תהליך שאינו מגיב נשקלו ונדחו — אין דרך אמינה להבחין בין תהליך תקוע לבין תהליך שעסוק באינדוקס כבד, והמחיר של טעות הוא הריגת תהליך באמצע כתיבה למסד הנתונים.

הערה לתיעוד: אותו דפוס קיים גם ב-`linux/runner/splash_window.cc` — `splash_window_close()` נקרא שם רק מערוץ ה-Dart ואין לו חסם זמן. לא נגעתי בו כאן כדי לשמור על תיקון ממוקד ומאומת-בנייה לפלטפורמה אחת.
