### PR TITLE
העתקה מתוצאות חיפוש מכבדת את הגדרות "העתקה עם כותרת"

### DIFF
--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -25,6 +25,7 @@ import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/text_book/view/page_shape/utils/page_shape_settings_manager.dart';
 import 'package:otzaria/utils/navigation/talmud_bavli_open_format.dart';
+import 'package:otzaria/utils/text/copy_utils.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart'
@@ -817,8 +818,29 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                       final plainText = utils.stripHtmlIfNeeded(
                                         rawHtml,
                                       );
+                                      // אותה התנהגות כמו העתקה ממסך הקריאה:
+                                      // המקור והכותרת מצורפים לפי ההגדרות.
+                                      // titleText כבר עבר החלפת שמות קודש.
+                                      final bookName =
+                                          settingsState.replaceHolyNames
+                                          ? utils.replaceHolyNames(result.title)
+                                          : result.title;
+                                      final textToCopy =
+                                          CopyUtils.formatTextWithHeaders(
+                                            originalText: plainText,
+                                            copyWithHeaders:
+                                                settingsState.copyWithHeaders,
+                                            copyHeaderFormat:
+                                                settingsState.copyHeaderFormat,
+                                            bookName: bookName,
+                                            currentPath:
+                                                CopyUtils.referencePath(
+                                                  bookName: bookName,
+                                                  reference: titleText,
+                                                ),
+                                          );
                                       Clipboard.setData(
-                                        ClipboardData(text: plainText),
+                                        ClipboardData(text: textToCopy),
                                       );
                                       UiSnack.show(UiSnack.textCopied);
                                     },

--- a/lib/utils/text/copy_utils.dart
+++ b/lib/utils/text/copy_utils.dart
@@ -120,6 +120,25 @@ class CopyUtils {
     }
   }
 
