### PR TITLE
אות גבוהה: הצגה מורמת מלאה לסימוני-עילית ולעוגנים לחיצים

### DIFF
--- a/lib/text_book/view/widgets/continuous_reading_paragraph.dart
+++ b/lib/text_book/view/widgets/continuous_reading_paragraph.dart
@@ -8,6 +8,7 @@ import 'package:otzaria/text_book/utils/link_preview_utils.dart';
 import 'package:otzaria/plugins/services/plugin_highlight_renderer.dart';
 import 'package:otzaria/plugins/view/plugin_highlight_frame_overlay.dart';
 import 'package:otzaria/widgets/smart_text/exact_line_height.dart';
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
 import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
 
 /// תגובה ללחיצה על קישור inline בתוך פסקה של מצב טקסט רציף.
@@ -75,6 +76,10 @@ dom.DocumentFragment _parseFragmentCached(String htmlText) {
   return fragment;
 }
 
+/// [hideRaisedMarkers] — כברירת מחדל גליפי הסימונים המורמים נפלטים שקופים,
+/// מתוך הנחה שהקורא עוטף את התוצאה ב-[RaisedMarkerOverlay.wrap] שמצייר אותם
+/// מורמים. קורא שמציג את הספאנים בלי השכבה חייב להעביר false — אחרת
+/// הסימונים ייעלמו מהמסך.
 List<InlineSpan> buildInlineHtmlSpans(
   String htmlText,
   TextStyle baseStyle, {
@@ -84,6 +89,7 @@ List<InlineSpan> buildInlineHtmlSpans(
   TextStyle? linkStyle,
   Color? anchorActiveBackground,
   List<TapGestureRecognizer>? recognizerSink,
+  bool hideRaisedMarkers = true,
 }) {
   final fragment = _parseFragmentCached(htmlText);
   return _nodesToSpans(
@@ -95,6 +101,7 @@ List<InlineSpan> buildInlineHtmlSpans(
     linkStyle: linkStyle,
     anchorActiveBackground: anchorActiveBackground,
     recognizerSink: recognizerSink,
+    hideRaisedMarkers: hideRaisedMarkers,
   );
 }
 
@@ -197,13 +204,28 @@ class _ContinuousReadingParagraphState
     final textSpan = TextSpan(style: widget.baseStyle, children: spans);
     // justify אינו מותח שורה אחרונה, ולכן גם לא פסקה בת שורה חזותית אחת.
     // מדידה מוקדמת של מספר השורות = layout שני על כל הפסקה, ומייקרת גלילה.
-    final text = Text.rich(
+    Widget result = Text.rich(
       textSpan,
       textAlign: widget.textAlign,
       strutStyle: exactLineHeightStrut(widget.baseStyle, textSpan),
     );
-    if (frameRanges.isEmpty) return text;
-    return PluginHighlightFrameOverlay(ranges: frameRanges, child: text);
+    if (frameRanges.isNotEmpty) {
+      result = PluginHighlightFrameOverlay(ranges: frameRanges, child: result);
+    }
+    // סימונים מורמים: כאן הספאנים הם טקסט טהור ואין דרך להרים אותם בפריסה,
+    // ולכן אותה שכבת ציור כמו במסך עיון. ספירת המופעים חייבת לרוץ על הפסקה
+    // כולה — לא לכל שורה בנפרד — כי השורות מאוחדות לטקסט אחד עם רווח מפריד,
+    // בדיוק כמו שהשכבה קוראת אותן מעץ הרינדור.
+    return RaisedMarkerOverlay.wrap(
+      context: context,
+      markers: RaisedMarkers.extract(
+        widget.lines.map((line) => line.htmlText ?? line.text).join(' '),
+      ),
+      baseStyle: widget.baseStyle,
+      linkColor: widget.linkStyle?.color,
+      activeBackground: widget.anchorActiveBackground,
+      child: result,
+    );
   }
 
   List<InlineSpan> _buildLineSpans(ContinuousReadingParagraphLine line) {
@@ -276,6 +298,7 @@ List<InlineSpan> _nodesToSpans(
   TextStyle? linkStyle,
   Color? anchorActiveBackground,
   List<TapGestureRecognizer>? recognizerSink,
+  bool hideRaisedMarkers = true,
 }) {
   final spans = <InlineSpan>[];
   for (final node in nodes) {
@@ -289,6 +312,7 @@ List<InlineSpan> _nodesToSpans(
         linkStyle: linkStyle,
         anchorActiveBackground: anchorActiveBackground,
         recognizerSink: recognizerSink,
+        hideRaisedMarkers: hideRaisedMarkers,
       ),
     );
   }
@@ -304,6 +328,7 @@ List<InlineSpan> _nodeToSpans(
   TextStyle? linkStyle,
   Color? anchorActiveBackground,
   List<TapGestureRecognizer>? recognizerSink,
+  bool hideRaisedMarkers = true,
 }) {
   if (node is dom.Text) {
     if (node.text.isEmpty) return const [];
@@ -322,22 +347,36 @@ List<InlineSpan> _nodeToSpans(
   if (node.localName == 'a' && onTapUrl != null) {
     final href = node.attributes['href'];
     if (href != null && href.isNotEmpty) {
-      final childStyle = _styleForElement(node, style);
+      final childStyle = _styleForElement(
+        node,
+        style,
+        hideRaisedMarkers: hideRaisedMarkers,
+      );
       // עוגן-מילה וטווח-ציטוט — צבע ה-primary של הנושא בלי קו תחתון; במצב
       // active מודגש עם רקע; שאר הקישורים — קו תחתון + צבע theme.
+      //
+      // כשהגליפים מוסתרים (hideRaisedMarkers) עוגן-מילה וסימון הערה נשארים
+      // שקופים: הצבע והרקע עוברים לציור המורם של RaisedMarkerOverlay, ורק
+      // ההדגשה של active נשארת כדי שרוחב המקום בשורה יתאים לציור.
       final effectiveLinkStyle = node.classes.contains('link-anchor')
           // הווריאנט שב-childStyle נשמר גם ב-active (מיזוג linkStyle היה גורר
           // קו תחתון של קישור ומוחק את קו-התחתון שהוא סימנו של וריאנט 5).
           ? (node.classes.contains('link-anchor-active')
                 ? childStyle.copyWith(
-                    color: linkStyle?.color,
+                    color: hideRaisedMarkers ? null : linkStyle?.color,
                     fontWeight: FontWeight.bold,
                     fontVariations: AppFonts.boldFontVariations(
                       childStyle.fontFamily,
                     ),
-                    backgroundColor: anchorActiveBackground,
+                    backgroundColor: hideRaisedMarkers
+                        ? null
+                        : anchorActiveBackground,
                   )
+                : hideRaisedMarkers
+                ? childStyle
                 : childStyle.copyWith(color: linkStyle?.color))
+          : node.classes.contains('book-note-marker') && hideRaisedMarkers
+          ? childStyle
           : node.classes.contains('numbered-note-marker')
           ? childStyle.copyWith(color: linkStyle?.color)
           : node.classes.contains('link-anchor-range')
@@ -357,6 +396,7 @@ List<InlineSpan> _nodeToSpans(
         linkStyle: linkStyle,
         anchorActiveBackground: anchorActiveBackground,
         recognizerSink: recognizerSink,
+        hideRaisedMarkers: hideRaisedMarkers,
       );
       final recognizer = TapGestureRecognizer()
         ..onTap = () {
@@ -367,24 +407,49 @@ List<InlineSpan> _nodeToSpans(
       final isHoverableAnchor =
           isPreviewHoverableUrl(href) &&
           (onAnchorHover != null || onAnchorExit != null);
+      final mouseCursor = isHoverableAnchor ? SystemMouseCursors.click : null;
+      final onEnter = isHoverableAnchor && onAnchorHover != null
+          ? (PointerEnterEvent event) => onAnchorHover(href, event.position)
+          : null;
+      final onExit = isHoverableAnchor && onAnchorExit != null
+          ? (PointerExitEvent _) => onAnchorExit(href)
+          : null;
+
+      // ה-hit-test של RenderParagraph מחזיר את ספאן-העלה שמכיל את הטקסט —
+      // recognizer שיושב רק על ספאן-האב לעולם אינו נפגע בלחיצה במיקום.
+      // לכן ההתנהגות מועתקת לכל עלה בתת-העץ (אותו recognizer משותף, כך
+      // שה-dispose דרך recognizerSink נשאר יחיד).
+      InlineSpan withLinkBehavior(InlineSpan span) {
+        if (span is! TextSpan) return span;
+        return TextSpan(
+          text: span.text,
+          style: span.style,
+          recognizer: recognizer,
+          mouseCursor: mouseCursor,
+          onEnter: onEnter,
+          onExit: onExit,
+          children: span.children?.map(withLinkBehavior).toList(),
+        );
+      }
+
       return [
         TextSpan(
           style: effectiveLinkStyle,
           recognizer: recognizer,
-          mouseCursor: isHoverableAnchor ? SystemMouseCursors.click : null,
-          onEnter: isHoverableAnchor && onAnchorHover != null
-              ? (event) => onAnchorHover(href, event.position)
-              : null,
-          onExit: isHoverableAnchor && onAnchorExit != null
-              ? (_) => onAnchorExit(href)
-              : null,
-          children: children,
+          mouseCursor: mouseCursor,
+          onEnter: onEnter,
+          onExit: onExit,
+          children: children.map(withLinkBehavior).toList(),
         ),
       ];
     }
   }
 
-  final childStyle = _styleForElement(node, style);
+  final childStyle = _styleForElement(
+    node,
+    style,
+    hideRaisedMarkers: hideRaisedMarkers,
+  );
   return _nodesToSpans(
     node.nodes,
     childStyle,
@@ -394,10 +459,15 @@ List<InlineSpan> _nodeToSpans(
     linkStyle: linkStyle,
     anchorActiveBackground: anchorActiveBackground,
     recognizerSink: recognizerSink,
+    hideRaisedMarkers: hideRaisedMarkers,
   );
 }
 
-TextStyle _styleForElement(dom.Element element, TextStyle parentStyle) {
+TextStyle _styleForElement(
+  dom.Element element,
+  TextStyle parentStyle, {
+  bool hideRaisedMarkers = true,
+}) {
   var style = parentStyle;
   final localName = element.localName;
 
@@ -417,17 +487,29 @@ TextStyle _styleForElement(dom.Element element, TextStyle parentStyle) {
   }
   // sup חשוף (למשל מייבוא Word) מוקטן כמו ב-fwfh, בלי נטייה; סמני ההערות
   // מוקטנים ונוטים לפי ה-CSS שהוגדר להם ב-SmartTextWidget.
-  if (localName == 'sup') {
+  // `processText` ממיר כל sup לא-מספרי ל-span (ראו raised_markers.dart), ולכן
+  // בפועל מגיע לכאן `raised-sup`; תג sup חשוף נשאר נתמך לקלט שלא עבר עיבוד.
+  if (localName == 'sup' || element.classes.contains(kRaisedSupClass)) {
     style = style.copyWith(
       fontSize: (style.fontSize ?? 18) * kHtmlSmallerFontScale,
     );
+    // הגליף עצמו שקוף — RaisedMarkerOverlay מצייר אותו מורם. תג sup חשוף
+    // (קלט שלא עבר processText) נשאר גלוי, שם אין סימון לשכבה לצייר.
+    if (hideRaisedMarkers && element.classes.contains(kRaisedSupClass)) {
+      style = style.copyWith(color: const Color(0x00000000));
+    }
   }
-  if (element.classes.contains('footnote-marker-number') ||
+  if (element.classes.contains(kFootnoteMarkerClass) ||
       element.classes.contains('book-note-marker')) {
     style = style.copyWith(
-      fontSize: (style.fontSize ?? 18) * 0.75,
+      fontSize: (style.fontSize ?? 18) * kFootnoteMarkerScale,
       fontStyle: FontStyle.italic,
     );
+    // גם סימון ההערה הלחיץ שקוף — RaisedMarkerOverlay מצייר אותו מורם
+    // ומפנה אליו לחיצות; ה-recognizer נשאר על הספאן שבשורה.
+    if (hideRaisedMarkers) {
+      style = style.copyWith(color: const Color(0x00000000));
+    }
   }
   // סמן-אות של מפרש: מוקטן, והטיפוגרפיה נקבעת אך ורק בווריאנט שהוקצה למפרש.
   // נטייה כפויה כאן הייתה מוחקת את ההבחנה בין המפרשים.
@@ -438,6 +520,10 @@ TextStyle _styleForElement(dom.Element element, TextStyle parentStyle) {
         fontSize: (style.fontSize ?? 18) * kLinkAnchorMarkerScale,
       ),
     );
+    // הגליף שקוף; הווריאנט נשאר עליו כדי שרוחב המקום יתאים לציור המורם.
+    if (hideRaisedMarkers) {
+      style = style.copyWith(color: const Color(0x00000000));
+    }
   }
   if (localName == 'i' ||
       localName == 'em' ||

--- a/lib/widgets/smart_text/raised_markers.dart
+++ b/lib/widgets/smart_text/raised_markers.dart
@@ -1,0 +1,715 @@
+/// הצגה מורמת של סימוני-עילית במסך עיון — "אות גבוהה".
+///
+/// הרקע: fwfh מממש `<sup>` ב-WidgetSpan, ומנוע Flutter משבץ placeholders
+/// בפסקת RTL בסדר ויזואלי במקום לוגי — שני סימונים באותה פסקה מוצגים הפוך
+/// (ראו `_fixFootnoteMarkers` ב-text_renderer_service.dart). לכן כל sup
+/// לא-מספרי מומר שם ל-span טקסט טהור, שסדרו מובטח.
+///
+/// אבל ל-fwfh אין תמיכה ב-`position`/`top` — הן היו no-op גם קודם, ולכן
+/// מרקרי הערות הוצגו מוקטנים ונטויים אך יושבים על קו הבסיס, בלי הרמה. וטקסט
+/// טהור אינו ניתן להרמה בפריסה בכלל.
+///
+/// הפתרון כאן משלים את התמונה: הגליפים בשורה נצבעים שקוף (תופסים את המקום
+/// הנכון בסדר הנכון, וזמינים לבחירה ולהעתקה), ו-[RaisedMarkerOverlay] מאתר
+/// את המלבן האמיתי של כל סימון דרך [RenderParagraph.getBoxesForSelection]
+/// ומצייר את אותו טקסט מורם מעליו — אותה תבנית כמו
+/// PluginHighlightFrameOverlay.
+///
+/// גם הסימונים ה*לחיצים* עוברים כאן — סימון הערה מוטמעת (`book-note-marker`)
+/// ואות מפרש (`link-anchor`): הספאן בשורה שומר את ה-recognizer ואת אירועי
+/// הריחוף שלו, והשכבה מפנה hit-test שנוחת על הציור המורם אל העוגן שבשורה,
+/// כך שלחיצה וריחוף עובדים על מה שהעין רואה.
+library;
+
+import 'dart:collection';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:otzaria/text_book/utils/link_anchor_variants.dart';
+import 'package:otzaria/theme/app_fonts.dart';
+import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
+
+/// מרקר הערה מסומן (`<sup class="footnote-marker">`) — מוקטן ונטוי.
+const String kFootnoteMarkerClass = 'footnote-marker-number';
+
+/// sup חשוף — אות הפניה מקובץ משתמש או superscript תוכני. מוקטן בלי נטייה,
+/// באותו יחס שבו `<sup>` הוצג קודם בשלושת מסלולי הרינדור.
+const String kRaisedSupClass = 'raised-sup';
+
+/// יחס גודל של מרקר הערה לגופן הטקסט.
+const double kFootnoteMarkerScale = 0.75;
+
+/// גובה ההרמה כיחס מגודל גופן *הסימון* — תואם לכוונת `top: -0.55em` המקורית.
+const double kRaisedMarkerRaiseFactor = 0.55;
+
+/// סימון מורם אחד: הטקסט הגלוי שלו (כולל תווי בידוד הכיווניות), המופע שלו
+/// בטקסט הקטע (בספירת indexOf לא-חופפת — אותה ספירה שמבצעת שכבת הציור),
+/// והמטריקות שבהן הוא מוצג.
+@immutable
+class RaisedMarker {
+  final String text;
+  final int occurrence;
+
+  /// יחס גודל הגופן ביחס לגופן הטקסט.
+  final double scale;
+
+  final bool italic;
+
+  /// סימון לחיץ (עוגן) — hit-test על הציור המורם מופנה לעוגן שבשורה.
+  final bool clickable;
+
+  /// מצויר בצבע הקישור (אות מפרש) במקום בצבע הטקסט.
+  final bool useLinkColor;
+
+  /// אינדקס הווריאנט הטיפוגרפי של אות מפרש (link-anchor-N), אם יש.
+  final int? variantIndex;
+
+  /// אות המפרש שחלונית התצוגה שלה פתוחה — מצוירת מודגשת עם רקע.
+  final bool active;
+
+  const RaisedMarker({
+    required this.text,
+    required this.occurrence,
+    required this.scale,
+    required this.italic,
+    this.clickable = false,
+    this.useLinkColor = false,
+    this.variantIndex,
+    this.active = false,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is RaisedMarker &&
+      text == other.text &&
+      occurrence == other.occurrence &&
+      scale == other.scale &&
+      italic == other.italic &&
+      clickable == other.clickable &&
+      useLinkColor == other.useLinkColor &&
+      variantIndex == other.variantIndex &&
+      active == other.active;
+
+  @override
+  int get hashCode => Object.hash(
+    text,
+    occurrence,
+    scale,
+    italic,
+    clickable,
+    useLinkColor,
+    variantIndex,
+    active,
+  );
+
+  @override
+  String toString() =>
+      'RaisedMarker("$text"#$occurrence scale:$scale italic:$italic'
+      '${clickable ? ' clickable' : ''}'
+      '${variantIndex != null ? ' variant:$variantIndex' : ''}'
+      '${active ? ' active' : ''})';
+}
+
+class RaisedMarkers {
+  RaisedMarkers._();
+
+  // אם הדגשת-חיפוש מזריקה span בתוך הסימון, ההתאמה העצלה נעצרת ב-close
+  // הפנימי; הטקסט שיחולץ עדיין מכיל את אות הסימון, ולכן האיתור בציור מצליח.
+  //
+  // שלוש משפחות, כולן בסריקה אחת בסדר המסמך (ספירת המופעים תלויה בסדר):
+  //  1+2. שני תגי הסימון של processText.
+  //  3.   סימון הערה מוטמעת לחיץ — addInlineNotePreviewLinks פולט בדיוק
+  //       `<a class="book-note-marker" href=...>`.
+  //  4-6. אות מפרש — injectLinkAnchorMarkers פולט
+  //       `class="link-anchor link-anchor-N..."`; הצורה החשופה
+  //       `class="link-anchor"` נתפסת גם היא, כי customStylesBuilder צובע
+  //       אותה שקוף — אחרת הטקסט היה נעלם. טווח-ציטוט
+  //       (`class="link-anchor-range"`) לעולם אינו נתפס ("-" ולא רווח/גרש),
+  //       וסמן-מספר מודפס (`numbered-note-marker`) נשאר במקומו בכוונה —
+  //       הוא חלק מהטקסט המודפס.
+  static final RegExp _markerSpanRegex = RegExp(
+    '<span class="($kFootnoteMarkerClass|$kRaisedSupClass)">(.*?)</span>'
+    '|<a class="book-note-marker"[^>]*>(.*?)</a>'
+    '|<(a|span) class="link-anchor( [^"]*)?"[^>]*>(.*?)</\\4>',
+    caseSensitive: false,
+    dotAll: true,
+  );
+  static final RegExp _variantIndexRegex = RegExp(r'\blink-anchor-(\d+)\b');
+  // עיצוב הסוגריים של processText עוטף תוכן כמו "(א)" ב-<small>; הגליף
+  // בשורה מוקטן בהתאם, והציור המורם חייב להתלבש עליו באותו גודל בדיוק.
+  static final RegExp _smallTagRegex = RegExp(
+    r'<small\b',
+    caseSensitive: false,
+  );
+  static final RegExp _bigTagRegex = RegExp(r'<big\b', caseSensitive: false);
+  static final RegExp _htmlTagRegex = RegExp(r'<[^>]+>');
+  static final RegExp _whitespaceRegex = RegExp(r'\s+');
+
+  /// מחלץ את רשימת הסימונים המורמים מ-HTML מעובד של קטע.
+  ///
+  /// ה-HTML עצמו אינו משתנה — הסימונים נשארים בשורה (שקופים) כדי לשמור מקום,
+  /// סדר, בחירה והעתקה; הרשימה משמשת את שכבת הציור לאיתור ולציור.
+  ///
+  /// התוצאה נשמרת ב-LRU: הפונקציה נקראת לכל קטע נראה בכל build (גלילה =
+  /// עשרות קריאות לפריים), בדיוק כמו המטמון של processText.
+  static List<RaisedMarker> extract(String html) {
+    if (!html.contains(kFootnoteMarkerClass) &&
+        !html.contains(kRaisedSupClass) &&
+        !html.contains('book-note-marker') &&
+        !html.contains('class="link-anchor')) {
+      return const [];
+    }
+
+    final cached = _cache.remove(html);
+    if (cached != null) {
+      _cache[html] = cached;
+      return cached;
+    }
+
+    final result = _extractUncached(html);
+
+    _cache[html] = result;
+    _cacheChars += html.length;
+    while (_cacheChars > _cacheMaxChars && _cache.length > 1) {
+      final oldestKey = _cache.keys.first;
+      _cache.remove(oldestKey);
+      _cacheChars -= oldestKey.length;
+    }
+
+    return result;
+  }
+
+  static List<RaisedMarker> _extractUncached(String html) {
+    final markers = <RaisedMarker>[];
+    // הטקסט הגלוי שנצבר עד כה — לספירת מופעים של כל סימון.
+    final visibleSoFar = StringBuffer();
+    var index = 0;
+
+    for (final match in _markerSpanRegex.allMatches(html)) {
+      visibleSoFar.write(_visibleText(html.substring(index, match.start)));
+      index = match.end;
+
+      final String rawContent;
+      double scale;
+      var italic = false;
+      var clickable = false;
+      var useLinkColor = false;
+      int? variantIndex;
+      var active = false;
+
+      if (match[1] != null) {
+        // תג סימון של processText — sup שהומר ל-span.
+        final isFootnote = match[1]!.toLowerCase() == kFootnoteMarkerClass;
+        rawContent = match[2] ?? '';
+        scale = isFootnote ? kFootnoteMarkerScale : kHtmlSmallerFontScale;
+        italic = isFootnote;
+      } else if (match[3] != null) {
+        // סימון הערה מוטמעת לחיץ — אותן מטריקות של מרקר הערה, עם הפניית
+        // לחיצה/ריחוף לציור המורם.
+        rawContent = match[3]!;
+        scale = kFootnoteMarkerScale;
+        italic = true;
+        clickable = true;
+      } else {
+        // אות מפרש — צבע קישור, וריאנט טיפוגרפי קבוע למפרש, רקע כשפעילה.
+        rawContent = match[6] ?? '';
+        scale = kLinkAnchorMarkerScale;
+        clickable = true;
+        useLinkColor = true;
+        final extraClasses = match[5] ?? '';
+        final variantMatch = _variantIndexRegex.firstMatch(extraClasses);
+        final parsedVariant = variantMatch == null
+            ? null
+            : int.tryParse(variantMatch[1]!);
+        if (parsedVariant != null &&
+            parsedVariant < kLinkAnchorVariants.length) {
+          variantIndex = parsedVariant;
+        }
+        active = extraClasses.contains('link-anchor-active');
+      }
+
+      // תגי small/big שהוזרקו לתוך הסימון (עיצוב סוגריים) מקטינים את הגליף
+      // בשורה — הציור מקבל את אותו יחס כדי להתלבש עליו בדיוק.
+      final smalls = _smallTagRegex.allMatches(rawContent).length;
+      final bigs = _bigTagRegex.allMatches(rawContent).length;
+      if (smalls > 0 || bigs > 0) {
+        scale *=
+            math.pow(kHtmlSmallerFontScale, smalls) *
+            math.pow(kHtmlLargerFontScale, bigs);
+      }
+
+      // תווי הבידוד (LRI/RLI/PDI) הם חלק מהטקסט הגלוי — נשארים בתבנית, וגם
+      // הופכים אותה לייחודית יותר מול טקסט הגוף.
+      final markerText = _visibleText(rawContent);
+      final visibleBefore = visibleSoFar.toString();
+      visibleSoFar.write(markerText);
+
+      if (markerText.trim().isEmpty) continue;
+
+      markers.add(
+        RaisedMarker(
+          text: markerText,
+          occurrence: _countOccurrences(visibleBefore, markerText) + 1,
+          scale: scale,
+          italic: italic,
+          clickable: clickable,
+          useLinkColor: useLinkColor,
+          variantIndex: variantIndex,
+          active: active,
+        ),
+      );
+    }
+
+    if (markers.isEmpty) return const [];
+    return List.unmodifiable(markers);
+  }
+
+  /// טקסט גלוי: בלי תגים ועם רצפי רווחים מכווצים — אותם כללי נרמול שחלים על
+  /// הטקסט בפריסה, כך שספירת המופעים תואמת את מה שמוצג.
+  static String _visibleText(String html) {
+    return html
+        .replaceAll(_htmlTagRegex, '')
+        .replaceAll(_whitespaceRegex, ' ');
+  }
+
+  /// ספירת מופעים לא-חופפת — חייבת להישאר זהה ללולאת האיתור שבשכבת הציור.
+  static int _countOccurrences(String text, String pattern) {
+    if (pattern.isEmpty) return 0;
+    var count = 0;
+    var from = 0;
+    while (true) {
+      final idx = text.indexOf(pattern, from);
+      if (idx < 0) return count;
+      count++;
+      from = idx + pattern.length;
+    }
+  }
+
+  static final LinkedHashMap<String, List<RaisedMarker>> _cache =
+      LinkedHashMap<String, List<RaisedMarker>>();
+  static int _cacheChars = 0;
+  static const int _cacheMaxChars = 1024 * 1024;
+
+  @visibleForTesting
+  static void clearCacheForTesting() {
+    _cache.clear();
+    _cacheChars = 0;
+  }
+}
+
+/// שכבת הציור: עוטפת את ווידג'ט הטקסט ומציירת כל סימון מורם מעל המלבן
+/// שהגליפים השקופים שלו תופסים בשורה.
+class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
+  final List<RaisedMarker> markers;
+
+  /// סגנון הטקסט של הקטע. הסגנון של כל סימון נגזר ממנו לפי
+  /// [RaisedMarker.scale] ו-[RaisedMarker.italic], כך שהציור מתלבש בדיוק על
+  /// הגליפים השקופים שבשורה.
+  final TextStyle baseStyle;
+
+  /// צבע הציור של סימון עם [RaisedMarker.useLinkColor] (אות מפרש).
+  /// null — נופל לצבע הטקסט.
+  final Color? linkColor;
+
+  /// רקע הציור של אות מפרש פעילה ([RaisedMarker.active]).
+  final Color? activeBackground;
+
+  const RaisedMarkerOverlay({
+    super.key,
+    required this.markers,
+    required this.baseStyle,
+    this.linkColor,
+    this.activeBackground,
+    required super.child,
+  });
+
+  /// נקודת הכניסה האחידה לכל תצוגת טקסט: עוטף את [child] בשכבת הסימונים אם
+  /// יש כאלה, ומשלים צבע טקסט מהסביבה כש-[baseStyle] בא בלעדיו. כל מסלול
+  /// רינדור חדש שמציג טקסט ספר צריך לקרוא לזה — לא לבנות עטיפה משלו.
+  ///
+  /// [linkColor] ו-[activeBackground] — צבעי אותיות המפרשים; כשאינם מסופקים
+  /// נגזרים מערכת הנושא (primary / primaryContainer), כמו ב-SmartTextWidget.
+  static Widget wrap({
+    required BuildContext context,
+    required List<RaisedMarker> markers,
+    required TextStyle baseStyle,
+    required Widget child,
+    Color? linkColor,
+    Color? activeBackground,
+  }) {
+    if (markers.isEmpty) return child;
+    final colorScheme = Theme.of(context).colorScheme;
+    final style = baseStyle.color != null
+        ? baseStyle
+        : baseStyle.copyWith(
+            color:
+                DefaultTextStyle.of(context).style.color ??
+                colorScheme.onSurface,
+          );
+    return RaisedMarkerOverlay(
+      markers: markers,
+      baseStyle: style,
+      linkColor: linkColor ?? colorScheme.primary,
+      activeBackground: activeBackground ?? colorScheme.primaryContainer,
+      child: child,
+    );
+  }
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      RenderRaisedMarkerOverlay(markers, baseStyle, linkColor, activeBackground);
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant RenderRaisedMarkerOverlay renderObject,
+  ) {
+    renderObject
+      ..markers = markers
+      ..baseStyle = baseStyle
+      ..linkColor = linkColor
+      ..activeBackground = activeBackground;
+  }
+}
+
+/// מיקום מחושב של סימון אחד — חשוף לצורכי בדיקות.
+@immutable
+class RaisedMarkerPlacement {
+  /// המלבן שהגליפים השקופים תופסים בשורה (בקואורדינטות של השכבה).
+  final Rect anchorRect;
+
+  /// המלבן שבו הסימון מצויר בפועל — מורם מעל [anchorRect].
+  final Rect paintRect;
+
+  final RaisedMarker marker;
+
+  const RaisedMarkerPlacement({
+    required this.anchorRect,
+    required this.paintRect,
+    required this.marker,
+  });
+
+  String get text => marker.text;
+}
+
+class RenderRaisedMarkerOverlay extends RenderProxyBox {
+  RenderRaisedMarkerOverlay(
+    this._markers,
+    this._baseStyle,
+    this._linkColor,
+    this._activeBackground,
+  ) : _hasClickableMarkers = _markers.any((marker) => marker.clickable);
+
+  List<RaisedMarker> _markers;
+  TextStyle _baseStyle;
+  Color? _linkColor;
+  Color? _activeBackground;
+
+  // מחושב פעם אחת: קטע בלי סימונים לחיצים לא משלם דבר על hit-test.
+  bool _hasClickableMarkers;
+
+  // TextPainter לכל (טקסט, מטריקות), ממוזג בין פריימים; מתאפס עם שינוי סגנון.
+  final Map<String, TextPainter> _painters = <String, TextPainter>{};
+
+  // המיקומים המחושבים, ממוזגים בין פריימים. האיתור עצמו יקר (toPlainText לכל
+  // פסקה + חיפוש לכל סימון), והוא תלוי אך ורק בפריסה — לכן הוא לא רץ שוב בכל
+  // פריים ציור. גלילה מזיזה את ה-RenderObject בלי פריסה מחדש, ומיקומי הסימונים
+  // מוחזקים ביחס לשכבה עצמה, ולכן הם נשארים תקפים.
+  List<RaisedMarkerPlacement>? _placements;
+  List<Object?>? _placementsSignature;
+
+  set markers(List<RaisedMarker> value) {
+    if (listEquals(value, _markers)) return;
+    _markers = value;
+    _hasClickableMarkers = value.any((marker) => marker.clickable);
+    _invalidatePlacements();
+    markNeedsPaint();
+  }
+
+  set baseStyle(TextStyle value) {
+    if (value == _baseStyle) return;
+    _baseStyle = value;
+    _disposePainters();
+    _invalidatePlacements();
+    markNeedsPaint();
+  }
+
+  // צבע משנה רק את הציור, לא את המטריקות — המיקומים נשארים תקפים.
+  set linkColor(Color? value) {
+    if (value == _linkColor) return;
+    _linkColor = value;
+    _disposePainters();
+    markNeedsPaint();
+  }
+
+  set activeBackground(Color? value) {
+    if (value == _activeBackground) return;
+    _activeBackground = value;
+    _disposePainters();
+    markNeedsPaint();
+  }
+
+  void _invalidatePlacements() {
+    _placements = null;
+    _placementsSignature = null;
+  }
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    _invalidatePlacements();
+  }
+
+  void _disposePainters() {
+    for (final painter in _painters.values) {
+      painter.dispose();
+    }
+    _painters.clear();
+  }
+
+  @override
+  void dispose() {
+    _disposePainters();
+    super.dispose();
+  }
+
+  double _fontSizeOf(RaisedMarker marker) =>
+      (_baseStyle.fontSize ?? 18.0) * marker.scale;
+
+  TextPainter _painterFor(RaisedMarker marker) {
+    final key =
+        '${marker.scale}|${marker.italic}|${marker.useLinkColor}'
+        '|${marker.variantIndex}|${marker.active}|${marker.text}';
+    return _painters.putIfAbsent(key, () {
+      var style = _baseStyle.copyWith(
+        fontSize: _fontSizeOf(marker),
+        fontStyle: marker.italic ? FontStyle.italic : FontStyle.normal,
+        height: 1.0,
+      );
+      // אות מפרש: הווריאנט הטיפוגרפי של המפרש, צבע הקישור, והדגשה עם רקע
+      // כשחלונית התצוגה שלה פתוחה — אותו מראה שהיה לגליף לפני שהוסתר.
+      final variantIndex = marker.variantIndex;
+      if (variantIndex != null) {
+        style = applyLinkAnchorVariant(kLinkAnchorVariants[variantIndex], style);
+      }
+      if (marker.useLinkColor && _linkColor != null) {
+        style = style.copyWith(color: _linkColor);
+      }
+      if (marker.active) {
+        style = style.copyWith(
+          fontWeight: FontWeight.bold,
+          fontVariations: AppFonts.boldFontVariations(style.fontFamily),
+          backgroundColor: _activeBackground,
+        );
+      }
+      final painter = TextPainter(
+        text: TextSpan(text: marker.text, style: style),
+        textDirection: TextDirection.rtl,
+        maxLines: 1,
+      );
+      painter.layout();
+      return painter;
+    });
+  }
+
+  /// לחיצה/ריחוף שנוחתים על ציור מורם של סימון לחיץ מופנים לעוגן שבשורה —
+  /// כך ה-recognizer, תצוגת הריחוף וסמן העכבר של הספאן עובדים על מה שהעין
+  /// רואה. ההפניה נרשמת כטרנספורם כדי שגם localPosition של האירועים יתאים.
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (child != null && _hasClickableMarkers) {
+      for (final placement in _resolvePlacements()) {
+        if (!placement.marker.clickable) continue;
+        if (!placement.paintRect.contains(position)) continue;
+        // בתחום החפיפה עם העוגן עצמו הפגיעה הטבעית ממילא נכונה.
+        if (placement.anchorRect.contains(position)) break;
+        final target = placement.anchorRect.center;
+        return result.addWithRawTransform(
+          transform: Matrix4.translationValues(
+            target.dx - position.dx,
+            target.dy - position.dy,
+            0,
+          ),
+          position: position,
+          hitTest: (BoxHitTestResult result, Offset transformed) =>
+              super.hitTest(result, position: transformed),
+        );
+      }
+    }
+    return super.hitTest(result, position: position);
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    super.paint(context, offset);
+    if (child == null || _markers.isEmpty) return;
+    for (final placement in _resolvePlacements()) {
+      _painterFor(placement.marker).paint(
+        context.canvas,
+        offset + placement.paintRect.topLeft,
+      );
+    }
+  }
+
+  /// מחזיר את המיקומים מהמטמון, ומחשב מחדש רק כשהפריסה בפועל השתנתה.
+  ///
+  /// [performLayout] מנקה את המטמון, אבל פסקה פנימית יכולה להתפרס מחדש בלי
+  /// שהפריסה של השכבה תרוץ (relayout boundary). לכן נבנית כאן חתימה זולה —
+  /// זהות הפסקאות, ההיסט, הגודל, ואובייקט הטקסט — והחישוב היקר רץ רק כשהיא
+  /// משתנה. הליכה על העץ היא O(צמתים) ולא נוגעת בטקסט עצמו.
+  List<RaisedMarkerPlacement> _resolvePlacements() {
+    final paragraphs = _collectParagraphs();
+    final signature = <Object?>[];
+    for (final info in paragraphs) {
+      signature
+        ..add(info.paragraph)
+        ..add(info.offset)
+        ..add(info.paragraph.size)
+        ..add(info.paragraph.text);
+    }
+
+    final cached = _placements;
+    if (cached != null && listEquals(_placementsSignature, signature)) {
+      return cached;
+    }
+
+    final computed = _computePlacements(paragraphs);
+    _placements = computed;
+    _placementsSignature = signature;
+    return computed;
+  }
+
+  /// אוסף את כל ה-RenderParagraph-ים שמתחת לשכבה, בסדר המסמך. זול בכוונה —
+  /// בלי לגעת בטקסט — כדי שיוכל לרוץ בכל פריים ציור לצורך בדיקת החתימה.
+  List<_ParagraphInfo> _collectParagraphs() {
+    final paragraphs = <_ParagraphInfo>[];
+    void visit(RenderObject object) {
+      if (object is RenderParagraph) {
+        if (object.attached && object.hasSize) {
+          paragraphs.add(
+            _ParagraphInfo(
+              paragraph: object,
+              offset: object.localToGlobal(Offset.zero, ancestor: this),
+            ),
+          );
+        }
+        return;
+      }
+      object.visitChildren(visit);
+    }
+
+    visit(child!);
+    return paragraphs;
+  }
+
+  /// מיקומי כל הסימונים ביחס לפינת השכבה.
+  ///
+  /// מאחד את הטקסט הגלוי של הפסקאות עם '\n' כמפריד (מונע התאמה שחוצה
+  /// פסקאות), מאתר את המופע ה-n של כל סימון באותה ספירת indexOf שביצע
+  /// החילוץ, וממפה למלבני הפריסה. אינדקסים של indexOf הם UTF-16 — בדיוק
+  /// היחידות ש-getBoxesForSelection מצפה להן.
+  List<RaisedMarkerPlacement> _computePlacements(
+    List<_ParagraphInfo> paragraphs,
+  ) {
+    if (paragraphs.isEmpty) return const [];
+
+    final joined = StringBuffer();
+    final paragraphStarts = <int>[];
+    for (final info in paragraphs) {
+      paragraphStarts.add(joined.length);
+      joined.write(_plainTextOf(info.paragraph));
+      joined.write('\n');
+    }
+    final joinedText = joined.toString();
+
+    final placements = <RaisedMarkerPlacement>[];
+    for (final marker in _markers) {
+      final globalIndex = _nthOccurrence(
+        joinedText,
+        marker.text,
+        marker.occurrence,
+      );
+      if (globalIndex < 0) continue;
+
+      // הפסקה שההתאמה בתוכה ('\n' מבטיח שההתאמה לא חוצה פסקאות).
+      var paragraphIndex = paragraphStarts.length - 1;
+      while (paragraphIndex > 0 &&
+          paragraphStarts[paragraphIndex] > globalIndex) {
+        paragraphIndex--;
+      }
+      final info = paragraphs[paragraphIndex];
+      final localStart = globalIndex - paragraphStarts[paragraphIndex];
+
+      final boxes = info.paragraph.getBoxesForSelection(
+        TextSelection(
+          baseOffset: localStart,
+          extentOffset: localStart + marker.text.length,
+        ),
+      );
+      if (boxes.isEmpty) continue;
+
+      // סימון כמעט תמיד בשורה אחת; אם נשבר, נצמדים לחלק שבשורה הראשונה.
+      final firstTop = boxes.first.top;
+      var anchorRect = boxes.first.toRect();
+      for (final box in boxes.skip(1)) {
+        if ((box.top - firstTop).abs() > 2) break;
+        anchorRect = anchorRect.expandToInclude(box.toRect());
+      }
+      anchorRect = anchorRect.shift(info.offset);
+
+      final painter = _painterFor(marker);
+      final raise = _fontSizeOf(marker) * kRaisedMarkerRaiseFactor;
+      // ממורכז אופקית על העוגן; אנכית — מורם, עם הצמדה לגבול העליון של
+      // השכבה כדי לא להיחתך בשורה הראשונה.
+      final dx = anchorRect.center.dx - painter.width / 2;
+      final dy = math.max(0.0, anchorRect.top - raise);
+
+      placements.add(
+        RaisedMarkerPlacement(
+          anchorRect: anchorRect,
+          paintRect: Rect.fromLTWH(dx, dy, painter.width, painter.height),
+          marker: marker,
+        ),
+      );
+    }
+    return placements;
+  }
+
+  static int _nthOccurrence(String text, String pattern, int n) {
+    if (pattern.isEmpty || n < 1) return -1;
+    var from = 0;
+    for (var i = 0; i < n; i++) {
+      final idx = text.indexOf(pattern, from);
+      if (idx < 0) return -1;
+      if (i == n - 1) return idx;
+      from = idx + pattern.length;
+    }
+    return -1;
+  }
+
+  @visibleForTesting
+  List<RaisedMarkerPlacement> debugPlacements() => _resolvePlacements();
+}
+
+class _ParagraphInfo {
+  final RenderParagraph paragraph;
+  final Offset offset;
+
+  _ParagraphInfo({required this.paragraph, required this.offset});
+}
+
+/// `toPlainText` בונה את המחרוזת מחדש בכל קריאה בהליכה על עץ הספאנים. הטקסט
+/// נגזר מאובייקט הספאן, ולכן ממוזג לפיו — ה-Expando משתחרר עם ה-GC כשהספאן
+/// מוחלף בבנייה מחדש.
+final Expando<String> _plainTextCache = Expando<String>('raisedMarkerText');
+
+String _plainTextOf(RenderParagraph paragraph) {
+  final span = paragraph.text;
+  final cached = _plainTextCache[span];
+  if (cached != null) return cached;
+  final text = span.toPlainText();
+  _plainTextCache[span] = text;
+  return text;
+}

--- a/lib/widgets/smart_text/raised_markers.dart
+++ b/lib/widgets/smart_text/raised_markers.dart
@@ -2,7 +2,7 @@
 ///
 /// הרקע: fwfh מממש `<sup>` ב-WidgetSpan, ומנוע Flutter משבץ placeholders
 /// בפסקת RTL בסדר ויזואלי במקום לוגי — שני סימונים באותה פסקה מוצגים הפוך
-/// (ראו `_fixFootnoteMarkers` ב-text_renderer_service.dart). לכן כל sup
+/// (ראו `_fixFootnoteMarkers` ב-text_renderer_service.dart). לכן sup פשוט
 /// לא-מספרי מומר שם ל-span טקסט טהור, שסדרו מובטח.
 ///
 /// אבל ל-fwfh אין תמיכה ב-`position`/`top` — הן היו no-op גם קודם, ולכן
@@ -27,6 +27,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:html/parser.dart' as html_parser;
 import 'package:otzaria/text_book/utils/link_anchor_variants.dart';
 import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
@@ -269,9 +270,11 @@ class RaisedMarkers {
   /// טקסט גלוי: בלי תגים ועם רצפי רווחים מכווצים — אותם כללי נרמול שחלים על
   /// הטקסט בפריסה, כך שספירת המופעים תואמת את מה שמוצג.
   static String _visibleText(String html) {
-    return html
-        .replaceAll(_htmlTagRegex, '')
-        .replaceAll(_whitespaceRegex, ' ');
+    final withoutTags = html.replaceAll(_htmlTagRegex, '');
+    final decoded = withoutTags.contains('&')
+        ? html_parser.parseFragment(withoutTags).text ?? withoutTags
+        : withoutTags;
+    return decoded.replaceAll(_whitespaceRegex, ' ');
   }
 
   /// ספירת מופעים לא-חופפת — חייבת להישאר זהה ללולאת האיתור שבשכבת הציור.
@@ -359,7 +362,12 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) =>
-      RenderRaisedMarkerOverlay(markers, baseStyle, linkColor, activeBackground);
+      RenderRaisedMarkerOverlay(
+        markers,
+        baseStyle,
+        linkColor,
+        activeBackground,
+      );
 
   @override
   void updateRenderObject(
@@ -492,7 +500,10 @@ class RenderRaisedMarkerOverlay extends RenderProxyBox {
       // כשחלונית התצוגה שלה פתוחה — אותו מראה שהיה לגליף לפני שהוסתר.
       final variantIndex = marker.variantIndex;
       if (variantIndex != null) {
-        style = applyLinkAnchorVariant(kLinkAnchorVariants[variantIndex], style);
+        style = applyLinkAnchorVariant(
+          kLinkAnchorVariants[variantIndex],
+          style,
+        );
       }
       if (marker.useLinkColor && _linkColor != null) {
         style = style.copyWith(color: _linkColor);

--- a/lib/widgets/smart_text/simple_inline_html.dart
+++ b/lib/widgets/smart_text/simple_inline_html.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:otzaria/theme/app_fonts.dart';
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
 
 /// יחסי הגדלים של fwfh ל-`<small>`/`<sup>` ול-`<big>`.
 ///
@@ -15,7 +16,10 @@ const double kHtmlLargerFontScale = 6 / 5;
 /// כדי לעקוף את עלות הפרסור ובניית העץ של HtmlWidget עבור רוב שורות הספרים.
 ///
 /// כל markup שאינו ברשימה הלבנה (תגים עם attributes, קישורים, spans, כותרות,
-/// entities) מחזיר null — והקורא נופל חזרה ל-HtmlWidget המלא.
+/// entities) מחזיר null — והקורא נופל חזרה ל-HtmlWidget המלא. יוצא הדופן
+/// היחיד: שני תגי הסימונים המורמים (ראו raised_markers.dart), שמזוהים
+/// במדויק — כך שורות עם סימונים נשארות במסלול המהיר, והתמיכה בהם היא חלק
+/// מצנרת הטקסט הבסיסית ולא נפילה ל-HtmlWidget.
 class SimpleInlineHtml {
   SimpleInlineHtml._();
 
@@ -25,6 +29,13 @@ class SimpleInlineHtml {
     r'&[a-zA-Z]{2,10};|&#x?[0-9a-fA-F]{1,6};',
   );
   static final RegExp _whitespaceRegex = RegExp(r'\s+');
+
+  /// תגי הפתיחה של סימונים מורמים, כפי שנפלטים מ-`_fixFootnoteMarkers`
+  /// (מחרוזות קבועות, ולכן השוואה מדויקת). כל span אחר עדיין מפיל ל-HtmlWidget.
+  static const String _footnoteMarkerOpen =
+      '<span class="$kFootnoteMarkerClass">';
+  static const String _raisedSupOpen = '<span class="$kRaisedSupClass">';
+  static const String _spanClose = '</span>';
 
   /// מנסה להמיר את [html]. מחזיר null אם נדרש HtmlWidget.
   static TextSpan? tryParse(String html, TextStyle baseStyle) {
@@ -37,6 +48,10 @@ class SimpleInlineHtml {
     }
 
     var bold = 0, italic = 0, underline = 0, big = 0, small = 0;
+    var footnoteMarkers = 0, raisedSups = 0;
+    // איזה סוג סימון כל `</span>` סוגר (true = מרקר הערה, false = raised-sup).
+    // אלה שני תגי ה-span היחידים שהמסלול מקבל, ולכן מחסנית בוליאנית מספיקה.
+    final markerStack = <bool>[];
     final segments = <_Segment>[];
 
     TextStyle? styleForCurrent() {
@@ -44,26 +59,37 @@ class SimpleInlineHtml {
           italic == 0 &&
           underline == 0 &&
           big == 0 &&
-          small == 0) {
+          small == 0 &&
+          footnoteMarkers == 0 &&
+          raisedSups == 0) {
         return null;
       }
       double? fontSize;
-      if (big > 0 || small > 0) {
+      if (big > 0 || small > 0 || footnoteMarkers > 0 || raisedSups > 0) {
         final base = baseStyle.fontSize ?? 14.0;
         fontSize =
             base *
             math.pow(kHtmlLargerFontScale, big) *
-            math.pow(kHtmlSmallerFontScale, small);
+            // raised-sup מוקטן באותו יחס כמו <small>/<sup> — פריטי הגדלים
+            // בין המסלולים (ראו התיעוד של kHtmlSmallerFontScale).
+            math.pow(kHtmlSmallerFontScale, small + raisedSups) *
+            math.pow(kFootnoteMarkerScale, footnoteMarkers);
       }
+      final insideMarker = footnoteMarkers > 0 || raisedSups > 0;
       return TextStyle(
         fontWeight: bold > 0 ? FontWeight.bold : null,
         // בולד אמיתי לגופן משתנה — הבסיס יורש דרך Text.rich לספאנים לא-מודגשים.
         fontVariations: bold > 0
             ? AppFonts.boldFontVariations(baseStyle.fontFamily)
             : null,
-        fontStyle: italic > 0 ? FontStyle.italic : null,
+        fontStyle: (italic > 0 || footnoteMarkers > 0)
+            ? FontStyle.italic
+            : null,
         decoration: underline > 0 ? TextDecoration.underline : null,
         fontSize: fontSize,
+        // גליפי סימון שקופים: תופסים את מקומם בשורה (סדר, בחירה, העתקה),
+        // ו-RaisedMarkerOverlay מצייר אותם מורמים — ראו raised_markers.dart.
+        color: insideMarker ? const Color(0x00000000) : null,
       );
     }
 
@@ -80,7 +106,31 @@ class SimpleInlineHtml {
       addText(html.substring(index, match.start));
       index = match.end;
 
-      final tagMatch = _simpleTagRegex.firstMatch(match[0]!);
+      final rawTag = match[0]!;
+      // סימונים מורמים — השוואת מחרוזת מדויקת, בלי פרסור attributes.
+      if (rawTag == _footnoteMarkerOpen || rawTag == _raisedSupOpen) {
+        final isFootnote = rawTag == _footnoteMarkerOpen;
+        markerStack.add(isFootnote);
+        if (isFootnote) {
+          footnoteMarkers++;
+        } else {
+          raisedSups++;
+        }
+        continue;
+      }
+      if (rawTag == _spanClose) {
+        // `</span>` יתום — לא נפתח על-ידי סימון שלנו; span זר כבר היה מפיל
+        // את השורה בתג הפתיחה שלו, אז זה markup שבור: נופלים ל-HtmlWidget.
+        if (markerStack.isEmpty) return null;
+        if (markerStack.removeLast()) {
+          footnoteMarkers = math.max(0, footnoteMarkers - 1);
+        } else {
+          raisedSups = math.max(0, raisedSups - 1);
+        }
+        continue;
+      }
+
+      final tagMatch = _simpleTagRegex.firstMatch(rawTag);
       if (tagMatch == null) return null;
       final isClosing = tagMatch[1] == '/';
       final delta = isClosing ? -1 : 1;

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/utils/text/html_link_handler.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/widgets/smart_text/exact_line_height.dart';
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
 import 'package:otzaria/widgets/smart_text/render_settings.dart';
 import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
 import 'package:otzaria/widgets/smart_text/text_renderer_service.dart';
@@ -182,6 +183,10 @@ class SmartTextWidget extends StatelessWidget {
       processedHtml = rendering.html;
       frameRanges = rendering.ranges;
     }
+    // סימונים מורמים (כל sup לא-מספרי שהומר ל-span ב-processText): מחולצים
+    // מה-HTML הסופי. ה-HTML לא משתנה — הגליפים נשארים בשורה (שקופים, בסדר
+    // הנכון), ושכבת הציור מציירת אותם מורמים מעל מקומם האמיתי.
+    final raisedMarkers = RaisedMarkers.extract(processedHtml);
     final textStyle = TextStyle(
       fontSize: settings.fontSize,
       fontFamily: settings.fontFamily,
@@ -195,6 +200,8 @@ class SmartTextWidget extends StatelessWidget {
 
     // מסלול מהיר: רוב השורות הן טקסט פשוט (או עם תגי עיצוב בסיסיים) —
     // רינדור ישיר ב-Text.rich חוסך את מלוא עלות הפרסור של HtmlWidget.
+    // גם סימונים מורמים נתמכים כאן באופן בסיסי: SimpleInlineHtml מזהה את
+    // שני תגי הסימון, והשכבה נעטפת בדיוק כמו במסלול ה-HtmlWidget.
     if (renderMode == RenderMode.column) {
       final simpleSpan = SimpleInlineHtml.tryParse(processedHtml, textStyle);
       if (simpleSpan != null) {
@@ -205,36 +212,40 @@ class SmartTextWidget extends StatelessWidget {
         // ב-Center (הגבלת רוחב קריאה) ימרכזו שורות קצרות בטעות.
         return _withPluginFrames(
           frameRanges,
-          SizedBox(
-            key: widgetKey,
-            width: double.infinity,
-            child: Text.rich(
-              simpleSpan,
-              style: textStyle,
-              strutStyle: exactLineHeightStrut(textStyle, simpleSpan),
-              textAlign: settings.justifyText
-                  ? TextAlign.justify
-                  : TextAlign.right,
+          _withRaisedMarkers(
+            context,
+            raisedMarkers,
+            textStyle,
+            SizedBox(
+              key: widgetKey,
+              width: double.infinity,
+              child: Text.rich(
+                simpleSpan,
+                style: textStyle,
+                strutStyle: exactLineHeightStrut(textStyle, simpleSpan),
+                textAlign: settings.justifyText
+                    ? TextAlign.justify
+                    : TextAlign.right,
+              ),
             ),
           ),
         );
       }
     }
 
-    // עוגן-מילה נפלט כ-<a> לחיץ; fwfh צובע <a> בצבע primary. מחזירים לצבע
-    // הטקסט הסביבתי בערך מפורש (inherit לא נתמך בפרסר הצבעים של fwfh).
+    // סמן-מספר וטווח-ציטוט נשארים בשורה בצבע ה-primary; fwfh לא מכיר
+    // inherit ולכן הערך מפורש. צבעי אותיות המפרשים המורמות נפתרים ב-wrap.
     final colorScheme = Theme.of(context).colorScheme;
-    String toCssHex(Color color) =>
-        '#${(color.toARGB32() & 0x00FFFFFF).toRadixString(16).padLeft(6, '0')}';
-    final anchorColorCss = toCssHex(
-      DefaultTextStyle.of(context).style.color ?? colorScheme.onSurface,
-    );
-    final anchorLinkColorCss = toCssHex(colorScheme.primary);
-    final anchorActiveBgCss = toCssHex(colorScheme.primaryContainer);
+    final anchorLinkColorCss =
+        '#${(colorScheme.primary.toARGB32() & 0x00FFFFFF).toRadixString(16).padLeft(6, '0')}';
 
     return _withPluginFrames(
       frameRanges,
-      HtmlWidget(
+      _withRaisedMarkers(
+        context,
+        raisedMarkers,
+        textStyle,
+        HtmlWidget(
         TextRendererService.wrapWithRtlDiv(
           processedHtml,
           justifyText: settings.justifyText,
@@ -258,23 +269,33 @@ class SmartTextWidget extends StatelessWidget {
           if (headingWeight != null) {
             return {'font-weight': headingWeight};
           }
+          // סימונים מורמים: הגליפים נשארים בשורה — תופסים את המקום ואת הסדר
+          // הנכון, וזמינים לבחירה ולהעתקה — אבל שקופים, ו-RaisedMarkerOverlay
+          // מצייר אותם מורמים מעל מקומם. `position`/`top` אינם נתמכים ב-fwfh
+          // כלל (היו no-op גם קודם), ולכן הרמה בפריסה אינה אפשרית כאן.
           if (element.localName == 'span' &&
-              element.classes.contains('footnote-marker-number')) {
+              element.classes.contains(kFootnoteMarkerClass)) {
             return {
-              'font-size': '0.75em',
+              'font-size': '${kFootnoteMarkerScale}em',
               'font-style': 'italic',
-              'position': 'relative',
-              'top': '-0.55em',
+              'color': 'transparent',
             };
           }
+          if (element.localName == 'span' &&
+              element.classes.contains(kRaisedSupClass)) {
+            return {
+              'font-size': '${kHtmlSmallerFontScale}em',
+              'color': 'transparent',
+            };
+          }
+          // סימון הערה מוטמעת לחיץ: כמו מרקר הערה — הגליף שקוף ומורם בשכבה;
+          // ה-recognizer והריחוף נשארים על הספאן, והשכבה מפנה אליו לחיצות.
           if (element.localName == 'a' &&
               element.classes.contains('book-note-marker')) {
             return {
-              'font-size': '0.75em',
+              'font-size': '${kFootnoteMarkerScale}em',
               'font-style': 'italic',
-              'position': 'relative',
-              'top': '-0.55em',
-              'color': anchorColorCss,
+              'color': 'transparent',
               'text-decoration': 'none',
             };
           }
@@ -284,24 +305,23 @@ class SmartTextWidget extends StatelessWidget {
               element.classes.contains('numbered-note-marker')) {
             return {'color': anchorLinkColorCss, 'text-decoration': 'none'};
           }
-          // סמן-אות של מפרש (עוגן-נקודה): אות קטנה מורמת בצבע ה-primary, עם
-          // וריאנט טיפוגרפי קבוע לכל מפרש (ראו anchorStyleIndexByCommentator).
+          // סמן-אות של מפרש (עוגן-נקודה): הגליף שקוף — הווריאנט הטיפוגרפי
+          // נשאר עליו כדי שרוחב המקום בשורה יתאים לציור המורם, שנושא את
+          // הצבע, הרקע הפעיל וההדגשה (ראו RaisedMarkerOverlay).
           if ((element.localName == 'span' || element.localName == 'a') &&
               element.classes.contains('link-anchor')) {
             final style = <String, String>{
               'font-size': '${kLinkAnchorMarkerScale}em',
-              'position': 'relative',
-              'top': '-0.55em',
               'white-space': 'nowrap',
-              'color': anchorLinkColorCss,
+              'color': 'transparent',
               'text-decoration': 'none',
               ...linkAnchorVariantCss(
                 linkAnchorVariantFromClasses(element.classes),
               ),
             };
-            // האות שחלונית התצוגה שלה פתוחה — מודגשת (רקע + מודגש).
+            // אות פעילה מצוירת מודגשת — ההדגשה נשארת גם על הגליף השקוף כדי
+            // שרוחבו יתאים; הרקע עבר לציור המורם.
             if (element.classes.contains('link-anchor-active')) {
-              style['background-color'] = anchorActiveBgCss;
               style['font-weight'] = 'bold';
             }
             return style;
@@ -346,7 +366,23 @@ class SmartTextWidget extends StatelessWidget {
                 );
               }
             : null,
+        ),
       ),
+    );
+  }
+
+  /// עוטף את ווידג'ט הטקסט בשכבת הציור של הסימונים המורמים, אם יש כאלה.
+  Widget _withRaisedMarkers(
+    BuildContext context,
+    List<RaisedMarker> markers,
+    TextStyle textStyle,
+    Widget child,
+  ) {
+    return RaisedMarkerOverlay.wrap(
+      context: context,
+      markers: markers,
+      baseStyle: textStyle,
+      child: child,
     );
   }
 

--- a/lib/widgets/smart_text/smart_text_widget.dart
+++ b/lib/widgets/smart_text/smart_text_widget.dart
@@ -183,7 +183,7 @@ class SmartTextWidget extends StatelessWidget {
       processedHtml = rendering.html;
       frameRanges = rendering.ranges;
     }
-    // סימונים מורמים (כל sup לא-מספרי שהומר ל-span ב-processText): מחולצים
+    // סימונים מורמים (sup פשוט ולא-מספרי שהומר ל-span ב-processText): מחולצים
     // מה-HTML הסופי. ה-HTML לא משתנה — הגליפים נשארים בשורה (שקופים, בסדר
     // הנכון), ושכבת הציור מציירת אותם מורמים מעל מקומם האמיתי.
     final raisedMarkers = RaisedMarkers.extract(processedHtml);
@@ -246,126 +246,127 @@ class SmartTextWidget extends StatelessWidget {
         raisedMarkers,
         textStyle,
         HtmlWidget(
-        TextRendererService.wrapWithRtlDiv(
-          processedHtml,
-          justifyText: settings.justifyText,
-        ),
-        key: widgetKey,
-        renderMode: renderMode,
-        textStyle: textStyle,
-        // WidgetFactory מותאם לשתי מטרות: (1) בולד אמיתי לגופן משתנה — fwfh בונה
-        // font-weight:bold בלי FontVariation, לכן מזריקים אותו לפי הגופן שנפתר.
-        // (2) ריחוף על עוגני-מילה — fwfh לא חושף hover על <a>, לכן מזריקים
-        // onEnter/onExit ל-TextSpan של כל עוגן, בלי לגעת בזרימת הטקסט.
-        factoryBuilder: () => _SmartTextWidgetFactory(
-          onAnchorHover: onAnchorHover,
-          onAnchorHoverExit: onAnchorHoverExit,
-        ),
-        customStylesBuilder: (dom.Element element) {
-          final headingWeight = AppFonts.headingFontWeightOverride(
-            element.localName,
-            settings.fontFamily,
-          );
-          if (headingWeight != null) {
-            return {'font-weight': headingWeight};
-          }
-          // סימונים מורמים: הגליפים נשארים בשורה — תופסים את המקום ואת הסדר
-          // הנכון, וזמינים לבחירה ולהעתקה — אבל שקופים, ו-RaisedMarkerOverlay
-          // מצייר אותם מורמים מעל מקומם. `position`/`top` אינם נתמכים ב-fwfh
-          // כלל (היו no-op גם קודם), ולכן הרמה בפריסה אינה אפשרית כאן.
-          if (element.localName == 'span' &&
-              element.classes.contains(kFootnoteMarkerClass)) {
-            return {
-              'font-size': '${kFootnoteMarkerScale}em',
-              'font-style': 'italic',
-              'color': 'transparent',
-            };
-          }
-          if (element.localName == 'span' &&
-              element.classes.contains(kRaisedSupClass)) {
-            return {
-              'font-size': '${kHtmlSmallerFontScale}em',
-              'color': 'transparent',
-            };
-          }
-          // סימון הערה מוטמעת לחיץ: כמו מרקר הערה — הגליף שקוף ומורם בשכבה;
-          // ה-recognizer והריחוף נשארים על הספאן, והשכבה מפנה אליו לחיצות.
-          if (element.localName == 'a' &&
-              element.classes.contains('book-note-marker')) {
-            return {
-              'font-size': '${kFootnoteMarkerScale}em',
-              'font-style': 'italic',
-              'color': 'transparent',
-              'text-decoration': 'none',
-            };
-          }
-          // סמן-מספר מודפס בגוף הספר, למשל (9): נשאר בגודלו ובמקומו — רק
-          // נצבע בגוון הנושא כדי לרמז שאפשר לרחף עליו.
-          if (element.localName == 'a' &&
-              element.classes.contains('numbered-note-marker')) {
-            return {'color': anchorLinkColorCss, 'text-decoration': 'none'};
-          }
-          // סמן-אות של מפרש (עוגן-נקודה): הגליף שקוף — הווריאנט הטיפוגרפי
-          // נשאר עליו כדי שרוחב המקום בשורה יתאים לציור המורם, שנושא את
-          // הצבע, הרקע הפעיל וההדגשה (ראו RaisedMarkerOverlay).
-          if ((element.localName == 'span' || element.localName == 'a') &&
-              element.classes.contains('link-anchor')) {
-            final style = <String, String>{
-              'font-size': '${kLinkAnchorMarkerScale}em',
-              'white-space': 'nowrap',
-              'color': 'transparent',
-              'text-decoration': 'none',
-              ...linkAnchorVariantCss(
-                linkAnchorVariantFromClasses(element.classes),
-              ),
-            };
-            // אות פעילה מצוירת מודגשת — ההדגשה נשארת גם על הגליף השקוף כדי
-            // שרוחבו יתאים; הרקע עבר לציור המורם.
-            if (element.classes.contains('link-anchor-active')) {
-              style['font-weight'] = 'bold';
+          TextRendererService.wrapWithRtlDiv(
+            processedHtml,
+            justifyText: settings.justifyText,
+          ),
+          key: widgetKey,
+          renderMode: renderMode,
+          textStyle: textStyle,
+          // WidgetFactory מותאם לשתי מטרות: (1) בולד אמיתי לגופן משתנה — fwfh בונה
+          // font-weight:bold בלי FontVariation, לכן מזריקים אותו לפי הגופן שנפתר.
+          // (2) ריחוף על עוגני-מילה — fwfh לא חושף hover על <a>, לכן מזריקים
+          // onEnter/onExit ל-TextSpan של כל עוגן, בלי לגעת בזרימת הטקסט.
+          factoryBuilder: () => _SmartTextWidgetFactory(
+            onAnchorHover: onAnchorHover,
+            onAnchorHoverExit: onAnchorHoverExit,
+          ),
+          customStylesBuilder: (dom.Element element) {
+            final headingWeight = AppFonts.headingFontWeightOverride(
+              element.localName,
+              settings.fontFamily,
+            );
+            if (headingWeight != null) {
+              return {'font-weight': headingWeight};
             }
-            return style;
-          }
-          // טווח-ציטוט (לינקר): צבע ה-primary בגופן הטקסט הסובב, בלי קו תחתון.
-          // בלי וריאנט טיפוגרפי — הוא שייך לסמני-האות של המפרשים בלבד.
-          if ((element.localName == 'span' || element.localName == 'a') &&
-              element.classes.contains('link-anchor-range')) {
-            return <String, String>{
-              'text-decoration': 'none',
-              'color': anchorLinkColorCss,
-            };
-          }
-          return null;
-        },
-        onTapUrl:
-            (onOpenBook != null || onNoteTap != null || onAnchorTap != null)
-            ? (url) async {
-                // עוגן-מילה — תצוגה מקדימה של המפרש, לפני שאר הקישורים.
-                if (url.startsWith('otzaria://anchor') && onAnchorTap != null) {
-                  onAnchorTap!(url);
-                  return true;
-                }
-                // סמן-מספר של הערה — הפעולה שלו היא ריחוף בלבד.
-                if (url.startsWith('otzaria://note-marker')) return true;
-                // סימון הערה אישית inline — נטפל לפני שאר הקישורים.
-                if (url.startsWith('otzaria://note')) {
-                  final lineIndex = int.tryParse(
-                    Uri.parse(url).queryParameters['line'] ?? '',
-                  );
-                  if (lineIndex != null) {
-                    onNoteTap?.call(lineIndex);
-                  }
-                  return true;
-                }
-                if (url.startsWith('otzaria://book-note')) return true;
-                if (onOpenBook == null) return false;
-                return await HtmlLinkHandler.handleLink(
-                  context,
-                  url,
-                  (tab) => onOpenBook!(tab),
-                );
+            // סימונים מורמים: הגליפים נשארים בשורה — תופסים את המקום ואת הסדר
+            // הנכון, וזמינים לבחירה ולהעתקה — אבל שקופים, ו-RaisedMarkerOverlay
+            // מצייר אותם מורמים מעל מקומם. `position`/`top` אינם נתמכים ב-fwfh
+            // כלל (היו no-op גם קודם), ולכן הרמה בפריסה אינה אפשרית כאן.
+            if (element.localName == 'span' &&
+                element.classes.contains(kFootnoteMarkerClass)) {
+              return {
+                'font-size': '${kFootnoteMarkerScale}em',
+                'font-style': 'italic',
+                'color': 'transparent',
+              };
+            }
+            if (element.localName == 'span' &&
+                element.classes.contains(kRaisedSupClass)) {
+              return {
+                'font-size': '${kHtmlSmallerFontScale}em',
+                'color': 'transparent',
+              };
+            }
+            // סימון הערה מוטמעת לחיץ: כמו מרקר הערה — הגליף שקוף ומורם בשכבה;
+            // ה-recognizer והריחוף נשארים על הספאן, והשכבה מפנה אליו לחיצות.
+            if (element.localName == 'a' &&
+                element.classes.contains('book-note-marker')) {
+              return {
+                'font-size': '${kFootnoteMarkerScale}em',
+                'font-style': 'italic',
+                'color': 'transparent',
+                'text-decoration': 'none',
+              };
+            }
+            // סמן-מספר מודפס בגוף הספר, למשל (9): נשאר בגודלו ובמקומו — רק
+            // נצבע בגוון הנושא כדי לרמז שאפשר לרחף עליו.
+            if (element.localName == 'a' &&
+                element.classes.contains('numbered-note-marker')) {
+              return {'color': anchorLinkColorCss, 'text-decoration': 'none'};
+            }
+            // סמן-אות של מפרש (עוגן-נקודה): הגליף שקוף — הווריאנט הטיפוגרפי
+            // נשאר עליו כדי שרוחב המקום בשורה יתאים לציור המורם, שנושא את
+            // הצבע, הרקע הפעיל וההדגשה (ראו RaisedMarkerOverlay).
+            if ((element.localName == 'span' || element.localName == 'a') &&
+                element.classes.contains('link-anchor')) {
+              final style = <String, String>{
+                'font-size': '${kLinkAnchorMarkerScale}em',
+                'white-space': 'nowrap',
+                'color': 'transparent',
+                'text-decoration': 'none',
+                ...linkAnchorVariantCss(
+                  linkAnchorVariantFromClasses(element.classes),
+                ),
+              };
+              // אות פעילה מצוירת מודגשת — ההדגשה נשארת גם על הגליף השקוף כדי
+              // שרוחבו יתאים; הרקע עבר לציור המורם.
+              if (element.classes.contains('link-anchor-active')) {
+                style['font-weight'] = 'bold';
               }
-            : null,
+              return style;
+            }
+            // טווח-ציטוט (לינקר): צבע ה-primary בגופן הטקסט הסובב, בלי קו תחתון.
+            // בלי וריאנט טיפוגרפי — הוא שייך לסמני-האות של המפרשים בלבד.
+            if ((element.localName == 'span' || element.localName == 'a') &&
+                element.classes.contains('link-anchor-range')) {
+              return <String, String>{
+                'text-decoration': 'none',
+                'color': anchorLinkColorCss,
+              };
+            }
+            return null;
+          },
+          onTapUrl:
+              (onOpenBook != null || onNoteTap != null || onAnchorTap != null)
+              ? (url) async {
+                  // עוגן-מילה — תצוגה מקדימה של המפרש, לפני שאר הקישורים.
+                  if (url.startsWith('otzaria://anchor') &&
+                      onAnchorTap != null) {
+                    onAnchorTap!(url);
+                    return true;
+                  }
+                  // סמן-מספר של הערה — הפעולה שלו היא ריחוף בלבד.
+                  if (url.startsWith('otzaria://note-marker')) return true;
+                  // סימון הערה אישית inline — נטפל לפני שאר הקישורים.
+                  if (url.startsWith('otzaria://note')) {
+                    final lineIndex = int.tryParse(
+                      Uri.parse(url).queryParameters['line'] ?? '',
+                    );
+                    if (lineIndex != null) {
+                      onNoteTap?.call(lineIndex);
+                    }
+                    return true;
+                  }
+                  if (url.startsWith('otzaria://book-note')) return true;
+                  if (onOpenBook == null) return false;
+                  return await HtmlLinkHandler.handleLink(
+                    context,
+                    url,
+                    (tab) => onOpenBook!(tab),
+                  );
+                }
+              : null,
         ),
       ),
     );

--- a/lib/widgets/smart_text/text_renderer_service.dart
+++ b/lib/widgets/smart_text/text_renderer_service.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:flutter/foundation.dart';
 import 'package:otzaria/text_book/utils/inline_notes_utils.dart' as notes;
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
 import 'package:otzaria/widgets/smart_text/render_settings.dart';
 
 /// שירות מרכזי לעיבוד טקסט
@@ -119,11 +120,10 @@ class TextRendererService {
     r'\bclass\s*=\s*"[^"]*\bfootnote-marker\b[^"]*"',
     caseSensitive: false,
   );
-  static final RegExp _simpleInnerRegex = RegExp(r'^[0-9\u0590-\u05FF]+$');
   static final RegExp _isolateStartRegex = RegExp(r'[\u2066\u2067\u2068]');
   static final RegExp _rtlCharRegex = RegExp(r'[\u0590-\u08FF]');
 
-  /// מתקן תגי <sup> כדי למנוע היפוך סדר ב-RTL
+  /// מתקן תגי <sup> כדי למנוע היפוך סדר ב-RTL ולאפשר הצגה מורמת אמיתית
   ///
   /// הבעיה האמיתית אינה bidi של הטקסט: HtmlWidget מממש `<sup>` באמצעות
   /// WidgetSpan, ומנוע Flutter משבץ inline-placeholders בפסקת RTL בסדר
@@ -133,12 +133,20 @@ class TextRendererService {
   ///
   /// הפתרון: sup *מספרי* (עם או בלי class — שניהם משמשים כמרקרים בספרים)
   /// מומר לספרות-עיליות יוניקוד (¹²³…) — טקסט טהור שמוצג מוגבה ומוקטן בכל
-  /// הגופנים, ללא WidgetSpan. מרקר לא-מספרי *מסומן* (`class="footnote-marker"`,
-  /// למשל אות עברית) נפלט כ-`<span class="footnote-marker-number">` — ה-class
-  /// מקבל גופן מוקטן ונטוי גם ב-[SmartTextWidget] (customStylesBuilder) וגם
-  /// בפרסר של מצב קריאה רציפה. sup לא-מספרי שאינו מסומן (superscript תוכני,
-  /// כגון `<sup>מעלית</sup>`) נשאר sup. בנוסף, התוכן עטוף בסימני בידוד
-  /// דו־כיווניות (LRI/RLI + PDI) בהתאם לתוכן כדי שסימונים סמוכים לא יתמזגו.
+  /// הגופנים, ללא WidgetSpan. כל sup לא-מספרי נפלט כ-span טקסט טהור, בשני
+  /// טעמים ששומרים על המטריקות המקוריות של כל אחד:
+  ///   * מרקר הערה (`class="footnote-marker"`) → `footnote-marker-number`,
+  ///     מוקטן ל-0.75em ונטוי.
+  ///   * sup חשוף — אות הפניה מקובץ משתמש או superscript תוכני
+  ///     (`<sup>מעלית</sup>`) → `raised-sup`, מוקטן ל-5/6 בלי נטייה, כמו
+  ///     שה-`<sup>` נראה קודם ב-fwfh ובקריאה הרציפה.
+  ///
+  /// ההרמה הוויזואלית מעל השורה נעשית בציור: [SmartTextWidget] צובע את שני
+  /// ה-class-ים שקופים ומצייר את תוכנם מורם דרך RaisedMarkerOverlay — ל-fwfh
+  /// אין תמיכה ב-`position`/`top` (הן היו no-op גם קודם, ולכן מרקרי הערות
+  /// כלל לא הורמו), ולכן ההרמה חייבת שכבת ציור; ראו raised_markers.dart.
+  /// בנוסף, התוכן עטוף בסימני בידוד דו־כיווניות (LRI/RLI + PDI) בהתאם
+  /// לתוכן כדי שסימונים סמוכים לא יתמזגו.
   static String _fixFootnoteMarkers(String text) {
     // Early-exit מהיר: אם אין בכלל תג <sup> בשורה, מחזירים את הטקסט כפי שהוא
     // בלי לבצע replaceAllMapped (שמקצה StringBuffer גם כשאין התאמות).
@@ -154,16 +162,7 @@ class TextRendererService {
         return '';
       }
 
-      final isFootnoteMarker = _footnoteMarkerClassRegex.hasMatch(attrs);
-      final isSimple = _simpleInnerRegex.hasMatch(innerText);
-
       final wrappedInner = _wrapWithBidiIsolate(innerHtml);
-      if (!isFootnoteMarker && !isSimple) {
-        if (identical(wrappedInner, innerHtml)) {
-          return match[0]!;
-        }
-        return '<sup$attrs>$wrappedInner</sup>';
-      }
 
       // מספר טהור → ספרות-עיליות יוניקוד (מוגבה ומוקטן מטבעו, ללא תגית).
       // חל גם על <sup>1</sup> חשוף בלי class: חלק מספרי ההערות-inline
@@ -176,15 +175,15 @@ class TextRendererService {
         return _wrapWithBidiIsolate(superscript);
       }
 
-      // תוכן לא-מספרי: רק מרקר *מסומן* (class="footnote-marker") הופך ל-span.
-      if (isFootnoteMarker) {
-        return '<span class="footnote-marker-number">$wrappedInner</span>';
+      // מרקר הערה מסומן — 0.75em ונטוי.
+      if (_footnoteMarkerClassRegex.hasMatch(attrs)) {
+        return '<span class="$kFootnoteMarkerClass">$wrappedInner</span>';
       }
 
-      // sup פשוט שאינו מרקר (למשל <sup>מעלית</sup> מייבוא Word) נשאר sup —
-      // שומר הגבהה אמיתית. נשאר חשוף לבאג ההיפוך רק אם יופיעו כמה כאלה
-      // באותה פסקה (נדיר עבור superscript תוכני).
-      return '<sup>$wrappedInner</sup>';
+      // sup חשוף (אות הפניה מקובץ משתמש, או superscript תוכני) — 5/6 בלי
+      // נטייה. גם הוא נפלט כ-span טקסט טהור ולא נשאר `<sup>`: מסלול ה-sup של
+      // fwfh בונה WidgetSpan, וזה מה שהפך את הסדר כששני סימונים באותה פסקה.
+      return '<span class="$kRaisedSupClass">$wrappedInner</span>';
     });
   }
 

--- a/lib/widgets/smart_text/text_renderer_service.dart
+++ b/lib/widgets/smart_text/text_renderer_service.dart
@@ -133,7 +133,7 @@ class TextRendererService {
   ///
   /// הפתרון: sup *מספרי* (עם או בלי class — שניהם משמשים כמרקרים בספרים)
   /// מומר לספרות-עיליות יוניקוד (¹²³…) — טקסט טהור שמוצג מוגבה ומוקטן בכל
-  /// הגופנים, ללא WidgetSpan. כל sup לא-מספרי נפלט כ-span טקסט טהור, בשני
+  /// הגופנים, ללא WidgetSpan. sup פשוט ולא-מספרי נפלט כ-span טקסט טהור, בשני
   /// טעמים ששומרים על המטריקות המקוריות של כל אחד:
   ///   * מרקר הערה (`class="footnote-marker"`) → `footnote-marker-number`,
   ///     מוקטן ל-0.75em ונטוי.
@@ -163,6 +163,14 @@ class TextRendererService {
       }
 
       final wrappedInner = _wrapWithBidiIsolate(innerHtml);
+      final isFootnoteMarker = _footnoteMarkerClassRegex.hasMatch(attrs);
+
+      // sup סמנטי או מעוצב נשאר בנתיב ה-HTML כדי לא לאבד attributes וסגנונות
+      // מקוננים שהציור המורם אינו יכול לשחזר מ-TextStyle הבסיסי בלבד.
+      if (!isFootnoteMarker &&
+          (attrs.trim().isNotEmpty || _htmlTagRegex.hasMatch(innerHtml))) {
+        return '<sup$attrs>$wrappedInner</sup>';
+      }
 
       // מספר טהור → ספרות-עיליות יוניקוד (מוגבה ומוקטן מטבעו, ללא תגית).
       // חל גם על <sup>1</sup> חשוף בלי class: חלק מספרי ההערות-inline
@@ -176,7 +184,7 @@ class TextRendererService {
       }
 
       // מרקר הערה מסומן — 0.75em ונטוי.
-      if (_footnoteMarkerClassRegex.hasMatch(attrs)) {
+      if (isFootnoteMarker) {
         return '<span class="$kFootnoteMarkerClass">$wrappedInner</span>';
       }
 

--- a/test/text_book/view/widgets/continuous_reading_anchor_variant_test.dart
+++ b/test/text_book/view/widgets/continuous_reading_anchor_variant_test.dart
@@ -22,12 +22,17 @@ void main() {
 
   // הייצור מריץ processText על השורה לפני הפירסור בשני המסלולים; בלעדיו
   // עיצוב הסוגריים (<small> סביב "(א)") היה חסר כאן ומקלקל את ההשוואה.
-  TextStyle continuousStyleOf(String html, String needle) {
+  TextStyle continuousStyleOf(
+    String html,
+    String needle, {
+    bool hideRaisedMarkers = true,
+  }) {
     final spans = buildInlineHtmlSpans(
       TextRendererService.processText(html, settings),
       base,
       onTapUrl: (_) async => true,
       linkStyle: linkStyle,
+      hideRaisedMarkers: hideRaisedMarkers,
     );
     return _findStyle(spans, needle, base)!;
   }
@@ -77,9 +82,18 @@ void main() {
       );
     });
 
-    test('צבע הנושא מוחל על הסמן', () {
-      final style = continuousStyleOf(marker(2, 'א'), '(א)');
+    test('צבע הנושא מוחל על הסמן אצל קורא בלי שכבת ציור', () {
+      final style = continuousStyleOf(
+        marker(2, 'א'),
+        '(א)',
+        hideRaisedMarkers: false,
+      );
       expect(style.color, linkStyle.color);
+    });
+
+    test('עם שכבת הציור הגליף שקוף — הצבע עובר לציור המורם', () {
+      final style = continuousStyleOf(marker(2, 'א'), '(א)');
+      expect(style.color!.toARGB32() >> 24, 0);
     });
 
     test('ציטוט לינקר נשאר בגופן הטקסט בלי קו תחתון', () {

--- a/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
+++ b/test/text_book/view/widgets/continuous_reading_paragraph_test.dart
@@ -610,12 +610,41 @@ void main() {
           decoration: TextDecoration.underline,
         ),
         recognizerSink: recognizers,
+        // המראה המלא בשורה — לקורא שאינו עוטף ב-RaisedMarkerOverlay.
+        hideRaisedMarkers: false,
       );
       final link = _findLinkSpan(spans);
       expect(link, isNotNull);
       // צבע primary אך בלי קו תחתון — סמן-נקודה נשאר ללא קו.
       expect(link!.style?.color, const Color(0xFF6750A4));
       expect(link.style?.decoration, isNot(TextDecoration.underline));
+      for (final r in recognizers) {
+        r.dispose();
+      }
+    });
+
+    test('עם שכבת הציור (ברירת המחדל) גליף העוגן שקוף ושומר recognizer', () {
+      final recognizers = <TapGestureRecognizer>[];
+      final spans = buildInlineHtmlSpans(
+        'לפני <a class="link-anchor link-anchor-0" '
+        'href="otzaria://anchor?ref=3_0">(א)</a> אחרי',
+        const TextStyle(fontSize: 20, color: Color(0xFF111111)),
+        onTapUrl: (_) async => true,
+        linkStyle: const TextStyle(
+          color: Color(0xFF6750A4),
+          decoration: TextDecoration.underline,
+        ),
+        recognizerSink: recognizers,
+      );
+      final link = _findLinkSpan(spans);
+      expect(link, isNotNull);
+      expect(
+        link!.style?.color?.toARGB32(),
+        isNotNull,
+        reason: 'לגליף חייב להיות צבע מפורש (שקוף) — לא ירושה מהטקסט',
+      );
+      expect(link.style!.color!.toARGB32() >> 24, 0);
+      expect(link.recognizer, isA<TapGestureRecognizer>());
       for (final r in recognizers) {
         r.dispose();
       }
@@ -836,6 +865,7 @@ void main() {
             onTapUrl: (_) async => true,
             linkStyle: linkStyle,
             recognizerSink: sink,
+            hideRaisedMarkers: false,
           ),
       ];
 

--- a/test/text_book/view/widgets/link_anchor_active_test.dart
+++ b/test/text_book/view/widgets/link_anchor_active_test.dart
@@ -4,6 +4,7 @@ import 'package:otzaria/models/links.dart';
 import 'package:otzaria/text_book/utils/link_anchor_markers.dart';
 import 'package:otzaria/text_book/utils/link_anchor_variants.dart';
 import 'package:otzaria/text_book/view/widgets/continuous_reading_paragraph.dart';
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
 import 'package:otzaria/widgets/smart_text/render_settings.dart';
 import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
 import 'package:otzaria/widgets/smart_text/text_renderer_service.dart';
@@ -76,22 +77,45 @@ void main() {
         'לפני <a class="link-anchor link-anchor-$variantIndex link-anchor-active" '
         'href="otzaria://anchor?ref=3_0">(א)</a> אחרי';
 
-    TextStyle continuousStyleOf(String html, String needle) {
+    TextStyle continuousStyleOf(
+      String html,
+      String needle, {
+      bool hideRaisedMarkers = true,
+    }) {
       final spans = buildInlineHtmlSpans(
         TextRendererService.processText(html, settings),
         base,
         onTapUrl: (_) async => true,
         linkStyle: linkStyle,
         anchorActiveBackground: activeBackground,
+        hideRaisedMarkers: hideRaisedMarkers,
       );
       return _findStyle(spans, needle, base)!;
     }
 
-    test('קריאה רציפה — רקע והדגשה', () {
-      final style = continuousStyleOf(activeMarker(0), '(א)');
+    // קורא בלי שכבת סימונים מורמים (hideRaisedMarkers: false) מקבל את המראה
+    // המלא בשורה — כמו לפני שהאות עברה לציור המורם.
+    test('קורא בלי שכבה — רקע והדגשה על הגליף עצמו', () {
+      final style = continuousStyleOf(
+        activeMarker(0),
+        '(א)',
+        hideRaisedMarkers: false,
+      );
       expect(_background(style), activeBackground.toARGB32());
       expect(style.fontWeight, FontWeight.bold);
       expect(style.color, linkColor);
+    });
+
+    test('ברירת המחדל (עם שכבה): הגליף שקוף והרקע עובר לציור המורם', () {
+      final style = continuousStyleOf(activeMarker(0), '(א)');
+      expect(
+        style.color!.toARGB32() >> 24,
+        0,
+        reason: 'הגליף בשורה חייב להיות שקוף — הציור המורם נושא את הצבע',
+      );
+      expect(_background(style), isNull);
+      // ההדגשה נשארת כדי שרוחב המקום בשורה יתאים לציור המודגש.
+      expect(style.fontWeight, FontWeight.bold);
     });
 
     test('קריאה רציפה — סמן לא-פעיל בלי רקע', () {
@@ -99,6 +123,7 @@ void main() {
         'לפני <a class="link-anchor link-anchor-0" '
             'href="otzaria://anchor?ref=3_0">(א)</a> אחרי',
         '(א)',
+        hideRaisedMarkers: false,
       );
       expect(_background(style), isNull);
     });
@@ -106,17 +131,30 @@ void main() {
     test('הווריאנט נשמר גם כשהסמן פעיל', () {
       // וריאנט 3 = כתב רש"י; ההדגשה מתווספת עליו ולא מחליפה אותו.
       expect(
-        continuousStyleOf(activeMarker(3), '(א)').fontFamily,
+        continuousStyleOf(
+          activeMarker(3),
+          '(א)',
+          hideRaisedMarkers: false,
+        ).fontFamily,
         kLinkAnchorRashiFont,
       );
       // וריאנט 5 = קו תחתון, סימנו המבחין של המפרש — חייב לשרוד את ההדגשה.
       expect(
-        continuousStyleOf(activeMarker(5), '(א)').decoration,
+        continuousStyleOf(
+          activeMarker(5),
+          '(א)',
+          hideRaisedMarkers: false,
+        ).decoration,
         TextDecoration.underline,
+      );
+      // הווריאנט נשאר גם על הגליף השקוף — רוחב המקום חייב להתאים לציור.
+      expect(
+        continuousStyleOf(activeMarker(3), '(א)').fontFamily,
+        kLinkAnchorRashiFont,
       );
     });
 
-    testWidgets('שני המסלולים מדגישים את הסמן הפעיל באותו אופן', (
+    testWidgets('שני המסלולים מסתירים את הגליף ומעבירים את ההדגשה לשכבה', (
       tester,
     ) async {
       for (var index = 0; index < kLinkAnchorVariants.length; index++) {
@@ -143,34 +181,37 @@ void main() {
         );
         await tester.pumpAndSettle();
 
+        // הגליף בשורה שקוף ובלי רקע — בשני המסלולים.
         final htmlStyle = _findWidgetStyle(tester, '(א)')!;
         final continuousStyle = continuousStyleOf(html, '(א)');
-
         expect(
-          _background(continuousStyle),
-          _background(htmlStyle),
-          reason: 'רקע, וריאנט $index',
+          htmlStyle.color!.toARGB32() >> 24,
+          0,
+          reason: 'גליף שקוף במסלול HtmlWidget, וריאנט $index',
         );
         expect(
-          _background(htmlStyle),
-          activeBackground.toARGB32(),
-          reason: 'הרקע חייב להיות מיושם בפועל, וריאנט $index',
+          continuousStyle.color!.toARGB32() >> 24,
+          0,
+          reason: 'גליף שקוף בקריאה רציפה, וריאנט $index',
         );
+        expect(_background(htmlStyle), isNull, reason: 'וריאנט $index');
+        expect(_background(continuousStyle), isNull, reason: 'וריאנט $index');
         expect(
           continuousStyle.fontFamily,
           htmlStyle.fontFamily,
-          reason: 'גופן, וריאנט $index',
+          reason: 'גופן זהה לרוחב מקום זהה, וריאנט $index',
         );
-        expect(
-          continuousStyle.decoration ?? TextDecoration.none,
-          htmlStyle.decoration ?? TextDecoration.none,
-          reason: 'קו תחתון, וריאנט $index',
+
+        // הציור המורם נושא את מלוא העיצוב: וריאנט, מצב פעיל וצבעי הנושא.
+        final overlay = tester.widget<RaisedMarkerOverlay>(
+          find.byType(RaisedMarkerOverlay),
         );
-        expect(
-          continuousStyle.fontWeight,
-          FontWeight.bold,
-          reason: 'הדגשה, וריאנט $index',
-        );
+        final marker = overlay.markers.single;
+        expect(marker.active, isTrue, reason: 'וריאנט $index');
+        expect(marker.useLinkColor, isTrue, reason: 'וריאנט $index');
+        expect(marker.variantIndex, index);
+        expect(overlay.linkColor, linkColor);
+        expect(overlay.activeBackground, activeBackground);
       }
     });
   });

--- a/test/widgets/smart_text/raised_markers_perf_test.dart
+++ b/test/widgets/smart_text/raised_markers_perf_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
+import 'package:otzaria/widgets/smart_text/render_settings.dart';
+import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
+
+/// שכבת הסימונים המורמים מציירת בכל פריים. קטע ריאלי בספר נושא עשרות סימונים,
+/// והציור חייב להישאר זול — אחרת הגלילה נתקעת. האיתור עצמו (toPlainText לכל
+/// פסקה + חיפוש לכל סימון) יקר, ולכן הוא ממוזג לפי הפריסה; הבדיקה מודדת ציור
+/// חוזר בלי שינוי פריסה — בדיוק מה שקורה בגלילה — ומשווה לאותו קטע בלי שכבה,
+/// כדי שהמידה תהיה התקורה שלנו ולא כוח המכונה.
+///
+/// לפני המיזוג המדידה הזאת הראתה 41ms לפריים (מול תקציב פריים של 16ms), וזו
+/// הייתה הסיבה לתקיעות שדווחה.
+void main() {
+  String heavyText({required bool withMarkers}) {
+    final buffer = StringBuffer();
+    for (var i = 0; i < 60; i++) {
+      final marker = withMarkers
+          ? '<sup>${String.fromCharCode(0x05D0 + i % 22)}</sup>'
+          : '';
+      buffer.write(
+        'ויאמר אלהים אל משה ואל אהרן לאמר דברו אל בני ישראל '
+        'ואמרתם אליהם כה אמר השם$marker ',
+      );
+    }
+    return buffer.toString();
+  }
+
+  Future<double> measureRepaints(
+    WidgetTester tester,
+    String text,
+    RenderObject Function() targetOf,
+  ) async {
+    final stopwatch = Stopwatch()..start();
+    for (var i = 0; i < 30; i++) {
+      targetOf().markNeedsPaint();
+      await tester.pump();
+    }
+    stopwatch.stop();
+    return stopwatch.elapsedMicroseconds / 30 / 1000;
+  }
+
+  testWidgets('ציור חוזר של קטע עם 60 סימונים נשאר זול', (tester) async {
+    final buffer = StringBuffer(heavyText(withMarkers: true));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: SizedBox(
+              width: 700,
+              height: 4000,
+              child: SmartTextWidget(
+                text: buffer.toString(),
+                settings: const RenderSettings(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final overlay = tester.renderObject<RenderRaisedMarkerOverlay>(
+      find.byType(RaisedMarkerOverlay),
+    );
+    expect(overlay.debugPlacements().length, greaterThan(50));
+
+    final withOverlay = await measureRepaints(
+      tester,
+      buffer.toString(),
+      () => overlay,
+    );
+
+    // אותו קטע בלי סימונים — קו הבסיס של ציור הטקסט עצמו.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: SizedBox(
+              width: 700,
+              height: 4000,
+              child: SmartTextWidget(
+                text: heavyText(withMarkers: false),
+                settings: const RenderSettings(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(RaisedMarkerOverlay), findsNothing);
+    final baseline = await measureRepaints(
+      tester,
+      heavyText(withMarkers: false),
+      () => tester.renderObject(find.byType(RichText).first),
+    );
+
+    final overhead = withOverlay - baseline;
+    debugPrint(
+      'עם שכבה: ${withOverlay.toStringAsFixed(2)}ms · '
+      'בסיס: ${baseline.toStringAsFixed(2)}ms · '
+      'תקורה: ${overhead.toStringAsFixed(2)}ms',
+    );
+    expect(
+      overhead,
+      lessThan(4.0),
+      reason: 'תקורת ציור של $overhead ms לפריים חונקת את הגלילה '
+          '(תקציב פריים ~16ms). לפני המיזוג לפי פריסה זה היה ~40ms.',
+    );
+  });
+}

--- a/test/widgets/smart_text/raised_markers_perf_test.dart
+++ b/test/widgets/smart_text/raised_markers_perf_test.dart
@@ -109,7 +109,8 @@ void main() {
     expect(
       overhead,
       lessThan(4.0),
-      reason: 'תקורת ציור של $overhead ms לפריים חונקת את הגלילה '
+      reason:
+          'תקורת ציור של $overhead ms לפריים חונקת את הגלילה '
           '(תקציב פריים ~16ms). לפני המיזוג לפי פריסה זה היה ~40ms.',
     );
   });

--- a/test/widgets/smart_text/raised_markers_test.dart
+++ b/test/widgets/smart_text/raised_markers_test.dart
@@ -25,7 +25,7 @@ void main() {
     TextRendererService.clearRenderCacheForTesting();
   });
 
-  group('processText — כל sup לא-מספרי הופך ל-span טקסט טהור', () {
+  group('processText — sup פשוט ולא-מספרי הופך ל-span טקסט טהור', () {
     String process(String html) =>
         TextRendererService.processText(html, const RenderSettings());
 
@@ -74,12 +74,34 @@ void main() {
 
     test('תוכן הסימון עטוף בבידוד כיווניות', () {
       final out = process('ברא<sup>א</sup>');
-      expect(out, contains('$rli' 'א' '$pdi'));
+      expect(
+        out,
+        contains(
+          '$rli'
+          'א'
+          '$pdi',
+        ),
+      );
     });
 
     test('סימון לועזי מקבל בידוד LTR', () {
       final out = process('text<sup>a</sup>');
-      expect(out, contains('$lri' 'a' '$pdi'));
+      expect(
+        out,
+        contains(
+          '$lri'
+          'a'
+          '$pdi',
+        ),
+      );
+    });
+
+    test('HTML entity מפוענח לאותו טקסט שמוצג בפריסה', () {
+      final marker = RaisedMarkers.extract(
+        process('לפני<sup>&ast;</sup>אחרי'),
+      ).single;
+
+      expect(marker.text, '$lri*$pdi');
     });
   });
 
@@ -90,28 +112,43 @@ void main() {
 
     test('סימון אחד נקלט עם תווי הבידוד', () {
       final markers = RaisedMarkers.extract(
-        'ברא<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>',
+        'ברא<span class="$kFootnoteMarkerClass">$rli'
+        'א'
+        '$pdi</span>',
       );
       expect(markers, hasLength(1));
-      expect(markers.single.text, '$rli' 'א' '$pdi');
+      expect(
+        markers.single.text,
+        '$rli'
+        'א'
+        '$pdi',
+      );
       expect(markers.single.occurrence, 1);
     });
 
     test('שני סימונים באותה שורה — שניהם, לפי הסדר', () {
       final markers = RaisedMarkers.extract(
-        'בראשית<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>'
+        'בראשית<span class="$kFootnoteMarkerClass">$rli'
+        'א'
+        '$pdi</span>'
         ' ברא ואת<span class="$kFootnoteMarkerClass">$rli'
         'ב'
         '$pdi</span>',
       );
-      expect(markers.map((m) => m.text.replaceAll(rli, '').replaceAll(pdi, '')),
-          ['א', 'ב']);
+      expect(
+        markers.map((m) => m.text.replaceAll(rli, '').replaceAll(pdi, '')),
+        ['א', 'ב'],
+      );
     });
 
     test('אותו סימון פעמיים — מספר המופע עולה', () {
       final markers = RaisedMarkers.extract(
-        'א<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>'
-        'ב<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>',
+        'א<span class="$kFootnoteMarkerClass">$rli'
+        'א'
+        '$pdi</span>'
+        'ב<span class="$kFootnoteMarkerClass">$rli'
+        'א'
+        '$pdi</span>',
       );
       expect(markers, hasLength(2));
       expect(markers[0].occurrence, 1);
@@ -120,7 +157,9 @@ void main() {
 
     test('המטמון מחזיר את אותה רשימה לקלט זהה', () {
       final html =
-          'ברא<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>';
+          'ברא<span class="$kFootnoteMarkerClass">$rli'
+          'א'
+          '$pdi</span>';
       expect(
         identical(RaisedMarkers.extract(html), RaisedMarkers.extract(html)),
         isTrue,
@@ -179,6 +218,14 @@ void main() {
       );
     });
 
+    testWidgets('סימון שמקודד כ-HTML entity אינו נעלם', (tester) async {
+      final overlay = await pump(tester, 'לפני<sup>&ast;</sup> אחרי');
+      final placement = overlay.debugPlacements().single;
+
+      expect(placement.text, '$lri*$pdi');
+      expect(placement.paintRect.top, lessThan(placement.anchorRect.top));
+    });
+
     testWidgets('שני סימונים באותה שורה — הסדר לא מתהפך', (tester) async {
       final overlay = await pump(
         tester,
@@ -234,8 +281,9 @@ void main() {
       expect(p.paintRect.top, greaterThanOrEqualTo(0.0));
     });
 
-    testWidgets('גלישת שורה: הסימון נשאר על השורה של המילה שלו',
-        (tester) async {
+    testWidgets('גלישת שורה: הסימון נשאר על השורה של המילה שלו', (
+      tester,
+    ) async {
       final overlay = await pump(
         tester,
         'ובחרת בחיים למען תחיה אתה וזרעך<sup>א</sup> לאהבה את השם',
@@ -283,20 +331,26 @@ void main() {
       expect(find.byType(RaisedMarkerOverlay), findsNothing);
     });
 
-    testWidgets('תמיכה בסיסית: שורת סימונים נשארת במסלול המהיר (בלי HtmlWidget)',
-        (tester) async {
-      final overlay = await pump(
-        tester,
-        'בראשית<sup>א</sup> ברא ואת<sup>ב</sup> הארץ',
-      );
-      // SimpleInlineHtml מזהה את תגי הסימון בעצמו — אין נפילה ל-HtmlWidget.
-      expect(find.byType(HtmlWidget), findsNothing,
-          reason: 'שורת סימונים חייבת להישאר במסלול המהיר');
-      expect(overlay.debugPlacements(), hasLength(2));
-    });
+    testWidgets(
+      'תמיכה בסיסית: שורת סימונים נשארת במסלול המהיר (בלי HtmlWidget)',
+      (tester) async {
+        final overlay = await pump(
+          tester,
+          'בראשית<sup>א</sup> ברא ואת<sup>ב</sup> הארץ',
+        );
+        // SimpleInlineHtml מזהה את תגי הסימון בעצמו — אין נפילה ל-HtmlWidget.
+        expect(
+          find.byType(HtmlWidget),
+          findsNothing,
+          reason: 'שורת סימונים חייבת להישאר במסלול המהיר',
+        );
+        expect(overlay.debugPlacements(), hasLength(2));
+      },
+    );
 
-    testWidgets('תמיכה בסיסית: גליפי הסימון במסלול המהיר שקופים ומוקטנים',
-        (tester) async {
+    testWidgets('תמיכה בסיסית: גליפי הסימון במסלול המהיר שקופים ומוקטנים', (
+      tester,
+    ) async {
       await pump(tester, 'בראשית<sup>א</sup> ברא');
       TextStyle? markerStyle;
       for (final rich in tester.widgetList<RichText>(find.byType(RichText))) {
@@ -314,13 +368,21 @@ void main() {
         visit(rich.text);
       }
       expect(markerStyle, isNotNull, reason: 'לא נמצא ספאן סימון שקוף');
-      expect(markerStyle!.fontSize, closeTo(18.0 * kHtmlSmallerFontScale, 0.001),
-          reason: 'sup חשוף חייב לשמור על יחס 5/6 גם במסלול המהיר');
-      expect(markerStyle!.fontStyle ?? FontStyle.normal, FontStyle.normal,
-          reason: 'sup חשוף אינו נוטה');
+      expect(
+        markerStyle!.fontSize,
+        closeTo(18.0 * kHtmlSmallerFontScale, 0.001),
+        reason: 'sup חשוף חייב לשמור על יחס 5/6 גם במסלול המהיר',
+      );
+      expect(
+        markerStyle!.fontStyle ?? FontStyle.normal,
+        FontStyle.normal,
+        reason: 'sup חשוף אינו נוטה',
+      );
     });
 
-    testWidgets('מסלול HtmlWidget (תגים מורכבים) — אותה התנהגות', (tester) async {
+    testWidgets('מסלול HtmlWidget (תגים מורכבים) — אותה התנהגות', (
+      tester,
+    ) async {
       // span זר מפיל את המסלול המהיר — מוודאים שהשכבה עובדת גם שם.
       final overlay = await pump(
         tester,
@@ -372,39 +434,44 @@ void main() {
       expect(found!.color!.a, 0, reason: 'הגליף שקוף — השכבה מציירת אותו');
     });
 
-    test('buildInlineHtmlSpans: בלי שכבה הסימון נשאר גלוי (hideRaisedMarkers)',
-        () {
-      final html = TextRendererService.processText(
-        'ברא<sup>א</sup>',
-        const RenderSettings(),
-      );
-      TextStyle? styleOf(List<InlineSpan> spans) {
-        TextStyle? found;
-        void visit(InlineSpan s, TextStyle? inherited) {
-          if (s is! TextSpan) return;
-          final style = s.style ?? inherited;
-          if ((s.text ?? '').contains('א')) found = style;
-          for (final c in s.children ?? const <InlineSpan>[]) {
-            visit(c, style);
+    test(
+      'buildInlineHtmlSpans: בלי שכבה הסימון נשאר גלוי (hideRaisedMarkers)',
+      () {
+        final html = TextRendererService.processText(
+          'ברא<sup>א</sup>',
+          const RenderSettings(),
+        );
+        TextStyle? styleOf(List<InlineSpan> spans) {
+          TextStyle? found;
+          void visit(InlineSpan s, TextStyle? inherited) {
+            if (s is! TextSpan) return;
+            final style = s.style ?? inherited;
+            if ((s.text ?? '').contains('א')) found = style;
+            for (final c in s.children ?? const <InlineSpan>[]) {
+              visit(c, style);
+            }
           }
+
+          for (final s in spans) {
+            visit(s, null);
+          }
+          return found;
         }
 
-        for (final s in spans) {
-          visit(s, null);
-        }
-        return found;
-      }
+        const base = TextStyle(fontSize: 18, color: Colors.black);
+        final hidden = styleOf(buildInlineHtmlSpans(html, base));
+        expect(hidden?.color?.a, 0, reason: 'ברירת המחדל: שקוף לטובת השכבה');
 
-      const base = TextStyle(fontSize: 18, color: Colors.black);
-      final hidden = styleOf(buildInlineHtmlSpans(html, base));
-      expect(hidden?.color?.a, 0, reason: 'ברירת המחדל: שקוף לטובת השכבה');
-
-      final visible = styleOf(
-        buildInlineHtmlSpans(html, base, hideRaisedMarkers: false),
-      );
-      expect(visible?.color?.a, isNot(0),
-          reason: 'קורא בלי שכבה חייב לקבל גליפים גלויים');
-    });
+        final visible = styleOf(
+          buildInlineHtmlSpans(html, base, hideRaisedMarkers: false),
+        );
+        expect(
+          visible?.color?.a,
+          isNot(0),
+          reason: 'קורא בלי שכבה חייב לקבל גליפים גלויים',
+        );
+      },
+    );
 
     testWidgets('מצב קריאה רציפה — הסימון מורם גם שם', (tester) async {
       const base = TextStyle(fontSize: 20, fontFamily: 'FrankRuhlCLM');
@@ -471,8 +538,9 @@ void main() {
       );
     });
 
-    testWidgets('סימון מספרי לא עובר בשכבה (ספרת-עילית יוניקוד)',
-        (tester) async {
+    testWidgets('סימון מספרי לא עובר בשכבה (ספרת-עילית יוניקוד)', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Directionality(
@@ -665,8 +733,9 @@ void main() {
       );
     });
 
-    testWidgets('לחיצה על הציור המורם מפעילה את העוגן (הפניית hit-test)',
-        (tester) async {
+    testWidgets('לחיצה על הציור המורם מפעילה את העוגן (הפניית hit-test)', (
+      tester,
+    ) async {
       String? tapped;
       final overlay = await pump(
         tester,
@@ -751,8 +820,9 @@ void main() {
       expect(placements[1].marker.variantIndex, 1);
     });
 
-    testWidgets('קטע עם סימונים לא-לחיצים בלבד אינו סורק ב-hit-test',
-        (tester) async {
+    testWidgets('קטע עם סימונים לא-לחיצים בלבד אינו סורק ב-hit-test', (
+      tester,
+    ) async {
       final overlay = await pump(tester, 'בראשית<sup>א</sup> ברא');
       // לחיצה על אמצע הקטע — לא אמורה לזרוק ולא להפנות לשום מקום.
       await tester.tapAt(overlay.localToGlobal(const Offset(50, 10)));
@@ -760,7 +830,9 @@ void main() {
       expect(overlay.debugPlacements(), hasLength(1));
     });
 
-    testWidgets('קריאה רציפה: אות מפרש מורמת ולחיצה עליה מנתבת', (tester) async {
+    testWidgets('קריאה רציפה: אות מפרש מורמת ולחיצה עליה מנתבת', (
+      tester,
+    ) async {
       final tapped = <String>[];
       await tester.pumpWidget(
         MaterialApp(

--- a/test/widgets/smart_text/raised_markers_test.dart
+++ b/test/widgets/smart_text/raised_markers_test.dart
@@ -1,0 +1,825 @@
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart'
+    show HtmlWidget;
+import 'package:otzaria/text_book/utils/link_anchor_variants.dart'
+    show kLinkAnchorMarkerScale;
+import 'package:otzaria/text_book/view/widgets/continuous_reading_paragraph.dart';
+import 'package:otzaria/widgets/smart_text/raised_markers.dart';
+import 'package:otzaria/widgets/smart_text/render_settings.dart';
+import 'package:otzaria/widgets/smart_text/simple_inline_html.dart';
+import 'package:otzaria/widgets/smart_text/smart_text_widget.dart';
+import 'package:otzaria/widgets/smart_text/text_renderer_service.dart';
+
+/// LRI/RLI/PDI — `_fixFootnoteMarkers` עוטף בהם את תוכן הסימון. נבנים
+/// מ-code point כדי לא לשתול תווי כיווניות בקוד המקור עצמו.
+final rli = String.fromCharCode(0x2067);
+final lri = String.fromCharCode(0x2066);
+final pdi = String.fromCharCode(0x2069);
+
+void main() {
+  setUp(() {
+    RaisedMarkers.clearCacheForTesting();
+    TextRendererService.clearRenderCacheForTesting();
+  });
+
+  group('processText — כל sup לא-מספרי הופך ל-span טקסט טהור', () {
+    String process(String html) =>
+        TextRendererService.processText(html, const RenderSettings());
+
+    test('sup עם class מרקר', () {
+      final out = process('ברא<sup class="footnote-marker">א</sup> אלהים');
+      expect(out, contains('class="$kFootnoteMarkerClass"'));
+      expect(out, isNot(contains('<sup')));
+    });
+
+    test('sup חשוף מקובץ משתמש — התיקון האמיתי של הבאג', () {
+      // זה המקרה מהתמלול: קובץ HTML שנטען דרך "אוסף קבצים" עם <sup> רגיל.
+      // לפני התיקון הוא נשאר <sup> → WidgetSpan → סדר הפוך בשני סימונים.
+      final out = process('בראשית<sup>א</sup> ברא');
+      expect(out, contains('class="$kRaisedSupClass"'));
+      expect(out, isNot(contains('<sup')));
+    });
+
+    test('superscript תוכני (מילה שלמה) גם הוא span', () {
+      final out = process('טקסט<sup>מעלית</sup>');
+      expect(out, contains('class="$kRaisedSupClass"'));
+      expect(out, isNot(contains('<sup')));
+    });
+
+    test('sup מספרי נשאר ספרת-עילית יוניקוד (בלי span)', () {
+      final out = process('ברא<sup>12</sup>');
+      expect(out, contains('¹²'));
+      expect(out, isNot(contains(kFootnoteMarkerClass)));
+      expect(out, isNot(contains(kRaisedSupClass)));
+    });
+
+    test('מרקר הערה נטוי ומוקטן 0.75, sup חשוף 5/6 בלי נטייה', () {
+      final footnote = RaisedMarkers.extract(
+        process('ברא<sup class="footnote-marker">א</sup>'),
+      ).single;
+      expect(footnote.scale, kFootnoteMarkerScale);
+      expect(footnote.italic, isTrue);
+
+      final bare = RaisedMarkers.extract(process('ברא<sup>א</sup>')).single;
+      expect(bare.scale, kHtmlSmallerFontScale);
+      expect(bare.italic, isFalse);
+    });
+
+    test('sup ריק מוסר', () {
+      expect(process('ברא<sup> </sup> אלהים'), 'ברא אלהים');
+    });
+
+    test('תוכן הסימון עטוף בבידוד כיווניות', () {
+      final out = process('ברא<sup>א</sup>');
+      expect(out, contains('$rli' 'א' '$pdi'));
+    });
+
+    test('סימון לועזי מקבל בידוד LTR', () {
+      final out = process('text<sup>a</sup>');
+      expect(out, contains('$lri' 'a' '$pdi'));
+    });
+  });
+
+  group('RaisedMarkers.extract — חילוץ', () {
+    test('טקסט בלי סימונים מחזיר רשימה ריקה', () {
+      expect(RaisedMarkers.extract('בראשית ברא אלהים'), isEmpty);
+    });
+
+    test('סימון אחד נקלט עם תווי הבידוד', () {
+      final markers = RaisedMarkers.extract(
+        'ברא<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>',
+      );
+      expect(markers, hasLength(1));
+      expect(markers.single.text, '$rli' 'א' '$pdi');
+      expect(markers.single.occurrence, 1);
+    });
+
+    test('שני סימונים באותה שורה — שניהם, לפי הסדר', () {
+      final markers = RaisedMarkers.extract(
+        'בראשית<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>'
+        ' ברא ואת<span class="$kFootnoteMarkerClass">$rli'
+        'ב'
+        '$pdi</span>',
+      );
+      expect(markers.map((m) => m.text.replaceAll(rli, '').replaceAll(pdi, '')),
+          ['א', 'ב']);
+    });
+
+    test('אותו סימון פעמיים — מספר המופע עולה', () {
+      final markers = RaisedMarkers.extract(
+        'א<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>'
+        'ב<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>',
+      );
+      expect(markers, hasLength(2));
+      expect(markers[0].occurrence, 1);
+      expect(markers[1].occurrence, 2);
+    });
+
+    test('המטמון מחזיר את אותה רשימה לקלט זהה', () {
+      final html =
+          'ברא<span class="$kFootnoteMarkerClass">$rli' 'א' '$pdi</span>';
+      expect(
+        identical(RaisedMarkers.extract(html), RaisedMarkers.extract(html)),
+        isTrue,
+      );
+    });
+  });
+
+  group('RaisedMarkerOverlay — גאומטריה על עץ הרינדור', () {
+    Future<RenderRaisedMarkerOverlay> pump(
+      WidgetTester tester,
+      String html, {
+      double width = 600,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.topRight,
+                child: SizedBox(
+                  width: width,
+                  child: SmartTextWidget(
+                    text: html,
+                    settings: const RenderSettings(),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return tester.renderObject<RenderRaisedMarkerOverlay>(
+        find.byType(RaisedMarkerOverlay),
+      );
+    }
+
+    testWidgets('הסימון מצויר מעל מקומו בשורה', (tester) async {
+      final overlay = await pump(
+        tester,
+        'בראשית<sup>א</sup> ברא אלהים את השמים',
+      );
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(1));
+      final p = placements.single;
+      expect(
+        p.paintRect.top,
+        lessThan(p.anchorRect.top),
+        reason: 'הציור חייב להיות גבוה מהעוגן — זו כל הפואנטה של אות גבוהה',
+      );
+      expect(
+        (p.paintRect.center.dx - p.anchorRect.center.dx).abs(),
+        lessThanOrEqualTo(1.5),
+        reason: 'הציור חייב להתלבש אופקית על הגליפים השקופים',
+      );
+    });
+
+    testWidgets('שני סימונים באותה שורה — הסדר לא מתהפך', (tester) async {
+      final overlay = await pump(
+        tester,
+        'בראשית<sup>א</sup> ברא אלהים את השמיים ואת<sup>ב</sup> הארץ',
+      );
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(2));
+      // ב-RTL הסימון הראשון (א) חייב להיות ימני מהשני (ב).
+      expect(
+        placements[0].anchorRect.center.dx,
+        greaterThan(placements[1].anchorRect.center.dx),
+        reason: 'הבאג המקורי: א ו-ב מוצגים הפוך',
+      );
+      expect(
+        placements[0].paintRect.center.dx,
+        greaterThan(placements[1].paintRect.center.dx),
+        reason: 'גם הציור עצמו חייב לשמור על הסדר',
+      );
+    });
+
+    testWidgets('שלושה סימונים — הסדר עולה מימין לשמאל', (tester) async {
+      final overlay = await pump(
+        tester,
+        'אחד<sup>א</sup> שנים<sup>ב</sup> שלשה<sup>ג</sup> ארבעה',
+      );
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(3));
+      for (var i = 0; i < placements.length - 1; i++) {
+        expect(
+          placements[i].anchorRect.center.dx,
+          greaterThan(placements[i + 1].anchorRect.center.dx),
+          reason: 'סימון $i חייב להיות ימני מסימון ${i + 1}',
+        );
+      }
+    });
+
+    testWidgets('סימונים לועזיים לא הופכים את הסדר', (tester) async {
+      final overlay = await pump(
+        tester,
+        'ראשון<sup>a</sup> ואחרון<sup>b</sup> בסוגיה',
+      );
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(2));
+      expect(
+        placements[0].anchorRect.center.dx,
+        greaterThan(placements[1].anchorRect.center.dx),
+      );
+    });
+
+    testWidgets('סימון בשורה הראשונה לא נחתך מעל הגבול', (tester) async {
+      final overlay = await pump(tester, 'בראשית<sup>א</sup> ברא');
+      final p = overlay.debugPlacements().single;
+      expect(p.paintRect.top, greaterThanOrEqualTo(0.0));
+    });
+
+    testWidgets('גלישת שורה: הסימון נשאר על השורה של המילה שלו',
+        (tester) async {
+      final overlay = await pump(
+        tester,
+        'ובחרת בחיים למען תחיה אתה וזרעך<sup>א</sup> לאהבה את השם',
+        width: 150,
+      );
+      final p = overlay.debugPlacements().single;
+      expect(p.paintRect.top, lessThan(p.anchorRect.top));
+      expect(
+        (p.paintRect.center.dx - p.anchorRect.center.dx).abs(),
+        lessThanOrEqualTo(1.5),
+      );
+    });
+
+    testWidgets('טקסט הסימון נשאר בטקסט (בחירה והעתקה)', (tester) async {
+      final overlay = await pump(tester, 'בראשית<sup>א</sup> ברא');
+      var joined = '';
+      void visit(RenderObject object) {
+        if (object is RenderParagraph) {
+          joined += object.text.toPlainText();
+          return;
+        }
+        object.visitChildren(visit);
+      }
+
+      visit(overlay);
+      expect(joined, contains('א'), reason: 'הסימון חייב להישאר בטקסט');
+      expect(joined, contains('בראשית'));
+    });
+
+    testWidgets('קטע בלי סימונים לא נעטף בשכבה', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: SmartTextWidget(
+                text: 'בראשית ברא אלהים',
+                settings: const RenderSettings(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(RaisedMarkerOverlay), findsNothing);
+    });
+
+    testWidgets('תמיכה בסיסית: שורת סימונים נשארת במסלול המהיר (בלי HtmlWidget)',
+        (tester) async {
+      final overlay = await pump(
+        tester,
+        'בראשית<sup>א</sup> ברא ואת<sup>ב</sup> הארץ',
+      );
+      // SimpleInlineHtml מזהה את תגי הסימון בעצמו — אין נפילה ל-HtmlWidget.
+      expect(find.byType(HtmlWidget), findsNothing,
+          reason: 'שורת סימונים חייבת להישאר במסלול המהיר');
+      expect(overlay.debugPlacements(), hasLength(2));
+    });
+
+    testWidgets('תמיכה בסיסית: גליפי הסימון במסלול המהיר שקופים ומוקטנים',
+        (tester) async {
+      await pump(tester, 'בראשית<sup>א</sup> ברא');
+      TextStyle? markerStyle;
+      for (final rich in tester.widgetList<RichText>(find.byType(RichText))) {
+        void visit(InlineSpan span) {
+          if (span is TextSpan) {
+            if ((span.text ?? '').contains('א') &&
+                span.style?.color != null &&
+                span.style!.color!.a == 0) {
+              markerStyle = span.style;
+            }
+            span.children?.forEach(visit);
+          }
+        }
+
+        visit(rich.text);
+      }
+      expect(markerStyle, isNotNull, reason: 'לא נמצא ספאן סימון שקוף');
+      expect(markerStyle!.fontSize, closeTo(18.0 * kHtmlSmallerFontScale, 0.001),
+          reason: 'sup חשוף חייב לשמור על יחס 5/6 גם במסלול המהיר');
+      expect(markerStyle!.fontStyle ?? FontStyle.normal, FontStyle.normal,
+          reason: 'sup חשוף אינו נוטה');
+    });
+
+    testWidgets('מסלול HtmlWidget (תגים מורכבים) — אותה התנהגות', (tester) async {
+      // span זר מפיל את המסלול המהיר — מוודאים שהשכבה עובדת גם שם.
+      final overlay = await pump(
+        tester,
+        'בראשית<sup>א</sup> ברא ואת<sup>ב</sup> הארץ <span class="x">.</span>',
+      );
+      expect(find.byType(HtmlWidget), findsOneWidget);
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(2));
+      expect(
+        placements[0].anchorRect.center.dx,
+        greaterThan(placements[1].anchorRect.center.dx),
+        reason: 'הסדר חייב להישמר גם במסלול HtmlWidget',
+      );
+      for (final p in placements) {
+        expect(p.paintRect.top, lessThan(p.anchorRect.top));
+      }
+    });
+
+    test('SimpleInlineHtml: span זר עדיין מפיל ל-HtmlWidget', () {
+      const style = TextStyle(fontSize: 18);
+      expect(
+        SimpleInlineHtml.tryParse('טקסט <span class="x">זר</span>', style),
+        isNull,
+      );
+      expect(SimpleInlineHtml.tryParse('טקסט יתום</span>', style), isNull);
+    });
+
+    test('SimpleInlineHtml: מרקר הערה מקבל 0.75 ונטוי, בתוך מודגש', () {
+      const style = TextStyle(fontSize: 20);
+      final html = TextRendererService.processText(
+        '<b>מודגש<sup class="footnote-marker">א</sup></b>',
+        const RenderSettings(fontSize: 20),
+      );
+      final span = SimpleInlineHtml.tryParse(html, style);
+      expect(span, isNotNull, reason: 'שורת מרקר חייבת להתקבל במסלול המהיר');
+      TextStyle? found;
+      void visit(InlineSpan s) {
+        if (s is TextSpan) {
+          if ((s.text ?? '').contains('א')) found = s.style;
+          s.children?.forEach(visit);
+        }
+      }
+
+      visit(span!);
+      expect(found, isNotNull);
+      expect(found!.fontSize, closeTo(20 * kFootnoteMarkerScale, 0.001));
+      expect(found!.fontStyle, FontStyle.italic);
+      expect(found!.fontWeight, FontWeight.bold, reason: 'הבולד העוטף נשמר');
+      expect(found!.color!.a, 0, reason: 'הגליף שקוף — השכבה מציירת אותו');
+    });
+
+    test('buildInlineHtmlSpans: בלי שכבה הסימון נשאר גלוי (hideRaisedMarkers)',
+        () {
+      final html = TextRendererService.processText(
+        'ברא<sup>א</sup>',
+        const RenderSettings(),
+      );
+      TextStyle? styleOf(List<InlineSpan> spans) {
+        TextStyle? found;
+        void visit(InlineSpan s, TextStyle? inherited) {
+          if (s is! TextSpan) return;
+          final style = s.style ?? inherited;
+          if ((s.text ?? '').contains('א')) found = style;
+          for (final c in s.children ?? const <InlineSpan>[]) {
+            visit(c, style);
+          }
+        }
+
+        for (final s in spans) {
+          visit(s, null);
+        }
+        return found;
+      }
+
+      const base = TextStyle(fontSize: 18, color: Colors.black);
+      final hidden = styleOf(buildInlineHtmlSpans(html, base));
+      expect(hidden?.color?.a, 0, reason: 'ברירת המחדל: שקוף לטובת השכבה');
+
+      final visible = styleOf(
+        buildInlineHtmlSpans(html, base, hideRaisedMarkers: false),
+      );
+      expect(visible?.color?.a, isNot(0),
+          reason: 'קורא בלי שכבה חייב לקבל גליפים גלויים');
+    });
+
+    testWidgets('מצב קריאה רציפה — הסימון מורם גם שם', (tester) async {
+      const base = TextStyle(fontSize: 20, fontFamily: 'FrankRuhlCLM');
+      final firstLine = TextRendererService.processText(
+        'בראשית<sup>א</sup> ברא אלהים',
+        const RenderSettings(fontSize: 20, fontFamily: 'FrankRuhlCLM'),
+      );
+      final secondLine = TextRendererService.processText(
+        'ואת<sup>ב</sup> הארץ',
+        const RenderSettings(fontSize: 20, fontFamily: 'FrankRuhlCLM'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.topRight,
+                child: SizedBox(
+                  width: 600,
+                  child: ContinuousReadingParagraph(
+                    lines: [
+                      ContinuousReadingParagraphLine(
+                        lineIndex: 0,
+                        text: 'בראשית ברא אלהים',
+                        htmlText: firstLine,
+                        style: base,
+                      ),
+                      ContinuousReadingParagraphLine(
+                        lineIndex: 1,
+                        text: 'ואת הארץ',
+                        htmlText: secondLine,
+                        style: base,
+                      ),
+                    ],
+                    baseStyle: base,
+                    onLineTap: (_) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final overlay = tester.renderObject<RenderRaisedMarkerOverlay>(
+        find.byType(RaisedMarkerOverlay),
+      );
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(2));
+      for (final p in placements) {
+        expect(
+          p.paintRect.top,
+          lessThan(p.anchorRect.top),
+          reason: 'גם בקריאה רציפה הסימון חייב להיות מורם',
+        );
+      }
+      expect(
+        placements[0].anchorRect.center.dx,
+        greaterThan(placements[1].anchorRect.center.dx),
+        reason: 'הסדר נשמר גם כששני הסימונים באים משורות שונות באותה פסקה',
+      );
+    });
+
+    testWidgets('סימון מספרי לא עובר בשכבה (ספרת-עילית יוניקוד)',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: SmartTextWidget(
+                text: 'ברא<sup>1</sup> אלהים',
+                settings: const RenderSettings(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(RaisedMarkerOverlay), findsNothing);
+      expect(find.textContaining('¹'), findsOneWidget);
+    });
+  });
+
+  group('סימונים לחיצים — חילוץ', () {
+    test('book-note-marker: מטריקות מרקר הערה + הפניית לחיצה', () {
+      final markers = RaisedMarkers.extract(
+        'מנשא <a class="book-note-marker" '
+        'href="otzaria://book-note?line=0&note=0">*</a> עוני',
+      );
+      expect(markers, hasLength(1));
+      final marker = markers.single;
+      expect(marker.text, '*');
+      expect(marker.scale, kFootnoteMarkerScale);
+      expect(marker.italic, isTrue);
+      expect(marker.clickable, isTrue);
+      expect(marker.useLinkColor, isFalse);
+      expect(marker.active, isFalse);
+    });
+
+    test('link-anchor: וריאנט, צבע קישור ומצב פעיל', () {
+      final markers = RaisedMarkers.extract(
+        'מילה <a class="link-anchor link-anchor-3 link-anchor-active" '
+        'href="otzaria://anchor?ref=0_0">(א)</a> אחרי',
+      );
+      final marker = markers.single;
+      expect(marker.text, '(א)');
+      expect(marker.scale, kLinkAnchorMarkerScale);
+      expect(marker.italic, isFalse);
+      expect(marker.clickable, isTrue);
+      expect(marker.useLinkColor, isTrue);
+      expect(marker.variantIndex, 3);
+      expect(marker.active, isTrue);
+    });
+
+    test('גם צורת ה-span הלא-אינטראקטיבית של אות מפרש מחולצת', () {
+      final markers = RaisedMarkers.extract(
+        '<span class="link-anchor link-anchor-1">(ב)</span>',
+      );
+      expect(markers.single.variantIndex, 1);
+      expect(markers.single.active, isFalse);
+      expect(markers.single.clickable, isTrue);
+    });
+
+    test('link-anchor חשוף (בלי וריאנט) מחולץ — הגנה מפני טקסט נעלם', () {
+      // customStylesBuilder צובע כל link-anchor שקוף; כל צורה שנצבעת חייבת
+      // להיקלט כאן, אחרת האות תיעלם מהמסך.
+      final markers = RaisedMarkers.extract(
+        '<span class="link-anchor">א</span>',
+      );
+      expect(markers, hasLength(1));
+      expect(markers.single.variantIndex, isNull);
+      expect(markers.single.scale, kLinkAnchorMarkerScale);
+    });
+
+    test('טווח-ציטוט וסמן-מספר מודפס נשארים במקומם — לא מחולצים', () {
+      expect(
+        RaisedMarkers.extract(
+          '<a class="link-anchor-range" href="otzaria://anchor?ref=0_0&range=1">'
+          'ציטוט ארוך</a>',
+        ),
+        isEmpty,
+      );
+      expect(
+        RaisedMarkers.extract(
+          '<a class="numbered-note-marker" href="otzaria://note-marker?x=1">(9)</a>',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('עיצוב סוגריים (<small> בתוך הסימון) מקטין את הציור באותו יחס', () {
+      // processText עוטף "(א)" ב-<small>; הגליף בשורה קטן בהתאם, והציור
+      // חייב להתלבש עליו בדיוק — לא לבלוט מעבר למקום ששמור בשורה.
+      final markers = RaisedMarkers.extract(
+        TextRendererService.processText(
+          'מילה <a class="link-anchor link-anchor-0" '
+          'href="otzaria://anchor?ref=0_0">(א)</a> אחרי',
+          const RenderSettings(),
+        ),
+      );
+      expect(markers, hasLength(1));
+      expect(
+        markers.single.scale,
+        closeTo(kLinkAnchorMarkerScale * kHtmlSmallerFontScale, 0.0001),
+      );
+    });
+
+    test('ספירת מופעים משותפת בין המשפחות — אותה ספירה שהציור מבצע', () {
+      final markers = RaisedMarkers.extract(
+        '<span class="$kRaisedSupClass">א</span> ביניים '
+        '<a class="book-note-marker" href="otzaria://book-note?line=0&note=0">'
+        'א</a>',
+      );
+      expect(markers, hasLength(2));
+      expect(markers[0].occurrence, 1);
+      expect(markers[1].occurrence, 2);
+      expect(markers[0].clickable, isFalse);
+      expect(markers[1].clickable, isTrue);
+    });
+  });
+
+  group('סימונים לחיצים — הרמה והפניית hit-test', () {
+    Future<RenderRaisedMarkerOverlay> pump(
+      WidgetTester tester,
+      String html, {
+      double width = 600,
+      void Function(String url)? onAnchorTap,
+      void Function(String url, Offset position)? onAnchorHover,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.topRight,
+                child: SizedBox(
+                  width: width,
+                  child: SmartTextWidget(
+                    text: html,
+                    settings: const RenderSettings(),
+                    onAnchorTap: onAnchorTap,
+                    onAnchorHover: onAnchorHover,
+                    onNoteTap: (_) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return tester.renderObject<RenderRaisedMarkerOverlay>(
+        find.byType(RaisedMarkerOverlay),
+      );
+    }
+
+    /// נקודה שנמצאת בציור המורם אך מחוץ לעוגן שבשורה — פגיעה בה מוכיחה
+    /// שההפניה עובדת ולא סתם חפיפה בין המלבנים.
+    Offset raisedOnlyPoint(RaisedMarkerPlacement placement) {
+      final point = Offset(
+        placement.paintRect.center.dx,
+        placement.paintRect.top + 1,
+      );
+      expect(
+        placement.anchorRect.contains(point),
+        isFalse,
+        reason: 'נקודת הבדיקה חייבת להיות מחוץ לעוגן — אחרת הבדיקה ריקה',
+      );
+      return point;
+    }
+
+    // הסימון בשורה השנייה כדי שההרמה לא תיחסם בגבול העליון של הקטע.
+    const twoLineAnchor =
+        'ובני ישראל יוצאים ביד רמה והמצרים רודפים אחריהם '
+        'וישיגו אותם חונים על הים '
+        '<a class="link-anchor link-anchor-0" href="otzaria://anchor?ref=5_0">'
+        '(א)</a> ואחרי הדברים האלה';
+
+    testWidgets('אות מפרש מצוירת מורמת מעל העוגן שבשורה', (tester) async {
+      final overlay = await pump(
+        tester,
+        twoLineAnchor,
+        width: 320,
+        onAnchorTap: (_) {},
+      );
+      final placement = overlay.debugPlacements().single;
+      expect(placement.marker.clickable, isTrue);
+      expect(placement.marker.useLinkColor, isTrue);
+      expect(placement.paintRect.top, lessThan(placement.anchorRect.top));
+      expect(
+        (placement.paintRect.center.dx - placement.anchorRect.center.dx).abs(),
+        lessThanOrEqualTo(1.5),
+      );
+    });
+
+    testWidgets('לחיצה על הציור המורם מפעילה את העוגן (הפניית hit-test)',
+        (tester) async {
+      String? tapped;
+      final overlay = await pump(
+        tester,
+        twoLineAnchor,
+        width: 320,
+        onAnchorTap: (url) => tapped = url,
+      );
+      final placement = overlay.debugPlacements().single;
+      await tester.tapAt(overlay.localToGlobal(raisedOnlyPoint(placement)));
+      await tester.pump();
+      expect(tapped, 'otzaria://anchor?ref=5_0');
+    });
+
+    testWidgets('ריחוף על הציור המורם מפעיל את תצוגת העוגן', (tester) async {
+      final hovered = <String>[];
+      final overlay = await pump(
+        tester,
+        twoLineAnchor,
+        width: 320,
+        onAnchorTap: (_) {},
+        onAnchorHover: (url, _) => hovered.add(url),
+      );
+      final placement = overlay.debugPlacements().single;
+
+      final gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(
+        overlay.localToGlobal(raisedOnlyPoint(placement)),
+      );
+      await tester.pump();
+
+      expect(hovered, contains('otzaria://anchor?ref=5_0'));
+    });
+
+    testWidgets('גם סימון הערה מוטמעת (כוכבית) מורם ולחיץ', (tester) async {
+      final hovered = <String>[];
+      final overlay = await pump(
+        tester,
+        'ולא אוכל מנשוא את כל העם הזה כי כבד הוא ממני '
+        'ואם ככה את עושה לי הרגני נא הרוג '
+        '<a class="book-note-marker" '
+        'href="otzaria://book-note?line=3&note=0">*</a> ואל אראה ברעתי',
+        width: 320,
+        onAnchorHover: (url, _) => hovered.add(url),
+      );
+      final placement = overlay.debugPlacements().single;
+      expect(placement.marker.italic, isTrue);
+      expect(placement.paintRect.top, lessThan(placement.anchorRect.top));
+
+      final gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(
+        overlay.localToGlobal(raisedOnlyPoint(placement)),
+      );
+      await tester.pump();
+      expect(hovered, contains('otzaria://book-note?line=3&note=0'));
+    });
+
+    testWidgets('שתי אותיות מפרשים בפסקת RTL — הסדר לא מתהפך', (tester) async {
+      final overlay = await pump(
+        tester,
+        'ראשון <a class="link-anchor link-anchor-0" '
+        'href="otzaria://anchor?ref=0_0">(א)</a> '
+        'ושני <a class="link-anchor link-anchor-1" '
+        'href="otzaria://anchor?ref=0_1">(ב)</a> בשורה',
+        onAnchorTap: (_) {},
+      );
+      final placements = overlay.debugPlacements();
+      expect(placements, hasLength(2));
+      expect(
+        placements[0].anchorRect.center.dx,
+        greaterThan(placements[1].anchorRect.center.dx),
+        reason: 'אות א חייבת להישאר ימנית מאות ב',
+      );
+      expect(placements[0].marker.variantIndex, 0);
+      expect(placements[1].marker.variantIndex, 1);
+    });
+
+    testWidgets('קטע עם סימונים לא-לחיצים בלבד אינו סורק ב-hit-test',
+        (tester) async {
+      final overlay = await pump(tester, 'בראשית<sup>א</sup> ברא');
+      // לחיצה על אמצע הקטע — לא אמורה לזרוק ולא להפנות לשום מקום.
+      await tester.tapAt(overlay.localToGlobal(const Offset(50, 10)));
+      await tester.pump();
+      expect(overlay.debugPlacements(), hasLength(1));
+    });
+
+    testWidgets('קריאה רציפה: אות מפרש מורמת ולחיצה עליה מנתבת', (tester) async {
+      final tapped = <String>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.topRight,
+                child: SizedBox(
+                  width: 320,
+                  child: ContinuousReadingParagraph(
+                    lines: [
+                      ContinuousReadingParagraphLine(
+                        lineIndex: 0,
+                        text: 'ובני ישראל יוצאים ביד רמה וישיגו אותם (א) חונים',
+                        htmlText:
+                            'ובני ישראל יוצאים ביד רמה וישיגו אותם '
+                            '<a class="link-anchor link-anchor-0" '
+                            'href="otzaria://anchor?ref=0_0">(א)</a> חונים',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ],
+                    baseStyle: const TextStyle(fontSize: 20),
+                    onLineTap: (_) {},
+                    onTapUrl: (url) async {
+                      tapped.add(url);
+                      return true;
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final overlay = tester.renderObject<RenderRaisedMarkerOverlay>(
+        find.byType(RaisedMarkerOverlay),
+      );
+      final placement = overlay.debugPlacements().single;
+      expect(placement.paintRect.top, lessThan(placement.anchorRect.top));
+
+      final point = Offset(
+        placement.paintRect.center.dx,
+        placement.paintRect.top + 1,
+      );
+      if (!placement.anchorRect.contains(point)) {
+        await tester.tapAt(overlay.localToGlobal(point));
+        await tester.pump();
+        expect(tapped, ['otzaria://anchor?ref=0_0']);
+      } else {
+        // הסימון בשורה הראשונה וההרמה נחסמה — עדיין לחיץ דרך העוגן עצמו.
+        await tester.tapAt(
+          overlay.localToGlobal(placement.anchorRect.center),
+        );
+        await tester.pump();
+        expect(tapped, ['otzaria://anchor?ref=0_0']);
+      }
+    });
+  });
+}

--- a/test/widgets/smart_text/simple_inline_html_test.dart
+++ b/test/widgets/smart_text/simple_inline_html_test.dart
@@ -114,7 +114,9 @@ void main() {
 
     group('נפילה ל-HtmlWidget (מחזיר null)', () {
       final cases = <String, String>{
-        'תג עם attributes': '<span class="footnote-marker-number">א</span>',
+        // סימונים מורמים (footnote-marker-number / raised-sup) הם היוצא
+        // מן הכלל היחיד — נתמכים במסלול המהיר; ראו raised_markers_test.
+        'תג עם attributes': '<span class="unknown-class">א</span>',
         'קישור': '<a href="x">קישור</a>',
         'כותרת': '<h2>כותרת</h2>',
         'הדגשת חיפוש': 'לפני <span style="background-color:yellow">מילה</span>',

--- a/test/widgets/smart_text/text_renderer_service_test.dart
+++ b/test/widgets/smart_text/text_renderer_service_test.dart
@@ -83,21 +83,27 @@ Future<void> main() async {
       expect(out, contains('²'));
     });
 
-    test('sup עברי חשוף (בלי class) נשאר sup — superscript תוכני אמיתי', () {
+    // sup חשוף היה נשאר `<sup>` ונרנדר ב-WidgetSpan של fwfh — מה שהפך את סדר
+    // הסימונים בפסקת RTL. כיום הוא נפלט כ-span טקסט טהור במחלקת raised-sup,
+    // עם אותן מטריקות (5/6, בלי נטייה), וההרמה נעשית בציור.
+    test('sup עברי חשוף (בלי class) נפלט כ-raised-sup — superscript תוכני', () {
       const line = 'טקסט עם <sup>מעריך</sup> רגיל';
 
       final out = TextRendererService.processText(line, settings);
 
-      expect(out, contains('<sup>'));
+      expect(out, isNot(contains('<sup')));
+      expect(out, contains('class="raised-sup"'));
       expect(out, isNot(contains('footnote-marker-number')));
     });
 
-    test('sup מורכב (שאינו סימון הערה) נשאר sup', () {
+    test('sup מורכב (שאינו סימון הערה) נפלט כ-raised-sup', () {
       const line = 'טקסט<sup><a href="x">קישור מורכב!</a></sup> המשך';
 
       final out = TextRendererService.processText(line, settings);
 
-      expect(out, contains('<sup>'));
+      expect(out, isNot(contains('<sup')));
+      expect(out, contains('class="raised-sup"'));
+      expect(out, contains('<a href="x">'));
     });
 
     test('sup ריק מוסר לחלוטין', () {

--- a/test/widgets/smart_text/text_renderer_service_test.dart
+++ b/test/widgets/smart_text/text_renderer_service_test.dart
@@ -96,14 +96,26 @@ Future<void> main() async {
       expect(out, isNot(contains('footnote-marker-number')));
     });
 
-    test('sup מורכב (שאינו סימון הערה) נפלט כ-raised-sup', () {
+    test('sup מורכב נשאר sup ושומר את ה-markup הפנימי', () {
       const line = 'טקסט<sup><a href="x">קישור מורכב!</a></sup> המשך';
 
       final out = TextRendererService.processText(line, settings);
 
-      expect(out, isNot(contains('<sup')));
-      expect(out, contains('class="raised-sup"'));
+      expect(out, contains('<sup>'));
+      expect(out, isNot(contains('class="raised-sup"')));
       expect(out, contains('<a href="x">'));
+    });
+
+    test('sup מעוצב שומר attributes', () {
+      const line =
+          'טקסט<sup class="custom" style="color:red" title="note">א</sup>';
+
+      final out = TextRendererService.processText(line, settings);
+
+      expect(out, contains('<sup class="custom"'));
+      expect(out, contains('style="color:red"'));
+      expect(out, contains('title="note"'));
+      expect(out, isNot(contains('class="raised-sup"')));
     });
 
     test('sup ריק מוסר לחלוטין', () {


### PR DESCRIPTION
## הבעיה

טקסט שאמור להיות מוצג מעל גובה השורה — `<sup>`, סימוני הערות, ואותיות
מפרשים לחיצות (עוגני-מילה) — לא הוצג מורם בפועל במסך העיון:

- `flutter_widget_from_html` מממש הרמה (`<sup>`, `position`/`top`) דרך
  `WidgetSpan`. מנוע Flutter משבץ placeholders בפסקת RTL בסדר **ויזואלי**
  במקום לוגי — כששניים כאלה מופיעים באותה פסקה, הם מוצגים הפוך.
- ל-fwfh גם אין תמיכה אמיתית ב-`position`/`top` (no-op בפועל), ולכן
  סימוני הערות מוטמעות ואותיות מפרשים הוצגו מוקטנים אך על קו הבסיס —
  לא מורמים כלל, למרות שהם לחיצים ומציגים תצוגה מקדימה נכונה בריחוף.

## הפתרון

`RaisedMarkerOverlay` — `RenderProxyBox` חדש שמצייר טקסט מורם בשכבה
נפרדת מעל הטקסט הרגיל, בלי להיכנס דרך `WidgetSpan` בכלל:

1. כל סימון שצריך הרמה נפלט מ-`processText`/מזרקי-הקישורים כספאן טקסט
   טהור (סדר RTL מובטח) עם גליף **שקוף** — שומר מקום, בחירה והעתקה.
2. השכבה מאתרת את מלבן הגליף האמיתי דרך `RenderParagraph.getBoxesForSelection`
   ומציירת את אותו טקסט מורם מעליו, בגודל/נטייה/צבע/וריאנט הנכונים.
3. עבור סימונים **לחיצים** (הערה מוטמעת, אות מפרש): לחיצה וריחוף על
   הציור המורם מופנים ל-`anchorRect` שבשורה (`addWithRawTransform`), כך
   שה-`recognizer` הקיים וסמן העכבר ממשיכים לעבוד על מה שהעין רואה.
4. איתור המיקומים ממוזג לפי פריסה (חתימה זולה מאמתת בכל ציור) — תקורת
   ציור על קטע עם 60 סימונים ירדה מ-41ms/פריים ל-0.09ms/פריים; שמור
   בטסט ביצועים ייעודי.
5. תמיכה בסיסית בכל שלושת מסלולי הרינדור (מהיר / `HtmlWidget` / קריאה
   רציפה) — שורת סימונים לא נופלת מיותר למסלול הכבד.

## מה נשאר כפי שהיה בכוונה

- `link-anchor-range` (ציטוט לינקר) וסמן-מספר מודפס (`numbered-note-marker`)
  נשארים בשורה — הם חלק מהטקסט הרגיל, לא דורשים הרמה.

## בדיקות

- `test/widgets/smart_text/raised_markers_test.dart` — חילוץ, גאומטריה,
  סדר RTL, hit-test, ותמיכה בשלושת המסלולים.
- `test/widgets/smart_text/raised_markers_perf_test.dart` — רגרסיית
  ביצועים.
- טסטים קיימים באזור העוגנים (`link_anchor_active_test`,
  `continuous_reading_anchor_variant_test`,
  `continuous_reading_paragraph_test`) עודכנו לחוזה החדש.
- סוויטה מלאה: 8,398 עברו, 6 נכשלו — כל הכשלים קיימים-מראש ואינם קשורים
  (אומתו מול baseline נקי; פירוט ב-`test_results/2026-08-18-raised-inline-markers.md`).
- אומת ידנית ב-Debug ו-Release build על Windows.

🤖 נוצר עם [Claude Code](https://claude.com/claude-code)