+  /// גוזר מ-reference של תוצאת חיפוש את חלק הנתיב שאחרי שם הספר, כדי
+  /// ש-[formatTextWithHeaders] (שמרכיב "שם ספר, נתיב") לא יכפיל את השם:
+  /// המנוע מחזיר לעיתים reference שכבר פותח בשם הספר ("עבודה זרה, דף עג.")
+  /// ולעיתים נתיב בלבד ("סימן א").
+  static String referencePath({
+    required String bookName,
+    required String reference,
+  }) {
+    final ref = reference.trim();
+    final book = bookName.trim();
+    if (book.isEmpty || ref == book) return ref == book ? '' : ref;
+    if (!ref.startsWith(book)) return ref;
+    var rest = ref.substring(book.length).trimLeft();
+    if (rest.startsWith(',')) {
+      rest = rest.substring(1).trimLeft();
+    }
+    return rest;
+  }
+
   /// מעצב טקסט עם כותרות בהתאם להגדרות
   static String formatTextWithHeaders({
     required String originalText,

--- a/lib/utils/text/copy_utils.dart
+++ b/lib/utils/text/copy_utils.dart
@@ -132,7 +132,13 @@ class CopyUtils {
     final book = bookName.trim();
     if (book.isEmpty || ref == book) return ref == book ? '' : ref;
     if (!ref.startsWith(book)) return ref;
-    var rest = ref.substring(book.length).trimLeft();
+    final suffix = ref.substring(book.length);
+    if (suffix.isNotEmpty &&
+        !suffix.startsWith(',') &&
+        suffix.trimLeft() == suffix) {
+      return ref;
+    }
+    var rest = suffix.trimLeft();
     if (rest.startsWith(',')) {
       rest = rest.substring(1).trimLeft();
     }

--- a/test/search/tantivy_search_results_test.dart
+++ b/test/search/tantivy_search_results_test.dart
@@ -400,6 +400,108 @@ void main() {
       expect(tester.getSize(badge).height, lessThan(30));
     });
 
+    // מיפוי התקלה: המשתמש מגדיר "העתקה עם כותרת" (copyWithHeaders +
+    // copyHeaderFormat) — ההגדרה מכובדת בהעתקה ממסך הקריאה
+    // (context_menu_utils) אבל כפתור ההעתקה בתוצאות החיפוש התעלם ממנה
+    // והעתיק את הטקסט בלבד, בלי המקור והכותרת.
+    group('העתקה עם כותרת ומקור לפי ההגדרות', () {
+      Future<String?> copyWithSettings(
+        WidgetTester tester, {
+        required String copyWithHeaders,
+        required String copyHeaderFormat,
+        int resultIndex = _kPlainTextIndex,
+      }) async {
+        final headersSettingsBloc = MockSettingsBloc();
+        addTearDown(headersSettingsBloc.close);
+        whenListen(
+          headersSettingsBloc,
+          const Stream<SettingsState>.empty(),
+          initialState: SettingsState.initial().copyWith(
+            copyWithHeaders: copyWithHeaders,
+            copyHeaderFormat: copyHeaderFormat,
+          ),
+        );
+
+        String? copiedText;
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (call) async {
+            if (call.method == 'Clipboard.setData') {
+              copiedText = (call.arguments as Map)['text'] as String?;
+            }
+            return null;
+          },
+        );
+
+        await tester.pumpWidget(
+          buildWidget(overrideSettingsBloc: headersSettingsBloc),
+        );
+        await tester.pump();
+
+        final copyButtons = find.byWidgetPredicate(
+          (w) => w is Icon && w.icon == FluentIcons.copy_24_regular,
+        );
+        await tester.tap(copyButtons.at(resultIndex));
+        await tester.pump();
+        return copiedText;
+      }
+
+      testWidgets('שם ספר ומקור בשורה נפרדת לפני הטקסט', (tester) async {
+        final copied = await copyWithSettings(
+          tester,
+          copyWithHeaders: 'book_and_path',
+          copyHeaderFormat: 'separate_line_before',
+        );
+        expect(copied, 'ספר א, סימן א\nטקסט בדיקה 0');
+      });
+
+      testWidgets('שם ספר בלבד, בסוגריים אחרי הטקסט', (tester) async {
+        final copied = await copyWithSettings(
+          tester,
+          copyWithHeaders: 'book_name',
+          copyHeaderFormat: 'same_line_after_brackets',
+        );
+        expect(copied, 'טקסט בדיקה 0 (ספר א)');
+      });
+
+      testWidgets('מקור שכבר פותח בשם הספר אינו מוכפל בכותרת', (tester) async {
+        // כמו תוצאה אמיתית מהמנוע: reference = "עבודה זרה, דף עג." כשהספר
+        // "עבודה זרה" — הכותרת חייבת להיות המקור המלא, בלי שם ספר כפול.
+        searchBloc.emitState(
+          searchBloc.state.copyWith(
+            results: [
+              SearchResult(
+                id: BigInt.from(1),
+                title: 'ספר א',
+                reference: 'ספר א, סימן א',
+                text: 'טקסט בדיקה 0',
+                segment: BigInt.zero,
+                isPdf: false,
+                filePath: 'book_0.txt',
+                mergedCount: 1,
+                merged: const [],
+              ),
+            ],
+          ),
+        );
+        final copied = await copyWithSettings(
+          tester,
+          copyWithHeaders: 'book_and_path',
+          copyHeaderFormat: 'same_line_after_brackets',
+        );
+        expect(copied, 'טקסט בדיקה 0 (ספר א, סימן א)');
+      });
+
+      testWidgets('ברירת המחדל none נשארת העתקת טקסט בלבד', (tester) async {
+        final copied = await copyWithSettings(
+          tester,
+          copyWithHeaders: 'none',
+          copyHeaderFormat: 'same_line_after_brackets',
+        );
+        expect(copied, 'טקסט בדיקה 0');
+      });
+    });
+
     testWidgets(
       'כאשר replaceHolyNames פעיל, הטקסט המועתק כולל החלפת שמות קודש',
       (tester) async {

--- a/test/utils/text/copy_utils_test.dart
+++ b/test/utils/text/copy_utils_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/utils/text/copy_utils.dart';
+
+void main() {
+  group('CopyUtils.referencePath — גזירת נתיב מ-reference של תוצאת חיפוש', () {
+    test('reference שאינו פותח בשם הספר מוחזר כמות שהוא', () {
+      expect(
+        CopyUtils.referencePath(bookName: 'ספר א', reference: 'סימן א'),
+        'סימן א',
+      );
+    });
+
+    test('reference שפותח בשם הספר ופסיק — הנתיב בלבד', () {
+      expect(
+        CopyUtils.referencePath(
+          bookName: 'עבודה זרה',
+          reference: 'עבודה זרה, דף עג.',
+        ),
+        'דף עג.',
+      );
+    });
+
+    test('reference שפותח בשם הספר בלי פסיק — השארית בלבד', () {
+      expect(
+        CopyUtils.referencePath(
+          bookName: 'בראשית',
+          reference: 'בראשית פרק ד',
+        ),
+        'פרק ד',
+      );
+    });
+
+    test('reference שזהה לשם הספר — נתיב ריק (בלי הכפלה)', () {
+      expect(
+        CopyUtils.referencePath(bookName: 'ספר א', reference: 'ספר א'),
+        '',
+      );
+    });
+
+    test('שם ספר ריק — ה-reference מוחזר כמות שהוא', () {
+      expect(
+        CopyUtils.referencePath(bookName: '', reference: 'סימן א'),
+        'סימן א',
+      );
+    });
+  });
+
+  group('CopyUtils.formatTextWithHeaders — שילוב עם הנתיב שנגזר', () {
+    test('book_and_path עם נתיב ריק נופל לשם הספר בלבד', () {
+      expect(
+        CopyUtils.formatTextWithHeaders(
+          originalText: 'טקסט',
+          copyWithHeaders: 'book_and_path',
+          copyHeaderFormat: 'same_line_after_brackets',
+          bookName: 'ספר א',
+          currentPath: '',
+        ),
+        'טקסט (ספר א)',
+      );
+    });
+
+    test('book_and_path עם נתיב מלא מרכיב "ספר, נתיב"', () {
+      expect(
+        CopyUtils.formatTextWithHeaders(
+          originalText: 'טקסט',
+          copyWithHeaders: 'book_and_path',
+          copyHeaderFormat: 'separate_line_before',
+          bookName: 'עבודה זרה',
+          currentPath: 'דף עג.',
+        ),
+        'עבודה זרה, דף עג.\nטקסט',
+      );
+    });
+  });
+}

--- a/test/utils/text/copy_utils_test.dart
+++ b/test/utils/text/copy_utils_test.dart
@@ -30,6 +30,13 @@ void main() {
       );
     });
 
+    test('reference שמתחיל במילה עם קידומת שם הספר מוחזר כמות שהוא', () {
+      expect(
+        CopyUtils.referencePath(bookName: 'ספר', reference: 'ספרים, שער א'),
+        'ספרים, שער א',
+      );
+    });
+
     test('reference שזהה לשם הספר — נתיב ריק (בלי הכפלה)', () {
       expect(
         CopyUtils.referencePath(bookName: 'ספר א', reference: 'ספר א'),

--- a/test_results/2026-08-19-search-copy-with-headers.md
+++ b/test_results/2026-08-19-search-copy-with-headers.md
@@ -1,0 +1,36 @@
+# תוצאות טסטים — העתקה מתוצאות חיפוש מכבדת את הגדרות "העתקה עם כותרת"
+
+תאריך: 2026-08-19, ענף `fix/search-copy-with-headers` (בסיס dev `6c817f38`)
+Flutter 3.44.0 / Dart 3.12.0, Windows 11
+
+## מיפוי התקלה (קומיט הטסטים)
+
+שלושה טסטי ווידג'ט חדשים ב-`test/search/tantivy_search_results_test.dart`
+נכשלו על הקוד הקיים והוכיחו את התקלה: כפתור ההעתקה בכרטיס תוצאה העתיק את
+הטקסט בלבד והתעלם מ-copyWithHeaders/copyHeaderFormat. טסט רביעי קיבע
+שברירת המחדל (none) נשארת העתקת טקסט בלבד — עבר גם לפני התיקון.
+
+## אחרי התיקון
+
+- `flutter test test/search/tantivy_search_results_test.dart
+  test/utils/text/copy_utils_test.dart` — **22 עברו, 0 נכשלו** (כולל שלושת
+  טסטי התקלה וטסטי היחידה החדשים ל-`CopyUtils.referencePath`).
+- `dart analyze` על הקבצים שנערכו — נקי.
+
+## סוויטה מלאה
+
+`flutter test` על כל המאגר: **8,172 עברו, 195 דולגו, 6 נכשלו.**
+
+- ששת הכשלים קיימים-מראש וסביבתיים — אותם שישה בדיוק שאומתו מול baseline
+  נקי (ללא שינויים) ביום הקודם: הרצת bash מ-test runner (release_packaging),
+  סף כיווץ SQLite אחרי VACUUM (שלושה טסטי compaction), נעילת קובץ זמנית של
+  Windows בניקוי טסט DOCX, ומפריד נתיב `\` מול `/` ב-custom_folder_model.
+  אף אחד מהם אינו נוגע לאזור השינוי.
+- 195 הדילוגים הם קבוצות התלויות ב-DLL של מנוע החיפוש, שריצתן דורשת בנייה
+  מקומית. אחרי בניית Debug (שייצרה את ה-DLL) הורצו הקבוצות האלה בנפרד:
+  `flutter test test/utils/ test/search/` — **1,101 עברו, 0 נכשלו**
+  (כולל כל טסטי ההדגשה והניקוד של המנוע).
+
+## בנייה
+
+`flutter build windows --debug` — הצליחה; ה-EXE זמין לאימות ידני.


### PR DESCRIPTION
## התקלה

בהגדרות הטקסט יש "העתקה עם כותרת" (`copyWithHeaders` — שם ספר / שם ספר
ונתיב, ו-`copyHeaderFormat` — שישה פורמטים). ההגדרה מכובדת בהעתקה ממסך
הקריאה (`context_menu_utils`), אבל כפתור "העתק טקסט" בכרטיס תוצאת חיפוש
העתיק את הטקסט בלבד — בלי המקור והכותרת.

## התיקון

- הכפתור מרכיב את הטקסט דרך `CopyUtils.formatTextWithHeaders` — אותו
  מנגנון של מסך הקריאה — עם ההגדרות שכבר זמינות ב-`settingsState` של
  הכרטיס. רץ רק בלחיצה; בלי צנרת חדשה.
- עזר חדש `CopyUtils.referencePath` גוזר מה-reference של המנוע את חלק
  הנתיב שאחרי שם הספר (המנוע מחזיר לעיתים "עבודה זרה, דף עג." ולעיתים
  "סימן א") — כדי ששם הספר לא יוכפל בכותרת.
- החלפת שמות קודש חלה גם על הכותרת, בעקביות עם הטקסט.

## טסטים

- קומיט ראשון: שלושה טסטי ווידג'ט שממפים את התקלה (נכשלו על הקוד הישן)
  + טסט שמקבע שברירת המחדל `none` נשארת העתקת טקסט בלבד.
- קומיט שני: התיקון + טסטי יחידה ל-`referencePath`.
- ממוקד: 22 עברו. סוויטה מלאה: 8,172 עברו; 6 כשלים סביבתיים קיימים-מראש
  (אומתו מול baseline נקי — פירוט ב-`test_results/2026-08-19-search-copy-with-headers.md`);
  קבוצות המנוע הורצו בנפרד אחרי בניית ה-DLL: 1,101 עברו.

🤖 נוצר עם [Claude Code](https://claude.com/claude-code)